### PR TITLE
Don't report to query mrn when it has variants. Use the code id

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -472,12 +472,9 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 			}
 
 			contentChecksum = contentChecksum.Add(check.Checksum)
-
-			var err error
-			executionChecksum, err = variantsExecutionChecksum(check, executionChecksum, true, getQuery)
-			if err != nil {
-				return err
-			}
+			executionChecksum = executionChecksum.
+				Add(check.CodeId).
+				AddUint(check.Impact.Checksum())
 		}
 
 		// DATA (must be sorted)
@@ -510,12 +507,8 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 			}
 
 			contentChecksum = contentChecksum.Add(query.Checksum)
-
-			var err error
-			executionChecksum, err = variantsExecutionChecksum(query, executionChecksum, false, getQuery)
-			if err != nil {
-				return err
-			}
+			executionChecksum = executionChecksum.
+				Add(query.CodeId)
 		}
 
 		// FILTERs (also sorted)
@@ -688,25 +681,4 @@ func (s *GroupType) UnmarshalJSON(data []byte) error {
 	}
 
 	return errors.New("failed to unmarshal group type: " + str)
-}
-
-func variantsExecutionChecksum(q *explorer.Mquery, c checksums.Fast, includeImpact bool, getQuery func(ctx context.Context, mrn string) (*explorer.Mquery, error)) (checksums.Fast, error) {
-	// This code assumes there are no cycles in the variant graph.
-	c = c.
-		Add(q.CodeId)
-	if includeImpact {
-		c = c.AddUint(q.Impact.Checksum())
-	}
-
-	for _, ref := range q.Variants {
-		if v, err := getQuery(context.Background(), ref.Mrn); err == nil {
-			c, err = variantsExecutionChecksum(v, c, includeImpact, getQuery)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			return 0, errors.New("cannot find dependent composed query '" + ref.Mrn + "'")
-		}
-	}
-	return c, nil
 }

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -909,6 +909,9 @@ func (cache *policyResolverCache) addCheckJob(ctx context.Context, check *explor
 	// ^^
 
 	if len(check.Variants) != 0 {
+		// Its easier to deal with things if we dont mix query code ids with
+		// query mrns.
+		queryJob.QrId = check.CodeId
 		err := cache.addCheckJobVariants(ctx, check, queryJob)
 		if err != nil {
 			log.Error().Err(err).Str("checkMrn", check.Mrn).Msg("failed to add data query variants")


### PR DESCRIPTION
Without this, we end up with some queries reporting by mrn and other reporting by code id.

Requires https://github.com/mondoohq/cnquery/pull/1154