### PR TITLE
🧹 add a deprecated v7 example

### DIFF
--- a/examples/example.deprecated_v7.mql.yaml
+++ b/examples/example.deprecated_v7.mql.yaml
@@ -15,6 +15,8 @@ policies:
     # Specs are a way to specify all the queries (and other policies)
     # that we want to apply. Specs are grouped together and can be filtered.
     # This allows you to only apply a group of queries if the condition is met.
+    props:
+      homeProp: ""
     specs:
       - scoring_queries:
           # These are queries that will be scored and contribute to the
@@ -26,10 +28,17 @@ policies:
           # These are queries which only collect data. They don't say
           # what you should or shouldn't do, they only provide insights.
           sshd-d-1:
+          home-info:
         asset_filter:
           # Here we specify that the queries in this spec are only applied
           # when the asset satisfies this condition:
           query: asset.family.contains(_ == 'unix')
+
+props:
+  - uid: homeProp
+    title: Some home property
+    query: |
+      return "/home"
 
 # These are all the queries that are part of this bundle. They are used
 # by the policies specified above.
@@ -52,3 +61,6 @@ queries:
   - uid: sshd-d-1
     title: Gather SSH config params
     query: sshd.config.params
+  - uid: home-info
+    title: Home information
+    query: file(props.homeProp) { * }


### PR DESCRIPTION
we didn't have any historic examples for properties. I fully expect this to be removed with v8 and then not matter anymore. But I'd love to have this in the history for v7 compatibility reasons