### PR TITLE
⭐️ add cnquery dependency to cnspec package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,8 @@ nfpms:
     formats:
       - deb
       - rpm
+    depends:
+      - cnquery
     contents:
       - src: "scripts/pkg/linux/cnspec.service"
         dst: "/etc/systemd/system/cnspec.service"
@@ -90,7 +92,12 @@ nfpms:
       postinstall: "scripts/pkg/linux/postinstall.sh"
       preremove: "scripts/pkg/linux/preremove.sh"
     overrides:
+      rpm:
+        depends:
+          - cnquery >= {{ .Version }}
       deb:
+        depends:
+          - cnquery (>= {{ .Version }})
         contents:
           - src: "scripts/pkg/debian/cnspec.service"
             dst: "/etc/systemd/system/cnspec.service"


### PR DESCRIPTION
This PR is not tested yet. Once merged we need to validate the tested edge package.

Reference from nfpm https://nfpm.goreleaser.com/configuration/:

```yaml
# All fields above marked as `overridable` can be overridden for a given
# package format in this section.
overrides:
  # The depends override can for example be used to provide version
  # constraints for dependencies where different package formats use different
  # versions or for dependencies that are named differently.
  deb:
    depends:
      - baz (>= 1.2.3-0)
      - some-lib-dev
    # ...
  rpm:
    depends:
      - baz >= 1.2.3-0
      - some-lib-devel
    # ...
  apk:
    # ...
  archlinux:
    depends:
      - baz
      - some-lib
 ```