### PR TITLE
🧹 remove internal reference to query isScored

### DIFF
--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -16,7 +16,6 @@ import (
 
 type wrapQuery struct {
 	*explorer.Mquery
-	isScored bool
 }
 
 type wrapPolicy struct {
@@ -55,8 +54,8 @@ func (db *Db) GetQuery(ctx context.Context, mrn string) (*explorer.Mquery, error
 
 // SetQuery stores a given query
 // Note: the query must be defined, it cannot be nil
-func (db *Db) SetQuery(ctx context.Context, mrn string, mquery *explorer.Mquery, isScored bool) error {
-	v := wrapQuery{mquery, isScored}
+func (db *Db) SetQuery(ctx context.Context, mrn string, mquery *explorer.Mquery) error {
+	v := wrapQuery{mquery}
 	ok := db.cache.Set(dbIDQuery+mrn, v, 1)
 	if !ok {
 		return errors.New("failed to save query '" + mrn + "' to cache")
@@ -75,7 +74,7 @@ func (db *Db) GetProperty(ctx context.Context, mrn string) (*explorer.Property, 
 
 // SetProperty stores a given query
 // Note: the query must be defined, it cannot be nil
-func (db *Db) SetProperty(ctx context.Context, mrn string, prop *explorer.Property, isScored bool) error {
+func (db *Db) SetProperty(ctx context.Context, mrn string, prop *explorer.Property) error {
 	ok := db.cache.Set(dbIDProp+mrn, prop, 1)
 	if !ok {
 		return errors.New("failed to save query '" + mrn + "' to cache")
@@ -150,7 +149,7 @@ func (db *Db) setPolicy(ctx context.Context, policyObj *policy.Policy, filters [
 	for i := range filters {
 		filter := filters[i]
 		policyObj.Filters.Items[filter.CodeId] = filter
-		if err = db.SetQuery(ctx, filter.Mrn, filter, false); err != nil {
+		if err = db.SetQuery(ctx, filter.Mrn, filter); err != nil {
 			return wrapPolicy{}, err
 		}
 	}

--- a/policy/datalake.go
+++ b/policy/datalake.go
@@ -25,12 +25,12 @@ type DataLake interface {
 	GetQuery(ctx context.Context, mrn string) (*explorer.Mquery, error)
 	// SetQuery stores a given query
 	// Note: the query must be defined, it cannot be nil
-	SetQuery(ctx context.Context, mrn string, query *explorer.Mquery, isScored bool) error
+	SetQuery(ctx context.Context, mrn string, query *explorer.Mquery) error
 	// GetProperty retrieves a given property
 	GetProperty(ctx context.Context, mrn string) (*explorer.Property, error)
 	// SetProperty stores a given property
 	// Note: the property must be defined, it cannot be nil
-	SetProperty(ctx context.Context, mrn string, prop *explorer.Property, isScored bool) error
+	SetProperty(ctx context.Context, mrn string, prop *explorer.Property) error
 
 	// GetValidatedPolicy retrieves and if necessary updates the policy
 	GetValidatedPolicy(ctx context.Context, mrn string) (*Policy, error)

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -41,12 +41,13 @@ func (s *LocalServices) SetBundle(ctx context.Context, bundle *Bundle) (*Empty, 
 
 // PreparePolicy takes a policy and an optional bundle and gets it
 // ready to be saved in the DB, including asset filters.
+//
 // Note1: The bundle must have been pre-compiled and validated!
 // Note2: The bundle may be nil, in which case we will try to find what is needed for the policy
 // Note3: We create the ent.PolicyBundle in this function, not in the `SetPolicyBundle`
 //
-//	Reason: SetPolicyBundle may be setting 1 outer and 3 embedded policies.
-//	But we need to create ent.PolicyBundles for all 4 of those.
+// Reason: SetPolicyBundle may be setting 1 outer and 3 embedded policies.
+// But we need to create ent.PolicyBundles for all 4 of those.
 func (s *LocalServices) PreparePolicy(ctx context.Context, policyObj *Policy, bundle *PolicyBundleMap) (*Policy, []*explorer.Mquery, error) {
 	logCtx := logger.FromContext(ctx)
 	var err error
@@ -97,17 +98,17 @@ func (s *LocalServices) PreparePolicy(ctx context.Context, policyObj *Policy, bu
 
 		// TODO: this may need to happen in a bulk call
 		for k, v := range queries {
-			if err := s.setQuery(ctx, k, v, false); err != nil {
+			if err := s.setQuery(ctx, k, v); err != nil {
 				return nil, nil, err
 			}
 		}
 		for k, v := range checks {
-			if err := s.setQuery(ctx, k, v, true); err != nil {
+			if err := s.setQuery(ctx, k, v); err != nil {
 				return nil, nil, err
 			}
 		}
 		for k, v := range props {
-			if err := s.setProperty(ctx, k, v, true); err != nil {
+			if err := s.setProperty(ctx, k, v); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -194,7 +195,7 @@ func (s *LocalServices) setPolicyBundleFromMap(ctx context.Context, bundleMap *P
 	return nil
 }
 
-func (s *LocalServices) setQuery(ctx context.Context, mrn string, query *explorer.Mquery, isScored bool) error {
+func (s *LocalServices) setQuery(ctx context.Context, mrn string, query *explorer.Mquery) error {
 	if query == nil {
 		return errors.New("cannot set query '" + mrn + "' as it is not defined")
 	}
@@ -203,10 +204,10 @@ func (s *LocalServices) setQuery(ctx context.Context, mrn string, query *explore
 		query.Title = query.Mql
 	}
 
-	return s.DataLake.SetQuery(ctx, mrn, query, isScored)
+	return s.DataLake.SetQuery(ctx, mrn, query)
 }
 
-func (s *LocalServices) setProperty(ctx context.Context, mrn string, prop *explorer.Property, isScored bool) error {
+func (s *LocalServices) setProperty(ctx context.Context, mrn string, prop *explorer.Property) error {
 	if prop == nil {
 		return errors.New("cannot set query '" + mrn + "' as it is not defined")
 	}
@@ -215,7 +216,7 @@ func (s *LocalServices) setProperty(ctx context.Context, mrn string, prop *explo
 		prop.Title = prop.Mql
 	}
 
-	return s.DataLake.SetProperty(ctx, mrn, prop, isScored)
+	return s.DataLake.SetProperty(ctx, mrn, prop)
 }
 
 // GetPolicy without cascading dependencies


### PR DESCRIPTION
It is a remnant of old code and not needed in this context (nor used).

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>