### PR TITLE
🐛 fix wrong assembly of query MRNs

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -298,7 +298,7 @@ func (p *Bundle) Compile(ctx context.Context, library Library) (*PolicyBundleMap
 
 		name, err := mrn.GetResource(query.Mrn, MRN_RESOURCE_QUERY)
 		if err != nil {
-			return nil, errors.New("could not read property name from query mrn: " + query.Mrn)
+			return nil, errors.New("failed to compile, could not read property name from query mrn: " + query.Mrn)
 		}
 		propQueries[name] = query
 		propQueries[query.Mrn] = query

--- a/policy/mquery.go
+++ b/policy/mquery.go
@@ -187,7 +187,7 @@ func (m *Mquery) Sanitize() {
 // RefreshMRN computes a MRN from the UID or validates the existing MRN.
 // Both of these need to fit the ownerMRN. It also removes the UID.
 func (m *Mquery) RefreshMRN(ownerMRN string) error {
-	nu, err := RefreshMRN(ownerMRN, m.Mrn, "query", m.Uid)
+	nu, err := RefreshMRN(ownerMRN, m.Mrn, MRN_RESOURCE_QUERY, m.Uid)
 	if err != nil {
 		log.Error().Err(err).Str("owner", ownerMRN).Str("uid", m.Uid).Msg("failed to refresh mrn")
 		return errors.Wrap(err, "failed to refresh mrn for query "+m.Title)

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1008,7 +1008,7 @@ func (s *LocalServices) jobsToQueries(ctx context.Context, useV2Code bool, polic
 		if isPropQuery {
 			propName, err := mrn.GetResource(curMRN, MRN_RESOURCE_QUERY)
 			if err != nil {
-				return nil, nil, errors.New("could not read property name from query mrn: " + curMRN)
+				return nil, nil, errors.New("could not resolve property name from query mrn: " + curMRN)
 			}
 			props[propName] = &llx.Primitive{Type: mquery.Type} // placeholder
 


### PR DESCRIPTION
which was causing e.g. properties to not be found

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>