### PR TITLE
⭐️ Release major version containers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,6 +87,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64"
       - "mondoo/{{ .ProjectName }}:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -99,6 +100,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8"
       - "mondoo/{{ .ProjectName }}:latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
@@ -112,6 +114,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarm: 6
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6"
       - "mondoo/{{ .ProjectName }}:latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
@@ -125,6 +128,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarm: 7
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7"
       - "mondoo/{{ .ProjectName }}:latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
@@ -139,6 +143,12 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-amd64
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv6
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv7
   - name_template: mondoo/{{ .ProjectName }}:latest
     image_templates:
       - mondoo/{{ .ProjectName }}:latest-amd64


### PR DESCRIPTION
Release major version containers for each release. Followed [this guide](https://goreleaser.com/customization/docker/#keeping-docker-images-updated-for-current-major)