### PR TITLE
🐛 handle case where all assets report an error

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -517,6 +517,14 @@ func RunScan(config *scanConfig) (*policy.ReportCollection, error) {
 		opts = append(opts, scan.WithUpstream(config.UpstreamConfig.ApiEndpoint, config.UpstreamConfig.SpaceMrn), scan.WithPlugins(config.UpstreamConfig.Plugins))
 	}
 
+	// show warning to the user of the policy filter container a bundle file name
+	for i := range config.PolicyNames {
+		entry := config.PolicyNames[i]
+		if strings.HasSuffix(entry, ".mql.yaml") || strings.HasSuffix(entry, ".mql.yml") {
+			log.Warn().Msg("you are using a bundle file as policy. Do you mean `--policy-bundle " + entry + "`")
+		}
+	}
+
 	scanner := scan.NewLocalScanner(opts...)
 	ctx := cnquery.SetFeatures(context.Background(), config.Features)
 

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -208,10 +208,11 @@ func (p *Bundle) ToMap() *PolicyBundleMap {
 // If the list of IDs is empty this function doesn't do anything.
 // This function does not remove orphaned queries from the bundle.
 func (p *Bundle) FilterPolicies(IDs []string) {
-	if len(IDs) == 0 {
+	if p == nil || len(IDs) == 0 {
 		return
 	}
 
+	log.Debug().Msg("filter policies for asset")
 	valid := make(map[string]struct{}, len(IDs))
 	for i := range IDs {
 		valid[IDs[i]] = struct{}{}
@@ -231,15 +232,19 @@ func (p *Bundle) FilterPolicies(IDs []string) {
 			uid, _ := mrn.GetResource(cur.Mrn, MRN_RESOURCE_POLICY)
 			if _, ok := valid[uid]; ok {
 				res = append(res, cur)
+				continue
 			}
 
+			log.Debug().Str("policy", cur.Mrn).Msg("policy does not match user-provided filter")
 			// if we have a MRN we do not check the UID
 			continue
 		}
 
 		if _, ok := valid[cur.Uid]; ok {
 			res = append(res, cur)
+			continue
 		}
+		log.Debug().Str("policy", cur.Uid).Msg("policy does not match user-provided filter")
 	}
 
 	p.Policies = res

--- a/policy/scan/aggregate_reporter.go
+++ b/policy/scan/aggregate_reporter.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"github.com/hashicorp/go-multierror"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnspec/policy"
 )
@@ -25,6 +26,7 @@ func NewAggregateReporter() *AggregateReporter {
 }
 
 func (r *AggregateReporter) AddReport(asset *asset.Asset, results *AssetReport) {
+	log.Debug().Str("asset", asset.Name).Msg("add scan result to report")
 	r.assets[asset.Mrn] = &policy.Asset{
 		Mrn:  asset.Mrn,
 		Name: asset.Name,
@@ -40,6 +42,7 @@ func (r *AggregateReporter) AddReport(asset *asset.Asset, results *AssetReport) 
 }
 
 func (r *AggregateReporter) AddScanError(asset *asset.Asset, err error) {
+	log.Debug().Str("asset", asset.Name).Msg("add scan error to report")
 	r.assets[asset.Mrn] = &policy.Asset{
 		Mrn:  asset.Mrn,
 		Name: asset.Name,

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -578,9 +578,9 @@ func noPolicyErr(availablePolicies []string, filter []string) error {
 		sb.WriteString("The following policies are available:\n")
 		for i := range availablePolicies {
 			policyMrn := availablePolicies[i]
-			sb.WriteString("- " + policyMrn)
+			sb.WriteString("- " + policyMrn + "\n")
 		}
-		sb.WriteString("\n\n")
+		sb.WriteString("\n")
 	} else {
 		sb.WriteString("The policy bundle for the asset does not contain any policies\n\n")
 	}
@@ -589,7 +589,7 @@ func noPolicyErr(availablePolicies []string, filter []string) error {
 		sb.WriteString("User selected policies that are allowed to run:\n")
 		for i := range filter {
 			policyMrn := filter[i]
-			sb.WriteString("- " + policyMrn)
+			sb.WriteString("- " + policyMrn + "\n")
 		}
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
fixes #231

- print warning if the `--policy` flag looks like a bundle
- renders asset errors when all assets have an error

<img width="1189" alt="Screenshot 2022-12-12 at 12 19 58" src="https://user-images.githubusercontent.com/1178413/207032752-4c20d923-0a78-4020-949f-642ae3c21768.png">
