### PR TITLE
⭐ scan report --json

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -296,6 +296,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 
 		// output rendering
 		cmd.Flags().StringP("output", "o", "compact", "set output format: "+reporter.AllFormats())
+		cmd.Flags().BoolP("json", "j", false, "set output to JSON (shorthand)")
 		cmd.Flags().Bool("no-pager", false, "disable interactive scan output pagination")
 		cmd.Flags().String("pager", "", "enable scan output pagination with custom pagination command. default is 'less -R'")
 	},
@@ -403,6 +404,12 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		fmt.Println("Available output formats: " + reporter.AllFormats())
 		os.Exit(0)
 	}
+
+	// --json takes precedence
+	if ok, _ := cmd.Flags().GetBool("json"); ok {
+		output = "json"
+	}
+	conf.Output = output
 
 	// check if the user used --password without a value
 	askPass, err := cmd.Flags().GetBool("ask-pass")

--- a/cli/reporter/json.go
+++ b/cli/reporter/json.go
@@ -1,0 +1,125 @@
+package reporter
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+
+	cr "go.mondoo.com/cnquery/cli/reporter"
+	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func ReportCollectionToJSON(data *policy.ReportCollection, out shared.OutputHelper) error {
+	if data == nil {
+		return nil
+	}
+
+	queryMrnIdx := map[string]string{}
+	for i := range data.Bundle.Queries {
+		query := data.Bundle.Queries[i]
+		queryMrnIdx[query.CodeId] = query.Mrn
+	}
+
+	out.WriteString(
+		"{" +
+			"\"assets\":")
+	assets, err := json.Marshal(data.Assets)
+	if err != nil {
+		return err
+	}
+	out.WriteString(string(assets))
+
+	out.WriteString("," +
+		"\"data\":" +
+		"{")
+	pre := ""
+	for id, report := range data.Reports {
+		out.WriteString(pre + llx.PrettyPrintString(id) + ":{")
+		pre = ","
+
+		resolved, ok := data.ResolvedPolicies[id]
+		if !ok {
+			return errors.New("cannot find resolved pack for " + id + " in report")
+		}
+
+		results := report.RawResults()
+		pre2 := ""
+		for qid, query := range resolved.ExecutionJob.Queries {
+			mrn := queryMrnIdx[qid]
+			// policies and other stuff
+			if mrn == "" {
+				continue
+			}
+			// controls
+			if _, ok := report.Scores[qid]; ok {
+				continue
+			}
+
+			out.WriteString(pre2 + llx.PrettyPrintString(mrn) + ":")
+			pre2 = ","
+
+			err := cr.BundleResultsToJSON(query.Code, results, out)
+			if err != nil {
+				return err
+			}
+		}
+		out.WriteString("}")
+	}
+
+	out.WriteString("}," +
+		"\"scores\":" +
+		"{")
+	pre = ""
+	for id, report := range data.Reports {
+		out.WriteString(pre + llx.PrettyPrintString(id) + ":{")
+		pre = ","
+
+		resolved, ok := data.ResolvedPolicies[id]
+		if !ok {
+			return errors.New("cannot find resolved pack for " + id + " in report")
+		}
+
+		pre2 := ""
+		for qid := range resolved.ExecutionJob.Queries {
+			mrn := queryMrnIdx[qid]
+			// policies and other stuff
+			if mrn == "" {
+				continue
+			}
+			// controls
+			score, ok := report.Scores[qid]
+			if !ok {
+				continue
+			}
+
+			status := score.TypeLabel()
+			if score.Type == policy.ScoreType_Result {
+				if score.Value == 100 {
+					status = "pass"
+				} else {
+					status = "fail"
+				}
+			}
+
+			out.WriteString(pre2 + llx.PrettyPrintString(mrn) +
+				":{\"score\":" + strconv.FormatUint(uint64(score.Value), 10) + "," +
+				"\"status\":\"" + status + "\"}")
+			pre2 = ","
+		}
+		out.WriteString("}")
+	}
+
+	out.WriteString("}," +
+		"\"errors\":" +
+		"{")
+	pre = ""
+	for id, err := range data.Errors {
+		out.WriteString(pre + llx.PrettyPrintString(id) + ":" + llx.PrettyPrintString(err))
+		pre = ","
+	}
+	out.WriteString("}}")
+
+	return nil
+}

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 
 	"go.mondoo.com/cnquery/cli/printer"
 	"go.mondoo.com/cnquery/cli/theme/colors"
+	"go.mondoo.com/cnquery/shared"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/executor"
 )
@@ -43,9 +44,6 @@ func New(typ string) (*Reporter, error) {
 }
 
 func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
-	var res []byte
-	var err error
-
 	switch r.Format {
 	case Compact:
 		rr := &defaultReporter{
@@ -77,8 +75,9 @@ func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
 	// 	return nil
 	// case YAML:
 	// 	res, err = data.ToYAML()
-	// case JSON:
-	// 	res, err = data.ToJSON()
+	case JSON:
+		w := shared.IOWriter{Writer: out}
+		return ReportCollectionToJSON(data, &w)
 	// case JUnit:
 	// 	res, err = data.ToJunit()
 	// case CSV:
@@ -86,11 +85,4 @@ func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
 	default:
 		return errors.New("unknown reporter type, don't recognize this Format")
 	}
-
-	if err != nil {
-		return err
-	}
-	out.Write(res)
-
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
-	go.mondoo.com/cnquery v0.0.0-20221013182737-d3a0ec180aa0
+	go.mondoo.com/cnquery v0.0.0-20221014082731-300fb6c373ae
 	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
 	go.opentelemetry.io/otel v1.10.0
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc

--- a/go.sum
+++ b/go.sum
@@ -1566,8 +1566,8 @@ go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6y
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
-go.mondoo.com/cnquery v0.0.0-20221013182737-d3a0ec180aa0 h1:59kcSvKYcHtDnfnT8JflQsc+OpDI57bM95+u56eWKTg=
-go.mondoo.com/cnquery v0.0.0-20221013182737-d3a0ec180aa0/go.mod h1:E7+94D2X1SMG2Gc7HL5P6FONssPF9i0cXlK9Vr5e+G4=
+go.mondoo.com/cnquery v0.0.0-20221014082731-300fb6c373ae h1:tJzoPav7UjwwpZ+nsAoUo+/GDHu3AnylDtgFWGOz9Ow=
+go.mondoo.com/cnquery v0.0.0-20221014082731-300fb6c373ae/go.mod h1:E7+94D2X1SMG2Gc7HL5P6FONssPF9i0cXlK9Vr5e+G4=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/policy/report.go
+++ b/policy/report.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	"encoding/json"
+
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/llx"
 )
@@ -78,4 +80,16 @@ func (sd *ScoreDistribution) Add(score *Score) {
 	case ScoreRating_failed:
 		sd.F++
 	}
+}
+
+func (p *ReportCollection) ToJSON() ([]byte, error) {
+	// removes the data to ensure the data is not exported
+	// NOTE: this has the side-effect that data is manipulated and a console print on the same struct
+	// would not work. When we need that, we need to copy the struct before we export it
+	for k := range p.Reports {
+		p.Reports[k].Data = nil
+	}
+
+	// pretty print json
+	return json.MarshalIndent(p, "", "  ")
 }


### PR DESCRIPTION
Introduces a custom printer to create reports. It doesn't just take the raw data and dump it all to CLI, but instead carefully constructs a JSON representation of the report that is useful for further processing. It contains MRNs for queries, eliminates pesky lookups, and nicely aggregates data.

after: #88 
    
Signed-off-by: Dominik Richter <dominik.richter@gmail.com>