### PR TITLE
🐛 fix policy example for v2

### DIFF
--- a/examples/example.mql.yaml
+++ b/examples/example.mql.yaml
@@ -1,3 +1,6 @@
+# To run this file:
+#   cnspec scan -f examples/example.mql.yaml
+#
 # This section lists all the policies that are part of this bundle.
 # In our case, we only have 1 policy: example1
 policies:
@@ -21,13 +24,13 @@ policies:
           # final score of this policy.
           - uid: sshd-01
             title: Set the port to 22
-            query: sshd.config.params["Port"] == 22
+            mql: sshd.config.params["Port"] == 22
             # Impact are used for scoring. 100 = critical. 0 = informational.
             impact: 30
 
           - uid: sshd-02
             title: Configure the address family
-            query: sshd.config.params["AddressFamily"] == /inet|inet6|any/
+            mql: sshd.config.params["AddressFamily"] == /inet|inet6|any/
             impact: 40
 
             # Here we use a referenced query. You can put multiple policies
@@ -39,7 +42,7 @@ policies:
           # what you should or shouldn't do, they only provide insights.
           - uid: sshd-d-1
             title: Gather SSH config params
-            query: sshd.config.params
+            mql: sshd.config.params
 
           # Here is an example of a query that uses embedded properties. 
           # These allow users to fine-tune the policy.
@@ -49,7 +52,7 @@ policies:
             props:
               - uid: home
                 mql: |
-                  "/root"
+                  "/home"
 
         filters:
           # Here we specify that the queries in this spec are only applied
@@ -63,6 +66,6 @@ queries:
   # The title helps in printing it.
   - uid: shared
     title: Enable strict mode
-    query: sshd.config.params["StrictModes"] == "yes"
+    mql: sshd.config.params["StrictModes"] == "yes"
     impact: 70
 


### PR DESCRIPTION
We were incorrectly using the query field, which is deprecated after v7