### PR TITLE
🧹 Exit browser report prompt if user specifies anything other than a 'y' or a 'yes'

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -396,18 +396,20 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		printReports(report, conf, cmd)
 
 		// if we are in an interactive terminal, running in incognito mode, and user responds "yes" then offer report viewer
-		if os.Getenv(featureReportEnv) == "1" && isatty.IsTerminal(os.Stdout.Fd()) && conf.IsIncognito &&
-			cnspec_components.AskAYesNoQuestion("Do you want to view the report in the browser?") {
-			proxy, err := cnquery_config.GetAPIProxy()
-			if err != nil {
-				log.Error().Err(err).Msg("error getting proxy information")
-			} else {
-				reportId, err := cnspec_upstream.UploadSharedReport(report, os.Getenv(featureReportAlternateUrlEnv), proxy)
+		if os.Getenv(featureReportEnv) == "1" && isatty.IsTerminal(os.Stdout.Fd()) && conf.IsIncognito {
+			answer := cnspec_components.AskAYesNoQuestion("Do you want to view the report in the browser?")
+			if answer {
+				proxy, err := cnquery_config.GetAPIProxy()
 				if err != nil {
-					log.Fatal().Err(err).Msg("error uploading shared report")
-				}
+					log.Error().Err(err).Msg("error getting proxy information")
+				} else {
+					reportId, err := cnspec_upstream.UploadSharedReport(report, os.Getenv(featureReportAlternateUrlEnv), proxy)
+					if err != nil {
+						log.Fatal().Err(err).Msg("error uploading shared report")
+					}
 
-				fmt.Printf("View report at %s\n", reportId.Url)
+					fmt.Printf("View report at %s\n", reportId.Url)
+				}
 			}
 		}
 

--- a/cli/components/question.go
+++ b/cli/components/question.go
@@ -12,20 +12,14 @@ import (
 func AskAYesNoQuestion(msg string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
-	for {
-		fmt.Printf("%s [(y)es/(n)o]: ", msg)
+	fmt.Printf("%s [Y/n] ", msg)
 
-		answer, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatal().Err(err).Msg("failed to read response")
-		}
-
-		answer = strings.ToLower(strings.TrimSpace(answer))
-
-		if answer == "y" || answer == "yes" {
-			return true
-		} else if answer == "n" || answer == "no" {
-			return false
-		}
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read response")
 	}
+
+	answer = strings.ToLower(strings.TrimSpace(answer))
+
+	return answer == "y" || answer == "yes"
 }


### PR DESCRIPTION
Changes the prompt text to '[Y/n]' and quits upon the first response. Anything. different than 'y' or a 'yes' will *not* upload the report

