### PR TITLE
🐛 re-activate and fix checksum generation on bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
-	go.mondoo.com/cnquery v0.0.0-20230201114235-16a98ab50221
+	go.mondoo.com/cnquery v0.0.0-20230206003900-ed231b6997fb
 	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
 	go.opentelemetry.io/otel v1.12.0
 	golang.org/x/sync v0.1.0
@@ -49,6 +49,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.9.0 // indirect
 	github.com/GoogleCloudPlatform/berglas v1.0.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230113180642-068501e20d67 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.24.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.22.0 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20221221165957-55f4180e6214 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.26.0 h1:dK659zI1MaYa0hF7JuRS
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.26.0/go.mod h1:zN3msBQ5/t4e3nvQvz8AM1cj++DWIekyYTatsBrcsZs=
 github.com/aws/aws-sdk-go-v2/service/backup v1.19.0 h1:MLR1keST/6ueXuVZnNSUtgh40+yei2UYMhO/z6neboc=
 github.com/aws/aws-sdk-go-v2/service/backup v1.19.0/go.mod h1:m3jiAtnpDj6PjnzUdK7uM3hCfDG3uvQ5TTOGfxNZCe4=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.24.0 h1:k1RJsiyqnUm5u+jrYOls9MoP9xgqsVUOrfsYy9mxCro=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.24.0/go.mod h1:xUOmvPrMKmH94stXswKsGSkL02vMpNU+rTG+eIzFfNQ=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.22.0 h1:Hdql8h9SancrQPqJoDcaJQT01zwaSP4gYbe8rmrQRrw=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.22.0/go.mod h1:1Li52ZBEvcubmtUtUFUjamRTQt4EoFzZpHDINdQ4Xso=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.24.0 h1:U7hDPPdDP7bptV6wJ5OJkshEw8P/K2k5WCjEYlVajLw=
@@ -1384,8 +1386,8 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20230201114235-16a98ab50221 h1:0volR9LxrygxautjFQOyguE5VW/9dnhHHOr7/gFAPug=
-go.mondoo.com/cnquery v0.0.0-20230201114235-16a98ab50221/go.mod h1:Ta3Yuxc57XFySpAnzDm+nRC8Dvzy7K+nXF1hfI8Dmlw=
+go.mondoo.com/cnquery v0.0.0-20230206003900-ed231b6997fb h1:OqZD8gerJRJWZUldjOvL+S3BeDnuSinplqydbCYTy+M=
+go.mondoo.com/cnquery v0.0.0-20230206003900-ed231b6997fb/go.mod h1:LvGUOSPIQ31zXDkK/Ig8oMgqmQU8zbKuJZyaqmQHRSE=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
 go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -12,8 +12,11 @@ func TestBundleFromPaths(t *testing.T) {
 		bundle, err := BundleFromPaths("../examples/example.mql.yaml")
 		require.NoError(t, err)
 		require.NotNil(t, bundle)
-		assert.Len(t, bundle.Queries, 4)
-		assert.Len(t, bundle.Policies, 1)
+		assert.Len(t, bundle.Queries, 1)
+		require.Len(t, bundle.Policies, 1)
+		require.Len(t, bundle.Policies[0].Groups, 1)
+		assert.Len(t, bundle.Policies[0].Groups[0].Checks, 3)
+		assert.Len(t, bundle.Policies[0].Groups[0].Queries, 2)
 	})
 
 	t.Run("mql bundle file with multiple policies and queries", func(t *testing.T) {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -360,7 +360,7 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 	if p.ScoringSystem == ScoringSystem_SCORING_UNSPECIFIED {
 		p.ScoringSystem = ScoringSystem_AVERAGE
 	}
-	executionChecksum = executionChecksum.Add(p.ScoringSystem.String())
+	executionChecksum = executionChecksum.AddUint(uint64(p.ScoringSystem))
 
 	// PROPS (must be sorted)
 	sort.Slice(p.Props, func(i, j int) bool {
@@ -410,6 +410,14 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 
 		for i := range group.Checks {
 			check := group.Checks[i]
+
+			if base, ok := bundle.Queries[check.Mrn]; ok {
+				check = check.Merge(base)
+				if err := check.RefreshChecksum(); err != nil {
+					return err
+				}
+			}
+
 			if check.Checksum == "" {
 				return errors.New("failed to get checksum for check " + check.Mrn)
 			}
@@ -428,6 +436,14 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 
 		for i := range group.Queries {
 			query := group.Queries[i]
+
+			if base, ok := bundle.Queries[query.Mrn]; ok {
+				query = query.Merge(base)
+				if err := query.RefreshChecksum(); err != nil {
+					return err
+				}
+			}
+
 			if query.Checksum == "" {
 				return errors.New("failed to get checksum for query " + query.Mrn)
 			}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,9 +1,13 @@
 package policy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/explorer"
+	"go.mondoo.com/cnquery/mrn"
 )
 
 func getChecksums(p *Policy) map[string]string {
@@ -26,117 +30,137 @@ func testChecksums(t *testing.T, equality []bool, expected map[string]string, ac
 	}
 }
 
-//func TestPolicyChecksums(t *testing.T) {
-//	f, err := os.ReadFile("../examples/example.mql.yaml")
-//	require.NoError(t, err)
-//
-//	b := Bundle{}
-//	err = yaml.Unmarshal(f, &b)
-//	require.NoError(t, err)
-//
-//	// check that the checksum is identical
-//	ctx := context.Background()
-//
-//	p := b.Policies[0]
-//	_, err = b.Compile(ctx, nil)
-//	require.NoError(t, err)
-//
-//	// regular checksum tests
-//
-//	err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
-//	require.NoError(t, err, "computing initial checksums works")
-//
-//	checksums := getChecksums(p)
-//	for k, sum := range checksums {
-//		assert.NotEmpty(t, sum, k+" checksum should not be empty")
-//	}
-//
-//	p.InvalidateLocalChecksums()
-//	err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
-//	assert.NoError(t, err, "computing checksums again")
-//	assert.Equal(t, checksums, getChecksums(p), "recomputing yields same checksums")
-//
-//	// content updates
-//
-//	contentTests := map[string]func(p *Policy){
-//		"author changed": func(p *Policy) {
-//			p.Authors = []*explorer.Author{{Name: "Bob"}}
-//		},
-//		"tags changed": func(p *Policy) {
-//			p.Tags = map[string]string{"key": "val"}
-//		},
-//		"name changed": func(p *Policy) {
-//			p.Name = "nu name"
-//		},
-//		"version changed": func(p *Policy) {
-//			p.Version = "1.2.3"
-//		},
-//		"spec date changed": func(p *Policy) {
-//			p.Groups[0].Created = 12345
-//		},
-//	}
-//
-//	runContentTest := func(p *Policy, msg string, f func(p *Policy)) {
-//		t.Run("content changed: "+msg, func(t *testing.T) {
-//			checksums = getChecksums(p)
-//			f(p)
-//			p.InvalidateLocalChecksums()
-//			err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
-//			assert.NoError(t, err, "computing checksums")
-//			testChecksums(t, []bool{false, true, false, true}, checksums, getChecksums(p))
-//		})
-//	}
-//
-//	for k, f := range contentTests {
-//		runContentTest(p, k, f)
-//	}
-//
-//	// special handling for asset policies
-//
-//	assetMrn, err := mrn.NewMRN("//some.domain/" + MRN_RESOURCE_ASSET + "/assetname123")
-//	require.NoError(t, err)
-//
-//	assetPolicy := &Policy{
-//		Mrn:  assetMrn.String(),
-//		Name: assetMrn.String(),
-//	}
-//	assetBundle := &Bundle{Policies: []*Policy{assetPolicy}}
-//	assetBundle.Compile(ctx, nil)
-//	assetPolicy.UpdateChecksums(ctx, nil, nil, assetBundle.ToMap())
-//
-//	runContentTest(assetPolicy, "changing asset policy mrn", func(p *Policy) {
-//		p.Mrn += "bling"
-//	})
-//
-//	// execution updates
-//
-//	executionTests := map[string]func(){
-//		"query changed": func() {
-//			b.Queries[0].CodeId = "12345"
-//		},
-//		"query spec set": func() {
-//			p.Groups[0].Checks = []*explorer.Mquery{
-//				{
-//					Mrn: "//local.cnspec.io/run/local-execution/queries/sshd-01",
-//					Impact: &explorer.Impact{
-//						Scoring: explorer.Impact_WORST,
-//					},
-//				},
-//			}
-//		},
-//		"mrn changed": func() {
-//			p.Mrn = "normal mrn"
-//		},
-//	}
-//
-//	for k, f := range executionTests {
-//		t.Run("execution context changed: "+k, func(t *testing.T) {
-//			checksums = getChecksums(p)
-//			f()
-//			p.InvalidateLocalChecksums()
-//			err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
-//			assert.NoError(t, err, "computing checksums")
-//			testChecksums(t, []bool{false, false, false, false}, checksums, getChecksums(p))
-//		})
-//	}
-//}
+func TestPolicyChecksums(t *testing.T) {
+	files := []string{
+		"../examples/example.mql.yaml",
+		"../examples/example.deprecated_v7.mql.yaml",
+	}
+
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			b, err := BundleFromPaths(file)
+			require.NoError(t, err)
+
+			// check that the checksum is identical
+			ctx := context.Background()
+
+			p := b.Policies[0]
+			_, err = b.Compile(ctx, nil)
+			require.NoError(t, err)
+
+			// regular checksum tests
+
+			err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
+			require.NoError(t, err, "computing initial checksums works")
+
+			checksums := getChecksums(p)
+			for k, sum := range checksums {
+				assert.NotEmpty(t, sum, k+" checksum should not be empty")
+			}
+
+			p.InvalidateLocalChecksums()
+			err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
+			assert.NoError(t, err, "computing checksums again")
+			assert.Equal(t, checksums, getChecksums(p), "recomputing yields same checksums")
+
+			// content updates
+
+			contentTests := map[string]func(p *Policy){
+				"author changed": func(p *Policy) {
+					p.Authors = []*explorer.Author{{Name: "Bob"}}
+				},
+				"tags changed": func(p *Policy) {
+					p.Tags = map[string]string{"key": "val"}
+				},
+				"name changed": func(p *Policy) {
+					p.Name = "nu name"
+				},
+				"version changed": func(p *Policy) {
+					p.Version = "1.2.3"
+				},
+				"group date changed": func(p *Policy) {
+					if p.Groups == nil {
+						p.Specs[0].Created = 12345
+					} else {
+						p.Groups[0].Created = 12345
+					}
+				},
+			}
+
+			runContentTest := func(p *Policy, msg string, f func(p *Policy)) {
+				t.Run("content changed: "+msg, func(t *testing.T) {
+					checksums = getChecksums(p)
+					f(p)
+					p.InvalidateLocalChecksums()
+					err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
+					assert.NoError(t, err, "computing checksums")
+					testChecksums(t, []bool{false, true, false, true}, checksums, getChecksums(p))
+				})
+			}
+
+			for k, f := range contentTests {
+				runContentTest(p, k, f)
+			}
+
+			// special handling for asset policies
+
+			assetMrn, err := mrn.NewMRN("//some.domain/" + MRN_RESOURCE_ASSET + "/assetname123")
+			require.NoError(t, err)
+
+			assetPolicy := &Policy{
+				Mrn:  assetMrn.String(),
+				Name: assetMrn.String(),
+			}
+			assetBundle := &Bundle{Policies: []*Policy{assetPolicy}}
+			assetBundle.Compile(ctx, nil)
+			assetPolicy.UpdateChecksums(ctx, nil, nil, assetBundle.ToMap())
+
+			runContentTest(assetPolicy, "changing asset policy mrn", func(p *Policy) {
+				p.Mrn += "bling"
+			})
+
+			// execution updates
+
+			executionTests := map[string]func(){
+				"query changed": func() {
+					// Note: changing the Checksum of a base query doesn't do anything.
+					// Only the content matters. Changing the base's CodeIDs/MQL/Type is only
+					// effective if the query is taking the mql bits from its base.
+					b.Queries[0].CodeId = "12345"
+				},
+				"query spec set": func() {
+					if p.Groups == nil {
+						p.Specs[0].ScoringQueries = map[string]*DeprecatedV7_ScoringSpec{
+							"//local.cnspec.io/run/local-execution/queries/sshd-01": {
+								ScoringSystem: ScoringSystem_WORST,
+							},
+						}
+					} else {
+						p.Groups[0].Checks = []*explorer.Mquery{
+							{
+								Mrn: "//local.cnspec.io/run/local-execution/queries/sshd-01",
+								Impact: &explorer.Impact{
+									Scoring: explorer.Impact_WORST,
+								},
+							},
+						}
+					}
+				},
+				"mrn changed": func() {
+					p.Mrn = "normal mrn"
+				},
+			}
+
+			for k, f := range executionTests {
+				t.Run("execution context changed: "+k, func(t *testing.T) {
+					checksums = getChecksums(p)
+					f()
+					p.InvalidateLocalChecksums()
+					err = p.UpdateChecksums(ctx, nil, nil, b.ToMap())
+					assert.NoError(t, err, "computing checksums")
+					testChecksums(t, []bool{false, false, false, false}, checksums, getChecksums(p))
+				})
+			}
+		})
+	}
+}

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -273,7 +273,6 @@ func (s *LocalServices) CreatePolicyObject(policyMrn string, ownerMrn string) *P
 			Policies: []*PolicyRef{},
 			Checks:   []*explorer.Mquery{},
 			Queries:  []*explorer.Mquery{},
-			Filters:  &explorer.Filters{},
 		}},
 		Filters:  &explorer.Filters{},
 		OwnerMrn: ownerMrn,


### PR DESCRIPTION
... using the updated cnquery methods to merge base queries and correctly re-generate their checksums.

The current approach had errors when it comes to base and embedded queries. That is because previously we would only deal with what we now call base queries and didn't have to worry too much about any overrides that were happening, because those were limited to scoring specs. However, the latter have now been replaced and merging queries has become the norm. In this world, we need correct checksums for all merged actions.

Additionally, we don't want to alter the structure of query overrides too much, i.e. we don't want to just pull the base query into the override and overwrite the policy group, since that would lose all context of a dependency existing. We will revisit some of this behavior when we get to version history of snapshotting in cnspec/cnquery, which is coming up soon.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>