### PR TITLE
🐛 fix asset score aggregation

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -740,6 +740,7 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 
 		scoring := &explorer.Impact{
 			Scoring: policy.ScoringSystem,
+			Weight:  -1,
 		}
 
 		// ADD


### PR DESCRIPTION
this is a problem that was introduced with the changes for policy v2. The unset value for weight is -1, not 0.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>