### PR TITLE
🧹 Replace deprecated goreleaser arg

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release -f .github/.goreleaser-edge.yml --rm-dist --timeout 120m
+          args: release -f .github/.goreleaser-edge.yml --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --timeout 120m
+          args: release --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ cnspec/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnspec/cnspec.go
 
 cnspec/dist/goreleaser/stable:
-	goreleaser release --rm-dist --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m
+	goreleaser release --clean --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m
 
 cnspec/dist/goreleaser/edge:
-	goreleaser release --rm-dist --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m --snapshot
+	goreleaser release --clean --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m --snapshot
 
 
 #   ⛹🏽‍ Testing   #


### PR DESCRIPTION
This fixes:
DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations\#-rm-dist for more details

Signed-off-by: Christian Zunker <christian@mondoo.com>