### PR TITLE
🧹Compress windows amd64 binary with upx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,10 @@ builds:
       - -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
     hooks:
       post:
+        - cmd: ./scripts/pkg/windows/windows-upx.sh '{{ .Path }}'
+          output: true
+          env:
+          - TARGET={{ .Target }}
         - ./scripts/pkg/windows/sign-windows-executable.sh '{{ .Path }}'
 nfpms:
   -

--- a/scripts/pkg/windows/windows-upx.sh
+++ b/scripts/pkg/windows/windows-upx.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+EXE="$1"
+
+if [ "$TARGET" == "windows_amd64_v1" ]; then
+  echo "Compressing binary with upx"
+  upx "$EXE"
+fi


### PR DESCRIPTION
This takes the size from 200MB to 50MB. It doesn't work for arm.

Some downsides may be that the binaries now take longer to start. Its also possible that this is more likely to trigger antivirus software.