### PR TITLE
🐛 base query creation and lookup

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -832,6 +832,10 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 				continue
 			}
 
+			if base, ok := cache.global.bundleMap.Queries[check.Mrn]; ok {
+				check = check.Merge(base)
+			}
+
 			// the job itself is global to the resolution
 			queryJob := cache.global.reportingJobsByChecksum[check.Checksum]
 			if queryJob == nil {
@@ -894,6 +898,10 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 		if query.Action == explorer.Mquery_UNKNOWN || query.Action == explorer.Mquery_ADD {
 			if _, ok := cache.removedQueries[query.Mrn]; ok {
 				continue
+			}
+
+			if base, ok := cache.global.bundleMap.Queries[query.Mrn]; ok {
+				query = query.Merge(base)
 			}
 
 			// the job itself is global to the resolution


### PR DESCRIPTION
After #330 

After the recent change on merging queries (where we now don't overwrite the object anymore) we have been missing the fully realized queries during the resolver step. Restore this by providing both the base queries (in the bundle) and the policy queries.

Fixes the basic query execution that failed after that changed merged in cnquery. Also has the nice side-effect that queries aren't (tried to be) created multiple times if they are referenced by multiple policies in a bundle.