### PR TITLE
Allow using upstream creds from scan job

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -508,7 +508,7 @@ func (c *scanConfig) loadPolicies() error {
 func RunScan(config *scanConfig) (*policy.ReportCollection, error) {
 	opts := []scan.ScannerOption{}
 	if config.UpstreamConfig != nil {
-		opts = append(opts, scan.WithUpstream(config.UpstreamConfig.ApiEndpoint, config.UpstreamConfig.SpaceMrn, config.UpstreamConfig.Plugins))
+		opts = append(opts, scan.WithUpstream(config.UpstreamConfig.ApiEndpoint, config.UpstreamConfig.SpaceMrn), scan.WithPlugins(config.UpstreamConfig.Plugins))
 	}
 
 	scanner := scan.NewLocalScanner(opts...)

--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -72,7 +72,7 @@ var serveApiCmd = &cobra.Command{
 			Plugins:     plugins,
 		}
 
-		scanner := scan.NewLocalScanner(scan.WithUpstream(upstreamConfig.ApiEndpoint, upstreamConfig.SpaceMrn, upstreamConfig.Plugins), scan.DisableProgressBar())
+		scanner := scan.NewLocalScanner(scan.WithUpstream(upstreamConfig.ApiEndpoint, upstreamConfig.SpaceMrn), scan.WithPlugins(plugins), scan.DisableProgressBar())
 		if err := scanner.EnableQueue(); err != nil {
 			log.Fatal().Err(err).Msg("could not enable scan queue")
 		}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
-	go.mondoo.com/cnquery v0.0.0-20221124161103-60bf39b98583
+	go.mondoo.com/cnquery v0.0.0-20221125140040-dc553534f335
 	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
 	go.opentelemetry.io/otel v1.11.1
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1313,8 +1313,8 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20221124161103-60bf39b98583 h1:IRspRVQvgXg5wm8GMVm0clDG8tw131ES9NkEYcXka6o=
-go.mondoo.com/cnquery v0.0.0-20221124161103-60bf39b98583/go.mod h1:MR/mjkXmbHtJKtZ5wl50zYfb0s8T5swjKOKESs3lf38=
+go.mondoo.com/cnquery v0.0.0-20221125140040-dc553534f335 h1:uE1tNkiwabLi624Ry3hNUeq7LSaPaxVuj/OrZ2BnW2s=
+go.mondoo.com/cnquery v0.0.0-20221125140040-dc553534f335/go.mod h1:MR/mjkXmbHtJKtZ5wl50zYfb0s8T5swjKOKESs3lf38=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -43,7 +43,7 @@ type LocalScanner struct {
 	fetcher             *fetcher
 
 	// allows setting the upstream credentials from a job
-	useJobCredentials bool
+	allowJobCredentials bool
 	// for remote connectivity
 	apiEndpoint        string
 	spaceMrn           string
@@ -66,9 +66,9 @@ func WithPlugins(plugins []ranger.ClientPlugin) ScannerOption {
 	}
 }
 
-func EnableJobCredentials() ScannerOption {
+func AllowJobCredentials() ScannerOption {
 	return func(s *LocalScanner) {
-		s.useJobCredentials = true
+		s.allowJobCredentials = true
 	}
 }
 
@@ -476,9 +476,9 @@ func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) resources.Ups
 	plugins := s.plugins
 	endpoint := s.apiEndpoint
 	spaceMrn := s.spaceMrn
-	jobCredentials := job.Inventory.Spec.UpstreamCredentals
 
-	if s.useJobCredentials && jobCredentials != nil {
+	jobCredentials := job.Inventory.Spec.UpstreamCredentals
+	if s.allowJobCredentials && jobCredentials != nil {
 		certAuth, _ := upstream.NewServiceAccountRangerPlugin(jobCredentials)
 		plugins = append(plugins, certAuth)
 		endpoint = jobCredentials.GetApiEndpoint()


### PR DESCRIPTION
Allow the scanner to use credentials from an inventory job. Only works if that's enabled via `EnableJobCredentials`