### PR TITLE
🌈 improve simple progressbar to overwrite last line

### DIFF
--- a/cli/progress/progress.go
+++ b/cli/progress/progress.go
@@ -89,8 +89,10 @@ func (p *progressbar) Open() error {
 				if p.Data.complete {
 					break
 				}
-				fmt.Println(p.View())
+				fmt.Print(p.View() + "\r\033[2A")
 			}
+
+			fmt.Print(p.View())
 		}()
 	}
 
@@ -163,7 +165,7 @@ func (p *progressbar) View() string {
 	}
 	p.lock.Unlock()
 
-	out += "\n\n"
+	out += "\n"
 	return out
 }
 


### PR DESCRIPTION
Not as high-fidelity as the original progressbar (which we still want to restore), but for simple progress indicator this does a nice job on the CLI right now

after #13 