### PR TITLE
🐛+🧹 fix impact aggregation + scoringspec support

### DIFF
--- a/policy/deprecated_v7.go
+++ b/policy/deprecated_v7.go
@@ -238,6 +238,30 @@ func (d deprecatedV7_PolicySpecs) ToV8() []*PolicyGroup {
 	return res
 }
 
+func Impact2ScoringSpec(impact *explorer.Impact, action QueryAction) *DeprecatedV7_ScoringSpec {
+	if impact == nil {
+		return nil
+	}
+
+	weight := impact.Weight
+	if weight == -1 {
+		weight = 1
+	}
+
+	var severity *DeprecatedV7_SeverityValue
+	if impact.Value != -1 {
+		severity = &DeprecatedV7_SeverityValue{Value: int64(impact.Value)}
+	}
+
+	return &DeprecatedV7_ScoringSpec{
+		Weight:             uint32(weight),
+		WeightIsPercentage: false,
+		ScoringSystem:      ScoringSystem(impact.Scoring), // numbers are identical in this enum
+		Action:             action,
+		Severity:           severity,
+	}
+}
+
 func (s *DeprecatedV7_ScoringSpec) ApplyToV8(ref *explorer.Mquery) {
 	// For convenience we allow calling it on nil and handle it here.
 	if s == nil {

--- a/policy/executor/internal/builder.go
+++ b/policy/executor/internal/builder.go
@@ -426,7 +426,7 @@ func (ge *GraphExecutor) addReportingJobNode(assetMrn string, reportingJobID str
 
 	for childReportingJobID, ss := range rj.ChildJobs {
 		nodeData.childScores[childReportingJobID] = &reportingJobResult{
-			scoringSpec: ss,
+			impact: ss,
 		}
 	}
 

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -410,8 +410,8 @@ type reportingJobDatapoint struct {
 }
 
 type reportingJobResult struct {
-	scoringSpec *explorer.Impact
-	score       *policy.Score
+	impact *explorer.Impact
+	score  *policy.Score
 }
 
 // ReportingJobNodeData is the data for nodes of type ReportingJobNodeType
@@ -540,7 +540,7 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 		if s == nil {
 			return nil, nil
 		}
-		policy.AddSpecdScore(calculator, s, rjRes.score != nil, rjRes.scoringSpec)
+		policy.AddSpecdScore(calculator, s, rjRes.score != nil, rjRes.impact)
 	}
 
 	policy.AddDataScore(calculator, len(nodeData.datapoints), finishedDatapoints)

--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -49,7 +49,7 @@ func AddSpecdScore(calculator ScoreCalculator, s *Score, found bool, impact *exp
 	}
 
 	score := proto.Clone(s).(*Score)
-	if impact != nil {
+	if impact != nil && impact.Value != -1 {
 		floor := 100 - uint32(impact.Value)
 		if floor > score.Value {
 			score.Value = floor


### PR DESCRIPTION
- the aggregation of impact values has caused e.g. the asset score to become an A, instead of what it actually should be. This is because the default Impact.Value was set to 0, which translates into an INFO score. To remedy this issue, we set the default impact.value to -1 as it should be (and as it is for parsing e.g. bundles)
- additionally, we were missing values for the scoringspec in reportingjobs, which is still in use for v7 clients and will be throughout v8. Make sure we continue to support them

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>