### PR TITLE
⭐️ Add container edge releases workflow

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -1,0 +1,170 @@
+---
+project_name: cnspec
+env:
+  - CGO_ENABLED=0
+builds:
+  - id: linux
+    main: ./apps/cnspec/cnspec.go
+    binary: cnspec
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - 386
+      - arm64
+      - arm
+      - ppc64le
+    # ARM 6= Raspberry Pi A, A+, B, B+, Zero
+    # ARM 7= Raspberry Pi 2, 3, 4
+    goarm:
+      - 6
+      - 7
+    flags:
+      - -tags="production netgo"
+    ldflags:
+      - "-extldflags=-static"
+      - -s -w -X go.mondoo.com/cnspec.Version={{.Version}} -X go.mondoo.com/cnspec.Build={{.ShortCommit}} -X go.mondoo.com/cnspec.Date={{.Date}}
+      - -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
+checksum:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+release:
+  disable: true
+changelog:
+  skip: true
+dockers: # https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64"
+      - "mondoo/{{ .ProjectName }}:edge-latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8"
+      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:-edge{{ .Version }}-armv6"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv6"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest"
+  # Rootless
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION=edge-latest-rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=VERSION={{ .Version }}-rootless"
+docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
+  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7
+  - name_template: mondoo/{{ .ProjectName }}:edge-latest
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-latest-amd64
+      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8
+      - mondoo/{{ .ProjectName }}:edge-latest-armv6
+      - mondoo/{{ .ProjectName }}:edge-latest-armv7
+  # Rootless
+  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless
+  - name_template: mondoo/{{ .ProjectName }}:edge-latest-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -1,0 +1,49 @@
+name: goreleaser edge containers
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+
+jobs:
+  goreleaser:
+    permissions:
+      # Add "contents" to write release
+      contents: 'write'
+      # Add "id-token" for google-github-actions/auth
+      id-token: 'write'
+
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Locally tag the current commit
+        run: |
+          VERSION=$(make version)
+          git tag ${VERSION/\+/-}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f .github/.goreleaser-edge.yml --rm-dist --timeout 120m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
Builds edge containers for every commit to `main`. Will use the latest edge release for cnquery as a base image