### PR TITLE
🐛⭐ fix variants execution

### DIFF
--- a/examples/complex.mql.yaml
+++ b/examples/complex.mql.yaml
@@ -9,7 +9,7 @@ policies:
         email: hello@mondoo.com
     groups:
       - title: Common SSH checks
-        filters: platform.family.contains("unix")
+        filters: asset.family.contains("unix")
         checks:
           - uid: sshd-01
             title: Set the port to 22
@@ -42,6 +42,11 @@ policies:
         queries:
           # In this case, we are using a shared query that is defined below
           - uid: uname
+        checks:
+          - uid: check-os
+            variants:
+              - uid: check-os-unix
+              - uid: check-os-windows
 
 queries:
   # This is a composed query which has two variants: one for unix type systems
@@ -58,3 +63,12 @@ queries:
   - uid: windows-uname
     mql: command("uname").stdout
     filters: asset.family.contains("windows")
+
+  - uid: check-os-unix
+    filters: asset.family.contains("unix")
+    title: A check only run on Linux/macOS
+    mql: users.contains(name == "root")
+  - uid: check-os-windows
+    filters: asset.family.contains("windows")
+    title: A check only run on Windows
+    mql: users.contains(name == "Administrator")

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -749,14 +749,6 @@ func (c *bundleCache) precompileQuery(query *explorer.Mquery, policy *Policy) *e
 		return nil
 	}
 
-	// filters will need to be aggregated into the pack's filters
-	if policy != nil {
-		if err := policy.ComputedFilters.RegisterQuery(query, c.lookupQuery); err != nil {
-			c.errors = append(c.errors, errors.New("failed to register filters for query "+query.Mrn))
-			return nil
-		}
-	}
-
 	// ensure MRNs for variants
 	for i := range query.Variants {
 		variant := query.Variants[i]
@@ -767,6 +759,15 @@ func (c *bundleCache) precompileQuery(query *explorer.Mquery, policy *Policy) *e
 		}
 		if uid != "" {
 			c.uid2mrn[uid] = variant.Mrn
+		}
+	}
+
+	// Filters will need to be aggregated into the pack's filters
+	// note: must happen after all MRNs (including variants) are computed
+	if policy != nil {
+		if err := policy.ComputedFilters.RegisterQuery(query, c.lookupQuery); err != nil {
+			c.errors = append(c.errors, errors.New("failed to register filters for query "+query.Mrn))
+			return nil
 		}
 	}
 

--- a/policy/bundle_map.go
+++ b/policy/bundle_map.go
@@ -282,7 +282,11 @@ func (p *PolicyBundleMap) policyExists(ctx context.Context, mrn string) (bool, e
 func (bundle *PolicyBundleMap) QueryMap() map[string]*explorer.Mquery {
 	res := make(map[string]*explorer.Mquery, len(bundle.Queries))
 	for _, v := range bundle.Queries {
-		res[v.CodeId] = v
+		if v.CodeId != "" {
+			res[v.CodeId] = v
+		} else {
+			res[v.Mrn] = v
+		}
 	}
 	return res
 }

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -23,7 +23,7 @@ func TestBundleFromPaths(t *testing.T) {
 		bundle, err := BundleFromPaths("../examples/complex.mql.yaml")
 		require.NoError(t, err)
 		require.NotNil(t, bundle)
-		assert.Len(t, bundle.Queries, 3)
+		assert.Len(t, bundle.Queries, 5)
 		assert.Len(t, bundle.Policies, 2)
 	})
 

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -57,7 +57,11 @@ func (s *LocalServices) PreparePolicy(ctx context.Context, policyObj *Policy, bu
 		return nil, nil, status.Error(codes.InvalidArgument, "policy mrn is required")
 	}
 
-	policyObj.RefreshLocalAssetFilters()
+	var queriesLookup map[string]*explorer.Mquery
+	if bundle != nil {
+		queriesLookup = bundle.Queries
+	}
+	policyObj.RefreshLocalAssetFilters(queriesLookup)
 
 	// TODO: we need to decide if it is up to the caller to ensure that the checksum is up-to-date
 	// e.g. ApplyScoringMutation changes the group. Right now we assume the caller invalidates the checksum
@@ -371,7 +375,7 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 
 			if nuPolicy.ComputedFilters == nil {
 				log.Error().Str("new-policy-mrn", policy.Mrn).Str("caller", mpolicyObj.Mrn).Msg("received a policy with nil ComputedFilters")
-				nuPolicy.RefreshLocalAssetFilters()
+				nuPolicy.RefreshLocalAssetFilters(bundleMap.Queries)
 			}
 
 			for k, v := range nuPolicy.ComputedFilters.Items {


### PR DESCRIPTION
Allows for variants in checks and queries to be properly executed in v8 (as planned).

The complex policy has been expanded with examples of variants in both checks and queries. We ... could reduce one of those, it's getting full in there, but it does get the point across. See `examples/complex.mql.yaml`

You'll get this output on a Linux system with the above policy:

![image](https://user-images.githubusercontent.com/1307529/225550401-a9353e82-037d-42a9-8d88-95597ff44c15.png)

As you can see: only one of the queries survived and returned the `uname -a` output, while the windows query variant was not run. We don't get more info on the default CLI output and frankly it's great to not confuse it.

Additionally only "A check only run on Linux/macOS" is executed, while the windows variant of the check is not run. We decided to keep the check's metadata, but should probably aggregate it better in a follow-up (e.g. if the base variant doesn't have a title, pull it from the parent...). 

Finally, if used with json output:

![image](https://user-images.githubusercontent.com/1307529/225551095-259c5eb1-4bbc-4b76-8339-ce80d66b7c26.png)

You can see both the variant check and its parent check being returned in the JSON data structure. Data queries are of course only returned for the executed query itself (and in the future these will be even stronger tied to the actual datafield and less to the query).
