### PR TITLE
⭐ allow specifying a proxy just for Mondoo API connections

### DIFF
--- a/apps/cnspec/cmd/bundle.go
+++ b/apps/cnspec/cmd/bundle.go
@@ -13,7 +13,6 @@ import (
 	cnquery_cmd "go.mondoo.com/cnquery/apps/cnquery/cmd"
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/config"
-	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"go.mondoo.com/cnspec/internal/bundle"
 	"go.mondoo.com/cnspec/policy"
@@ -203,11 +202,11 @@ var policyPublishCmd = &cobra.Command{
 			os.Exit(cnquery_cmd.ConfigurationErrorCode)
 		}
 
-		rangerClient, err := rangerclient.NewRangerClient()
+		httpClient, err := opts.GetHttpClient()
 		if err != nil {
 			log.Fatal().Err(err).Msg("error while creating Mondoo API client")
 		}
-		queryHubServices, err := policy.NewPolicyHubClient(opts.UpstreamApiEndpoint(), rangerClient, certAuth)
+		queryHubServices, err := policy.NewPolicyHubClient(opts.UpstreamApiEndpoint(), httpClient, certAuth)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not connect to policy hub")
 		}

--- a/apps/cnspec/cmd/bundle.go
+++ b/apps/cnspec/cmd/bundle.go
@@ -13,10 +13,10 @@ import (
 	cnquery_cmd "go.mondoo.com/cnquery/apps/cnquery/cmd"
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/config"
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"go.mondoo.com/cnspec/internal/bundle"
 	"go.mondoo.com/cnspec/policy"
-	"go.mondoo.com/ranger-rpc"
 )
 
 func init() {
@@ -202,7 +202,12 @@ var policyPublishCmd = &cobra.Command{
 			log.Error().Err(err).Msg(errorMessageServiceAccount)
 			os.Exit(cnquery_cmd.ConfigurationErrorCode)
 		}
-		queryHubServices, err := policy.NewPolicyHubClient(opts.UpstreamApiEndpoint(), ranger.DefaultHttpClient(), certAuth)
+
+		rangerClient, err := rangerclient.NewRangerClient()
+		if err != nil {
+			log.Fatal().Err(err).Msg("error while creating Mondoo API client")
+		}
+		queryHubServices, err := policy.NewPolicyHubClient(opts.UpstreamApiEndpoint(), rangerClient, certAuth)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not connect to policy hub")
 		}

--- a/apps/cnspec/cmd/login.go
+++ b/apps/cnspec/cmd/login.go
@@ -14,6 +14,7 @@ import (
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/cli/sysinfo"
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/plugins/authentication/statictoken"
@@ -63,6 +64,10 @@ func register(token string) {
 	apiEndpoint := viper.GetString("api_endpoint")
 	token = strings.TrimSpace(token)
 
+	rangerClient, err := rangerclient.NewRangerClient()
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while setting up HTTP client")
+	}
 	// we handle three cases here:
 	// 1. user has a token provided
 	// 2. user has no token provided, but has a service account file is already there
@@ -92,7 +97,7 @@ func register(token string) {
 		plugins = append(plugins, defaultPlugins...)
 		plugins = append(plugins, statictoken.NewRangerPlugin(token))
 
-		client, err := upstream.NewAgentManagerClient(apiEndpoint, ranger.DefaultHttpClient(), plugins...)
+		client, err := upstream.NewAgentManagerClient(apiEndpoint, rangerClient, plugins...)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not connect to mondoo platform")
 		}
@@ -162,7 +167,7 @@ func register(token string) {
 			}
 			plugins = append(plugins, certAuth)
 
-			client, err := upstream.NewAgentManagerClient(apiEndpoint, ranger.DefaultHttpClient(), plugins...)
+			client, err := upstream.NewAgentManagerClient(apiEndpoint, rangerClient, plugins...)
 			if err != nil {
 				log.Fatal().Err(err).Msg("could not connect to Mondoo Platform")
 			}
@@ -211,7 +216,7 @@ func register(token string) {
 		os.Exit(cnquery_cmd.ConfigurationErrorCode)
 	}
 	plugins = append(plugins, certAuth)
-	client, err := upstream.NewAgentManagerClient(apiEndpoint, ranger.DefaultHttpClient(), plugins...)
+	client, err := upstream.NewAgentManagerClient(apiEndpoint, rangerClient, plugins...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not connect to mondoo platform")
 	}

--- a/apps/cnspec/cmd/logout.go
+++ b/apps/cnspec/cmd/logout.go
@@ -11,8 +11,8 @@ import (
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/cli/sysinfo"
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
-	"go.mondoo.com/ranger-rpc"
 	"sigs.k8s.io/yaml"
 )
 
@@ -65,7 +65,11 @@ the credentials cannot be used in future anymore.
 		}
 		plugins = append(plugins, certAuth)
 
-		client, err := upstream.NewAgentManagerClient(opts.UpstreamApiEndpoint(), ranger.DefaultHttpClient(), plugins...)
+		rangerClient, err := rangerclient.NewRangerClient()
+		if err != nil {
+			log.Fatal().Err(err).Msg("error while creating Mondoo API client")
+		}
+		client, err := upstream.NewAgentManagerClient(opts.UpstreamApiEndpoint(), rangerClient, plugins...)
 		if err != nil {
 			log.Error().Err(err).Msg("could not initialize connection to Mondoo Platform")
 			os.Exit(cnquery_cmd.ConfigurationErrorCode)

--- a/apps/cnspec/cmd/logout.go
+++ b/apps/cnspec/cmd/logout.go
@@ -11,7 +11,6 @@ import (
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/cli/sysinfo"
-	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"sigs.k8s.io/yaml"
 )
@@ -65,11 +64,11 @@ the credentials cannot be used in future anymore.
 		}
 		plugins = append(plugins, certAuth)
 
-		rangerClient, err := rangerclient.NewRangerClient()
+		httpClient, err := opts.GetHttpClient()
 		if err != nil {
 			log.Fatal().Err(err).Msg("error while creating Mondoo API client")
 		}
-		client, err := upstream.NewAgentManagerClient(opts.UpstreamApiEndpoint(), rangerClient, plugins...)
+		client, err := upstream.NewAgentManagerClient(opts.UpstreamApiEndpoint(), httpClient, plugins...)
 		if err != nil {
 			log.Error().Err(err).Msg("could not initialize connection to Mondoo Platform")
 			os.Exit(cnquery_cmd.ConfigurationErrorCode)

--- a/apps/cnspec/cmd/root.go
+++ b/apps/cnspec/cmd/root.go
@@ -94,8 +94,10 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().String("log-level", "info", "Set log level: error, warn, info, debug, trace")
+	rootCmd.PersistentFlags().String("api-proxy", "", "Set proxy for communications with Mondoo API")
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	viper.BindPFlag("api-proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
 	viper.BindEnv("features")
 
 	config.Init(rootCmd)

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -506,11 +506,18 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 			log.Warn().Err(err).Msg("could not gather client information")
 		}
 		plugins = append(plugins, defaultRangerPlugins(sysInfo, opts.GetFeatures())...)
+		httpClient, err := opts.GetHttpClient()
+		if err != nil {
+			log.Error().Err(err).Msg("error setting up httpclient")
+			os.Exit(cnquery_cmd.ConfigurationErrorCode)
+
+		}
 		log.Info().Msg("using service account credentials")
 		conf.UpstreamConfig = &resources.UpstreamConfig{
 			SpaceMrn:    opts.GetParentMrn(),
 			ApiEndpoint: opts.UpstreamApiEndpoint(),
 			Plugins:     plugins,
+			HttpClient:  httpClient,
 		}
 	}
 
@@ -562,7 +569,7 @@ func RunScan(config *scanConfig, opts ...scan.ScannerOption) (*policy.ReportColl
 	scannerOpts = append(scannerOpts, opts...)
 
 	if config.UpstreamConfig != nil {
-		scannerOpts = append(scannerOpts, scan.WithUpstream(config.UpstreamConfig.ApiEndpoint, config.UpstreamConfig.SpaceMrn), scan.WithPlugins(config.UpstreamConfig.Plugins))
+		scannerOpts = append(scannerOpts, scan.WithUpstream(config.UpstreamConfig.ApiEndpoint, config.UpstreamConfig.SpaceMrn, config.UpstreamConfig.HttpClient), scan.WithPlugins(config.UpstreamConfig.Plugins))
 	}
 
 	// show warning to the user of the policy filter container a bundle file name

--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -70,14 +70,20 @@ var serveApiCmd = &cobra.Command{
 			log.Warn().Err(err).Msg("could not gather client information")
 		}
 		plugins = append(plugins, defaultRangerPlugins(sysInfo, opts.GetFeatures())...)
+		httpClient, err := opts.GetHttpClient()
+		if err != nil {
+			log.Error().Err(err).Msg("error seting up http client")
+			os.Exit(cnquery_cmd.ConfigurationErrorCode)
+		}
 		log.Info().Msg("using service account credentials")
 		upstreamConfig := resources.UpstreamConfig{
 			SpaceMrn:    opts.GetParentMrn(),
 			ApiEndpoint: opts.UpstreamApiEndpoint(),
 			Plugins:     plugins,
+			HttpClient:  httpClient,
 		}
 
-		scanner := scan.NewLocalScanner(scan.WithUpstream(upstreamConfig.ApiEndpoint, upstreamConfig.SpaceMrn), scan.WithPlugins(plugins), scan.DisableProgressBar())
+		scanner := scan.NewLocalScanner(scan.WithUpstream(upstreamConfig.ApiEndpoint, upstreamConfig.SpaceMrn, upstreamConfig.HttpClient), scan.WithPlugins(plugins), scan.DisableProgressBar())
 		if err := scanner.EnableQueue(); err != nil {
 			log.Fatal().Err(err).Msg("could not enable scan queue")
 		}

--- a/apps/cnspec/cmd/status.go
+++ b/apps/cnspec/cmd/status.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/local"
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"go.mondoo.com/cnquery/upstream/health"
 	"go.mondoo.com/ranger-rpc"
@@ -103,7 +104,11 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 			plugins = append(plugins, certAuth)
 
 			// try to ping the server
-			client, err := upstream.NewAgentManagerClient(s.Upstream.API.Endpoint, ranger.DefaultHttpClient(), plugins...)
+			rangerClient, err := rangerclient.NewRangerClient()
+			if err != nil {
+				log.Fatal().Err(err).Msg("error while creating Mondoo API client")
+			}
+			client, err := upstream.NewAgentManagerClient(s.Upstream.API.Endpoint, rangerClient, plugins...)
 			if err == nil {
 				_, err = client.PingPong(context.Background(), &upstream.Ping{})
 				if err != nil {

--- a/apps/cnspec/cmd/status.go
+++ b/apps/cnspec/cmd/status.go
@@ -19,7 +19,6 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/local"
-	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/cnquery/upstream"
 	"go.mondoo.com/cnquery/upstream/health"
 	"go.mondoo.com/ranger-rpc"
@@ -67,6 +66,11 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 			log.Fatal().Err(err).Send()
 		}
 
+		httpClient, err := opts.GetHttpClient()
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to set up Mondoo API client")
+		}
+
 		sysInfo, err := sysinfo.GatherSystemInfo(sysinfo.WithMotor(m))
 		if err == nil {
 			s.Client.Platform = sysInfo.Platform
@@ -75,7 +79,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		}
 
 		// check server health and clock skew
-		upstreamStatus, err := health.CheckApiHealth(opts.UpstreamApiEndpoint())
+		upstreamStatus, err := health.CheckApiHealth(httpClient, opts.UpstreamApiEndpoint())
 		if err != nil {
 			log.Error().Err(err).Msg("could not check upstream health")
 		}
@@ -104,11 +108,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 			plugins = append(plugins, certAuth)
 
 			// try to ping the server
-			rangerClient, err := rangerclient.NewRangerClient()
-			if err != nil {
-				log.Fatal().Err(err).Msg("error while creating Mondoo API client")
-			}
-			client, err := upstream.NewAgentManagerClient(s.Upstream.API.Endpoint, rangerClient, plugins...)
+			client, err := upstream.NewAgentManagerClient(s.Upstream.API.Endpoint, httpClient, plugins...)
 			if err == nil {
 				_, err = client.PingPong(context.Background(), &upstream.Ping{})
 				if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,10 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
 	// joel's cnquery for now
-	go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96
-	go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5
+	go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0
+	go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009
 	go.opentelemetry.io/otel v1.14.0
-	golang.org/x/sync v0.1.0
+	golang.org/x/sync v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.mondoo.com/cnspec
 
 go 1.19
 
+replace github.com/slack-go/slack v0.12.1 => github.com/imilchev/slack v0.0.0-20230324120548-5380d7dd00a5
+
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cockroachdb/errors v1.9.1
@@ -26,9 +28,8 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	// joel's cnquery for now
-	go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0
-	go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009
+	go.mondoo.com/cnquery v0.0.0-20230328163439-27fcddaefc71
+	go.mondoo.com/ranger-rpc v0.0.0-20230328135530-12135c17095f
 	go.opentelemetry.io/otel v1.14.0
 	golang.org/x/sync v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
@@ -422,7 +423,7 @@ require (
 	github.com/sivchari/containedctx v1.0.2 // indirect
 	github.com/sivchari/nosnakecase v1.7.0 // indirect
 	github.com/sivchari/tenv v1.7.1 // indirect
-	github.com/slack-go/slack v0.11.4 // indirect
+	github.com/slack-go/slack v0.12.1 // indirect
 	github.com/sonatard/noctx v0.0.1 // indirect
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,9 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	go.mondoo.com/cnquery v0.0.0-20230321163439-9786ebf33b26
-	go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34
+	// joel's cnquery/ranger for now
+	go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684
+	go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2
 	go.opentelemetry.io/otel v1.14.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f

--- a/go.mod
+++ b/go.mod
@@ -26,9 +26,9 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	// joel's cnquery/ranger for now
-	go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684
-	go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2
+	// joel's cnquery for now
+	go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96
+	go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5
 	go.opentelemetry.io/otel v1.14.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f

--- a/go.sum
+++ b/go.sum
@@ -791,6 +791,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imilchev/slack v0.0.0-20230324120548-5380d7dd00a5 h1:aNFjgSeqhIzc+g0SyzXxypHI87MzN32fCd2kI6OD/1o=
+github.com/imilchev/slack v0.0.0-20230324120548-5380d7dd00a5/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -1213,8 +1215,6 @@ github.com/sivchari/nosnakecase v1.7.0 h1:7QkpWIRMe8x25gckkFd2A5Pi6Ymo0qgr4JrhGt
 github.com/sivchari/nosnakecase v1.7.0/go.mod h1:CwDzrzPea40/GB6uynrNLiorAlgFRvRbFSgJx2Gs+QY=
 github.com/sivchari/tenv v1.7.1 h1:PSpuD4bu6fSmtWMxSGWcvqUUgIn7k3yOJhOIzVWn8Ak=
 github.com/sivchari/tenv v1.7.1/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl018Icvg=
-github.com/slack-go/slack v0.11.4 h1:ojSa7KlPm3PqY2AomX4VTxEsK5eci5JaxCjlzGV5zoM=
-github.com/slack-go/slack v0.11.4/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -1344,10 +1344,10 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0 h1:Mi70LvlhicGyjCOMJ/OL73nhNzZcqZNyY5AYqxk/SmU=
-go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0/go.mod h1:IaO6/QFKeMsSNElZWRKk6CdjBi8ye3dH6FQ0TiQUjLc=
-go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009 h1:IcLP8/sxXoYgtTI1zkTHgehMkdUUF0CkTh5zsLJe9sU=
-go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
+go.mondoo.com/cnquery v0.0.0-20230328163439-27fcddaefc71 h1:6e9rvxGVnwxA2uwjSG7sVv5SDuSCTz5FaW5xsaoK5dc=
+go.mondoo.com/cnquery v0.0.0-20230328163439-27fcddaefc71/go.mod h1:+s3BWL2KwtEm36pm+FNtdZ1op1n+hdIzWfTkb6hkI6E=
+go.mondoo.com/ranger-rpc v0.0.0-20230328135530-12135c17095f h1:l8N+cU5Ul8+NzC3DtyjrUqpzSDpPQDnGqvxpwMz7CMw=
+go.mondoo.com/ranger-rpc v0.0.0-20230328135530-12135c17095f/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -1344,10 +1344,10 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20230321163439-9786ebf33b26 h1:y8qE52qMNRqb/9B5/4EY04Y8hoj5DMC8EM4GDEjC47w=
-go.mondoo.com/cnquery v0.0.0-20230321163439-9786ebf33b26/go.mod h1:8GAmoT3wwGRp7lru1K13r/mDIN2Yq8Ri0mgEPGjK0SE=
-go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34 h1:mtPZ1J+nRI/ivV+n41bjIwY6Rfxb2Jf49svZSQMGHIA=
-go.mondoo.com/ranger-rpc v0.5.1-0.20220923135836-9e7732899d34/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
+go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684 h1:GkEpSaU9uaRaZaF/sY1eHJBk5xMzPV6VhCiOFhKTYg4=
+go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684/go.mod h1:Q1r9SdtEbQxXifyHN4HmV7L2NDP6cQDx5VhlLEGWELw=
+go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2 h1:tIATr5bPaUfDgHVszLI1Ts+sBUa4hoAutN2kNCqE0LY=
+go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -1344,10 +1344,10 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96 h1:ZnVKGDS5/2ze2jxhehRfwfoWax5h92kYSz9WuURO2oc=
-go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96/go.mod h1:5H4lL4yUTCVnhOHChc3BE0PRIUCk7jBzbVfYWFopgdA=
-go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5 h1:8T17y5Q3J8QhNDAMIYN0KfhnvFhiqzqIvKpOesMRE9g=
-go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
+go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0 h1:Mi70LvlhicGyjCOMJ/OL73nhNzZcqZNyY5AYqxk/SmU=
+go.mondoo.com/cnquery v0.0.0-20230328140056-8a0d9fbee3d0/go.mod h1:IaO6/QFKeMsSNElZWRKk6CdjBi8ye3dH6FQ0TiQUjLc=
+go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009 h1:IcLP8/sxXoYgtTI1zkTHgehMkdUUF0CkTh5zsLJe9sU=
+go.mondoo.com/ranger-rpc v0.0.0-20230328124904-31ca0d483009/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -1344,10 +1344,10 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
-go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684 h1:GkEpSaU9uaRaZaF/sY1eHJBk5xMzPV6VhCiOFhKTYg4=
-go.mondoo.com/cnquery v0.0.0-20230323165235-a03c529c8684/go.mod h1:Q1r9SdtEbQxXifyHN4HmV7L2NDP6cQDx5VhlLEGWELw=
-go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2 h1:tIATr5bPaUfDgHVszLI1Ts+sBUa4hoAutN2kNCqE0LY=
-go.mondoo.com/ranger-rpc v0.0.0-20230316222251-d7b69b75dae2/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
+go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96 h1:ZnVKGDS5/2ze2jxhehRfwfoWax5h92kYSz9WuURO2oc=
+go.mondoo.com/cnquery v0.0.0-20230327144612-70806f9f8f96/go.mod h1:5H4lL4yUTCVnhOHChc3BE0PRIUCk7jBzbVfYWFopgdA=
+go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5 h1:8T17y5Q3J8QhNDAMIYN0KfhnvFhiqzqIvKpOesMRE9g=
+go.mondoo.com/ranger-rpc v0.0.0-20230326140211-135247b908c5/go.mod h1:3YKcqFrlPgaB4FZ4EoLgdmRtwMQdO7RoAkZYFn+F1eY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/logger"
-	"go.mondoo.com/ranger-rpc"
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"go.opentelemetry.io/otel"
@@ -278,7 +278,12 @@ func (s *LocalServices) DefaultPolicies(ctx context.Context, req *DefaultPolicie
 		registryEndpoint = defaultRegistryUrl
 	}
 
-	client, err := NewPolicyHubClient(registryEndpoint, ranger.DefaultHttpClient())
+	rangerClient, err := rangerclient.NewRangerClient()
+	if err != nil {
+		log.Error().Err(err).Msg("error setting up HTTP client")
+		return nil, err
+	}
+	client, err := NewPolicyHubClient(registryEndpoint, rangerClient)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/logger"
-	"go.mondoo.com/cnquery/shared/rangerclient"
+	"go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"go.opentelemetry.io/otel"
@@ -278,12 +278,9 @@ func (s *LocalServices) DefaultPolicies(ctx context.Context, req *DefaultPolicie
 		registryEndpoint = defaultRegistryUrl
 	}
 
-	rangerClient, err := rangerclient.NewRangerClient()
-	if err != nil {
-		log.Error().Err(err).Msg("error setting up HTTP client")
-		return nil, err
-	}
-	client, err := NewPolicyHubClient(registryEndpoint, rangerClient)
+	// Note, this does not use the proxy config override from the mondoo.yml since we only get here when
+	// it is used without upstream config
+	client, err := NewPolicyHubClient(registryEndpoint, ranger.DefaultHttpClient())
 	if err != nil {
 		return nil, err
 	}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -58,10 +58,11 @@ type LocalScanner struct {
 
 type ScannerOption func(*LocalScanner)
 
-func WithUpstream(apiEndpoint string, spaceMrn string) ScannerOption {
+func WithUpstream(apiEndpoint string, spaceMrn string, httpClient *http.Client) ScannerOption {
 	return func(s *LocalScanner) {
 		s.apiEndpoint = apiEndpoint
 		s.spaceMrn = spaceMrn
+		s.httpClient = httpClient
 	}
 }
 
@@ -538,6 +539,7 @@ func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) (resources.Up
 	}
 	endpoint := s.apiEndpoint
 	spaceMrn := s.spaceMrn
+	httpClient := s.httpClient
 
 	jobCredentials := job.Inventory.Spec.UpstreamCredentials
 	if s.allowJobCredentials && jobCredentials != nil {
@@ -558,12 +560,16 @@ func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) (resources.Up
 	if spaceMrn == "" {
 		return resources.UpstreamConfig{}, errors.New("missing space mrn")
 	}
+	if httpClient == nil {
+		return resources.UpstreamConfig{}, errors.New("empty httpclient")
+	}
 
 	return resources.UpstreamConfig{
 		SpaceMrn:    spaceMrn,
 		ApiEndpoint: endpoint,
 		Incognito:   false,
 		Plugins:     plugins,
+		HttpClient:  httpClient,
 	}, nil
 }
 

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -51,6 +52,7 @@ type LocalScanner struct {
 	apiEndpoint        string
 	spaceMrn           string
 	pluginsMap         map[string]ranger.ClientPlugin
+	httpClient         *http.Client
 	disableProgressBar bool
 }
 
@@ -302,7 +304,7 @@ func (s *LocalScanner) RunAssetJob(job *AssetJob) {
 	var err error
 	if job.UpstreamConfig.ApiEndpoint != "" && !job.UpstreamConfig.Incognito {
 		log.Debug().Msg("using API endpoint " + job.UpstreamConfig.ApiEndpoint)
-		upstream, err = policy.NewRemoteServices(job.UpstreamConfig.ApiEndpoint, job.UpstreamConfig.Plugins)
+		upstream, err = policy.NewRemoteServices(job.UpstreamConfig.ApiEndpoint, job.UpstreamConfig.Plugins, s.httpClient)
 		if err != nil {
 			log.Error().Err(err).Msg("could not connect to upstream")
 		}
@@ -399,7 +401,7 @@ func (s *LocalScanner) runMotorizedAsset(job *AssetJob) (*AssetReport, error) {
 	runtimeErr := inmemory.WithDb(s.resolvedPolicyCache, func(db *inmemory.Db, services *policy.LocalServices) error {
 		if job.UpstreamConfig.ApiEndpoint != "" && !job.UpstreamConfig.Incognito {
 			log.Debug().Msg("using API endpoint " + job.UpstreamConfig.ApiEndpoint)
-			upstream, err := policy.NewRemoteServices(job.UpstreamConfig.ApiEndpoint, job.UpstreamConfig.Plugins)
+			upstream, err := policy.NewRemoteServices(job.UpstreamConfig.ApiEndpoint, job.UpstreamConfig.Plugins, s.httpClient)
 			if err != nil {
 				return err
 			}
@@ -480,7 +482,7 @@ func (s *LocalScanner) GarbageCollectAssets(ctx context.Context, garbageCollectO
 	for _, p := range s.pluginsMap {
 		plugins = append(plugins, p)
 	}
-	pClient, err := policy.NewRemoteServices(s.apiEndpoint, plugins)
+	pClient, err := policy.NewRemoteServices(s.apiEndpoint, plugins, s.httpClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize asset synchronization")
 	}

--- a/policy/services.go
+++ b/policy/services.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"go.mondoo.com/cnquery/shared/rangerclient"
+	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/ranger-rpc"
-	"golang.org/x/sync/semaphore"
 )
 
 type ResolvedPolicyVersion string
@@ -50,20 +49,20 @@ func NewLocalServices(datalake DataLake, uuid string) *LocalServices {
 }
 
 // NewRemoteServices initializes a services struct with a remote endpoint
-func NewRemoteServices(addr string, auth []ranger.ClientPlugin) (*Services, error) {
-	client, err := rangerclient.NewRangerClient()
-	if err != nil {
-		return nil, err
+func NewRemoteServices(addr string, auth []ranger.ClientPlugin, httpClient *http.Client) (*Services, error) {
+	if httpClient == nil {
+		httpClient = ranger.DefaultHttpClient()
 	}
+
 	// restrict parallel upstream connections to two connections
-	client.Transport = NewMaxParallelConnTransport(client.Transport, 2)
+	httpClient.Transport = explorer.NewMaxParallelConnTransport(httpClient.Transport, 2)
 
-	policyHub, err := NewPolicyHubClient(addr, client, auth...)
+	policyHub, err := NewPolicyHubClient(addr, httpClient, auth...)
 	if err != nil {
 		return nil, err
 	}
 
-	policyResolver, err := NewPolicyResolverClient(addr, client, auth...)
+	policyResolver, err := NewPolicyResolverClient(addr, httpClient, auth...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,33 +71,4 @@ func NewRemoteServices(addr string, auth []ranger.ClientPlugin) (*Services, erro
 		PolicyHub:      policyHub,
 		PolicyResolver: policyResolver,
 	}, nil
-}
-
-// MaxParallelConnHTTPTransport restricts the parallel connections that the client is doing upstream.
-// This has many advantages:
-// - we do not run into max ulimit issues because of parallel execution
-// - we do not ddos our server in case something is wrong upstream
-// - implementing this as http.RoundTripper has the advantage that the http timeout still applies and calls are canceled properly on the client-side
-type MaxParallelConnHTTPTransport struct {
-	transport     http.RoundTripper
-	parallelConns *semaphore.Weighted
-}
-
-// RoundTrip executes a single HTTP transaction, returning
-// a Response for the provided Request.
-func (t *MaxParallelConnHTTPTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	err := t.parallelConns.Acquire(r.Context(), 1)
-	if err != nil {
-		return nil, err
-	}
-	defer t.parallelConns.Release(1)
-	return t.transport.RoundTrip(r)
-}
-
-// NewMaxParallelConnTransport creates a transport with parallel HTTP connections
-func NewMaxParallelConnTransport(transport http.RoundTripper, parallel int64) *MaxParallelConnHTTPTransport {
-	return &MaxParallelConnHTTPTransport{
-		transport:     transport,
-		parallelConns: semaphore.NewWeighted(parallel),
-	}
 }

--- a/policy/services.go
+++ b/policy/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"go.mondoo.com/cnquery/shared/rangerclient"
 	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/sync/semaphore"
 )
@@ -50,7 +51,10 @@ func NewLocalServices(datalake DataLake, uuid string) *LocalServices {
 
 // NewRemoteServices initializes a services struct with a remote endpoint
 func NewRemoteServices(addr string, auth []ranger.ClientPlugin) (*Services, error) {
-	client := ranger.DefaultHttpClient()
+	client, err := rangerclient.NewRangerClient()
+	if err != nil {
+		return nil, err
+	}
 	// restrict parallel upstream connections to two connections
 	client.Transport = NewMaxParallelConnTransport(client.Transport, 2)
 


### PR DESCRIPTION
Allow cnspec to be told to use a specific proxy for connections to the Mondoo API. In high-to-low order of precedence:

1) MONDOO_API_PROXY env var
2) --api-proxy CLI param
3) api_proxy value in config file

Update the various places in cnspec where connections are set up for the Mondoo API to use the httpclient with proxy.