### PR TITLE
⭐️ detect missing asset filter in policies

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -67,7 +67,7 @@ var rules = []Rule{
 	{
 		ID:          policyUidUnique,
 		Name:        "No unique policy UID",
-		Description: "Every policy uid must not be used twice in the same bundle and namespace",
+		Description: "Every policy UID must not be used twice in the same bundle and namespace",
 	},
 	{
 		ID:          policyMissingAssetFilter,

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -355,7 +355,7 @@ func lintFile(file string) (*Results, error) {
 
 				res.Entries = append(res.Entries, Entry{
 					RuleID:   policyMissingAssetFilter,
-					Message:  "Policy " + policy.Uid + " is missing asset filter",
+					Message:  "Policy " + policy.Uid + " doesn't define an asset filter.",
 					Level:    levelError,
 					Location: []Location{location},
 				})

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -72,7 +72,7 @@ var rules = []Rule{
 	{
 		ID:          policyMissingAssetFilter,
 		Name:        "Policy Spec is missing an asset filter",
-		Description: "Policy Spec has no asset filter defined",
+		Description: "Policy Spec doesn't define an asset filter.",
 	},
 	{
 		ID:          policyMissingChecks,


### PR DESCRIPTION
This change detects missing asset filter:

```yaml
policies:
- uid: mondoo-azure-security
  name: Microsoft Azure Security by Mondoo
  version: 1.0.0
  specs:
  - scoring_queries:
      mondoo-azure-security-ensure-os-disk-are-encrypted: null
      mondoo-azure-security-ssh-access-restricted-from-internet: null
```

would create an error since the `spec` has no filter defined. The correct one would be:

```yaml
policies:
- uid: mondoo-azure-security
  name: Microsoft Azure Security by Mondoo
  version: 1.0.0
  specs:
  - asset_filter:
      query: |
         platform.name == "azure"
         platform.kind == "api"
    scoring_queries:
      mondoo-azure-security-ensure-os-disk-are-encrypted: null
      mondoo-azure-security-ssh-access-restricted-from-internet: null
```



