### PR TITLE
Fix typo in github-org short command

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -211,7 +211,7 @@ configure your Azure credentials and have SSH access to your instances.`,
 			"github": {
 				Short: "Scan a GitHub organization or repository",
 			},
-			"gitlab-org": {
+			"github-org": {
 				Short: "Scan a GitHub organization",
 			},
 			"github-user": {


### PR DESCRIPTION
This was incorrectly typo'd as a gitlab command

Signed-off-by: Tim Smith <tsmith84@gmail.com>