### PR TITLE
🐛 avoid panic when no login/token available

### DIFF
--- a/apps/cnspec/cmd/login.go
+++ b/apps/cnspec/cmd/login.go
@@ -158,8 +158,9 @@ func register(token string) {
 			certAuth, err := upstream.NewServiceAccountRangerPlugin(credential)
 			if err != nil {
 				log.Warn().Err(err).Msg("could not initialize certificate authentication")
+			} else {
+				plugins = append(plugins, certAuth)
 			}
-			plugins = append(plugins, certAuth)
 
 			client, err := upstream.NewAgentManagerClient(apiEndpoint, ranger.DefaultHttpClient(), plugins...)
 			if err != nil {


### PR DESCRIPTION
running 'cnspec login' on a fresh system results in a panic

~  % cnspec login
→ no Mondoo configuration file provided. using defaults ! could not initialize certificate authentication error="agent credentials must be set"
panic: runtime error: invalid memory address or nil pointer dereference

avoid adding a nil client plugin so we get a more sensible error:

% ./cnspec login
→ no Mondoo configuration file provided. using defaults ! could not initialize certificate authentication error="agent credentials must be set" FTL failed to log in client error="failed to do request: Post \"https:///AgentManager/RegisterAgent\": http: no Host in request URL"

Signed-off-by: Joel Diaz <joel@mondoo.com>