### PR TITLE
🐛 Display asset names in overview

### DIFF
--- a/cli/reporter/summary.go
+++ b/cli/reporter/summary.go
@@ -86,6 +86,7 @@ func (s *summaryPrinter) GenerateStats(report *policy.ReportCollection) summaryS
 	// extract statistics from scan report
 	pbm := report.Bundle.ToMap()
 	for assetMrn := range report.Assets {
+		stats.assetNames[assetMrn] = report.Assets[assetMrn].Name
 		assetReport, ok := report.Reports[assetMrn]
 		if !ok {
 			if errMsg := report.Errors[assetMrn]; errMsg != "" {


### PR DESCRIPTION
When running cnspec with `-o report`, the asset overview looked like this:
```
Summary
=======

Asset Overview

■  A   
■  A   
■  A   
■  X   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
■  A   
```

Now it looks like this:
```
Summary
=======

Asset Overview

■  A   kube-system/kube-scheduler-kind-control-plane
■  A   local-path-storage/local-path-provisioner-684f458cdd-6zl25
■  A   kube-system/coredns-565d847f94
■  X   K8s Cluster kind-kind
■  A   local-path-storage/local-path-provisioner
■  A   kube-system/kube-apiserver-kind-control-plane
■  A   kube-system/coredns
■  A   local-path-storage/local-path-provisioner-684f458cdd
■  A   kube-system/etcd-kind-control-plane
■  A   kube-system/kube-controller-manager-kind-control-plane
■  A   kube-system/kindnet-962sh
■  A   kube-system/kube-proxy-6f849
■  A   kube-system/kube-proxy
■  A   kube-system/coredns-565d847f94-84l99
■  A   kube-system/coredns-565d847f94-mxtvx
■  A   kube-system/kindnet

Aggregated Policy Overview
```

Fixes #351

Signed-off-by: Christian Zunker <christian@mondoo.com>