### PR TITLE
🐛 Save filters associated with queries

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -287,9 +287,11 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 		Props:    map[string]*explorer.Property{},
 	}
 
-	// we need to re-compute the asset filters
-	mpolicyObj.Filters = &explorer.Filters{
-		Items: map[string]*explorer.Mquery{},
+	if mpolicyObj.Filters == nil {
+		// we need to re-compute the asset filters
+		mpolicyObj.Filters = &explorer.Filters{
+			Items: map[string]*explorer.Mquery{},
+		}
 	}
 	bundleMap.Policies[mpolicyObj.Mrn] = mpolicyObj
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -110,8 +110,14 @@ func WaitUntilDone(resolver PolicyResolver, entity string, scoringMrn string, ti
 
 // RefreshLocalAssetFilters looks through the local policy asset filters and rolls them up
 func (p *Policy) RefreshLocalAssetFilters() {
-	p.Filters = &explorer.Filters{
-		Items: map[string]*explorer.Mquery{},
+	if p.Filters == nil {
+		p.Filters = &explorer.Filters{
+			Items: map[string]*explorer.Mquery{},
+		}
+	}
+
+	if p.Filters.Items == nil {
+		p.Filters.Items = map[string]*explorer.Mquery{}
 	}
 
 	for i := range p.Groups {
@@ -132,6 +138,11 @@ func (p *Policy) RefreshLocalAssetFilters() {
 // recursive tells us if we want to call this function for all policy dependencies (costly; set to false by default)
 func (p *Policy) ComputeAssetFilters(ctx context.Context, getPolicy func(ctx context.Context, mrn string) (*Policy, error), recursive bool) ([]*explorer.Mquery, error) {
 	filters := map[string]*explorer.Mquery{}
+
+	for i := range p.Filters.Items {
+		filter := p.Filters.Items[i]
+		filters[filter.CodeId] = filter
+	}
 
 	for i := range p.Groups {
 		group := p.Groups[i]


### PR DESCRIPTION
Persist filters which are attached to queries, e.g. in the Kubernetes Inventory pack:
```
- uid: mondoo-kubernetes-pods-inventory
    name: Mondoo Kubernetes Pods Inventory
    version: 1.0.0
    tags:
      mondoo.com/platform: kubernetes
      mondoo.com/category: best-practices
    filters:
      - asset.platform == "k8s-pod"
    queries:
      - uid: k8s-pod
        title: Gather Pod Information
        query: |
          k8s.pod { * }
```

This fixes this error message in cnquery, when running a query pack:
```
x query.hub> failed to set query pack retrieved from upstream error="cannot compute filters for a querypack, unless it was compiled first" querypack=
```