### PR TITLE
🐛 fix copying errors in goreleaser for UBI containers

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -37,7 +37,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: amd64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64"
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64"
@@ -51,7 +50,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: arm64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64"
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,7 +119,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: amd64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64"
@@ -133,7 +132,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: arm64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64"
@@ -208,7 +206,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: amd64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64-rootless"
@@ -222,7 +219,6 @@ dockers: # https://goreleaser.com/customization/docker/
   - use: buildx
     goos: linux
     goarch: arm64
-    dockerfile: Dockerfile-ubi
     image_templates:
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64-rootless"


### PR DESCRIPTION
I copied some things that were not supposed to be in this repo and the release didn't work because of that