### PR TITLE
🐛 Don't panic when we only have errors

### DIFF
--- a/cli/reporter/print_report.go
+++ b/cli/reporter/print_report.go
@@ -39,11 +39,14 @@ func (r *reportRenderer) print() error {
 	// TODO: sort assets by reverse score
 
 	var res bytes.Buffer
+	var scanSummary string
 
 	// print summaryPrinter
 	s := NewSummaryRenderer(r.printer)
-	scanSummary := s.Render(r.data)
-	res.WriteString(scanSummary)
+	if len(r.data.Reports) > 0 {
+		scanSummary = s.Render(r.data)
+		res.WriteString(scanSummary)
+	}
 
 	// render asset name/summaryPrinter + policy results
 	for assetMrn := range r.data.Assets {
@@ -53,6 +56,7 @@ func (r *reportRenderer) print() error {
 		} else {
 			res.WriteString(renderedAsset)
 		}
+		res.WriteString(NewLineCharacter)
 	}
 
 	// print errors


### PR DESCRIPTION
When we only scanned assets which errored, cnspec would panic:
```
→ resolved assets resolved-assets=1

 brave_joliot ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    X score: X


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x74b2ece]

goroutine 1 [running]:
go.mondoo.com/cnspec/policy.(*Bundle).ToMap(0x0)
	/home/christian/workspace/mondoo/github.com/cnspec/policy/bundle.go:224 +0x2e
```

Now, the output looks like this:
```
→ resolved assets resolved-assets=1

 brave_joliot ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    X score: X


✕ Could not find report for asset //policy.api.mondoo.com/assets/2Lik7NWXjuAhGTWlnCaQQKVT4pd
Scan Failures

■ Asset: //policy.api.mondoo.com/assets/2Lik7NWXjuAhGTWlnCaQQKVT4pd
  Error: rpc error: code = Unknown desc = cannot find any policy for this search

exit status 1
```

Fixes #348

Signed-off-by: Christian Zunker <christian@mondoo.com>