### PR TITLE
🐛 set cnquery version when we build cnspec

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
     ldflags:
       - "-extldflags=-static"
       - -s -w -X go.mondoo.com/cnspec.Version={{.Version}} -X go.mondoo.com/cnspec.Build={{.ShortCommit}} -X go.mondoo.com/cnspec.Date={{.Date}}
+      - -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
   - id: macos
     main: ./apps/cnspec/cnspec.go
     binary: cnspec
@@ -35,6 +36,7 @@ builds:
     ldflags:
       # clang + macos does not support static: - -extldflags "-static"
       - -s -w -X go.mondoo.com/cnspec.Version={{.Version}} -X go.mondoo.com/cnspec.Build={{.ShortCommit}} -X go.mondoo.com/cnspec.Date={{.Date}}
+      - -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
   - id: windows
     main: ./apps/cnspec/cnspec.go
     binary: cnspec
@@ -48,6 +50,7 @@ builds:
     ldflags:
       - "-extldflags -static"
       - -s -w -X go.mondoo.com/cnspec.Version={{.Version}} -X go.mondoo.com/cnspec.Build={{.ShortCommit}} -X go.mondoo.com/cnspec.Date={{.Date}}
+      - -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
     hooks:
       post:
         - ./scripts/pkg/windows/sign-windows-executable.sh '{{ .Path }}'


### PR DESCRIPTION
Before we have not properly set the build flags for cnquery