### PR TITLE
🐛 don't throw errors if queries in bundles activate

### DIFF
--- a/policy/bundle_map.go
+++ b/policy/bundle_map.go
@@ -206,9 +206,6 @@ func (p *PolicyBundleMap) validateGroup(ctx context.Context, group *PolicyGroup,
 			return err
 		}
 
-		if check.Action == explorer.Action_ACTIVATE && exist {
-			return errors.New("check already exists, but policy is trying to add it: " + check.Mrn)
-		}
 		if check.Action == explorer.Action_MODIFY && !exist {
 			return errors.New("check does not exist, but policy is trying to modify it: " + check.Mrn)
 		}
@@ -222,9 +219,6 @@ func (p *PolicyBundleMap) validateGroup(ctx context.Context, group *PolicyGroup,
 			return err
 		}
 
-		if query.Action == explorer.Action_ACTIVATE && exist {
-			return errors.New("query already exists, but policy is trying to add it: " + query.Mrn)
-		}
 		if query.Action == explorer.Action_MODIFY && !exist {
 			return errors.New("query does not exist, but policy is trying to modify it: " + query.Mrn)
 		}


### PR DESCRIPTION
This is lost in translation, where it correctly errors when we try to modify a query that doesn't exist, but it incorrectly errors if the query exists in the bundle and users try to activate it. Typically we don't run into this case, but the edge-case are policies that were written in v7 and have an explicit action ACTIVATE set.