### PR TITLE
⭐️ format policy bundles

### DIFF
--- a/apps/cnspec/cmd/fmtbundle/bundle.go
+++ b/apps/cnspec/cmd/fmtbundle/bundle.go
@@ -1,0 +1,159 @@
+package fmtbundle
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// PolicyBundle is a struct only optimized for yaml parsing and formatting. In contrast to the normal k8s yaml parser
+// it keeps most of the comments. DO NOT USE THE STRUCT DIRECTLY IN CODE.
+//
+// The data structure is copied from policy.PolicyBundle since the yaml.v3 keeps order of fields. Therefore the order
+// of the fields matter and allow a nice formatting.
+// TODO: figure out how to keep comments and metadata with custom structs
+// TODO: we probably want to re-implement this to use our default yaml converter and use custom json marshal functions
+type PolicyBundle struct {
+	OwnerMrn string    `yaml:"owner_mrn,omitempty"`
+	Policies []*Policy `yaml:"policies,omitempty"`
+	Props    []*Mquery `yaml:"props,omitempty"`
+	Queries  []*Mquery `yaml:"queries,omitempty"`
+}
+
+type AssetFilter struct {
+	Query      string `yaml:"query,omitempty"`
+	Indicators string `yaml:"indicators,omitempty"`
+}
+
+type AssetFilters struct {
+	AssetFilters []*AssetFilter `yaml:"asset_filters,omitempty"`
+}
+
+type DataType int32
+
+type Mquery struct {
+	Uid      string            `yaml:"uid,omitempty"`
+	Title    string            `yaml:"title,omitempty"`
+	Severity int64             `yaml:"severity,omitempty"`
+	Checksum string            `yaml:"checksum,omitempty"`
+	Type     DataType          `yaml:"type,omitempty"`
+	Docs     *MqueryDocs       `yaml:"docs,omitempty"`
+	Tags     map[string]string `yaml:"tags,omitempty"`
+	Refs     []*MqueryRef      `yaml:"refs,omitempty"`
+	Query    string            `yaml:"query,omitempty"`
+}
+
+type MqueryDocs struct {
+	Desc        string ` yaml:"desc,omitempty"`
+	Audit       string `yaml:"audit,omitempty"`
+	Remediation string `yaml:"remediation,omitempty"`
+}
+
+type MqueryRef struct {
+	Title string `yaml:"title,omitempty"`
+	Url   string `yaml:"url,omitempty"`
+}
+
+type Author struct {
+	Name  string `yaml:"name,omitempty"`
+	Email string `yaml:"email,omitempty"`
+}
+
+type PolicyVar struct {
+	Name  string `yaml:"name,omitempty"`
+	Query string `yaml:"query,omitempty"`
+}
+
+type (
+	ScoringSystem int32
+	QueryAction   int32
+)
+
+type ScoringSpec struct {
+	Id                 string        `yaml:"id,omitempty"`
+	Weight             uint32        `yaml:"weight,omitempty"`
+	WeightIsPercentage bool          `yaml:"weight_is_percentage,omitempty"`
+	ScoringSystem      ScoringSystem `yaml:"scoring_system,omitempty"`
+	Action             QueryAction   `yaml:"action,omitempty"`
+}
+
+type PolicySpec struct {
+	Title             string                  `yaml:"title,omitempty"`
+	Docs              *PolicySpecDocs         `yaml:"docs,omitempty"`
+	AssetFilter       *AssetFilter            `yaml:"asset_filter,omitempty"`
+	ExecutionChecksum string                  `yaml:"execution_checksum,omitempty"`
+	ScoringChecksum   string                  `yaml:"scoring_checksum,omitempty"`
+	StartDate         int64                   `yaml:"start_date,omitempty"`
+	EndDate           int64                   `yaml:"end_date,omitempty"`
+	ReminderDate      int64                   `yaml:"reminder_date,omitempty"`
+	Created           int64                   `yaml:"created,omitempty"`
+	Modified          int64                   `yaml:"modified,omitempty"`
+	Policies          map[string]*ScoringSpec `yaml:"policies,omitempty"`
+	ScoringQueries    map[string]*ScoringSpec `yaml:"scoring_queries,omitempty"`
+	DataQueries       map[string]QueryAction  `yaml:"data_queries,omitempty"`
+}
+
+func (ps *PolicySpec) Clone() *PolicySpec {
+	if ps == nil {
+		return nil
+	}
+	clone := &PolicySpec{
+		Title:             ps.Title,
+		ExecutionChecksum: ps.ExecutionChecksum,
+		ScoringChecksum:   ps.ScoringChecksum,
+		StartDate:         ps.StartDate,
+		EndDate:           ps.EndDate,
+		ReminderDate:      ps.ReminderDate,
+		Created:           ps.Created,
+		Modified:          ps.Modified,
+		Policies:          ps.Policies,
+		ScoringQueries:    ps.ScoringQueries,
+		DataQueries:       ps.DataQueries,
+	}
+
+	if ps.AssetFilter != nil {
+		clone.AssetFilter = &AssetFilter{
+			Query:      ps.AssetFilter.Query,
+			Indicators: ps.AssetFilter.Indicators,
+		}
+	}
+
+	return clone
+}
+
+type PolicySpecDocs struct {
+	Desc string `yaml:"desc,omitempty"`
+}
+
+type Policy struct {
+	Uid           string                  `yaml:"uid,omitempty"`
+	Mrn           string                  `yaml:"mrn,omitempty"`
+	Name          string                  `yaml:"name,omitempty"`
+	Version       string                  `yaml:"version,omitempty"`
+	OwnerMrn      string                  `yaml:"owner_mrn,omitempty"`
+	Authors       []*Author               `yaml:"authors,omitempty"`
+	Created       int64                   `yaml:"created,omitempty"`
+	Modified      int64                   `yaml:"modified,omitempty"`
+	IsPublic      bool                    `yaml:"is_public,omitempty"`
+	Tags          map[string]string       `yaml:"tags,omitempty"`
+	Props         map[string]string       `yaml:"props,omitempty" `
+	AssetFilters  map[string]*AssetFilter `yaml:"asset_filters,omitempty"`
+	ScoringSystem ScoringSystem           `yaml:"scoring_system,omitempty"`
+	Specs         []*PolicySpec           `yaml:"specs,omitempty"`
+	Vars          []*PolicyVar            `yaml:"vars,omitempty"`
+	Docs          *PolicyDocs             `yaml:"docs,omitempty"`
+}
+
+type PolicyDocs struct {
+	Desc string `yaml:"desc,omitempty"`
+}
+
+// ParseYaml loads a yaml file and parse it into the go struct
+func ParseYaml(data []byte) (*PolicyBundle, error) {
+	baseline := PolicyBundle{}
+
+	err := yaml.Unmarshal([]byte(data), &baseline)
+	if err != nil {
+		return nil, err
+	}
+
+	return &baseline, nil
+}

--- a/apps/cnspec/cmd/fmtbundle/bundle_test.go
+++ b/apps/cnspec/cmd/fmtbundle/bundle_test.go
@@ -1,0 +1,33 @@
+package fmtbundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser(t *testing.T) {
+	data := `
+queries:
+  - uid: mondoo-client-linux-security-baseline-1.2_ensure_secure_boot_is_enabled
+    title: Ensure Secure Boot is enabled
+    severity: 100
+    docs:
+      desc: |
+        Secure Boot is required in order to ensure that the booting kernel hasn't been modified. It needs to be enabled in your computer's firmware and be supported by your Linux distribution.
+      audit: |
+        Run the "mokutil --sb-state" command and check whether it prints "SecureBoot enabled"
+      remediation: |
+        Enable Secure Boot in your computer's firmware and use a Linux distribution supporting Secure Boot
+    query: |
+      command('mokutil --sb-state').stdout.downcase.contains('secureboot enabled')
+`
+
+	baseline, err := ParseYaml([]byte(data))
+	require.NoError(t, err)
+	assert.NotNil(t, baseline)
+	assert.Equal(t, 1, len(baseline.Queries))
+	assert.Equal(t, int64(100), baseline.Queries[0].Severity)
+}

--- a/apps/cnspec/cmd/fmtbundle/fmt.go
+++ b/apps/cnspec/cmd/fmtbundle/fmt.go
@@ -1,0 +1,19 @@
+package fmtbundle
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Formats the given bundle to a yaml string
+func Format(bundle *PolicyBundle) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	err := enc.Encode(bundle)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/apps/cnspec/cmd/fmtbundle/fmt_test.go
+++ b/apps/cnspec/cmd/fmtbundle/fmt_test.go
@@ -1,0 +1,78 @@
+package fmtbundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleFormatter(t *testing.T) {
+	data := `
+policies:
+  - uid: sshd-server-policy
+    authors:
+      - name: Jane Doe
+        email: jane@example.com
+    tags:
+      key: value
+      another-key: another-value
+    name: SSH Server Policy
+    specs:
+      - asset_filter:
+          query: platform.family.contains(_ == 'unix')
+        scoring_queries:
+          query1:
+    version: "1.0.0"
+queries:
+  - uid: query1
+    docs:
+      desc: |
+        Secure Boot is required in order to ensure that the booting kernel hasn't been modified. It needs to be enabled in your computer's firmware and be supported by your Linux distribution.
+      audit: |
+        Run the "mokutil --sb-state" command and check whether it prints "SecureBoot enabled"
+      remediation: |
+        Enable Secure Boot in your computer's firmware and use a Linux distribution supporting Secure Boot
+    query: |
+      command('mokutil --sb-state').stdout.downcase.contains('secureboot enabled')
+    severity: 100
+    title: Ensure Secure Boot is enabled
+`
+
+	baseline, err := ParseYaml([]byte(data))
+	require.NoError(t, err)
+
+	formattedData, err := Format(baseline)
+	require.NoError(t, err)
+
+	expected := `policies:
+  - uid: sshd-server-policy
+    name: SSH Server Policy
+    version: 1.0.0
+    authors:
+      - name: Jane Doe
+        email: jane@example.com
+    tags:
+      another-key: another-value
+      key: value
+    specs:
+      - asset_filter:
+          query: platform.family.contains(_ == 'unix')
+        scoring_queries:
+          query1: null
+queries:
+  - uid: query1
+    title: Ensure Secure Boot is enabled
+    severity: 100
+    docs:
+      desc: |
+        Secure Boot is required in order to ensure that the booting kernel hasn't been modified. It needs to be enabled in your computer's firmware and be supported by your Linux distribution.
+      audit: |
+        Run the "mokutil --sb-state" command and check whether it prints "SecureBoot enabled"
+      remediation: |
+        Enable Secure Boot in your computer's firmware and use a Linux distribution supporting Secure Boot
+    query: |
+      command('mokutil --sb-state').stdout.downcase.contains('secureboot enabled')
+`
+	assert.Equal(t, expected, string(formattedData))
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -417,7 +418,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.3.3 // indirect
 	howett.net/plist v1.0.0 // indirect
 	k8s.io/api v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1565,8 +1565,6 @@ go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6y
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
-go.mondoo.com/cnquery v0.0.0-20221005212352-6f50702be7c3 h1:I4pdlnSidnT7C87H9YdNUzlwZUqtYQ0+fZkpFiVHpMg=
-go.mondoo.com/cnquery v0.0.0-20221005212352-6f50702be7c3/go.mod h1:8lE4KvG8B47zDVpa7qqeTLxVWbHH84m7ZpwXDC6b2wo=
 go.mondoo.com/cnquery v0.0.0-20221008235237-1858632361fc h1:PJbq1djdNJFMIgSMdkFhgnR/7PoZuGQCM3dGrNEsLS0=
 go.mondoo.com/cnquery v0.0.0-20221008235237-1858632361fc/go.mod h1:emcRY+x7Zsaa15EUGpX+Et4JqQ7LsVTJEUUrXcs+dmk=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=


### PR DESCRIPTION
This change allows an user to format a bundle with `.mql.yaml`. 

You can format individual bundles:

```
cnspec bundle fmt example-policy.mql.yaml
→ format policy bundle(s) file=example-policy.mql.yaml
→ format file filename=example-policy.mql.yaml
```

or format a directory that contains many bundles:

```
cnspec bundle fmt policy/examples/directory
→ format policy bundle(s) file=policy/examples/directory
→ format file filename=policy/examples/directory/example1.mql.yaml
→ format file filename=policy/examples/directory/example2.mql.yaml
→ format file filename=policy/examples/directory/queries/linux-1.mql.yaml
→ format file filename=policy/examples/directory/queries/sshd-01.mql.yaml
→ format file filename=policy/examples/directory/queries/sshd-02.mql.yaml
→ format file filename=policy/examples/directory/queries/sshd-03.mql.yaml
→ format file filename=policy/examples/directory/queries/sshd-d-1.mql.yaml
```