### PR TITLE
Add functions to remove add and remove ratings from score dist

### DIFF
--- a/policy/report.go
+++ b/policy/report.go
@@ -66,9 +66,16 @@ func (s *Stats) Add(score *Score) {
 }
 
 func (sd *ScoreDistribution) Add(score *Score) {
-	sd.Total++
+	sd.AddRating(score.Rating())
+}
 
-	switch score.Rating() {
+func (sd *ScoreDistribution) Remove(score *Score) {
+	sd.RemoveRating(score.Rating())
+}
+
+func (sd *ScoreDistribution) AddRating(scoreRating ScoreRating) {
+	sd.Total++
+	switch scoreRating {
 	case ScoreRating_aPlus, ScoreRating_a, ScoreRating_aMinus:
 		sd.A++
 	case ScoreRating_bPlus, ScoreRating_b, ScoreRating_bMinus:
@@ -83,6 +90,26 @@ func (sd *ScoreDistribution) Add(score *Score) {
 		sd.Error++
 	case ScoreRating_unrated:
 		sd.Unrated++
+	}
+}
+
+func (sd *ScoreDistribution) RemoveRating(scoreRating ScoreRating) {
+	sd.Total--
+	switch scoreRating {
+	case ScoreRating_aPlus, ScoreRating_a, ScoreRating_aMinus:
+		sd.A--
+	case ScoreRating_bPlus, ScoreRating_b, ScoreRating_bMinus:
+		sd.B--
+	case ScoreRating_cPlus, ScoreRating_c, ScoreRating_cMinus:
+		sd.C--
+	case ScoreRating_dPlus, ScoreRating_d, ScoreRating_dMinus:
+		sd.D--
+	case ScoreRating_failed:
+		sd.F--
+	case ScoreRating_error:
+		sd.Error--
+	case ScoreRating_unrated:
+		sd.Unrated--
 	}
 }
 

--- a/policy/report.go
+++ b/policy/report.go
@@ -93,6 +93,19 @@ func (sd *ScoreDistribution) AddRating(scoreRating ScoreRating) {
 	}
 }
 
+func (x *ScoreDistribution) AddScoreDistribution(y *ScoreDistribution) *ScoreDistribution {
+	return &ScoreDistribution{
+		Total:   x.GetTotal() + y.GetTotal(),
+		A:       x.GetA() + y.GetA(),
+		B:       x.GetB() + y.GetB(),
+		C:       x.GetC() + y.GetC(),
+		D:       x.GetD() + y.GetD(),
+		F:       x.GetF() + y.GetF(),
+		Error:   x.GetError() + y.GetError(),
+		Unrated: x.GetUnrated() + y.GetUnrated(),
+	}
+}
+
 func (sd *ScoreDistribution) RemoveRating(scoreRating ScoreRating) {
 	sd.Total--
 	switch scoreRating {

--- a/policy/report.go
+++ b/policy/report.go
@@ -65,10 +65,12 @@ func (s *Stats) Add(score *Score) {
 	}
 }
 
+// this function also handles nil scores and updates the score distribution accordingly
 func (sd *ScoreDistribution) Add(score *Score) {
 	sd.AddRating(score.Rating())
 }
 
+// this function also handles nil scores and updates the score distribution accordingly
 func (sd *ScoreDistribution) Remove(score *Score) {
 	sd.RemoveRating(score.Rating())
 }

--- a/policy/report_test.go
+++ b/policy/report_test.go
@@ -24,6 +24,7 @@ func TestScoreDistributionAdd(t *testing.T) {
 	scoreDist.Add(&policy.Score{Value: 5, Type: policy.ScoreType_Result, ScoreCompletion: 100})
 	scoreDist.Add(&policy.Score{Type: policy.ScoreType_Error})
 	scoreDist.Add(&policy.Score{Type: policy.ScoreType_Unscored})
+	scoreDist.Add(nil)
 
 	require.Equal(t, uint32(3), scoreDist.GetA())
 	require.Equal(t, uint32(3), scoreDist.GetB())
@@ -31,21 +32,21 @@ func TestScoreDistributionAdd(t *testing.T) {
 	require.Equal(t, uint32(3), scoreDist.GetD())
 	require.Equal(t, uint32(1), scoreDist.GetF())
 	require.Equal(t, uint32(1), scoreDist.GetError())
-	require.Equal(t, uint32(1), scoreDist.GetUnrated())
+	require.Equal(t, uint32(2), scoreDist.GetUnrated())
 
-	require.Equal(t, uint32(15), scoreDist.GetTotal())
+	require.Equal(t, uint32(16), scoreDist.GetTotal())
 }
 
 func TestScoreDistributionRemove(t *testing.T) {
 	scoreDist := &policy.ScoreDistribution{
-		Total:   18,
+		Total:   19,
 		A:       3,
 		B:       3,
 		C:       3,
 		D:       3,
 		F:       2,
 		Error:   2,
-		Unrated: 2,
+		Unrated: 3,
 	}
 
 	scoreDist.Remove(&policy.Score{Value: 100, Type: policy.ScoreType_Result, ScoreCompletion: 100})
@@ -63,6 +64,8 @@ func TestScoreDistributionRemove(t *testing.T) {
 	scoreDist.Remove(&policy.Score{Value: 5, Type: policy.ScoreType_Result, ScoreCompletion: 100})
 	scoreDist.Remove(&policy.Score{Type: policy.ScoreType_Error})
 	scoreDist.Remove(&policy.Score{Type: policy.ScoreType_Unscored})
+	scoreDist.Remove(nil)
+
 	require.Equal(t, uint32(0), scoreDist.GetA())
 	require.Equal(t, uint32(0), scoreDist.GetB())
 	require.Equal(t, uint32(0), scoreDist.GetC())

--- a/policy/report_test.go
+++ b/policy/report_test.go
@@ -72,3 +72,34 @@ func TestScoreDistributionRemove(t *testing.T) {
 	require.Equal(t, uint32(1), scoreDist.GetUnrated())
 	require.Equal(t, uint32(3), scoreDist.GetTotal())
 }
+
+func TestScoreDistributionAddScoreDist(t *testing.T) {
+	a := &policy.ScoreDistribution{
+		Total:   18,
+		A:       3,
+		B:       3,
+		C:       3,
+		D:       3,
+		F:       2,
+		Error:   2,
+		Unrated: 2,
+	}
+
+	b := &policy.ScoreDistribution{
+		Total:   10,
+		A:       3,
+		B:       3,
+		C:       3,
+		Unrated: 1,
+	}
+	c := a.AddScoreDistribution(b)
+
+	require.Equal(t, uint32(28), c.GetTotal())
+	require.Equal(t, uint32(6), c.GetA())
+	require.Equal(t, uint32(6), c.GetB())
+	require.Equal(t, uint32(6), c.GetC())
+	require.Equal(t, uint32(3), c.GetD())
+	require.Equal(t, uint32(2), c.GetF())
+	require.Equal(t, uint32(2), c.GetError())
+	require.Equal(t, uint32(3), c.GetUnrated())
+}

--- a/policy/report_test.go
+++ b/policy/report_test.go
@@ -1,0 +1,74 @@
+package policy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func TestScoreDistributionAdd(t *testing.T) {
+	scoreDist := &policy.ScoreDistribution{}
+	scoreDist.Add(&policy.Score{Value: 100, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 85, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 80, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 75, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 65, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 60, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 50, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 40, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 30, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 29, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 15, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 10, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Value: 5, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Add(&policy.Score{Type: policy.ScoreType_Error})
+	scoreDist.Add(&policy.Score{Type: policy.ScoreType_Unscored})
+
+	require.Equal(t, uint32(3), scoreDist.GetA())
+	require.Equal(t, uint32(3), scoreDist.GetB())
+	require.Equal(t, uint32(3), scoreDist.GetC())
+	require.Equal(t, uint32(3), scoreDist.GetD())
+	require.Equal(t, uint32(1), scoreDist.GetF())
+	require.Equal(t, uint32(1), scoreDist.GetError())
+	require.Equal(t, uint32(1), scoreDist.GetUnrated())
+
+	require.Equal(t, uint32(15), scoreDist.GetTotal())
+}
+
+func TestScoreDistributionRemove(t *testing.T) {
+	scoreDist := &policy.ScoreDistribution{
+		Total:   18,
+		A:       3,
+		B:       3,
+		C:       3,
+		D:       3,
+		F:       2,
+		Error:   2,
+		Unrated: 2,
+	}
+
+	scoreDist.Remove(&policy.Score{Value: 100, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 85, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 80, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 75, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 65, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 60, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 50, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 40, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 30, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 29, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 15, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 10, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Value: 5, Type: policy.ScoreType_Result, ScoreCompletion: 100})
+	scoreDist.Remove(&policy.Score{Type: policy.ScoreType_Error})
+	scoreDist.Remove(&policy.Score{Type: policy.ScoreType_Unscored})
+	require.Equal(t, uint32(0), scoreDist.GetA())
+	require.Equal(t, uint32(0), scoreDist.GetB())
+	require.Equal(t, uint32(0), scoreDist.GetC())
+	require.Equal(t, uint32(0), scoreDist.GetD())
+	require.Equal(t, uint32(1), scoreDist.GetF())
+	require.Equal(t, uint32(1), scoreDist.GetError())
+	require.Equal(t, uint32(1), scoreDist.GetUnrated())
+	require.Equal(t, uint32(3), scoreDist.GetTotal())
+}


### PR DESCRIPTION
There's already a function to add, based on the `Score` struct. This PR adds a `Remove` function and adds functions to do the same, this time based solely on `ScoreRating`. 