### PR TITLE
🐛 Hide progress bar when explicitly disabled

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -230,7 +230,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstreamConf
 		orderedKeys = append(orderedKeys, assetList[i].PlatformIds[0])
 	}
 	var multiprogress progress.MultiProgress
-	if isatty.IsTerminal(os.Stdout.Fd()) {
+	if isatty.IsTerminal(os.Stdout.Fd()) && !s.disableProgressBar {
 		multiprogress, err = progress.NewMultiProgressBars(progressBarElements, orderedKeys)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "could not create progress bar")


### PR DESCRIPTION
`serve` mode and the cnspec-runner do not want to show a progress bar.

This fix hides the progress bar, when they explicitly disable it.

Signed-off-by: Christian Zunker <christian@mondoo.com>