### PR TITLE
🧹 Sort options for --output

### DIFF
--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -1,6 +1,7 @@
 package reporter
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/muesli/termenv"
@@ -44,6 +45,7 @@ func AllFormats() string {
 			res = append(res, k)
 		}
 	}
+	sort.Strings(res)
 	return strings.Join(res, ", ")
 }
 


### PR DESCRIPTION
This prevents them from showing up in a random order when running help / building documentation