### PR TITLE
🧹 make status err reporting clearer

### DIFF
--- a/apps/cnspec/cmd/status.go
+++ b/apps/cnspec/cmd/status.go
@@ -193,7 +193,9 @@ func (s Status) RenderCliStatus() {
 	if s.Client.Registered && s.Client.PingPongError == nil {
 		log.Info().Msg(theme.DefaultTheme.Success("client authenticated successfully"))
 	} else {
-		log.Error().Err(s.Client.PingPongError).Msg("could not connect to mondoo platform")
+		log.Error().Err(s.Client.PingPongError).
+			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with the Mondoo Platform. To learn how, read: https://mondoo.com/docs/cnspec/cnspec-adv-install/registration",
+				viper.ConfigFileUsed())
 	}
 
 	for i := range s.Upstream.Warnings {


### PR DESCRIPTION
fixes #365

```
→ loaded configuration from /Users/ivanmilchev/Downloads/temp.json using source --config
→ Platform:     macos
→ Version:      13.3.1
→ Hostname:     Ivan-Milchev.local
→ IP:           192.168.2.4
→ Time:         2023-04-24T12:49:43+02:00
→ Version:      unstable (API Version: unstable)
→ API ConnectionConfig: https://us.api.mondoo.com
→ API Status:   SERVING
→ API Time:     2023-04-24T10:49:43Z
→ API Version:  8
! API versions do not match, please update the client
→ Owner:        //captain.api.mondoo.app/spaces/keen-banzai-154123
→ Client:       no managed client
→ Service Account:      //agents.api.mondoo.app/spaces/keen-banzai-154123/serviceaccounts/2OrwvXItmEV0Aue93mep5oPIiS4
→ client is registered
x The Mondoo Platform credentials provided at /Users/ivanmilchev/Downloads/temp.json didn't successfully authenticate with Mondoo Platform. Please re-authenticate e.g. via `cnspec login` with Mondoo Platform. For instructions, read https://mondoo.com/docs/install/registration. error="rpc error: code = Unauthenticated desc = request permission unauthenticated"
```