### PR TITLE
⭐️ use upstream configuration if credentials are provided

### DIFF
--- a/policy/scan/scan.go
+++ b/policy/scan/scan.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnspec/policy"
 )
 
@@ -24,13 +25,13 @@ func init() {
 }
 
 type AssetJob struct {
-	DoRecord      bool
-	Incognito     bool
-	Asset         *asset.Asset
-	Bundle        *policy.Bundle
-	PolicyFilters []string
-	Ctx           context.Context
-	GetCredential func(cred *vault.Credential) (*vault.Credential, error)
-	Reporter      Reporter
-	connection    *motor.Motor
+	DoRecord       bool
+	UpstreamConfig resources.UpstreamConfig
+	Asset          *asset.Asset
+	Bundle         *policy.Bundle
+	PolicyFilters  []string
+	Ctx            context.Context
+	GetCredential  func(cred *vault.Credential) (*vault.Credential, error)
+	Reporter       Reporter
+	connection     *motor.Motor
 }


### PR DESCRIPTION
This allows the upstream communication and reporting of results as well as the use of the Mondoo Vulnerability Database. `cnspec` supports running the Vulnerability Policy and the Platform End-of-Life Policy.

<img width="1176" alt="Screenshot 2022-10-21 at 16 15 09" src="https://user-images.githubusercontent.com/1178413/197217158-6d732ec9-29fe-4194-97b3-fc9511d333ad.png">

<img width="1540" alt="Screenshot 2022-10-21 at 16 14 48" src="https://user-images.githubusercontent.com/1178413/197217165-c6e3c47c-7156-4b64-801d-5fb52e4db2d9.png">
