### PR TITLE
⭐️ allow filtering of policies by short mrns

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -3,20 +3,35 @@ package policy
 import (
 	"context"
 	"os"
+	"path"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/logger"
+	"go.mondoo.com/cnquery/mrn"
 	"go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"go.opentelemetry.io/otel"
 )
 
-const defaultRegistryUrl = "https://registry.api.mondoo.com"
+const (
+	defaultRegistryUrl    = "https://registry.api.mondoo.com"
+	RegistryServiceName   = "registry.mondoo.com"
+	CollectionIDNamespace = "namespace"
+	CollectionIDPolicies  = "policies"
+)
 
 var tracer = otel.Tracer("go.mondoo.com/cnspec/policy")
+
+func NewPolicyMrn(namespace string, uid string) string {
+	m := &mrn.MRN{
+		ServiceName:          RegistryServiceName,
+		RelativeResourceName: path.Join(CollectionIDNamespace, namespace, CollectionIDPolicies, uid),
+	}
+	return m.String()
+}
 
 // ValidateBundle and check queries, relationships, MRNs, and versions
 func (s *LocalServices) ValidateBundle(ctx context.Context, bundle *Bundle) (*Empty, error) {

--- a/policy/hub_test.go
+++ b/policy/hub_test.go
@@ -1,0 +1,19 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyMrn(t *testing.T) {
+	// given
+	namespace := "test-namespace"
+	uid := "test-uid"
+
+	// when
+	mrn := NewPolicyMrn(namespace, uid)
+
+	// then
+	assert.Equal(t, "//registry.mondoo.com/namespace/test-namespace/policies/test-uid", mrn)
+}

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -1,0 +1,26 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterPreprocess(t *testing.T) {
+	// given
+	filters := []string{
+		"namespace1/policy1",
+		"namespace2/policy2",
+		"//registry.mondoo.com/namespace/namespace3/policies/policy3",
+	}
+
+	// when
+	preprocessed := preprocessPolicyFilters(filters)
+
+	// then
+	assert.Equal(t, []string{
+		"//registry.mondoo.com/namespace/namespace1/policies/policy1",
+		"//registry.mondoo.com/namespace/namespace2/policies/policy2",
+		"//registry.mondoo.com/namespace/namespace3/policies/policy3",
+	}, preprocessed)
+}


### PR DESCRIPTION
his change adds support to filter the policies available in https://mondoo.com/registry by short mrns:


```
cnspec scan okta --organization dev-12345.okta.com --token $OKTA_TOKEN --policy mondoohq/mondoo-okta-security
```