### PR TITLE
🧹 remove unnecessary properties fields

### DIFF
--- a/policy/datalake.go
+++ b/policy/datalake.go
@@ -26,11 +26,6 @@ type DataLake interface {
 	// SetQuery stores a given query
 	// Note: the query must be defined, it cannot be nil
 	SetQuery(ctx context.Context, mrn string, query *explorer.Mquery) error
-	// GetProperty retrieves a given property
-	GetProperty(ctx context.Context, mrn string) (*explorer.Property, error)
-	// SetProperty stores a given property
-	// Note: the property must be defined, it cannot be nil
-	SetProperty(ctx context.Context, mrn string, prop *explorer.Property) error
 
 	// GetValidatedPolicy retrieves and if necessary updates the policy
 	GetValidatedPolicy(ctx context.Context, mrn string) (*Policy, error)

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -319,22 +319,26 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 			}
 		}
 
+		// For all queries and checks we are looking to get the shared objects only.
+		// This is because the embedded queries and checks are already part of the
+		// policy and what the bundle represents in its toplevel Queries field is
+		// the collection of shared content (not its overrides). So the section
+		// below is all about adding the shared content only.
+
 		for i := range group.Queries {
 			query := group.Queries[i]
-			base, err := s.DataLake.GetQuery(ctx, query.Mrn)
-			if err == nil {
-				query.Merge(base)
+			if base, _ := s.DataLake.GetQuery(ctx, query.Mrn); base != nil {
+				query = base
 			}
 			bundleMap.Queries[query.Mrn] = query
 		}
 
 		for i := range group.Checks {
 			check := group.Checks[i]
-			base, err := s.DataLake.GetQuery(ctx, check.Mrn)
-			if err != nil {
-				return nil, err
+			if base, _ := s.DataLake.GetQuery(ctx, check.Mrn); base != nil {
+				check = base
 			}
-			bundleMap.Queries[check.Mrn] = base
+			bundleMap.Queries[check.Mrn] = check
 		}
 
 		for i := range group.Policies {

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -157,18 +157,6 @@ func (s *LocalServices) setQuery(ctx context.Context, mrn string, query *explore
 	return s.DataLake.SetQuery(ctx, mrn, query)
 }
 
-func (s *LocalServices) setProperty(ctx context.Context, mrn string, prop *explorer.Property) error {
-	if prop == nil {
-		return errors.New("cannot set query '" + mrn + "' as it is not defined")
-	}
-
-	if prop.Title == "" {
-		prop.Title = prop.Mql
-	}
-
-	return s.DataLake.SetProperty(ctx, mrn, prop)
-}
-
 // GetPolicy without cascading dependencies
 func (s *LocalServices) GetPolicy(ctx context.Context, in *Mrn) (*Policy, error) {
 	logCtx := logger.FromContext(ctx)
@@ -300,12 +288,6 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 
 	for i := range mpolicyObj.Props {
 		prop := mpolicyObj.Props[i]
-
-		base, err := s.DataLake.GetProperty(ctx, prop.Mrn)
-		if err == nil {
-			prop.Merge(base)
-		}
-
 		bundleMap.Props[prop.Mrn] = prop
 	}
 

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -837,6 +837,12 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 		check := group.Checks[i]
 		if base, ok := cache.global.bundleMap.Queries[check.Mrn]; ok {
 			check = check.Merge(base)
+			if err := check.RefreshChecksum(); err != nil {
+				return err
+			}
+		}
+		if check.Checksum == "" {
+			return errors.New("invalid check encountered, missing checksum for: " + check.Mrn)
 		}
 
 		impact := check.Impact
@@ -913,6 +919,12 @@ func (s *LocalServices) policyspecToJobs(ctx context.Context, group *PolicyGroup
 		query := group.Queries[i]
 		if base, ok := cache.global.bundleMap.Queries[query.Mrn]; ok {
 			query = query.Merge(base)
+			if err := query.RefreshChecksum(); err != nil {
+				return err
+			}
+		}
+		if query.Checksum == "" {
+			return errors.New("invalid query encountered, missing checksum for: " + query.Mrn)
 		}
 
 		// Dom: Note: we do not carry over the impact from data queries yet


### PR DESCRIPTION
After #358

We can largely take the pattern that was established in cnquery now and remove outdated property patterns. Just SetProps for an entity and every other type of property is embedded in either a query, pack, or policy.