### PR TITLE
🐛 Fix the scoring when scaning with inventory packs

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -373,14 +373,17 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 		r.out.Write([]byte(NewLineCharacter))
 	}
 
-	if len(report.Scores) > 0 {
+	foundControls := map[string]*policy.Score{}
+	for id, score := range report.Scores {
+		_, ok := resolved.CollectorJob.ReportingQueries[id]
+		if !ok {
+			continue
+		}
+		foundControls[id] = score
+	}
+	if len(foundControls) > 0 {
 		r.out.Write([]byte("Controls:" + NewLineCharacter))
-		for id, score := range report.Scores {
-			_, ok := resolved.CollectorJob.ReportingQueries[id]
-			if !ok {
-				continue
-			}
-
+		for id, score := range foundControls {
 			query, ok := queries[id]
 			if !ok {
 				r.out.Write([]byte("Couldn't find any queries for incoming value for " + id))

--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -347,7 +347,7 @@ func (c *worstScoreCalculator) Calculate() *Score {
 func NewScoreCalculator(scoringSystem explorer.ScoringSystem) (ScoreCalculator, error) {
 	var res ScoreCalculator
 	switch scoringSystem {
-	case explorer.ScoringSystem_AVERAGE, explorer.ScoringSystem_SCORING_UNSPECIFIED:
+	case explorer.ScoringSystem_AVERAGE, explorer.ScoringSystem_SCORING_UNSPECIFIED, explorer.ScoringSystem_DATA_ONLY:
 		res = &averageScoreCalculator{}
 	case explorer.ScoringSystem_WEIGHTED:
 		res = &weightedScoreCalculator{}


### PR DESCRIPTION
The score for inventory packs is now unscored and no longer error.

Fixes: #482