### PR TITLE
⭐️ tar scanning for cnspec

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -139,6 +139,13 @@ You can also explicitly request the scan of an image or a container registry:
 			"container-image": {
 				Short: "Scan a container image.",
 			},
+			"container-tar": {
+				Short: "Scan a container image from a tar file.",
+				Long: `Scan OCI container image. This supports more parameters for different registries:
+
+    cnspec scan container tar /path/to/file.tar
+`,
+			},
 			"container-registry": {
 				Short: "Scan a container registry.",
 				Long: `Scan a container registry. Supports more parameters for different registries:

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -140,10 +140,10 @@ You can also explicitly request the scan of an image or a container registry:
 				Short: "Scan a container image.",
 			},
 			"container-tar": {
-				Short: "Scan a container image from a tar file.",
-				Long: `Scan OCI container image. This supports more parameters for different registries:
+				Short: "Scan an OCI container image from a tar file.",
+				Long: `Scan an OCI container image by providing a path to the tar file: 
 
-    cnspec scan container tar /path/to/file.tar
+    cnspec scan container tar /path/to/image.tar
 `,
 			},
 			"container-registry": {


### PR DESCRIPTION
depends on https://github.com/mondoohq/cnquery/pull/1116 to work properly

related to the discussion in https://github.com/orgs/mondoohq/discussions/855

A simple:

```
docker save debian:11 > debian11.tar  
cnspec scan container tar debian11.tar
```

will then allow you to scan the container image:

<img width="808" alt="Screenshot 2023-03-30 at 14 59 52" src="https://user-images.githubusercontent.com/1178413/228845058-05c87aaa-9fbb-4a3c-b7d5-98d5f8d8a500.png">

