### PR TITLE
🐛 fix incorrect bundle caching and checksums

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -319,22 +319,26 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 			}
 		}
 
+		// For all queries and checks we are looking to get the shared objects only.
+		// This is because the embedded queries and checks are already part of the
+		// policy and what the bundle represents in its toplevel Queries field is
+		// the collection of shared content (not its overrides). So the section
+		// below is all about adding the shared content only.
+
 		for i := range group.Queries {
 			query := group.Queries[i]
-			base, err := s.DataLake.GetQuery(ctx, query.Mrn)
-			if err == nil {
-				query.Merge(base)
+			if base, _ := s.DataLake.GetQuery(ctx, query.Mrn); base != nil {
+				query = base
 			}
 			bundleMap.Queries[query.Mrn] = query
 		}
 
 		for i := range group.Checks {
 			check := group.Checks[i]
-			base, err := s.DataLake.GetQuery(ctx, check.Mrn)
-			if err != nil {
-				return nil, err
+			if base, _ := s.DataLake.GetQuery(ctx, check.Mrn); base != nil {
+				check = base
 			}
-			bundleMap.Queries[check.Mrn] = base
+			bundleMap.Queries[check.Mrn] = check
 		}
 
 		for i := range group.Policies {

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -837,6 +837,12 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 		check := group.Checks[i]
 		if base, ok := cache.global.bundleMap.Queries[check.Mrn]; ok {
 			check = check.Merge(base)
+			if err := check.RefreshChecksum(); err != nil {
+				return err
+			}
+		}
+		if check.Checksum == "" {
+			return errors.New("invalid check encountered, missing checksum for: " + check.Mrn)
 		}
 
 		impact := check.Impact
@@ -913,6 +919,12 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 		query := group.Queries[i]
 		if base, ok := cache.global.bundleMap.Queries[query.Mrn]; ok {
 			query = query.Merge(base)
+			if err := query.RefreshChecksum(); err != nil {
+				return err
+			}
+		}
+		if query.Checksum == "" {
+			return errors.New("invalid query encountered, missing checksum for: " + query.Mrn)
 		}
 
 		// Dom: Note: we do not carry over the impact from data queries yet


### PR DESCRIPTION
1: I noticed that with the deprecated policy example data queries
   weren't pulled from the bundle. It turns out the code was treating
   checks and queries differently. Fixed that.

   Additionally, the bundle didn't cache the base objects. Bundles have
   a global space to expose shared queries. This is used for both
   embed-only queries as well as queries that are actually shared.
   However, the code was pushing import objects (i.e. a query that only
   has the MRN and nothing else) into the shared query space, instead of
   the actual query.

2: Checksums weren't recalculated when base queries were pulled in.
   Again, in most v8 cases this wasn't noticeable, but with v7 code this
   broke the policy execution.

   This PR introduces both a fix to checksums when queries are merged
   (just refresh it) as well as a sanity-check since these missing
   checksums are both devestating to the resolved policy and go by
   unnoticed.

Now with the v7 policy:

![image](https://user-images.githubusercontent.com/1307529/219253700-5cb59de1-6984-4bae-8828-061e7a410424.png)

And with the v8 policy:

![image](https://user-images.githubusercontent.com/1307529/219253795-91d36c30-d3aa-4964-b85c-3122aa787974.png)

