### PR TITLE
⭐️ cnspec bundle subcommand to create a policy and to validate a bundle

### DIFF
--- a/apps/cnspec/cmd/bundle.go
+++ b/apps/cnspec/cmd/bundle.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	_ "embed"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func init() {
+	// policy init
+	policyBundlesCmd.AddCommand(policyInitCmd)
+
+	// validate
+	policyBundlesCmd.AddCommand(policyValidateCmd)
+
+	rootCmd.AddCommand(policyBundlesCmd)
+}
+
+var policyBundlesCmd = &cobra.Command{
+	Use:   "bundle",
+	Short: "Manage policy bundles",
+}
+
+//go:embed policy-example.mql.yaml
+var embedPolicyTemplate []byte
+
+var policyInitCmd = &cobra.Command{
+	Use:   "init [path]",
+	Short: "Creates an example policy bundle that can be used as a starting point. If no filename is provided, `example-policy.mql.yml` us used",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := "example-policy.mql.yaml"
+		if len(args) == 1 {
+			name = args[0]
+		}
+
+		_, err := os.Stat(name)
+		if err == nil {
+			log.Fatal().Msgf("Policy '%s' already exists", name)
+		}
+
+		err = os.WriteFile(name, embedPolicyTemplate, 0o640)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("Could not write '%s'", name)
+		}
+		log.Info().Msgf("Example policy file written to %s", name)
+	},
+}
+
+var policyValidateCmd = &cobra.Command{
+	Use:   "validate [path]",
+	Short: "Validates a policy bundle",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Info().Str("file", args[0]).Msg("validate policy bundle")
+		policyBundle, err := policy.BundleFromPaths(args[0])
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not load policy bundle")
+		}
+
+		_, err = policyBundle.Compile(context.Background(), nil)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not validate policy bundle")
+		}
+		log.Info().Msg("valid policy bundle")
+	},
+}

--- a/apps/cnspec/cmd/policy-example.mql.yaml
+++ b/apps/cnspec/cmd/policy-example.mql.yaml
@@ -1,0 +1,31 @@
+# Read more about the policy structure at https://mondoo.com/docs/platform/policies/overview
+policies:
+  - uid: sshd-server-policy
+    name: SSH Server Policy
+    version: "1.0.0"
+    authors:
+      - name: Jane Doe
+        email: jane@example.com
+    tags:
+      key: value
+      another-key: another-value
+    specs:
+      - asset_filter:
+          query: platform.family.contains(_ == 'unix')
+        scoring_queries:
+          sshd-score-01:
+queries:
+  - uid: sshd-score-01
+    title: Ensure SSH MaxAuthTries is set to 4 or less
+    query: sshd.config.params["MaxAuthTries"] <= 4
+    docs:
+      desc: |
+        The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection.
+        When the login failure count reaches half the number, error messages will be written to the syslog file
+        detailing the login failure.
+      audit: Run the `sshd -T | grep maxauthtries` command and verify that output MaxAuthTries is 4 or less
+      remediation: |
+        Open your `/etc/ssh/sshd_config` and set `MaxAuthTries` to `4`.
+    refs:
+      - title: CIS Distribution Independent Linux
+        url: https://www.cisecurity.org/benchmark/distribution_independent_linux/


### PR DESCRIPTION
The new `bundle` sub command allows users to get started quickly. It creates a new sample policy and also comes with a validate command to see if the policy bundle can be compiled.

```bash
cnspec bundle init
→ Example policy file written to example-policy.mql.yaml

cnspec bundle validate example-policy.mql.yaml
→ validate policy bundle file=example-policy.mql.yaml
→ valid policy bundle
```

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>