### PR TITLE
⭐️ load config and service credentials

### DIFF
--- a/apps/cnspec/cmd/config/config.go
+++ b/apps/cnspec/cmd/config/config.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/viper"
+	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
+)
+
+func ReadConfig() (*CliConfig, error) {
+	// load viper config into a struct
+	var opts CliConfig
+	err := viper.Unmarshal(&opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decode into config struct")
+	}
+
+	return &opts, nil
+}
+
+type CliConfig struct {
+	// inherit common config
+	cnquery_config.CommonCliConfig `mapstructure:",squash"`
+
+	// Asset Category
+	Category               string `json:"category,omitempty" mapstructure:"category"`
+	AutoDetectCICDCategory bool   `json:"detect-cicd,omitempty" mapstructure:"detect-cicd"`
+}

--- a/apps/cnspec/cmd/config/config_test.go
+++ b/apps/cnspec/cmd/config/config_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spf13/viper"
+)
+
+func TestConfigParsing(t *testing.T) {
+	data := `
+agent_mrn: //agents.api.mondoo.app/spaces/musing-saha-952142/agents/1zDY7auR20SgrFfiGUT5qZWx6mE
+api_endpoint: https://us.api.mondoo.com
+certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIICV .. fis=
+  -----END CERTIFICATE-----
+
+mrn: //agents.api.mondoo.app/spaces/musing-saha-952142/serviceaccounts/1zDY7cJ7bA84JxxNBWDxBdui2xE
+private_key: |
+  -----BEGIN PRIVATE KEY-----
+  MIG2AgE....C0Dvs=
+  -----END PRIVATE KEY-----
+space_mrn: //captain.api.mondoo.app/spaces/musing-saha-952142
+`
+
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(strings.NewReader(data))
+
+	cfg, err := ReadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "//agents.api.mondoo.app/spaces/musing-saha-952142/agents/1zDY7auR20SgrFfiGUT5qZWx6mE", cfg.AgentMrn)
+	assert.Equal(t, "//agents.api.mondoo.app/spaces/musing-saha-952142/serviceaccounts/1zDY7cJ7bA84JxxNBWDxBdui2xE", cfg.ServiceAccountMrn)
+	assert.Equal(t, "-----BEGIN PRIVATE KEY-----\nMIG2AgE....C0Dvs=\n-----END PRIVATE KEY-----\n", cfg.PrivateKey)
+	assert.Equal(t, "-----BEGIN CERTIFICATE-----\nMIICV .. fis=\n-----END CERTIFICATE-----\n", cfg.Certificate)
+}

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -16,12 +15,18 @@ import (
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder"
 	"go.mondoo.com/cnquery/cli/components"
 	"go.mondoo.com/cnquery/cli/config"
+	"go.mondoo.com/cnquery/cli/execruntime"
 	"go.mondoo.com/cnquery/cli/inventoryloader"
+	"go.mondoo.com/cnquery/motor/asset"
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/resources"
+	"go.mondoo.com/cnquery/upstream"
+	cnspec_config "go.mondoo.com/cnspec/apps/cnspec/cmd/config"
 	"go.mondoo.com/cnspec/cli/reporter"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/scan"
+	"go.mondoo.com/ranger-rpc"
 )
 
 func init() {
@@ -416,17 +421,29 @@ type scanConfig struct {
 
 	IsIncognito bool
 	DoRecord    bool
+
+	UpstreamConfig *resources.UpstreamConfig
 }
 
 func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType builder.AssetType) (*scanConfig, error) {
+	opts, optsErr := cnspec_config.ReadConfig()
+	if optsErr != nil {
+		log.Fatal().Err(optsErr).Msg("could not load configuration")
+	}
+	config.DisplayUsedConfig()
+
+	// display activated features
+	if len(opts.Features) > 0 {
+		log.Info().Strs("features", opts.Features).Msg("user activated features")
+	}
+
 	conf := scanConfig{
-		Features:    cnquery.DefaultFeatures,
+		Features:    opts.GetFeatures(),
 		IsIncognito: viper.GetBool("incognito"),
 		DoRecord:    viper.GetBool("record"),
 		PolicyPaths: viper.GetStringSlice("policy-bundle"),
 		PolicyNames: viper.GetStringSlice("policies"),
 	}
-	config.DisplayUsedConfig()
 
 	// if users want to get more information on available output options,
 	// print them before executing the scan
@@ -453,15 +470,42 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		return nil, errors.Wrap(err, "could not load configuration")
 	}
 
-	// TODO: DETECT CI/CD
-	// TODO: SERVICE CREDENTIALS
+	// detect CI/CD runs and read labels from runtime and apply them to all assets in the inventory
+	runtimeEnv := execruntime.Detect()
+	if opts.AutoDetectCICDCategory && runtimeEnv.IsAutomatedEnv() || opts.Category == "cicd" {
+		log.Info().Msg("detected ci-cd environment")
+		// NOTE: we only apply those runtime environment labels for CI/CD runs to ensure other assets from the
+		// inventory are not touched, we may consider to add the data to the flagAsset
+		if runtimeEnv != nil {
+			runtimeLabels := runtimeEnv.Labels()
+			conf.Inventory.ApplyLabels(runtimeLabels)
+		}
+		conf.Inventory.ApplyCategory(asset.AssetCategory_CATEGORY_CICD)
+	}
+
+	serviceAccount := opts.GetServiceCredential()
+	if serviceAccount != nil {
+		log.Info().Msg("using service account credentials")
+		certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
+
+		conf.UpstreamConfig = &resources.UpstreamConfig{
+			SpaceMrn:    opts.GetParentMrn(),
+			ApiEndpoint: opts.UpstreamApiEndpoint(),
+			Plugins:     []ranger.ClientPlugin{certAuth},
+		}
+	}
 
 	if len(conf.PolicyPaths) > 0 && !conf.IsIncognito {
 		log.Warn().Msg("Scanning with local policy bundles will switch into --incognito mode by default. Your results will not be sent upstream.")
 		conf.IsIncognito = true
 	}
 
-	// print headline when its not printed to yaml
+	if serviceAccount == nil && !conf.IsIncognito {
+		log.Warn().Msg("No credentials provided. Switching to --incogito mode.")
+		conf.IsIncognito = true
+	}
+
+	// print headline when it is not printed to yaml
 	if output == "" {
 		fmt.Fprintln(os.Stdout, cnspecLogo)
 	}
@@ -493,9 +537,6 @@ func (c *scanConfig) loadPolicies() error {
 func RunScan(config *scanConfig) *policy.ReportCollection {
 	scanner := scan.NewLocalScanner()
 	ctx := cnquery.SetFeatures(context.Background(), config.Features)
-
-	// always overwrite the owner of the bundle since run incognito
-	config.Bundle.OwnerMrn = "//local.cnspec.io/run/" + uuid.New().String()
 
 	reports, err := scanner.RunIncognito(
 		ctx,

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
-	go.mondoo.com/cnquery v0.0.0-20221005212352-6f50702be7c3
+	go.mondoo.com/cnquery v0.0.0-20221008235237-1858632361fc
 	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
 	go.opentelemetry.io/otel v1.10.0
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc

--- a/go.sum
+++ b/go.sum
@@ -1567,6 +1567,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mondoo.com/cnquery v0.0.0-20221005212352-6f50702be7c3 h1:I4pdlnSidnT7C87H9YdNUzlwZUqtYQ0+fZkpFiVHpMg=
 go.mondoo.com/cnquery v0.0.0-20221005212352-6f50702be7c3/go.mod h1:8lE4KvG8B47zDVpa7qqeTLxVWbHH84m7ZpwXDC6b2wo=
+go.mondoo.com/cnquery v0.0.0-20221008235237-1858632361fc h1:PJbq1djdNJFMIgSMdkFhgnR/7PoZuGQCM3dGrNEsLS0=
+go.mondoo.com/cnquery v0.0.0-20221008235237-1858632361fc/go.mod h1:emcRY+x7Zsaa15EUGpX+Et4JqQ7LsVTJEUUrXcs+dmk=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gogo/status"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/segmentio/ksuid"
@@ -271,6 +272,11 @@ func (s *localAssetScanner) prepareAsset() error {
 
 	if err := s.ensureBundle(); err != nil {
 		return err
+	}
+
+	// always overwrite the owner of bundle since we run incognito
+	if s.job.Bundle != nil {
+		s.job.Bundle.OwnerMrn = "//local.cnspec.io/run/" + uuid.New().String()
 	}
 
 	// FIXME: we do not currently respect policy filters!


### PR DESCRIPTION
depends on https://github.com/mondoohq/cnquery/pull/222

- re-uses new common config from cnquery
- load service account when `cnspec scan` is used
- if no credentials are provided, fall back to incognito mode

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>