### PR TITLE
🐛 fix case where the inventory was not auto-loaded in serve-mode

### DIFF
--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -37,6 +37,8 @@ func init() {
 	// background scan flags
 	serveCmd.Flags().Int("timer", 60, "scan interval in minutes")
 	serveCmd.Flags().MarkHidden("timer")
+	// set inventory
+	serveCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
 }
 
 var serveCmd = &cobra.Command{
@@ -45,6 +47,7 @@ var serveCmd = &cobra.Command{
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("timer", cmd.Flags().Lookup("timer"))
+		viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		prof.InitProfiler()
@@ -53,9 +56,12 @@ var serveCmd = &cobra.Command{
 		viper.Set("color", "none")
 
 		// check if an inventory file exists
-		inventoryFilePath, ok := config.InventoryPath(viper.ConfigFileUsed())
-		if ok {
-			viper.Set("inventory", inventoryFilePath)
+		if viper.GetString("inventory-file") == "" {
+			inventoryFilePath, ok := config.InventoryPath(viper.ConfigFileUsed())
+			if ok {
+				log.Info().Str("path", inventoryFilePath).Msg("found inventory file")
+				viper.Set("inventory-file", inventoryFilePath)
+			}
 		}
 
 		// determine the scan config from pipe or args


### PR DESCRIPTION
This change fixes an issue where an inventory file in the same location as the config is not picked up automatically. This change also allows users to pass in an inventory via the cli flags.