### PR TITLE
🐛 soften requirement on policy spec keys

### DIFF
--- a/cli/reporter/summary.go
+++ b/cli/reporter/summary.go
@@ -167,6 +167,8 @@ func (s *summaryPrinter) Render(report *policy.ReportCollection) string {
 		ratings := []map[string]int{}
 
 		for k := range summaryStats.policyNames {
+			// We are looking for MRNs that are policies only. Everything else
+			// may be filtered
 			if err := policy.IsPolicyMrn(k); err != nil {
 				continue
 			}

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -504,8 +504,9 @@ func translateSpecUIDs(ownerMrn string, policyObj *Policy, uid2mrn map[string]st
 					continue
 				}
 
-				if err := IsPolicyMrn(k); err == nil {
+				if mrn.IsValid(k) {
 					policies[k] = v
+					continue
 				}
 
 				return errors.New("found a policy reference which is neither an MRN nor in this bundle: " + k)

--- a/policy/bundle_map.go
+++ b/policy/bundle_map.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/mrn"
 )
 
 // PolicyBundleMap is a PolicyBundle with easier access to policies and queries
@@ -180,8 +181,8 @@ func sortPolicies(p *Policy, bundle *PolicyBundleMap, indexer map[string]struct{
 
 // ValidatePolicy against the given bundle
 func (p *PolicyBundleMap) ValidatePolicy(ctx context.Context, policy *Policy) error {
-	if err := IsPolicyMrn(policy.Mrn); err != nil {
-		return err
+	if mrn.IsValid(policy.Mrn) {
+		return errors.New("policy MRN is not valid: " + policy.Mrn)
 	}
 
 	for i := range policy.Specs {


### PR DESCRIPTION
So far we were checking for the MRN to be a a policy MRN during the validation.

However, there are cases where we may associate dynamic policies with assets, whose MRNs are not policy MRNs. Only check for MRN in these places of validation and. Note: When it comes to printing, however, we do look for specific policies, so the `IsPolicyMrn` method is still necessary to filter results from the report and not print things that are not policies.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>