### PR TITLE
🧹 fix cmd descriptions for run command

### DIFF
--- a/apps/cnspec/cmd/run.go
+++ b/apps/cnspec/cmd/run.go
@@ -17,8 +17,8 @@ func init() {
 
 var execCmd = builder.NewProviderCommand(builder.CommandOpts{
 	Use:   "run",
-	Short: "Run a MQL query",
-	Long:  `Run a MQL query on the CLI and displays its results.`,
+	Short: "Run an MQL query",
+	Long:  `Run an MQL query on the CLI and displays its results.`,
 	CommonFlags: func(cmd *cobra.Command) {
 		cmd.Flags().Bool("parse", false, "Parse the query and return the logical structure")
 		cmd.Flags().Bool("ast", false, "Parse the query and return the Abstract Syntax Tree (AST)")


### PR DESCRIPTION
aligns descriptions with the feedback from @misterpantz in https://github.com/mondoohq/cnquery/pull/497 