### PR TITLE
⭐️ serve mode for cnspec

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,48 @@ nfpms:
     formats:
       - deb
       - rpm
+    contents:
+      - src: "scripts/pkg/config/mondoo.yml"
+        dst: "/etc/opt/mondoo/mondoo.yml.example"
+        type: config
+        file_info:
+          mode: 0644
+      - src: "scripts/pkg/linux/cnspec.service"
+        dst: "/etc/systemd/system/cnspec.service"
+        type: config
+        file_info:
+          mode: 0644
+      - src: "scripts/pkg/linux/cnspec.conf"
+        dst: "/etc/init/cnspec.conf"
+        type: config
+        file_info:
+          mode: 0644
+    scripts:
+      preinstall: "scripts/pkg/linux/preinstall.sh"
+      postinstall: "scripts/pkg/linux/postinstall.sh"
+      preremove: "scripts/pkg/linux/preremove.sh"
+    overrides:
+      deb:
+        contents:
+          - src: "scripts/pkg/config/mondoo.yml"
+            dst: "/etc/opt/mondoo/mondoo.yml.example"
+            type: config
+            file_info:
+              mode: 0644
+          - src: "scripts/pkg/debian/cnspec.service"
+            dst: "/etc/systemd/system/cnspec.service"
+            type: config
+            file_info:
+              mode: 0644
+          - src: "scripts/pkg/debian/cnspec.conf"
+            dst: "/etc/init/cnspec.conf"
+            type: config
+            file_info:
+              mode: 0644
+        scripts:
+          preinstall: "scripts/pkg/debian/preinstall.sh"
+          postinstall: "scripts/pkg/debian/postinstall.sh"
+          preremove: "scripts/pkg/debian/preremove.sh"
     rpm:
       signature:
         key_file: '{{ .Env.GPG_KEY_PATH }}'

--- a/apps/cnspec/cmd/backgroundjob/background.go
+++ b/apps/cnspec/cmd/backgroundjob/background.go
@@ -1,0 +1,25 @@
+package backgroundjob
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	// Service Name
+	SvcName = "cnspec" // NOTE: this name needs to align with the service name in packages
+)
+
+type JobRunner func() error
+
+func New() (*BackgroundScanner, error) {
+	return &BackgroundScanner{}, nil
+}
+
+type BackgroundScanner struct{}
+
+func (bs *BackgroundScanner) Run(runScanFn JobRunner) error {
+	Serve(time.Duration(viper.GetInt64("timer"))*time.Minute, runScanFn)
+	return nil
+}

--- a/apps/cnspec/cmd/backgroundjob/healthping.go
+++ b/apps/cnspec/cmd/backgroundjob/healthping.go
@@ -1,0 +1,60 @@
+package backgroundjob
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/upstream/health"
+)
+
+type healthPinger struct {
+	ctx      context.Context
+	interval time.Duration
+	quit     chan struct{}
+	wg       sync.WaitGroup
+	endpoint string
+}
+
+func NewHealthPinger(ctx context.Context, endpoint string, interval time.Duration) *healthPinger {
+	return &healthPinger{
+		ctx:      ctx,
+		interval: interval,
+		quit:     make(chan struct{}),
+		endpoint: endpoint,
+	}
+}
+
+func (h *healthPinger) Start() {
+	h.wg.Add(1)
+	runHealthCheck := func() {
+		_, err := health.CheckApiHealth(h.endpoint)
+		if err != nil {
+			log.Info().Err(err).Msg("could not perform health check")
+		}
+	}
+
+	// run health check once on startup
+	runHealthCheck()
+
+	// TODO we may want to add jitter and backoff
+	healthTicker := time.NewTicker(h.interval)
+	go func() {
+		defer h.wg.Done()
+		for {
+			select {
+			case <-healthTicker.C:
+				runHealthCheck()
+			case <-h.quit:
+				healthTicker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (h *healthPinger) Stop() {
+	close(h.quit)
+	h.wg.Wait()
+}

--- a/apps/cnspec/cmd/backgroundjob/serve_unix.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_unix.go
@@ -1,0 +1,65 @@
+//go:build linux || darwin || netbsd || openbsd || freebsd
+// +build linux darwin netbsd openbsd freebsd
+
+package backgroundjob
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+func Serve(timer time.Duration, handler JobRunner) {
+	log.Info().Msg("start cnspec background service")
+	log.Info().Msgf("scan interval is %d minute(s)", int(timer.Minutes()))
+
+	quitChannel := make(chan os.Signal)
+	signal.Notify(quitChannel, syscall.SIGINT, syscall.SIGTERM)
+
+	shutdownChannel := make(chan struct{})
+	waitGroup := &sync.WaitGroup{}
+
+	initTick := time.Tick(1 * time.Second)
+	defaultTick := time.Tick(timer)
+	tick := initTick
+	waitGroup.Add(1)
+
+	go func(shutdownChannel chan struct{}, wg *sync.WaitGroup) {
+		defer wg.Done()
+		for {
+			// Give shutdown priority
+			select {
+			case <-shutdownChannel:
+				log.Info().Msg("stop worker")
+				return
+			default:
+			}
+
+			select {
+			case <-tick:
+				if tick == initTick {
+					tick = defaultTick
+				}
+				err := handler()
+				if err != nil {
+					log.Error().Err(err).Send()
+				}
+			case <-shutdownChannel:
+				log.Info().Msg("stop worker")
+				return
+			}
+		}
+	}(shutdownChannel, waitGroup)
+
+	<-quitChannel // received SIGINT or SIGTERM
+	close(shutdownChannel)
+
+	log.Info().Msg("stop service gracefully")
+
+	waitGroup.Wait() // wait for all goroutines
+	log.Info().Msg("bye bye space cowboy")
+}

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -27,10 +27,10 @@ func Serve(timer time.Duration, handler JobRunner) {
 		log.Logger = log.Output(w)
 
 		// run service
-		runService(SvcName, false, timer, handler)
+		runService(false, timer, handler)
 		return
 	}
-	runService(SvcName, true, timer, handler)
+	runService(true, timer, handler)
 }
 
 type windowsService struct {
@@ -94,21 +94,21 @@ loop:
 	return
 }
 
-func runService(name string, isDebug bool, timer time.Duration, handler JobRunner) {
+func runService(isDebug bool, timer time.Duration, handler JobRunner) {
 	var err error
 
-	log.Info().Msgf("starting %s service", name)
+	log.Info().Msgf("starting %s service", SvcName)
 	run := svc.Run
 	if isDebug {
 		run = debug.Run
 	}
-	err = run(name, &windowsService{
+	err = run(SvcName, &windowsService{
 		Handler: handler,
 		Timer:   timer,
 	})
 	if err != nil {
-		log.Info().Msgf("%s service failed: %v", name, err)
+		log.Info().Msgf("%s service failed: %v", SvcName, err)
 		return
 	}
-	log.Info().Msgf("%s service stopped", name)
+	log.Info().Msgf("%s service stopped", SvcName)
 }

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -1,0 +1,114 @@
+//go:build windows
+// +build windows
+
+package backgroundjob
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/logger/eventlog"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/debug"
+)
+
+func Serve(timer time.Duration, handler JobRunner) {
+	isIntSess, err := svc.IsAnInteractiveSession()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to determine if we are running in an interactive session")
+	}
+	// if it is an service ...
+	if !isIntSess {
+		// set windows eventlogger
+		w, err := eventlog.NewEventlogWriter(SvcName)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to connect to windows event log")
+		}
+		log.Logger = log.Output(w)
+
+		// run service
+		runService(SvcName, false, timer, handler)
+		return
+	}
+	runService(SvcName, true, timer, handler)
+}
+
+type windowsService struct {
+	Timer   time.Duration
+	Handler JobRunner
+}
+
+// NOTE: we do not support svc.AcceptPauseAndContinue yet, we may reconsider this later
+func (m *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+	initTick := time.Tick(1 * time.Second)
+	defaulttick := time.Tick(m.Timer)
+	tick := initTick
+	log.Info().Msg("schedule background scan")
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+
+	runChan := make(chan struct{})
+	go func() {
+		// This goroutine doesn't stop cleanly.
+		// This isn't great, but we cannot block the service event loop.
+		// It would be good to make sure this shuts down cleanly, but
+		// that's not possible right now and requires wiring through
+		// context throughout the execution.
+		for range runChan {
+			log.Info().Msg("starting background scan")
+			err := m.Handler()
+			if err != nil {
+				log.Error().Err(err).Send()
+			} else {
+				log.Info().Msg("scan completed")
+			}
+		}
+	}()
+loop:
+	for {
+		select {
+		case <-tick:
+			if tick == initTick {
+				tick = defaulttick
+			}
+			select {
+			case runChan <- struct{}{}:
+			default:
+				log.Error().Msg("scan not started. may be stuck")
+			}
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Info().Msg("stopping cnspec service")
+				break loop
+			default:
+				log.Error().Msgf("unexpected control request #%d", c)
+			}
+		}
+	}
+	close(runChan)
+	changes <- svc.Status{State: svc.StopPending}
+	return
+}
+
+func runService(name string, isDebug bool, timer time.Duration, handler JobRunner) {
+	var err error
+
+	log.Info().Msgf("starting %s service", name)
+	run := svc.Run
+	if isDebug {
+		run = debug.Run
+	}
+	err = run(name, &windowsService{
+		Handler: handler,
+		Timer:   timer,
+	})
+	if err != nil {
+		log.Info().Msgf("%s service failed: %v", name, err)
+		return
+	}
+	log.Info().Msgf("%s service stopped", name)
+}

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.mondoo.com/cnquery"
+	"go.mondoo.com/cnquery/cli/config"
+	"go.mondoo.com/cnquery/cli/execruntime"
+	"go.mondoo.com/cnquery/cli/inventoryloader"
+	"go.mondoo.com/cnquery/cli/prof"
+	"go.mondoo.com/cnquery/cli/sysinfo"
+	"go.mondoo.com/cnquery/motor/asset"
+	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
+	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/resources"
+	"go.mondoo.com/cnquery/upstream"
+	"go.mondoo.com/cnspec"
+	"go.mondoo.com/cnspec/apps/cnspec/cmd/backgroundjob"
+	cnspec_config "go.mondoo.com/cnspec/apps/cnspec/cmd/config"
+	"go.mondoo.com/cnspec/policy/scan"
+	"go.mondoo.com/ranger-rpc"
+)
+
+// we send a 78 exit code to prevent systemd from restart
+// NOTE: if we change the code here we also need to adapt the systemd service
+const ConfigurationErrorCode = 78
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+	// background scan flags
+	serveCmd.Flags().Int("timer", 60, "scan interval in minutes")
+	serveCmd.Flags().MarkHidden("timer")
+}
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start cnspec in background mode",
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("timer", cmd.Flags().Lookup("timer"))
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		prof.InitProfiler()
+
+		// prevent colors on windows
+		viper.Set("color", "none")
+
+		// check if an inventory file exists
+		inventoryFilePath, ok := config.InventoryPath(viper.ConfigFileUsed())
+		if ok {
+			viper.Set("inventory", inventoryFilePath)
+		}
+
+		// determine the scan config from pipe or args
+		conf, err := getServeConfig()
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to prepare config")
+		}
+
+		ctx := cnquery.SetFeatures(context.Background(), cnquery.DefaultFeatures)
+
+		if conf != nil && conf.UpstreamConfig != nil {
+			hc := backgroundjob.NewHealthPinger(ctx, conf.UpstreamConfig.ApiEndpoint, 5*time.Minute)
+			hc.Start()
+			defer hc.Stop()
+		}
+
+		bj, err := backgroundjob.New()
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not start background listener")
+		}
+
+		bj.Run(func() error {
+			// TODO: check in every 5 min via timer, init time in Background job
+			result, err := RunScan(conf, scan.DisableProgressBar())
+			if err != nil {
+				log.Error().Err(err).Msg("could not successfully complete scan")
+			}
+
+			// log errors
+			if result != nil && result.GetErrors() != nil && len(result.GetErrors()) > 0 {
+				assetErrors := result.GetErrors()
+				for a, err := range assetErrors {
+					log.Error().Err(errors.New(err)).Str("asset", a).Msg("could not connect to asset")
+				}
+			}
+			return nil
+		})
+	},
+}
+
+func getServeConfig() (*scanConfig, error) {
+	opts, optsErr := cnspec_config.ReadConfig()
+	if optsErr != nil {
+		log.Fatal().Err(optsErr).Msg("could not load configuration")
+	}
+	config.DisplayUsedConfig()
+
+	logClientInfo(opts.SpaceMrn, opts.AgentMrn, opts.ServiceAccountMrn)
+
+	// display activated features
+	if len(opts.Features) > 0 {
+		log.Info().Strs("features", opts.Features).Msg("user activated features")
+	}
+
+	conf := scanConfig{
+		Features:   opts.GetFeatures(),
+		DoRecord:   viper.GetBool("record"),
+		ReportType: scan.ReportType_ERROR,
+		Output:     "",
+	}
+
+	// detect CI/CD runs and read labels from runtime and apply them to all assets in the inventory
+	runtimeEnv := execruntime.Detect()
+	if opts.AutoDetectCICDCategory && runtimeEnv.IsAutomatedEnv() || opts.Category == "cicd" {
+		log.Info().Msg("detected ci-cd environment")
+		// NOTE: we only apply those runtime environment labels for CI/CD runs to ensure other assets from the
+		// inventory are not touched, we may consider to add the data to the flagAsset
+		if runtimeEnv != nil {
+			runtimeLabels := runtimeEnv.Labels()
+			conf.Inventory.ApplyLabels(runtimeLabels)
+		}
+		conf.Inventory.ApplyCategory(asset.AssetCategory_CATEGORY_CICD)
+	}
+
+	serviceAccount := opts.GetServiceCredential()
+	if serviceAccount != nil {
+		certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
+		plugins := []ranger.ClientPlugin{certAuth}
+		// determine information about the client
+		sysInfo, err := sysinfo.GatherSystemInfo()
+		if err != nil {
+			log.Warn().Err(err).Msg("could not gather client information")
+		}
+		plugins = append(plugins, defaultRangerPlugins(sysInfo, opts.GetFeatures())...)
+		log.Info().Msg("using service account credentials")
+		conf.UpstreamConfig = &resources.UpstreamConfig{
+			SpaceMrn:    opts.GetParentMrn(),
+			ApiEndpoint: opts.UpstreamApiEndpoint(),
+			Plugins:     plugins,
+		}
+	}
+
+	var err error
+	conf.Inventory, err = inventoryloader.ParseOrUse(nil, viper.GetBool("insecure"))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load configuration")
+	}
+
+	// fall back to local machine if no inventory was localed
+	if conf.Inventory == nil || conf.Inventory.Spec == nil || len(conf.Inventory.Spec.Assets) == 0 {
+		log.Info().Msg("configure inventory to scan local operating system")
+		conf.Inventory = v1.New(v1.WithAssets(&asset.Asset{
+			Connections: []*providers.Config{
+				{
+					Backend: providers.ProviderType_LOCAL_OS,
+				},
+			},
+		}))
+	}
+
+	return &conf, nil
+}
+
+func logClientInfo(spaceMrn string, clientMrn string, serviceAccountMrn string) {
+	if spaceMrn == "" {
+		spaceMrn = "unset"
+	}
+	if serviceAccountMrn == "" {
+		serviceAccountMrn = "unset"
+	}
+	if clientMrn == "" {
+		clientMrn = "unset"
+	}
+	version := cnspec.Version
+	if version == "" {
+		version = "unstable"
+	}
+	log.Info().Str("version", version).Str("space", spaceMrn).Str("service_account", serviceAccountMrn).Str("client", clientMrn).Msg("start cnspec")
+}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20221221165957-55f4180e6214 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/sethvargo/go-retry v0.2.3 // indirect
+	github.com/toravir/csd v0.0.0-20200911003203-13ae77ad849c // indirect
 )
 
 require (
@@ -451,7 +452,7 @@ require (
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.3.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/sys v0.3.0
 	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	golang.org/x/time v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1317,6 +1317,8 @@ github.com/tomarrell/wrapcheck/v2 v2.6.2 h1:3dI6YNcrJTQ/CJQ6M/DUkc0gnqYSIk6o0rCh
 github.com/tomarrell/wrapcheck/v2 v2.6.2/go.mod h1:ao7l5p0aOlUNJKI0qVwB4Yjlqutd0IvAB9Rdwyilxvg=
 github.com/tommy-muehle/go-mnd/v2 v2.5.0 h1:iAj0a8e6+dXSL7Liq0aXPox36FiN1dBbjA6lt9fl65s=
 github.com/tommy-muehle/go-mnd/v2 v2.5.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
+github.com/toravir/csd v0.0.0-20200911003203-13ae77ad849c h1:s2rHknvMWxiVGZPekoOXz4tDxI2Tz/u0WArWzqbocrE=
+github.com/toravir/csd v0.0.0-20200911003203-13ae77ad849c/go.mod h1:l8YgrzvJ38JrK6doqizvD1liXl0Uz/W3Uz8kwvMTP8U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/scripts/pkg/config/mondoo.yml
+++ b/scripts/pkg/config/mondoo.yml
@@ -1,0 +1,22 @@
+# Sample configuration for Mondoo Platform
+#
+# To setup cnspec command line with Mondoo Platform:
+# https://mondoo.com/docs/tutorials/mondoo/account-setup/
+#
+
+api_endpoint: https://us.api.mondoo.app
+mrn: //agents.api.mondoo.app/spaces/yourspace/agents/agentid
+space_mrn: //captain.api.mondoo.app/spaces/yourspace
+certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIICejCCAgCgAwIBAgIQPJbAYJt7dWfKYUczMIczYzAKBggqhkjOPQQDAzBJMUcw
+  ...
+  vwslpvFVlcqz7cLJAjAGliwok123Wtbfqsflx2Y0jI7piYq0doS3LERwk3o3dvLP
+  tzc9MCERV1GLqyJ8YTI=
+  -----END CERTIFICATE-----
+private_key: |
+  -----BEGIN PRIVATE KEY-----
+  MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAueHZkyYbyeGpdcI1V
+  ...
+  LaCIG0tdW8WL1rUH9WaxWguU0mAMIbY3muEcwYvcTcJH7NX7hiLYN6I=
+  -----END PRIVATE KEY-----

--- a/scripts/pkg/debian/cnspec.conf
+++ b/scripts/pkg/debian/cnspec.conf
@@ -8,4 +8,4 @@ respawn
 respawn limit 10 60
 normal exit 0
 
-exec /opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+exec /usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve

--- a/scripts/pkg/debian/cnspec.conf
+++ b/scripts/pkg/debian/cnspec.conf
@@ -1,0 +1,11 @@
+description     "cnspec Service"
+author          "Mondoo, Inc."
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 60
+normal exit 0
+
+exec /opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve

--- a/scripts/pkg/debian/cnspec.service
+++ b/scripts/pkg/debian/cnspec.service
@@ -4,8 +4,8 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/mondoo/bin/
-ExecStart=/opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+WorkingDirectory=/etc/opt/mondoo/
+ExecStart=/usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
 KillMode=process
 Restart=on-failure
 RestartSec=90

--- a/scripts/pkg/debian/cnspec.service
+++ b/scripts/pkg/debian/cnspec.service
@@ -8,7 +8,8 @@ WorkingDirectory=/opt/mondoo/bin/
 ExecStart=/opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
 KillMode=process
 Restart=on-failure
-RestartSec=15min
+RestartSec=90
+RestartPreventExitStatus=78
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/pkg/debian/cnspec.service
+++ b/scripts/pkg/debian/cnspec.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=cnspec Service
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/mondoo/bin/
+ExecStart=/opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+KillMode=process
+Restart=on-failure
+RestartSec=15min
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/pkg/debian/postinstall.sh
+++ b/scripts/pkg/debian/postinstall.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# call the cnspec migrate command
+echo " -> Migrate cnspec configuration"
+cnspec --config /etc/opt/mondoo/mondoo.yml migrate
+
+if [ "$(cat /proc/1/comm)" = "init" ]
+then
+  test -n "$(initctl status cnspec | grep -o running)" && \
+    echo " -> Restart cnspec service (init)" && \
+    initctl restart cnspec
+elif [ "$(cat /proc/1/comm)" = "systemd" ]
+then
+  systemctl is-active --quiet cnspec && \
+    echo " -> Restart cnspec service (systemd)" && \
+    systemctl daemon-reload && \
+    systemctl restart cnspec
+fi
+
+exit 0

--- a/scripts/pkg/debian/preinstall.sh
+++ b/scripts/pkg/debian/preinstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo " -> Prepare for cnspec installation"

--- a/scripts/pkg/debian/preremove.sh
+++ b/scripts/pkg/debian/preremove.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ "$1" = "remove" ]; then
+    if [ "$(cat /proc/1/comm)" = "init" ]
+    then
+      echo " -> Stop cnspec service (init)"
+      if [ -f "$FILE" ]; then
+        stop cnspec || true
+      fi
+    elif [ "$(cat /proc/1/comm)" = "systemd" ]
+    then
+        echo " -> Stop cnspec service"
+        systemctl stop cnspec
+        systemctl disable cnspec
+        systemctl daemon-reload
+    fi
+fi

--- a/scripts/pkg/linux/cnspec.conf
+++ b/scripts/pkg/linux/cnspec.conf
@@ -1,0 +1,11 @@
+description     "cnspec Service"
+author          "Mondoo, Inc."
+
+start on (runlevel [345] and started network)
+stop on (runlevel [!345] or stopping network)
+
+respawn
+respawn limit 10 60
+normal exit 0
+
+exec /opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve

--- a/scripts/pkg/linux/cnspec.conf
+++ b/scripts/pkg/linux/cnspec.conf
@@ -8,4 +8,4 @@ respawn
 respawn limit 10 60
 normal exit 0
 
-exec /opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+exec /usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve

--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=cnspec Service
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/mondoo/bin/
+ExecStart=/opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+KillMode=process
+Restart=on-failure
+RestartSec=90
+RestartPreventExitStatus=78
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -4,8 +4,8 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/mondoo/bin/
-ExecStart=/opt/mondoo/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
+WorkingDirectory=/etc/opt/mondoo/
+ExecStart=/usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
 KillMode=process
 Restart=on-failure
 RestartSec=90

--- a/scripts/pkg/linux/postinstall.sh
+++ b/scripts/pkg/linux/postinstall.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# call the cnspec migrate command
+echo " -> Migrate cnspec configuration"
+cnspec --config /etc/opt/mondoo/mondoo.yml migrate
+
+if [ "$(cat /proc/1/comm)" = "init" ]
+then
+  test -n "$(initctl status cnspec | grep -o running)" && \
+    echo " -> Restart cnspec service (init)" && \
+    initctl restart cnspec
+elif [ "$(cat /proc/1/comm)" = "systemd" ]
+then
+  systemctl is-active --quiet cnspec && \
+    echo " -> Restart cnspec service (systemd)" && \
+    systemctl daemon-reload && \
+    systemctl restart cnspec
+fi
+
+exit 0

--- a/scripts/pkg/linux/preinstall.sh
+++ b/scripts/pkg/linux/preinstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo " -> Prepare for cnspec installation"

--- a/scripts/pkg/linux/preremove.sh
+++ b/scripts/pkg/linux/preremove.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Run during uninstall
+# Note: rpm runs this phase even during upgrades therefore we need to include a condition
+if [ "$1" -eq 0 ] ; then
+    if [ "$(cat /proc/1/comm)" = "init" ]
+    then
+        echo " -> Stop cnspec service (init)"
+        stop cnspec || true
+    elif [ "$(cat /proc/1/comm)" = "systemd" ]
+    then
+        echo " -> Stop cnspec service"
+        systemctl stop cnspec
+        systemctl disable cnspec
+        systemctl daemon-reload
+    fi
+fi


### PR DESCRIPTION
This change depends on https://github.com/mondoohq/cnquery/pull/786 and https://github.com/mondoohq/cnquery/pull/787

**Problem**

As a user, I want to run cnspec continuously and report the results into Mondoo Platform.

**Solution**

With this new change, `cnspec` has a new `serve` subcommand that runs scans in the background. The package also comes with Linux service configuration for SysV and Systemd.

```bash
cnspec serve
→ loaded configuration from /Users/chris/.config/mondoo/mondoo.yml using source default
→ start cnspec client=//agents.api.mondoo.app/spaces/saha-saha-123/agents/1zDY7auR20SgrFfiGUT5qZWx6mE service_account=//agents.api.mondoo.app/spaces/saha-saha-123/serviceaccounts/1zDY7cJ7bA84JxxNBWDxBdui2xE space=//captain.api.mondoo.app/spaces/saha-saha-123 version=v7.12.1
→ using service account credentials
→ scan local operating system
→ start cnspec background service
→ scan interval is 60 minute(s)
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
→ connecting to asset spacerocket.fritz.box (baremetal)
→ scan for asset spacerocket.fritz.box (baremetal) completed
^C→ stop service gracefully
→ stop worker
→ bye bye space cowboy
```

If you want to enable `cnspec` as a service on Linux run the following commands:

```
systemctl enable cnspec.service
systemctl start cnspec.service
systemctl daemon-reload
```
