### PR TITLE
pass in default ranger client if using incognito.

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -551,7 +551,7 @@ func (s *LocalScanner) HealthCheck(ctx context.Context, req *HealthCheckRequest)
 
 func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) (resources.UpstreamConfig, error) {
 	if incognito {
-		return resources.UpstreamConfig{Incognito: true}, nil
+		return resources.UpstreamConfig{Incognito: true, HttpClient: ranger.DefaultHttpClient()}, nil
 	}
 
 	// Make a copy here, we do not want to add to the original plugins map if we're connecting upstream with credentials from a job.


### PR DESCRIPTION
Fixes nil panics if trying to fetch a vuln report when using incognito.
The vuln report requires upstream communication and it does that via the http client in the UpstreamConfig