### PR TITLE
🧹 do not show lint error if the policy spec has either scoring queries or data queries attached

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -361,8 +361,8 @@ func lintFile(file string) (*Results, error) {
 				})
 			}
 
-			// issue warning if no check is assigned
-			if len(spec.ScoringQueries) == 0 {
+			// issue warning if no checks or data queries are assigned
+			if len(spec.ScoringQueries) == 0 && len(spec.DataQueries) == 0 {
 				res.Entries = append(res.Entries, Entry{
 					RuleID:  policyMissingChecks,
 					Message: "Policy " + policy.Uid + " is missing checks",


### PR DESCRIPTION
Before this implementation the linter was displaying an error when there was a policy with pure data queries. This change fixes the warning.