### PR TITLE
🧹 configure dependabot to only run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To minimise distraction, we want to reduce the time dependabot opens PRs. This doesn't apply to security updates, which will be suggested by dependabot in any case.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>