### PR TITLE
⭐ restore scan -o report

### DIFF
--- a/cli/components/barchart.go
+++ b/cli/components/barchart.go
@@ -1,0 +1,214 @@
+package components
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnquery/cli/theme/colors"
+)
+
+func maxWidth(labels []string) int {
+	max := 0
+	for i := range labels {
+		l := len(labels[i])
+		if l > max {
+			max = l
+		}
+	}
+	return max
+}
+
+type BarChartOption func(chart *BarChart)
+
+func WithBarChartBorder() BarChartOption {
+	return func(m *BarChart) {
+		m.border = true
+	}
+}
+
+func WithBarChartTitle(title string) BarChartOption {
+	return func(m *BarChart) {
+		m.title = title
+	}
+}
+
+type BarChartLabelFunc func(i int, datapoints []float64) string
+
+func WithBarChartLabelFunc(labelFunc BarChartLabelFunc) BarChartOption {
+	return func(m *BarChart) {
+		m.labelFunc = labelFunc
+	}
+}
+
+func noLabelFunc(i int, datapoints []float64) string { return "" }
+
+func BarChartPercentageLabelFunc(i int, datapoints []float64) string {
+	// write percentage, handle case where we get a NaN
+	p := datapoints[i] * 100
+	if math.IsNaN(p) {
+		p = 0
+	}
+	return fmt.Sprintf("%.1f%%", p)
+}
+
+func NewBarChart(opts ...BarChartOption) *BarChart {
+	theme := AnsiPaperCars
+	if colors.Profile == termenv.Ascii {
+		theme = AsciiPaperCars
+	}
+
+	bc := &BarChart{
+		width:       defaultWidth,
+		EntryChar:   '█',
+		border:      false,
+		borderColor: colors.Profile.Color("#a9a9a9"),
+		theme:       theme,
+		labelFunc:   noLabelFunc,
+	}
+
+	for _, opt := range opts {
+		opt(bc)
+	}
+
+	return bc
+}
+
+type BarChart struct {
+	// title of the chart, if set is printed on the chart
+	title string
+
+	// function to calculate the label values
+	labelFunc BarChartLabelFunc
+
+	// total width of the bar chart including labels
+	width int
+
+	// visual representation for one entry in the stack bar
+	EntryChar rune
+
+	// chart with a border
+	border bool
+
+	// color of the border
+	borderColor termenv.Color
+
+	// character theme for border
+	theme PaperCharsTheme
+}
+
+func (m BarChart) Render(datapoints []float64, colorMap []termenv.Color, labels []string) string {
+	b := strings.Builder{}
+
+	boxWidth := m.width
+
+	// if its rendered with a box, we need to substract two char from each end
+	if m.border {
+		boxWidth = boxWidth - 4
+	}
+
+	// determine max size labels
+	maxLabelWidth := maxWidth(labels)
+
+	datapoints = sanitizeDatapoints(datapoints)
+
+	// TODO: sorting changes the index for color and label
+	//if m.SortByMax {
+	//	sort.Sort(sort.Reverse(sort.Float64Slice(datapoints)))
+	//}
+
+	// maxLabelWidth + colon + one whitespace
+	// 6 for percentages + 1 whitespace between box and label
+	maxBarWidth := boxWidth - maxLabelWidth - 9
+	sizes := make([]int, len(datapoints))
+	maxBarWidthUsed := 0
+	for i := range datapoints {
+		percentage := datapoints[i]
+		// round down
+		width := int(percentage * float64(maxBarWidth))
+		sizes[i] = width
+		if width > maxBarWidthUsed {
+			maxBarWidthUsed = width
+		}
+	}
+
+	// calculate stretch factor
+	whitespaceForBox := maxBarWidth - maxBarWidthUsed
+	stretchFactor := float64(whitespaceForBox) / float64(maxBarWidth)
+
+	if m.border {
+		line := string(m.theme.TopLeft)
+
+		// print title if it set and if it fits
+		if m.title != "" && m.width-2-len(m.title)-2 > 0 {
+			line += string(m.theme.Horizontal) + " " + m.title + " "
+			line += strings.Repeat(string(m.theme.Horizontal), m.width-2-len(m.title)-3)
+		} else {
+			line += strings.Repeat(string(m.theme.Horizontal), m.width-2)
+		}
+
+		line += string(m.theme.TopRight)
+		line += string('\n')
+
+		b.WriteString(termenv.String(line).Foreground(m.borderColor).String())
+	} else if m.title != "" {
+		b.WriteString(m.title)
+	}
+
+	// render bar
+	for i := range datapoints {
+		if m.border {
+			b.WriteString(termenv.String(string(m.theme.Vertical)).Foreground(m.borderColor).String())
+			b.WriteRune(' ')
+		}
+		// write label
+		b.WriteString(labels[i])
+		b.WriteString(": ")
+
+		// write gap
+		gap := maxLabelWidth - len(labels[i])
+		if gap > 0 {
+			b.WriteString(strings.Repeat(" ", gap))
+		}
+
+		usedSpaces := maxLabelWidth + 2 // label + colon + space
+
+		// render bar
+		if sizes[i] > 0 {
+			// stretch values if we still have space left
+			size := sizes[i] + int(float64(sizes[i])*stretchFactor)
+			val := strings.Repeat(string(m.EntryChar), size)
+			b.WriteString(termenv.String(val).Foreground(colorMap[i]).String())
+			b.WriteRune(' ')
+			usedSpaces += size + 1
+		}
+
+		barLabel := m.labelFunc(i, datapoints)
+
+		usedSpaces += len(barLabel)
+		b.WriteString(barLabel)
+
+		if m.border {
+			gap := boxWidth - usedSpaces
+			if gap > 0 {
+				b.WriteString(strings.Repeat(" ", gap))
+			}
+			b.WriteRune(' ')
+			b.WriteString(termenv.String(string(m.theme.Vertical)).Foreground(m.borderColor).String())
+		}
+
+		b.WriteRune('\n')
+	}
+
+	if m.border {
+		b.WriteString(termenv.String(
+			string(m.theme.BottomLeft) +
+				strings.Repeat(string(m.theme.Horizontal), m.width-2) +
+				string(m.theme.BottomRight) +
+				string('\n'),
+		).Foreground(m.borderColor).String())
+	}
+
+	return b.String()
+}

--- a/cli/reporter/print_report.go
+++ b/cli/reporter/print_report.go
@@ -1,0 +1,460 @@
+package reporter
+
+import (
+	"bytes"
+	"fmt"
+	io "io"
+	"sort"
+	"strings"
+
+	"github.com/muesli/termenv"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/cli/pager"
+	"go.mondoo.com/cnquery/cli/printer"
+	"go.mondoo.com/cnquery/cli/theme/colors"
+	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/stringx"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+const (
+	assetOverviewPolicyMrn = "//policy.api.mondoo.app/policies/asset-overview"
+	advisoryPolicyMrn      = "//policy.api.mondoo.app/policies/platform-vulnerability"
+)
+
+type policyRenderer func(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, data []reportRow) string
+
+type reportRenderer struct {
+	printer  *printer.Printer
+	pager    string
+	usePager bool
+	out      io.Writer
+	data     *policy.ReportCollection
+}
+
+func (r *reportRenderer) print() error {
+	// TODO: render to a buffer and print later, to enable pager printing
+	// TODO: sort assets by reverse score
+
+	var res bytes.Buffer
+
+	// print summaryPrinter
+	s := NewSummaryRenderer(r.printer)
+	scanSummary := s.Render(r.data)
+	res.WriteString(scanSummary)
+
+	// render asset name/summaryPrinter + policy results
+	for assetMrn := range r.data.Assets {
+		renderedAsset, err := r.printAsset(assetMrn)
+		if err != nil {
+			log.Error().Err(err).Send()
+		} else {
+			res.WriteString(renderedAsset)
+		}
+	}
+
+	// print errors
+	if len(r.data.Errors) > 0 {
+		res.WriteString(r.printer.Primary("Scan Failures\n\n"))
+
+		for name, errMsg := range r.data.Errors {
+			// TODO: most likely we need to fetch the asset name here
+			assetLine := termenv.String(fmt.Sprintf("■ Asset: %s\n", name)).
+				Foreground(colors.DefaultColorTheme.Critical).String()
+			res.WriteString(assetLine)
+			errLine := termenv.String(stringx.Indent(2, fmt.Sprintf("Error: %s\n", errMsg))).
+				Foreground(colors.DefaultColorTheme.Critical).String()
+			res.WriteString(errLine)
+		}
+	}
+
+	if r.usePager && pager.Supported(r.pager) {
+		err := pager.Display(res.String(), r.pager)
+		if err != nil {
+			log.Error().Err(err).Send()
+		}
+		// we print the summary again to make it visible after the pager is closed of the page
+		fmt.Fprintln(r.out, "\n"+scanSummary)
+	} else {
+		fmt.Fprintln(r.out, res.String())
+	}
+
+	return nil
+}
+
+func (r *reportRenderer) printAsset(assetMrn string) (string, error) {
+	assetObj := r.data.Assets[assetMrn]
+	report := r.data.Reports[assetMrn]
+	resolvedPolicy := r.data.ResolvedPolicies[assetMrn]
+
+	if report == nil {
+		return `✕ Could not find report for asset ` + assetObj.Mrn, nil
+	}
+
+	var res bytes.Buffer
+	assetScore := report.Scores[assetObj.Mrn]
+	overview := r.assetSummary(assetObj, assetScore)
+	res.WriteString(overview)
+
+	// render scanReport
+	bundle := r.data.Bundle.ToMap()
+	policies, err := resolvedPolicy.RootBundlePolicies(bundle, assetMrn)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range policies {
+		reportOutput, err := r.renderPolicyReport(policies[i], report, bundle, resolvedPolicy, nil)
+		if err != nil {
+			return "", err
+		}
+		res.WriteString(reportOutput)
+	}
+
+	return res.String(), nil
+}
+
+func (r *reportRenderer) assetSummary(assetObj *policy.Asset, score *policy.Score) string {
+	var res bytes.Buffer
+
+	if assetObj == nil {
+		return res.String()
+	}
+
+	res.WriteString("\n")
+
+	// header with asset name
+	res.WriteString(r.printer.H1(assetObj.Name))
+	res.WriteString(components.NewScoreCard().Render(score))
+
+	res.WriteString("\n")
+	return res.String()
+}
+
+// policyModActions tracks the remove and modify actions to pass them to childs for proper rendering of ignores
+type policyModActions map[string]policy.QueryAction
+
+func (p policyModActions) Clone() policyModActions {
+	res := policyModActions{}
+	for k := range p {
+		res[k] = p[k]
+	}
+	return res
+}
+
+func (r *reportRenderer) renderPolicyReport(policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolved *policy.ResolvedPolicy, parentQueryActions policyModActions) (string, error) {
+	var res bytes.Buffer
+	var queryActionsForChildren policyModActions
+
+	log.Trace().Str("mrn", policyObj.Mrn).Msgf("match policy assetfilter: %v, pfilter: %v", resolved.Filters, policyObj.AssetFilters)
+	filters, err := policy.MatchingAssetFilters(policyObj.Mrn, resolved.Filters, policyObj)
+	if err != nil {
+		return r.printer.Error(err.Error), nil
+	}
+
+	// print policy details
+	// NOTE: asset policies and space policies have no filter set but we want to render them too
+	if len(filters) > 0 || len(policyObj.AssetFilters) == 0 {
+		var scoringData []reportRow
+		scoringData, queryActionsForChildren = r.generateScoringResults(policyObj, report, bundle, resolved, parentQueryActions)
+
+		// determine renderer for policy
+		var render policyRenderer
+		switch policyObj.Mrn {
+		case assetOverviewPolicyMrn:
+			render = renderAssetOverview
+		case advisoryPolicyMrn:
+			render = renderAdvisoryPolicy
+		default:
+			render = renderPolicy
+		}
+
+		// use meta renderer for asset and space policies
+		if strings.HasPrefix(policyObj.Mrn, "//assets.api.mondoo.app") || strings.HasPrefix(policyObj.Mrn, "//captain.api.mondoo.app") {
+			render = renderMetaPolicy
+		}
+
+		result := render(r.printer, policyObj, report, bundle, resolved, scoringData)
+		res.WriteString(result)
+	}
+
+	policies := r.policyReportChildren(&res, policyObj, bundle)
+
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].Name < policies[j].Name
+	})
+
+	// render sub-policies
+	for i := range policies {
+		// NOTE: do not pass the filtered asset filter, eg. a space policy may not include a filter but its childs
+		// if we pass-through the filtered queryes, childs polices matching the original asset filter are not rendered
+		x, err := r.renderPolicyReport(policies[i], report, bundle, resolved, queryActionsForChildren.Clone())
+		if err != nil {
+			return "", err
+		}
+		res.WriteString(x)
+	}
+
+	return res.String(), nil
+}
+
+func (r *reportRenderer) policyReportChildren(res *bytes.Buffer, policyObj *policy.Policy, bundle *policy.PolicyBundleMap) []*policy.Policy {
+	policies := map[string]*policy.ScoringSpec{}
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+		for qid, spec := range spec.Policies {
+			policies[qid] = spec
+		}
+	}
+
+	policyRefs := []*policy.Policy{}
+	if len(policies) > 0 {
+		for id := range policies {
+			curPolicy := bundle.Policies[id]
+			if curPolicy == nil {
+				continue
+			}
+			policyRefs = append(policyRefs, curPolicy)
+		}
+	}
+	return policyRefs
+}
+
+func (r *reportRenderer) generateScoringResults(policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolved *policy.ResolvedPolicy, parentQueryActions policyModActions) ([]reportRow, policyModActions) {
+	scoreQueries := map[string]*policy.ScoringSpec{}
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+		for qid, scoring := range spec.ScoringQueries {
+			scoreQueries[qid] = scoring
+		}
+	}
+
+	data := []reportRow{}
+
+	// we are passing all actions that are not handled here through to the childs
+	// - Add is handled directly within this policy, no need to pass through
+	// - Remove is passed-throguh to the first child that adds or readds a query
+	// - Modify is not-handled yet but would work similar to Remove
+	actionsForChilds := policyModActions{}
+
+	// extract queries for scores that are in the bundle
+	for qid := range scoreQueries {
+		scoringSpec := scoreQueries[qid]
+
+		action := policy.QueryAction_ACTIVATE
+		var actionSpec *policy.ScoringSpec
+		if scoringSpec != nil {
+			action = scoringSpec.Action
+			actionSpec = scoringSpec
+		}
+
+		// we only render query additions, all others need to be passed-through to the child policy
+		// NOTE: we need to copy the map when we pass eg. Remove to Children, since multiple children can add the same query
+		if action != policy.QueryAction_ACTIVATE {
+			actionsForChilds[qid] = action
+			continue
+		}
+
+		// overwrite action if we got a modify from parent
+		modifiedAction, isActionModified := parentQueryActions[qid]
+		if isActionModified {
+			action = modifiedAction
+			// modififies parent actions so
+			delete(parentQueryActions, qid)
+		}
+
+		query := bundle.Queries[qid]
+		if query == nil {
+			log.Warn().Msg("failed to find query '" + qid + "' in bundle")
+			continue
+		}
+
+		codeBundle := resolved.GetCodeBundle(query)
+		if codeBundle == nil {
+			log.Debug().Msg("failed to find code bundle for query '" + qid + "' in bundle")
+			continue
+		}
+
+		var score *policy.Score
+		var assessment *llx.Assessment
+		if report != nil {
+			score = report.Scores[query.CodeId]
+			assessment = policy.Query2Assessment(codeBundle, report)
+		}
+
+		data = append(data, reportRow{
+			Query:      query,
+			Bundle:     codeBundle,
+			Score:      score,
+			Action:     action,
+			ActionSpec: actionSpec,
+			Assessment: assessment,
+		})
+	}
+
+	// merge unhandled actions from parent with new actions for childs
+	for k := range parentQueryActions {
+		actionsForChilds[k] = parentQueryActions[k]
+	}
+
+	// sort by severity and title
+	sort.Sort(rowByScoreAndAction(data))
+
+	return data, actionsForChilds
+}
+
+type reportRow struct {
+	Query      *policy.Mquery
+	Bundle     *llx.CodeBundle
+	Score      *policy.Score
+	Action     policy.QueryAction
+	ActionSpec *policy.ScoringSpec
+	Assessment *llx.Assessment
+}
+
+func (row reportRow) Indicator() string {
+	char := '■'
+	color := components.DefaultRatingColors.Color(scoreRating(row.Score))
+
+	if row.Score != nil {
+
+		if row.Score.Type == policy.ScoreType_Error {
+			color = colors.DefaultColorTheme.Error
+			char = '×'
+		}
+
+		if row.Action == policy.QueryAction_DEACTIVATE {
+			color = colors.DefaultColorTheme.Disabled
+			char = '×'
+		}
+
+		if row.Action == policy.QueryAction_MODIFY && row.ActionSpec != nil && row.ActionSpec.Weight == 0 {
+			color = colors.DefaultColorTheme.Secondary
+			char = '»'
+		}
+
+		if row.Score.Type == policy.ScoreType_Skip {
+			color = colors.DefaultColorTheme.Disabled
+			char = '»'
+		}
+	}
+
+	return termenv.String(string(char)).Foreground(color).String()
+}
+
+func colorizeRow(row reportRow, text string) string {
+	explain := ""
+	severity := scoreRating(row.Score)
+	color := components.DefaultRatingColors.Color(severity)
+
+	if severity == policy.ScoreRating_aPlus {
+		explain = "(passed)"
+	} else if severity == policy.ScoreRating_unrated {
+		explain = ""
+	} else {
+		explain = "(failed)"
+	}
+
+	if row.Score != nil {
+		if row.Score.Type == policy.ScoreType_Error {
+			color = colors.DefaultColorTheme.Error
+			explain = "(error)"
+		}
+
+		if row.Score.Type == policy.ScoreType_Unknown {
+			color = colors.DefaultColorTheme.Unknown
+			explain = "(unknown)"
+		}
+
+		if row.Score.Type == policy.ScoreType_Unscored {
+			color = colors.DefaultColorTheme.Unknown
+			explain = "(unscored)"
+		}
+
+		if row.Action == policy.QueryAction_DEACTIVATE {
+			color = colors.DefaultColorTheme.Disabled
+			explain = "(removed)"
+		}
+
+		if row.Action == policy.QueryAction_MODIFY && row.ActionSpec != nil && row.ActionSpec.Weight == 0 {
+			color = colors.DefaultColorTheme.Low
+			explain = "(modified)"
+		}
+
+		if row.Score.Type == policy.ScoreType_Skip {
+			color = colors.DefaultColorTheme.Disabled
+			explain = "(skipped)"
+		}
+	} else {
+		explain = "(unscored)"
+	}
+
+	return termenv.String(text + " " + explain).Foreground(color).String()
+}
+
+type rowByScoreAndAction []reportRow
+
+func (data rowByScoreAndAction) Len() int { return len(data) }
+
+var sortedScores = map[uint32]uint32{
+	policy.ScoreType_Error:   0,
+	policy.ScoreType_Result:  1,
+	policy.ScoreType_Skip:    2,
+	policy.ScoreType_Unknown: 3,
+}
+
+// sort by severity and title
+func (data rowByScoreAndAction) Less(i, j int) bool {
+	if data[i].Action != data[j].Action {
+		if data[i].Action == policy.QueryAction_DEACTIVATE {
+			return false
+		}
+		if data[j].Action == policy.QueryAction_DEACTIVATE {
+			return true
+		}
+	}
+
+	if data[i].Score != nil && data[j].Score == nil {
+		return true
+	}
+	if data[i].Score != nil && data[j].Score != nil {
+		// we want to sort by score type error, result, skip, unknown
+		itype := data[i].Score.Type
+		jtype := data[j].Score.Type
+		if itype != jtype {
+			return sortedScores[itype] < sortedScores[jtype]
+		}
+
+		if data[i].Score.Value == data[j].Score.Value {
+			return data[i].Query.Title < data[j].Query.Title
+		}
+		return data[i].Score.Value < data[j].Score.Value
+	}
+	if data[i].Score == nil && data[j].Score == nil {
+		return data[i].Query.Title < data[j].Query.Title
+	}
+	return false
+}
+
+func (data rowByScoreAndAction) Swap(i, j int) {
+	data[i], data[j] = data[j], data[i]
+}
+
+func scoreRating(score *policy.Score) policy.ScoreRating {
+	severity := policy.ScoreRating_unrated
+	if score != nil {
+		if score.Type == policy.ScoreType_Result {
+			if score.Value == 100 {
+				severity = policy.ScoreRating_aPlus
+			} else {
+				severity = policy.ScoreRating_failed
+			}
+		}
+
+		if score.Type == policy.ScoreType_Error {
+			severity = policy.ScoreRating_failed
+		}
+	}
+	return severity
+}

--- a/cli/reporter/render_advisory_policy.go
+++ b/cli/reporter/render_advisory_policy.go
@@ -1,0 +1,265 @@
+package reporter
+
+import (
+	"bytes"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnquery/cli/printer"
+	"go.mondoo.com/cnquery/cli/theme/colors"
+	"go.mondoo.com/cnquery/resources/packs/core"
+	"go.mondoo.com/cnquery/resources/packs/core/vadvisor"
+	"go.mondoo.com/cnquery/stringx"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func renderAdvisoryPolicy(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, scoringData []reportRow) string {
+	var b bytes.Buffer
+
+	b.WriteString(print.H2(policyObj.Name))
+
+	// render mini score card
+	score := report.Scores[policyObj.Mrn]
+
+	var vulnReport vadvisor.VulnReport
+	results := report.Data
+	value, ok := results[vulnReportDatapointChecksum]
+	if !ok {
+		b.WriteString(print.Error("could not find advisory report\n\n"))
+		return b.String()
+	}
+
+	if value == nil || value.Data == nil {
+		b.WriteString(print.Error("could not load advisory report\n\n"))
+		return b.String()
+	}
+
+	if value.Error != "" {
+		b.WriteString(print.Error("could not load advisory report: " + value.Error + "\n\n"))
+		return b.String()
+	}
+
+	rawData := value.Data.RawData().Value
+
+	cfg := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   &vulnReport,
+		TagName:  "json",
+	}
+	decoder, _ := mapstructure.NewDecoder(cfg)
+	err := decoder.Decode(rawData)
+	if err != nil {
+		b.WriteString(print.Error("could not decode advisory report\n\n"))
+		return b.String()
+	}
+
+	cvssScore := ""
+	if vulnReport.Stats != nil {
+		v := float64(vulnReport.Stats.Score) / 10
+		cvssScore = print.Primary("CVSS:    ") + strconv.FormatFloat(v, 'f', 1, 32)
+	}
+
+	// render policy headline
+	box1 := components.NewMiniScoreCard().Render(score)
+	box2 := "\n" + stringx.Indent(2, print.Primary("Policy:  ")+policyObj.Name+"\n"+print.Primary("Version: ")+policyObj.Version+"\n"+print.Primary("Score:   ")+score.HumanStatus()+"\n"+cvssScore)
+	b.WriteString(stringx.MergeSideBySide(
+		box1,
+		box2,
+	))
+
+	// summary graph
+	if vulnReport.Stats != nil {
+		stats := vulnReport.Stats
+
+		// only render if we have advisories
+		if stats.Advisories.Total > 0 {
+			total := stats.Advisories.Total
+			colorMap := []termenv.Color{
+				colors.DefaultColorTheme.Critical,
+				colors.DefaultColorTheme.High,
+				colors.DefaultColorTheme.Medium,
+				colors.DefaultColorTheme.Low,
+				colors.DefaultColorTheme.Good,
+			}
+			labels := []string{"Critical", "High", "Medium", "Low", "None"}
+			datapoints := []float64{
+				(float64(stats.Advisories.Critical) / float64(total)),
+				(float64(stats.Advisories.High) / float64(total)),
+				(float64(stats.Advisories.Medium) / float64(total)),
+				(float64(stats.Advisories.Low) / float64(total)),
+				(float64(stats.Advisories.None) / float64(total)),
+			}
+
+			// only add unknown if it really happend
+			if vulnReport.Stats.Advisories.Unknown > 0 {
+				colorMap = append(colorMap, colors.DefaultColorTheme.Unknown)
+				labels = append(labels, "Unknown")
+				datapoints = append(datapoints, (float64(vulnReport.Stats.Advisories.Unknown) / float64(total)))
+			}
+
+			// render advisories bar chart
+			advisoriesBarChart := components.NewBarChart(
+				components.WithBarChartBorder(),
+				components.WithBarChartTitle("Advisories"),
+				components.WithBarChartLabelFunc(components.BarChartPercentageLabelFunc),
+			)
+			b.WriteString(advisoriesBarChart.Render(datapoints, colorMap, labels))
+			b.WriteString("\n")
+		}
+
+		// only render if we have packages scanned, not the case for vmware ESXi
+		if stats.Packages.Total > 0 {
+			pkgTotal := stats.Packages.Total
+			pkgColorMap := []termenv.Color{
+				colors.DefaultColorTheme.Unknown,
+				colors.DefaultColorTheme.Critical,
+				colors.DefaultColorTheme.High,
+				colors.DefaultColorTheme.Medium,
+				colors.DefaultColorTheme.Low,
+			}
+			pkgLabels := []string{"Total", "Critical", "High", "Medium", "Low"}
+			pkgDatapoints := []float64{
+				float64(1.0), // number of packages is always 100%
+				(float64(stats.Packages.Critical) / float64(pkgTotal)),
+				(float64(stats.Packages.High) / float64(pkgTotal)),
+				(float64(stats.Packages.Medium) / float64(pkgTotal)),
+				(float64(stats.Packages.Low) / float64(pkgTotal)),
+			}
+
+			// values for datapoints
+			valueLabels := []int32{pkgTotal, stats.Packages.Critical, stats.Packages.High, stats.Packages.Medium, stats.Packages.Low}
+
+			// render packages bar chart
+			packagesBarChart := components.NewBarChart(
+				components.WithBarChartBorder(),
+				components.WithBarChartTitle("Packages"),
+				components.WithBarChartLabelFunc(func(i int, datapoints []float64) string {
+					return strconv.FormatInt(int64(valueLabels[i]), 10)
+				}),
+			)
+			b.WriteString(packagesBarChart.Render(pkgDatapoints, pkgColorMap, pkgLabels))
+			b.WriteString("\n")
+		}
+	}
+
+	if vulnReport.Stats == nil || vulnReport.Stats.Advisories.Total == 0 {
+		color := components.DefaultRatingColors.Color(policy.ScoreRating_aPlus)
+		indicatorChar := '■'
+		title := "No advisories found"
+		state := "(passed)"
+		b.WriteString(termenv.String(string(indicatorChar)).Foreground(color).String())
+		b.WriteString(termenv.String(" " + title + " " + state).Foreground(color).String())
+		b.WriteString("\n\n")
+	} else {
+		// render advisory table
+		renderer := components.NewAdvisoryResultTable()
+		output, err := renderer.Render(&vulnReport)
+		if err != nil {
+			return err.Error()
+		}
+		b.WriteString(output)
+		b.WriteString("\n")
+	}
+
+	// render additional information
+	kernelDataValue, ok := results[kernelListDatapointChecksum]
+	if ok && kernelDataValue.Data != nil {
+		if kernelDataValue.Error != "" {
+			b.WriteString(print.Error(kernelDataValue.Error + "\n"))
+		} else {
+			rawData := kernelDataValue.Data.RawData().Value
+
+			kernelVersions := []core.KernelVersion{}
+
+			cfg := &mapstructure.DecoderConfig{
+				Metadata: nil,
+				Result:   &kernelVersions,
+				TagName:  "json",
+			}
+			decoder, _ := mapstructure.NewDecoder(cfg)
+			err := decoder.Decode(rawData)
+			if err != nil {
+				b.WriteString(print.Error("could not decode kernel versions\n"))
+			} else {
+				b.WriteString("Installed Kernel Versions:\n")
+
+				// sort the kernel version
+				// NOTE: this is poor man's version since the versions can vary a lot and comparison is more complicated
+				sort.SliceStable(kernelVersions, func(i, j int) bool {
+					return kernelVersions[i].Version > kernelVersions[j].Version
+				})
+
+				// print kernel versions
+				for i := range kernelVersions {
+					kv := kernelVersions[i]
+					if kv.Running {
+						b.WriteString(print.Secondary(" * " + kv.Version + " (running)"))
+					} else {
+						b.WriteString(print.Disabled(" * " + kv.Version + " (not running)"))
+					}
+					b.WriteString("\n")
+				}
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// TODO: iterate over all other scoring queries that are not covered within the screen above
+	b.WriteString("Additional Checks:\n")
+	scoreQueries := map[string]*policy.ScoringSpec{}
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+		for qid, scoring := range spec.ScoringQueries {
+			scoreQueries[qid] = scoring
+		}
+	}
+
+	ignoreList := []string{"no-platform-advisories", "no-platform-cves", "installed-kernels"}
+	ignore := func(k string) bool {
+		// skip query its already included
+		for j := range ignoreList {
+			if strings.HasSuffix(k, ignoreList[j]) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for k := range scoreQueries {
+		if ignore(k) {
+			continue
+		}
+
+		q, ok := bundle.Queries[k]
+		if ok {
+			state := print.Disabled("(unscored)")
+			score, sok := report.Scores[q.CodeId]
+			if sok {
+				if score.Value == 100 {
+					state = print.Success("(passed) ")
+				} else {
+					state = print.Failed("(failed)")
+				}
+			}
+
+			b.WriteString(scoreIndicator(score))
+			severity := scoreRating(score)
+			color := components.DefaultRatingColors.Color(severity)
+			b.WriteString(termenv.String(" " + q.Title + " " + state).Foreground(color).String())
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	return b.String()
+}
+
+func scoreIndicator(score *policy.Score) string {
+	char := '■'
+	color := components.DefaultRatingColors.Color(scoreRating(score))
+	return termenv.String(string(char)).Foreground(color).String()
+}

--- a/cli/reporter/render_asset_overview.go
+++ b/cli/reporter/render_asset_overview.go
@@ -1,0 +1,137 @@
+package reporter
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/cli/printer"
+	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/stringx"
+	"go.mondoo.com/cnspec/policy"
+)
+
+var mqlQueryNames = map[string]string{
+	"true": "General",
+	"platform.family.contains(_ == 'unix') || platform.family.contains(_ == 'linux') || platform.family.contains(_ == 'windows')": "Operating System",
+	"platform.name == \"vmware-vsphere\"": "vSphere",
+	"platform.name == \"vmware-esxi\"":    "ESXi",
+	"platform.name == \"aws\"":            "Amazon Web Services",
+	"platform.name == \"arista-eos\"":     "Arista",
+}
+
+func hasAssetFilter(assetFilters []*policy.Mquery, filter *policy.Mquery) bool {
+	if assetFilters == nil || filter == nil {
+		return false
+	}
+	for i := range assetFilters {
+		if assetFilters[i].Query == filter.Query {
+			return true
+		}
+	}
+	return false
+}
+
+func renderAssetOverview(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, scoringData []reportRow) string {
+	var res bytes.Buffer
+
+	type row struct {
+		Title string
+		Value string
+	}
+
+	stringResult := func(bundle *llx.CodeBundle, results map[string]*llx.RawResult) string {
+		var res strings.Builder
+		for k := range results {
+			v := results[k]
+			if v == nil {
+				log.Warn().Str("checksum", k).Msg("missing result")
+				continue
+			}
+			r := v.Data
+			res.WriteString(print.Data(r.Type, r.Value, v.CodeID, bundle, ""))
+		}
+		return res.String()
+	}
+
+	res.WriteString(print.H2(policyObj.Name))
+	results := report.RawResults()
+
+	// TODO: refactor once we have the json/dict export for policies since it will make the access a lot easier
+	// iterate over the data queries get the title and display the individual results
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+
+		// filter by asset filter that do not match
+		if !hasAssetFilter(resolvedPolicy.Filters, spec.AssetFilter) {
+			continue
+		}
+
+		// FIXME: use spec name from bundle if available
+		category, ok := mqlQueryNames[spec.AssetFilter.Query]
+		if !ok {
+			category = "General"
+		}
+
+		table := []row{}
+		maxKeyWidth := 0
+
+		for qid := range spec.DataQueries {
+			query := bundle.Queries[qid]
+
+			if len(query.Title) > maxKeyWidth {
+				maxKeyWidth = len(query.Title)
+			}
+
+			codeBundle := resolvedPolicy.GetCodeBundle(query)
+			if codeBundle == nil {
+				res.WriteString("\n" + print.Error("failed to find code bundle for query '"+qid+"' in bundle"))
+				continue
+			}
+
+			// print data results
+			// copy all contents where we have labels
+			filteredResults := map[string]*llx.RawResult{}
+			for i := range codeBundle.DeprecatedV5Code.Checksums {
+				checksum := codeBundle.DeprecatedV5Code.Checksums[i]
+
+				res, ok := results[checksum]
+				if ok {
+					filteredResults[checksum] = res
+				}
+			}
+
+			value := stringResult(codeBundle, filteredResults)
+
+			table = append(table, row{
+				Title: query.Title,
+				Value: value,
+			})
+		}
+
+		// sort row by title
+		sort.Slice(table, func(i, j int) bool {
+			return table[i].Title < table[j].Title
+		})
+
+		res.WriteString(print.Primary(category) + ":\n")
+		for i := range table {
+			row := table[i]
+			whitespace := maxKeyWidth - len(row.Title)
+			res.WriteString("  " + row.Title + ":")
+			res.WriteString(strings.Repeat(" ", whitespace+1))
+
+			if strings.Contains(row.Value, "\n") {
+				res.WriteString("\n")
+				res.WriteString(stringx.Indent(2, row.Value))
+			} else {
+				res.WriteString(row.Value)
+				res.WriteString("\n")
+			}
+		}
+		res.WriteString("\n")
+	}
+
+	return res.String()
+}

--- a/cli/reporter/render_meta_policy.go
+++ b/cli/reporter/render_meta_policy.go
@@ -1,0 +1,90 @@
+package reporter
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnquery/cli/printer"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+var colorProfile func(string) termenv.Color = termenv.ColorProfile().Color
+
+func renderMetaPolicy(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, scoringData []reportRow) string {
+	var res bytes.Buffer
+
+	// custom name for space or asset mrn
+	name := policyObj.Name
+	res.WriteString(print.H2(name))
+
+	// extract list of policies and gather policy name from bundle
+	policies := map[string]string{}
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+		for k := range spec.Policies {
+			name := k // fallback to mrn if we do not find a name
+			p, ok := bundle.Policies[k]
+			if ok {
+				name = p.Name
+			}
+			policies[k] = name
+		}
+	}
+
+	// sort list of policies by asset overview, then name
+	policyList := []string{}
+	for key := range policies {
+		policyList = append(policyList, key)
+	}
+
+	// this sorts the list of policies by name but ensures all unrated policies are following below
+	// TODO: we need to improve that for data policies, will be solved once we caan distingush between
+	// not applicable and unrated
+	sort.Slice(policyList, func(i, j int) bool {
+		// check for asset overview policy
+		if policyList[i] == assetOverviewPolicyMrn {
+			return true
+		}
+		if policyList[j] == assetOverviewPolicyMrn {
+			return false
+		}
+
+		// sort unscored polices at the end
+		scoreI := report.Scores[policyList[i]]
+		scoreJ := report.Scores[policyList[j]]
+
+		if scoreI == nil && scoreJ != nil {
+			return true
+		}
+
+		if scoreJ == nil && scoreI != nil {
+			return true
+		}
+
+		// sort by name
+		return policies[policyList[i]] < policies[policyList[j]]
+	})
+
+	// render policy list
+	mircoScoreCard := components.NewMicroScoreCard()
+	for i := range policyList {
+		k := policyList[i]
+		score := report.Scores[k]
+
+		// do not print not applicable policies in overview
+		if score == nil || score.Type == policy.ScoreType_Unknown {
+			continue
+		}
+
+		res.WriteString("■ ")
+		res.WriteString(mircoScoreCard.Render(score))
+		res.WriteString(" ")
+		res.WriteString(policies[k])
+		res.WriteString("\n")
+	}
+	res.WriteString("\n")
+
+	return res.String()
+}

--- a/cli/reporter/render_policy.go
+++ b/cli/reporter/render_policy.go
@@ -1,0 +1,252 @@
+package reporter
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnquery/cli/printer"
+	"go.mondoo.com/cnquery/cli/theme/colors"
+	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/stringx"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func renderPolicy(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, scoringData []reportRow) string {
+	var res bytes.Buffer
+
+	res.WriteString(print.H2(policyObj.Name))
+
+	// render mini score card
+	score := report.Scores[policyObj.Mrn]
+	humanScore := "N/A"
+	if score != nil {
+		humanScore = fmt.Sprintf("%d (completion: %d%%, via %s score)", score.Value, score.Completion(), strings.ToLower(policyObj.ScoringSystem.String()))
+	}
+
+	box1 := components.NewMiniScoreCard().Render(score)
+	box2 := "\n" + stringx.Indent(2, print.Primary("Policy:  ")+policyObj.Name+"\n"+print.Primary("Version: ")+policyObj.Version+"\n"+print.Primary("Mrn:     ")+policyObj.Mrn+"\n"+print.Primary("Score:   ")+humanScore)
+	res.WriteString(stringx.MergeSideBySide(
+		box1,
+		box2,
+	))
+
+	// print scoring queries
+	renderScoringQueries(print, policyObj, report, bundle, resolvedPolicy, scoringData, &res)
+	res.WriteString("\n")
+
+	// print data queries
+	renderDataQueries(print, policyObj, report, bundle, resolvedPolicy, &res)
+
+	return res.String()
+}
+
+func renderDataQueries(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundleMap *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, res *bytes.Buffer) {
+	dataQueries := map[string]policy.QueryAction{}
+	for i := range policyObj.Specs {
+		spec := policyObj.Specs[i]
+		for qid, queryAction := range spec.DataQueries {
+			dataQueries[qid] = queryAction
+		}
+	}
+
+	// TODO: this highlights an internal issue when Results are converted to RawResults
+	results := report.RawResults()
+	if len(dataQueries) > 0 {
+		res.WriteString(print.Primary("Data Queries:\n\n"))
+	}
+
+	// iterate over queries and render them properly
+	// TODO: we need to take care of the query action
+	for qid := range dataQueries {
+		query := bundleMap.Queries[qid]
+		if query == nil {
+			res.WriteString("\n" + print.Error("failed to find query '"+qid+"' in bundle"))
+			continue
+		}
+
+		codeBundle := resolvedPolicy.GetCodeBundle(query)
+		if codeBundle == nil {
+			res.WriteString("\n" + print.Error("failed to find code bundle for query '"+qid+"' in bundle"))
+			continue
+		}
+
+		res.WriteString("■ Title: ")
+		res.WriteString(query.Title)
+		res.WriteString("\n")
+		res.WriteString("  ID:    ")
+		res.WriteString(query.Mrn)
+		res.WriteString("\n")
+		writeQueryCompact(res, "  Query: ", print.Disabled(query.Query))
+
+		// print data results
+		// copy all contents where we have labels
+		filteredResults := map[string]*llx.RawResult{}
+		for i := range codeBundle.CodeV2.Checksums {
+			checksum := codeBundle.CodeV2.Checksums[i]
+
+			res, ok := results[checksum]
+			if ok {
+				filteredResults[checksum] = res
+			}
+		}
+
+		result := print.Results(codeBundle, filteredResults)
+		writeQueryCompact(res, "  Result:", result)
+
+		res.WriteString("\n")
+	}
+}
+
+// if we have a multi-line query, place the query in newline
+func writeQueryCompact(res *bytes.Buffer, title string, value string) {
+	res.WriteString(title)
+	if strings.Contains(value, "\n") {
+		res.WriteString("\n")
+		res.WriteString(stringx.Indent(4, value))
+	} else {
+		res.WriteString(value)
+		res.WriteString("\n")
+	}
+}
+
+func renderScoringQueries(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, data []reportRow, res *bytes.Buffer) {
+	// return if we do not have any queries to render for this policy
+	if len(data) == 0 {
+		res.WriteString(print.Disabled("\nno scored queries\n"))
+		return
+	}
+
+	res.WriteString(print.Primary("Scoring Queries:\n"))
+
+	// print summary
+	renderPolicySummary(res, data)
+
+	// print report results
+	renderPolicyReportTable(print, report, bundle, resolvedPolicy, res, data)
+}
+
+func renderPolicySummary(res *bytes.Buffer, data []reportRow) {
+	ps := policy.Stats{
+		Passed: &policy.ScoreDistribution{},
+		Failed: &policy.ScoreDistribution{},
+		Errors: &policy.ScoreDistribution{},
+	}
+
+	for i := range data {
+		row := data[i]
+
+		ps.Total++
+		if row.Action == policy.QueryAction_DEACTIVATE {
+			ps.Skipped++
+		} else if row.Action == policy.QueryAction_MODIFY && row.ActionSpec != nil && row.ActionSpec.Weight == 0 {
+			ps.Skipped++
+		} else if row.Score != nil && row.Score.Type == policy.ScoreType_Error {
+			ps.Errors.Total++
+		} else if row.Score != nil && row.Score.Type == policy.ScoreType_Skip {
+			ps.Skipped++
+		} else if scoreRating(row.Score) == policy.ScoreRating_failed {
+			ps.Failed.Total++
+		} else if scoreRating(row.Score) == policy.ScoreRating_aPlus {
+			ps.Passed.Total++
+		} else {
+			ps.Unknown++
+		}
+	}
+
+	colorMap := []termenv.Color{
+		colors.DefaultColorTheme.Good,
+		colors.DefaultColorTheme.High,
+		colors.DefaultColorTheme.Critical,
+		colors.DefaultColorTheme.Unknown,
+		colors.DefaultColorTheme.Unknown,
+	}
+	labels := []string{"Passed", "Failed", "Errors", "Ignored", "Unknown"}
+	datapoints := []float64{
+		(float64(ps.Passed.Total) / float64(ps.Total)),
+		(float64(ps.Failed.Total) / float64(ps.Total)),
+		(float64(ps.Errors.Total) / float64(ps.Total)),
+		(float64(ps.Skipped) / float64(ps.Total)),
+		(float64(ps.Unknown) / float64(ps.Total)),
+	}
+
+	// render bar chart
+	barChart := components.NewBarChart(components.WithBarChartBorder(), components.WithBarChartLabelFunc(components.BarChartPercentageLabelFunc))
+	res.WriteString(barChart.Render(datapoints, colorMap, labels))
+}
+
+func renderPolicyReportTable(print *printer.Printer, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, res *bytes.Buffer, data []reportRow) {
+	results := report.RawResults()
+	res.WriteRune('\n')
+	for i := range data {
+		row := data[i]
+
+		action := ""
+		if row.Action == policy.QueryAction_DEACTIVATE {
+			action = "// removed by user"
+		} else if row.Action == policy.QueryAction_MODIFY && (row.ActionSpec == nil || row.ActionSpec.Weight == 0) {
+			action = "// ignored by user"
+		} else if row.Score != nil && row.Score.Type == policy.ScoreType_Skip {
+			action = "// skipped by query condition"
+		}
+
+		res.WriteString(row.Indicator())
+		res.WriteString(" Title:  ")
+		res.WriteString(colorizeRow(row, row.Query.Title))
+		res.WriteString(" " + action)
+		res.WriteRune('\n')
+
+		// passed scores do not need to print details
+		if row.Score != nil && row.Score.Value == 100 {
+			continue
+		}
+
+		// do not display the result if the score was not completed
+		if row.Score == nil || row.Score.ScoreCompletion == 0 {
+			continue
+		}
+
+		writeQueryCompact(res, "  Query:  ", print.Disabled(row.Query.Query))
+
+		// print error if we got one
+		errorMsg := row.Score.MessageLine()
+		if errorMsg != "" {
+			res.WriteString("  Error: ")
+			// Print out original errorMsg so we get nice newline formatting
+			res.WriteString(print.Failed(row.Score.Message))
+			res.WriteRune('\n')
+		} else if row.Score == nil || row.Score.Value != 100 {
+			// print more details if the test failed
+			if row.Query != nil {
+				if row.Assessment != nil {
+					res.WriteString("  Assessment:\n")
+					res.WriteString(stringx.Indent(2, print.Assessment(row.Bundle, row.Assessment)))
+				} else {
+					// If we don't have an assessment, print as result so we can display something
+					// useful
+					qid := row.Query.Mrn
+					query := bundle.Queries[qid]
+					if query == nil {
+						res.WriteString("\n" + print.Error("failed to find query '"+qid+"' in bundle"))
+						continue
+					}
+
+					codeBundle := resolvedPolicy.GetCodeBundle(query)
+					if codeBundle == nil {
+						res.WriteString("\n" + print.Error("failed to find code bundle for query '"+qid+"' in bundle"))
+						continue
+					}
+
+					filteredResults := codeBundle.FilterResults(results)
+					result := print.Results(codeBundle, filteredResults)
+					writeQueryCompact(res, "  Result: ", result)
+
+				}
+			}
+		}
+		res.WriteRune('\n')
+
+	}
+}

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -15,7 +15,6 @@ import (
 var (
 	vulnReportDatapointChecksum = executor.MustGetOneDatapoint(executor.MustCompile("platform.vulnerabilityReport"))
 	kernelListDatapointChecksum = executor.MustGetOneDatapoint(executor.MustCompile("kernel.installed"))
-	advisoryPolicyMrn           = "//policy.api.mondoo.app/policies/platform-vulnerability"
 )
 
 type Reporter struct {
@@ -70,9 +69,15 @@ func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
 			data:      data,
 		}
 		return rr.print()
-	// case Report:
-	// 	r.printReport(data, out)
-	// 	return nil
+	case Report:
+		rr := &reportRenderer{
+			printer:  r.Printer,
+			pager:    r.Pager,
+			usePager: r.UsePager,
+			out:      out,
+			data:     data,
+		}
+		return rr.print()
 	// case YAML:
 	// 	res, err = data.ToYAML()
 	case JSON:

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
-	go.mondoo.com/cnquery v0.0.0-20221014085712-3f9f42876848
+	go.mondoo.com/cnquery v0.0.0-20221014220524-5bb7420b2901
 	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
 	go.opentelemetry.io/otel v1.11.0
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc

--- a/go.sum
+++ b/go.sum
@@ -1566,8 +1566,8 @@ go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6y
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
-go.mondoo.com/cnquery v0.0.0-20221014085712-3f9f42876848 h1:DqJ00RZvhAIEvrRcLjhKHKgoGDJSqC357d3zmki6bqI=
-go.mondoo.com/cnquery v0.0.0-20221014085712-3f9f42876848/go.mod h1:E7+94D2X1SMG2Gc7HL5P6FONssPF9i0cXlK9Vr5e+G4=
+go.mondoo.com/cnquery v0.0.0-20221014220524-5bb7420b2901 h1:BR3orlzkv6DaoUwOH4z0eDB/PoEwh7UAICSpkpyp86A=
+go.mondoo.com/cnquery v0.0.0-20221014220524-5bb7420b2901/go.mod h1:E7+94D2X1SMG2Gc7HL5P6FONssPF9i0cXlK9Vr5e+G4=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=


### PR DESCRIPTION
Note: After the migration we are loosing some context from policy bundles, so we don't always have the asset policy available in the bundle. There is a new shared call in the resolved policy, which can help find the top policies given any bundle. This also means that we can hand it any random bundle we are about and given a resolved policy find the root policies that were pulled from the bundle. It helps render policies in order i.e. embedded policies are can be tackled further down. We only need this approach when looking at policies in their hierarchy, as for everything else we can just take the bundle and the results. Since the report displays policies in their hierarchy, it required these new calls.

![image](https://user-images.githubusercontent.com/1307529/195967087-da3396a3-6a57-40bb-8edb-ea4e1fdccfa1.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>