### PR TITLE
Modify ComputeAssetFilters to take variants into account

### DIFF
--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnspec/policy"
+	"google.golang.org/protobuf/proto"
 )
 
 // this section lists internal data structures that map additional metadata
@@ -69,7 +70,7 @@ func (db *Db) GetProperty(ctx context.Context, mrn string) (*explorer.Property, 
 	if !ok {
 		return nil, errors.New("query '" + mrn + "' not found")
 	}
-	return q.(*explorer.Property), nil
+	return proto.Clone(q.(*explorer.Property)).(*explorer.Property), nil
 }
 
 // SetProperty stores a given query
@@ -88,7 +89,7 @@ func (db *Db) GetRawPolicy(ctx context.Context, mrn string) (*policy.Policy, err
 	if !ok {
 		return nil, errors.New("policy '" + mrn + "' not found")
 	}
-	return (q.(wrapPolicy)).Policy, nil
+	return proto.Clone((q.(wrapPolicy)).Policy).(*policy.Policy), nil
 }
 
 // GetPolicyFilters retrieves the list of asset filters for a policy (fast)
@@ -105,7 +106,7 @@ func (db *Db) GetPolicyFilters(ctx context.Context, mrn string) ([]*explorer.Mqu
 	res := make([]*explorer.Mquery, len(r.ComputedFilters.Items))
 	var i int
 	for _, v := range r.ComputedFilters.Items {
-		res[i] = v
+		res[i] = proto.Clone(v).(*explorer.Mquery)
 		i++
 	}
 
@@ -376,7 +377,7 @@ func (db *Db) GetValidatedBundle(ctx context.Context, mrn string) (*policy.Bundl
 		return nil, errors.New("failed to save policy bundle '" + policyv.Mrn + "' to cache")
 	}
 
-	return bundle, nil
+	return proto.Clone(bundle).(*policy.Bundle), nil
 }
 
 // GetValidatedPolicy retrieves and if necessary updates the policy
@@ -394,7 +395,7 @@ func (db *Db) GetValidatedPolicy(ctx context.Context, mrn string) (*policy.Polic
 		}
 	}
 
-	return p.Policy, nil
+	return proto.Clone(p.Policy).(*policy.Policy), nil
 }
 
 func (db *Db) fixInvalidatedPolicy(ctx context.Context, wrap *wrapPolicy) error {

--- a/internal/datalakes/inmemory/policyresolver.go
+++ b/internal/datalakes/inmemory/policyresolver.go
@@ -150,6 +150,7 @@ func (db *Db) refreshAssetFilters(ctx context.Context, policyw *wrapPolicy) erro
 	policyObj := policyw.Policy
 	filters, err := policyObj.ComputeAssetFilters(ctx,
 		func(ctx context.Context, mrn string) (*policy.Policy, error) { return db.GetRawPolicy(ctx, mrn) },
+		func(ctx context.Context, mrn string) (*explorer.Mquery, error) { return db.GetQuery(ctx, mrn) },
 		false,
 	)
 	if err != nil {


### PR DESCRIPTION
The following example was not working:
```
policies:
  # This is a second policy in the same bundle
  - uid: example2
    name: Another policy
    version: "1.0.0"
    groups:
      # Additionally it defines some queries of its own
      - type: chapter
        title: Hello World
        filters: asset.platform == "arch" || asset.platform == "asdf"
        checks:
          - uid: helloworld
            variants:
              - uid: helloworld1
              - uid: helloworld2
queries:
- uid: helloworld1
  title: Hello World Query
  filters: asset.platform == "arch"
  query: |
    "hello" == "hello"
- uid: helloworld2
  filters: asset.platform == "asdf"
  title: Hello World Query
  query: |
    "hello" == "world"
```

My platform is arch. I would expect helloworld1 to run. Instead, no queries run and I get a `U`

I'm not sure of the following:
- Why do we need both RefreshLocalAssetFilters and ComputeAssetFilters
- Why was ComputeBundle not using ComputeAssetFilters to recalculate the
  filters

I've also changed the inmemory database implementation to make a copy of the data it returns. I was running into issues where functions would get data from the db and scribble on it, affecting the data in the db. Now that I think about it, it probably should be copied on the way in as well

requires https://github.com/mondoohq/cnquery/pull/1077