### PR TITLE
🐛 Fix empty http client if the scanner does not have upstream config.

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -547,6 +547,8 @@ func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) (resources.Up
 		pluginsCopyMap[certAuth.GetName()] = certAuth
 		endpoint = jobCredentials.GetApiEndpoint()
 		spaceMrn = jobCredentials.GetParentMrn()
+		// TODO: if we want proxy here it has to be defined on UpstreamCredentials proto level too
+		httpClient = ranger.DefaultHttpClient()
 	}
 
 	plugins := []ranger.ClientPlugin{}


### PR DESCRIPTION
If the scanner is expecting job creds instead of pre-provided upstream creds, init the http client to default to avoid crashes