### PR TITLE
🧹 move the worst score calculation to the ReportCollection

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -350,26 +350,11 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		}
 		printReports(report, conf, cmd)
 
-		if getWorstScore(report) < uint32(conf.ScoreThreshold) {
+		if report.GetWorstScore() < uint32(conf.ScoreThreshold) {
 			os.Exit(1)
 		}
 	},
 })
-
-func getWorstScore(report *policy.ReportCollection) uint32 {
-	worstScore := uint32(100)
-	for _, r := range report.Reports {
-		if r == nil || r.Score == nil {
-			continue
-		}
-
-		if r.Score.Value < worstScore {
-			worstScore = r.Score.Value
-		}
-	}
-
-	return worstScore
-}
 
 // helper method to retrieve the list of policies for the policy flag
 func getPoliciesForCompletion() []string {

--- a/policy/report.go
+++ b/policy/report.go
@@ -93,3 +93,18 @@ func (p *ReportCollection) ToJSON() ([]byte, error) {
 	// pretty print json
 	return json.MarshalIndent(p, "", "  ")
 }
+
+func (r *ReportCollection) GetWorstScore() uint32 {
+	worstScore := uint32(100) // pass
+	for _, r := range r.Reports {
+		if r == nil || r.Score == nil {
+			continue
+		}
+
+		if r.Score.Value < worstScore {
+			worstScore = r.Score.Value
+		}
+	}
+
+	return worstScore
+}


### PR DESCRIPTION
- allow other components to easily reuse the worst score calculation
- is going to be used in https://github.com/mondoohq/packer-plugin-mondoo/pull/48 once merged