### PR TITLE
🧹 remove unhelpful warning messages

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -473,12 +473,10 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	}
 
 	if len(conf.PolicyPaths) > 0 && !conf.IsIncognito {
-		log.Warn().Msg("Scanning with local policy bundles will switch into --incognito mode by default. Your results will not be sent upstream.")
 		conf.IsIncognito = true
 	}
 
 	if serviceAccount == nil && !conf.IsIncognito {
-		log.Warn().Msg("No credentials provided. Switching to --incognito mode.")
 		conf.IsIncognito = true
 	}
 


### PR DESCRIPTION
Since we switch to unauthenticated as default, those warning messages are actually not helpful anymore. We display specifically when a service account is used.