### PR TITLE
🐛 use score-threshold param after scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ policy/generate:
 
 #   🏗 Binary   #
 
+.PHONY: cnspec/build
+cnspec/build:
+	go build -o cnspec ${LDFLAGSDIST} apps/cnspec/cnspec.go
+
 .PHONY: cnspec/install
 cnspec/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnspec/cnspec.go


### PR DESCRIPTION
The --score-threshold param wasn't being used to determine whether or not the cnspec binary should have a non-zero exit based on the provided --score-threshold parameter.

Walk through the scan results to calculate the worst score and use that to determine whether or not cnspec should exit non-zero.

Signed-off-by: Joel Diaz <joel@mondoo.com>