### PR TITLE
🐛 fix goreleaser dependency definition

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,7 @@ nfpms:
     formats:
       - deb
       - rpm
-    depends:
+    dependencies:
       - cnquery
     contents:
       - src: "scripts/pkg/linux/cnspec.service"
@@ -93,10 +93,10 @@ nfpms:
       preremove: "scripts/pkg/linux/preremove.sh"
     overrides:
       rpm:
-        depends:
+        dependencies:
           - cnquery >= {{ .Version }}
       deb:
-        depends:
+        dependencies:
           - cnquery (>= {{ .Version }})
         contents:
           - src: "scripts/pkg/debian/cnspec.service"


### PR DESCRIPTION
turns out #509 was not working properly and docs between nfpm and goreleaser are inconsistent