### PR TITLE
🐛 incorrect query IDs usage + swallowed error

### DIFF
--- a/policy/deprecated_v7.go
+++ b/policy/deprecated_v7.go
@@ -367,7 +367,6 @@ func Impact2ScoringSpec(impact *explorer.Impact, action QueryAction) *Deprecated
 func (s *DeprecatedV7_ScoringSpec) ApplyToV8(ref *explorer.Mquery) {
 	// For convenience we allow calling it on nil and handle it here.
 	if s == nil {
-		log.Error().Msg("cannot apply v7 scoring spec to mquery, spec is nil")
 		return
 	}
 	if ref == nil {
@@ -436,7 +435,7 @@ func (d *DeprecatedV7_PolicySpec) ToV8() *PolicyGroup {
 	queries := make([]*explorer.Mquery, len(d.DataQueries))
 	queryIDs := sortedKeys(d.DataQueries)
 	for i := range queryIDs {
-		id := checkIDs[i]
+		id := queryIDs[i]
 		action := d.DataQueries[id]
 		ref := &explorer.Mquery{}
 

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -73,10 +73,13 @@ func (s *LocalServices) PreparePolicy(ctx context.Context, policyObj *Policy, bu
 	// otherwise we generate the old GraphChecksum
 	if policyObj.GraphExecutionChecksum == "" || policyObj.GraphContentChecksum == "" {
 		logCtx.Trace().Str("policy", policyObj.Mrn).Msg("marketplace> update graphchecksum")
-		policyObj.UpdateChecksums(ctx,
+		err = policyObj.UpdateChecksums(ctx,
 			s.DataLake.GetValidatedPolicy,
 			s.DataLake.GetQuery,
 			bundle)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	filters, err := policyObj.ComputeAssetFilters(


### PR DESCRIPTION
- using checkIDs during the queryIDs loop leads to incorrect results at best and panics at worst
- swallowing the error for checksums hides problems