### PR TITLE
🌈 prefix score indication on cli reports

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -278,14 +278,14 @@ func (r *defaultReporter) printScore(title string, score *policy.Score, query *p
 		passfail = termenv.String("✕ Fail:  ").Foreground(color).String()
 	}
 
-	var suffix string
+	var scoreIndicator string
 	if query.Severity != nil && score.Value != 100 {
-		suffix = termenv.String(
-			fmt.Sprintf(" %s %d", rating.Letter(), score.Value),
+		scoreIndicator = termenv.String(
+			fmt.Sprintf("%s %3d  ", rating.Letter(), score.Value),
 		).Foreground(color).String()
 	}
 
-	return passfail + title + suffix + "\n"
+	return passfail + scoreIndicator + title + "\n"
 }
 
 func (r *defaultReporter) printControl(score *policy.Score, query *policy.Mquery, asset *policy.Asset, resolved *policy.ResolvedPolicy, report *policy.Report, results map[string]*llx.RawResult) {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1307529/195403643-486a09ff-7394-4b82-b144-fe2cf313cc2d.png)

^^ vs the previous version where it was added after the title

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>