### PR TITLE
🐛 Show errors for asset scans

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -296,7 +296,7 @@ func addSpace(s string) string {
 }
 
 func (r *defaultReporter) printAssetSections(orderedAssets []assetMrnName) {
-	if len(orderedAssets) == 0 || len(r.data.Errors) == len(orderedAssets) {
+	if len(orderedAssets) == 0 {
 		return
 	}
 


### PR DESCRIPTION
Before:
```
→ resolved assets resolved-assets=1

 brave_joliot ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    X score: X


Scanned 1 assets

scratch
    X brave_joliot
```

With this fix:
```
→ resolved assets resolved-assets=1

 brave_joliot ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    X score: X


Asset: brave_joliot
-------------------

error: rpc error: code = Unknown desc = cannot find any policy for this search


Scanned 1 assets

scratch
    X brave_joliot
```

When running with `-o summary`, the asset section isn't shown.

Fixes #347

Signed-off-by: Christian Zunker <christian@mondoo.com>