### PR TITLE
🐛 return err if it's not nil in SetBundleMap

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -139,7 +139,7 @@ func (s *LocalServices) SetBundleMap(ctx context.Context, bundleMap *PolicyBundl
 
 	for mrn, query := range bundleMap.Queries {
 		if err := s.setQuery(ctx, mrn, query); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
Seems like a bug. It causes weird behaviour when errors happen since they are ignored