### PR TITLE
🐛 Fix progress for unscored assets

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -373,20 +373,22 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 		r.out.Write([]byte(NewLineCharacter))
 	}
 
-	r.out.Write([]byte("Controls:" + NewLineCharacter))
-	for id, score := range report.Scores {
-		_, ok := resolved.CollectorJob.ReportingQueries[id]
-		if !ok {
-			continue
-		}
+	if len(report.Scores) > 0 {
+		r.out.Write([]byte("Controls:" + NewLineCharacter))
+		for id, score := range report.Scores {
+			_, ok := resolved.CollectorJob.ReportingQueries[id]
+			if !ok {
+				continue
+			}
 
-		query, ok := queries[id]
-		if !ok {
-			r.out.Write([]byte("Couldn't find any queries for incoming value for " + id))
-			continue
-		}
+			query, ok := queries[id]
+			if !ok {
+				r.out.Write([]byte("Couldn't find any queries for incoming value for " + id))
+				continue
+			}
 
-		r.printControl(score, query, asset, resolved, report, results)
+			r.printControl(score, query, asset, resolved, report, results)
+		}
 	}
 }
 

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -595,7 +595,11 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 		return ar, err
 	}
 	s.ProgressReporter.Score(report.Score.Rating().Letter())
-	s.ProgressReporter.Completed()
+	if report.Score.Rating().Letter() == "U" {
+		s.ProgressReporter.NotApplicable()
+	} else {
+		s.ProgressReporter.Completed()
+	}
 
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("scan complete")
 	ar.Report = report


### PR DESCRIPTION
Before, the progress bars looked like this, when unscored assets where included:
```
 kube-system/coredns                                ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────   0% score: U
 mondoo-operator/mondoo-client-scan-api             ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────   0% score: U
 mondoo-operator/mondoo-operator-controller-manager ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────   0% score: U
 mondoo-operator/mondoo-client-k8s-scan             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% score: A
 mondoo-operator/mondoo-client-node-minikube        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% score: A

 5/5 scanned                                        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━──────────────────────────────────────────────────────────────────────────────────────────────────────────────  40%

```

Now, it looks like this:
```
 kube-system/coredns                                ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  n/a score: U
 mondoo-operator/mondoo-client-scan-api             ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  n/a score: U
 mondoo-operator/mondoo-operator-controller-manager ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  n/a score: U
 mondoo-operator/mondoo-client-k8s-scan             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% score: A
 mondoo-operator/mondoo-client-node-minikube        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% score: A

 2/5 scanned 3/5 n/a                                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%

```