### PR TITLE
⭐️ Release rootless containers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,7 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}"
   - use: buildx
     goos: linux
     goarch: arm64
@@ -108,6 +109,7 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}"
   - use: buildx
     goos: linux
     goarch: arm
@@ -122,6 +124,7 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}"
   - use: buildx
     goos: linux
     goarch: arm
@@ -136,6 +139,62 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}"
+  # Rootless
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
+      - "mondoo/{{ .ProjectName }}:latest-amd64-rootless"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
+      - "mondoo/{{ .ProjectName }}:latest-arm64v8-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
+      - "mondoo/{{ .ProjectName }}:latest-armv6-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
+      - "mondoo/{{ .ProjectName }}:latest-armv7-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}-rootless"
 docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
     image_templates:
@@ -155,3 +214,16 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:latest-arm64v8
       - mondoo/{{ .ProjectName }}:latest-armv6
       - mondoo/{{ .ProjectName }}:latest-armv7
+  # Rootless
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
+  - name_template: mondoo/{{ .ProjectName }}:latest-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:latest-amd64-rootless
+      - mondoo/{{ .ProjectName }}:latest-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:latest-armv6-rootless
+      - mondoo/{{ .ProjectName }}:latest-armv7-rootless

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -146,6 +146,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64-rootless"
       - "mondoo/{{ .ProjectName }}:latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -159,6 +160,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless"
       - "mondoo/{{ .ProjectName }}:latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
@@ -173,6 +175,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarm: 6
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6-rootless"
       - "mondoo/{{ .ProjectName }}:latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
@@ -187,6 +190,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarm: 7
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
+      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7-rootless"
       - "mondoo/{{ .ProjectName }}:latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
@@ -221,6 +225,12 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-amd64-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv6-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv7-rootless
   - name_template: mondoo/{{ .ProjectName }}:latest-rootless
     image_templates:
       - mondoo/{{ .ProjectName }}:latest-amd64-rootless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM mondoo/cnquery:7.3.0
+ARG VERSION
+FROM mondoo/cnquery:$VERSION
 COPY cnspec /usr/local/bin
 ENTRYPOINT ["cnspec"]
 CMD ["help"]


### PR DESCRIPTION
Note that this also makes sure it is no longer required to manually update the `Dockerfile` for every release. Now the version is set via a build arg that is set by goreleaser

Fixes #176 