### PR TITLE
✨ Add different output formatters to `cnspec vuln`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -141,6 +141,21 @@
       ],
     },
     {
+      "name": "Vuln container image",
+      "type": "go",
+      "request": "launch",
+      "program": "${workspaceRoot}/apps/cnspec/cnspec.go",
+      "cwd": "${workspaceRoot}/",
+      "args": [
+        "vuln",
+        "container",
+        "image",
+        "ubuntu:focal-20220113",
+        "-o",
+        "summary",
+      ],
+    },
+    {
       "name": "Upstream status",
       "type": "go",
       "request": "launch",

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -479,9 +479,14 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		log.Info().Strs("features", opts.Features).Msg("user activated features")
 	}
 
-	props, err := cmd.Flags().GetStringToString("props")
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to parse props")
+	props := map[string]string{}
+	var err error
+	propsFlag := cmd.Flags().Lookup("props")
+	if propsFlag != nil {
+		props, err = cmd.Flags().GetStringToString("props")
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to parse props")
+		}
 	}
 
 	conf := scanConfig{

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -20,6 +20,7 @@ import (
 	"go.mondoo.com/cnquery/cli/shell"
 	"go.mondoo.com/cnquery/cli/theme"
 	"go.mondoo.com/cnquery/explorer/executor"
+	"go.mondoo.com/cnquery/logger"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery"
 	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
@@ -358,6 +359,7 @@ func printVulns(report *mvd.VulnReport, conf *scanConfig, target string) {
 		log.Fatal().Msg(err.Error())
 	}
 
+	logger.DebugDumpJSON("vulnReport", report)
 	if err = r.PrintVulns(report, os.Stdout, target); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")
 	}

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -6,16 +6,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
 	"github.com/mattn/go-isatty"
 	"github.com/mitchellh/mapstructure"
-	"github.com/muesli/termenv"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	cnquery_app "go.mondoo.com/cnquery/apps/cnquery/cmd"
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder"
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
 	"go.mondoo.com/cnquery/cli/components"
@@ -215,7 +212,7 @@ configure your Azure credentials and have SSH access to your virtual machines.`,
 		},
 	},
 	Run: func(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType builder.AssetType) {
-		conf, err := cnquery_app.GetCobraShellConfig(cmd, args, provider, assetType)
+		conf, err := getCobraScanConfig(cmd, args, provider, assetType)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to prepare config")
 		}
@@ -333,13 +330,7 @@ configure your Azure credentials and have SSH access to your virtual machines.`,
 			target = connectAsset.Mrn
 		}
 
-		header := fmt.Sprintf("\nTarget:     %s\n", target)
-		b.WriteString(termenv.String(header).Foreground(theme.DefaultTheme.Colors.Primary).String())
-		summaryDivider := strings.Repeat("=", utf8.RuneCountInString(header))
-		b.WriteString(termenv.String(summaryDivider + "\n\n").Foreground(theme.DefaultTheme.Colors.Secondary).String())
-		b.WriteString(reporter.RenderVulnerabilityStats(&vulnReport))
-		b.WriteString(reporter.RenderVulnReport(&vulnReport))
-		fmt.Println(b.String())
+		printVulns(&vulnReport, conf, target)
 	},
 })
 
@@ -358,4 +349,16 @@ func filterAssetByPlatformID(assetList []*asset.Asset, selectionID string) (*ass
 		return nil, errors.New("could not find an asset with the provided identifier: " + selectionID)
 	}
 	return foundAsset, nil
+}
+
+func printVulns(report *mvd.VulnReport, conf *scanConfig, target string) {
+	// print the output using the specified output format
+	r, err := reporter.New(conf.Output)
+	if err != nil {
+		log.Fatal().Msg(err.Error())
+	}
+
+	if err = r.PrintVulns(report, os.Stdout, target); err != nil {
+		log.Fatal().Err(err).Msg("failed to print")
+	}
 }

--- a/cli/components/advisories/report.go
+++ b/cli/components/advisories/report.go
@@ -44,6 +44,19 @@ func RenderReport(report *mvd.VulnReport, writer RowWriter, opts RowWriterOpts) 
 		return err
 	}
 
+	rows := ReportAffectedPackages(report, opts)
+	for i := range rows {
+		err = writer.Write(*rows[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ReportAffectedPackages(report *mvd.VulnReport, opts RowWriterOpts) []*ReportFindingRow {
+	rows := make([]*ReportFindingRow, 0)
 	advisoriesByPackage := advisoriesByPackage(report.Advisories)
 
 	// iterate over all affected packages, therefore we filter the package list by affected
@@ -79,10 +92,7 @@ func RenderReport(report *mvd.VulnReport, writer RowWriter, opts RowWriterOpts) 
 				Advisory:  "",
 				Cves:      nil,
 			}
-			err = writer.Write(row)
-			if err != nil {
-				return err
-			}
+			rows = append(rows, &row)
 
 			if opts.AdvisoryDetails {
 				// iterate over all advisories and print details
@@ -105,10 +115,7 @@ func RenderReport(report *mvd.VulnReport, writer RowWriter, opts RowWriterOpts) 
 						Cves:      cvesToString(advisory.Cves),
 					}
 
-					err = writer.Write(row)
-					if err != nil {
-						return err
-					}
+					rows = append(rows, &row)
 				}
 			}
 		} else {
@@ -123,13 +130,10 @@ func RenderReport(report *mvd.VulnReport, writer RowWriter, opts RowWriterOpts) 
 				Cves:      nil,
 			}
 
-			err = writer.Write(row)
-			if err != nil {
-				return err
-			}
+			rows = append(rows, &row)
 		}
 	}
-	return nil
+	return rows
 }
 
 // filters a leading 0: for rpm versions

--- a/cli/reporter/csv_vuln.go
+++ b/cli/reporter/csv_vuln.go
@@ -26,7 +26,7 @@ func (c csvStruct) toSlice() []string {
 }
 
 // ReportCollectionToCSV writes the given report collection to the given output directory
-func VulnReportCollectionToCSV(data *mvd.VulnReport, out shared.OutputHelper) error {
+func VulnReportToCSV(data *mvd.VulnReport, out shared.OutputHelper) error {
 	w := csv.NewWriter(out)
 
 	// write header

--- a/cli/reporter/csv_vuln.go
+++ b/cli/reporter/csv_vuln.go
@@ -1,0 +1,86 @@
+package reporter
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/cli/components/advisories"
+)
+
+type csvStruct struct {
+	Name      string
+	Score     string
+	Installed string
+	Fixed     string
+	Available string
+	Advisory  string
+	Cves      string
+}
+
+func (c csvStruct) toSlice() []string {
+	return []string{c.Name, c.Score, c.Installed, c.Fixed, c.Available, c.Advisory, c.Cves}
+}
+
+// ReportCollectionToCSV writes the given report collection to the given output directory
+func VulnReportCollectionToCSV(data *mvd.VulnReport, out shared.OutputHelper) error {
+	w := csv.NewWriter(out)
+
+	// write header
+	err := w.Write(csvStruct{
+		"Package Name",
+		"Score",
+		"Installed",
+		"Fixed",
+		"Available",
+		"Advisory",
+		"CVEs",
+	}.toSlice())
+	if err != nil {
+		return err
+	}
+
+	pkgs := renderVulnerabilitiesAsCSV(data)
+
+	for i := range pkgs {
+		pkg := pkgs[i]
+		err := w.Write(pkg.toSlice())
+		if err != nil {
+			return err
+		}
+	}
+
+	w.Flush()
+	return w.Error()
+}
+
+func renderVulnerabilitiesAsCSV(r *mvd.VulnReport) []*csvStruct {
+	if r == nil {
+		return []*csvStruct{}
+	}
+
+	// packages advisories
+	var packages []*advisories.ReportFindingRow
+	var printPkgs []*csvStruct
+	if r.Stats != nil && r.Stats.Packages != nil {
+		packages = advisories.ReportAffectedPackages(r, advisories.RowWriterOpts{AdvisoryDetails: true})
+		for i := range packages {
+			pkg := packages[i]
+			outPkg := &csvStruct{
+				Score:     fmt.Sprintf("%v", components.IntScore2Float(pkg.Score)),
+				Name:      pkg.Name,
+				Installed: pkg.Installed,
+				Fixed:     pkg.Fixed,
+				Available: pkg.Available,
+				Advisory:  pkg.Advisory,
+				Cves:      strings.Join(pkg.Cves, " "),
+			}
+			printPkgs = append(printPkgs, outPkg)
+		}
+	}
+
+	return printPkgs
+}

--- a/cli/reporter/csv_vuln_test.go
+++ b/cli/reporter/csv_vuln_test.go
@@ -1,0 +1,29 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
+)
+
+func TestCsvConverter(t *testing.T) {
+	reportRaw, err := os.ReadFile("./testdata/mondoo-debug-vulnReport.json")
+	require.NoError(t, err)
+
+	report := &mvd.VulnReport{}
+	err = json.Unmarshal(reportRaw, report)
+	require.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	writer := shared.IOWriter{Writer: &buf}
+	err = VulnReportToCSV(report, &writer)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "libblkid1,5.5,2.34-0.1ubuntu9.1,2.34-0.1ubuntu9.3,2.34-0.1ubuntu9.3,USN-5279-1,CVE-2021-3995 CVE-2021-3996")
+}

--- a/cli/reporter/json_vuln.go
+++ b/cli/reporter/json_vuln.go
@@ -127,7 +127,7 @@ func renderVulnerabilitiesAsJson(r *mvd.VulnReport) string {
 		platformAdvisory = append(platformAdvisory, advisory)
 	}
 
-	printables := []*advisoryPrintable{}
+	printAdvisories := []*advisoryPrintable{}
 	if len(platformAdvisory) > 0 {
 		// sort advisories by score
 		sort.Sort(sort.Reverse(mvd.BySeverity(platformAdvisory)))
@@ -159,7 +159,7 @@ func renderVulnerabilitiesAsJson(r *mvd.VulnReport) string {
 				Fixed:    fixedVersion,
 				Patch:    patch,
 			}
-			printables = append(printables, outAdvisory)
+			printAdvisories = append(printAdvisories, outAdvisory)
 		}
 	}
 
@@ -183,7 +183,7 @@ func renderVulnerabilitiesAsJson(r *mvd.VulnReport) string {
 		}
 	}
 
-	outJson, err := json.Marshal(printables)
+	advisoriesJson, err := json.Marshal(printAdvisories)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to marshal json")
 	}
@@ -195,7 +195,7 @@ func renderVulnerabilitiesAsJson(r *mvd.VulnReport) string {
 
 	out := "{" +
 		"\"platform\": " +
-		string(outJson) +
+		string(advisoriesJson) +
 		"," +
 		"\"packages\": " +
 		string(packagesJson) +

--- a/cli/reporter/json_vuln.go
+++ b/cli/reporter/json_vuln.go
@@ -43,7 +43,7 @@ type packagePrintable struct {
 	Cves      []string `json:"cves"`
 }
 
-func VulnReportCollectionToJSON(target string, data *mvd.VulnReport, out shared.OutputHelper) error {
+func VulnReportToJSON(target string, data *mvd.VulnReport, out shared.OutputHelper) error {
 	if data == nil {
 		return nil
 	}

--- a/cli/reporter/json_vuln.go
+++ b/cli/reporter/json_vuln.go
@@ -1,0 +1,205 @@
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/cli/components/advisories"
+)
+
+// advisoryPrintable is a snapshot of the fields that get exported
+// when doing things like JSON output
+type advisoryPrintable struct {
+	Score    string `json:"score,omitempty"`
+	Advisory string `json:"advisory,omitempty"`
+	Current  string `json:"current,omitempty"`
+	Fixed    string `json:"fixed,omitempty"`
+	Patch    string `json:"patch,omitempty"`
+}
+
+type statsPrintable struct {
+	Total    int32 `json:"total"`
+	Critical int32 `json:"critical"`
+	High     int32 `json:"high"`
+	Medium   int32 `json:"medium"`
+	Low      int32 `json:"low"`
+	None     int32 `json:"none"`
+	Unknown  int32 `json:"unknown"`
+}
+
+type packagePrintable struct {
+	Score     float32  `json:"score"`
+	Name      string   `json:"package"`
+	Installed string   `json:"installed"`
+	Fixed     string   `json:"vulnerable"`
+	Available string   `json:"available"`
+	Advisory  string   `json:"advisory"`
+	Cves      []string `json:"cves"`
+}
+
+func VulnReportCollectionToJSON(target string, data *mvd.VulnReport, out shared.OutputHelper) error {
+	if data == nil {
+		return nil
+	}
+
+	out.WriteString(
+		"{" +
+			"\"target\": ")
+	out.WriteString("\"" + target + "\"")
+
+	out.WriteString("," +
+		"\"stats\":" +
+		"{")
+	out.WriteString(renderVulnerabilityStatsAsJson(data))
+	out.WriteString("}")
+	out.WriteString("," +
+		"\"vulnerabilities\":")
+	out.WriteString(renderVulnerabilitiesAsJson(data))
+	out.WriteString("}")
+
+	return nil
+}
+
+func renderVulnerabilityStatsAsJson(vulnReport *mvd.VulnReport) string {
+	if vulnReport == nil || vulnReport.Stats == nil {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// summary graph
+	stats := vulnReport.Stats
+
+	advisoryStats := statsPrintable{
+		Total:    stats.Advisories.Total,
+		Critical: stats.Advisories.Critical,
+		High:     stats.Advisories.High,
+		Medium:   stats.Advisories.Medium,
+		Low:      stats.Advisories.Low,
+		None:     stats.Advisories.None,
+		Unknown:  stats.Advisories.Unknown,
+	}
+	jsonStats, err := json.Marshal(advisoryStats)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal advisory stats")
+	}
+	b.WriteString("\"advisories\":")
+	b.Write(jsonStats)
+
+	packageStats := statsPrintable{
+		Total:    stats.Packages.Total,
+		Critical: stats.Packages.Critical,
+		High:     stats.Packages.High,
+		Medium:   stats.Packages.Medium,
+		Low:      stats.Packages.Low,
+		None:     stats.Packages.None,
+		Unknown:  stats.Packages.Unknown,
+	}
+	jsonStats, err = json.Marshal(packageStats)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal advisory stats")
+	}
+	b.WriteString(",")
+	b.WriteString("\"packages\":")
+	b.Write(jsonStats)
+
+	return b.String()
+}
+
+func renderVulnerabilitiesAsJson(r *mvd.VulnReport) string {
+	if r == nil {
+		return ""
+	}
+
+	// platform advisories
+	platformAdvisory := []*mvd.Advisory{}
+	for i := range r.Advisories {
+		advisory := r.Advisories[i]
+		if len(advisory.FixedPlatforms) == 0 {
+			continue
+		}
+		platformAdvisory = append(platformAdvisory, advisory)
+	}
+
+	printables := []*advisoryPrintable{}
+	if len(platformAdvisory) > 0 {
+		// sort advisories by score
+		sort.Sort(sort.Reverse(mvd.BySeverity(platformAdvisory)))
+
+		for i := range platformAdvisory {
+			advisory := platformAdvisory[i]
+			score := components.IntScore2Float(advisory.Score)
+
+			currentVersion := r.Platform.Release
+			if len(r.Platform.Build) > 0 {
+				currentVersion += "/" + r.Platform.Build
+			}
+
+			fixedVersion := ""
+			patch := ""
+			// TODO: find the correct fixed platform entry
+			if len(advisory.FixedPlatforms) > 0 {
+				fixedVersion = advisory.FixedPlatforms[0].Release
+				if len(advisory.FixedPlatforms[0].Build) > 0 {
+					fixedVersion += "/" + advisory.FixedPlatforms[0].Build
+				}
+				patch = advisory.FixedPlatforms[0].PatchName
+			}
+
+			outAdvisory := &advisoryPrintable{
+				Score:    fmt.Sprintf("%v", score),
+				Advisory: advisory.ID,
+				Current:  currentVersion,
+				Fixed:    fixedVersion,
+				Patch:    patch,
+			}
+			printables = append(printables, outAdvisory)
+		}
+	}
+
+	// packages advisories
+	var packages []*advisories.ReportFindingRow
+	var printPkgs []*packagePrintable
+	if r.Stats != nil && r.Stats.Packages != nil {
+		packages = advisories.ReportAffectedPackages(r, advisories.RowWriterOpts{AdvisoryDetails: true})
+		for i := range packages {
+			pkg := packages[i]
+			outPkg := &packagePrintable{
+				Score:     components.IntScore2Float(pkg.Score),
+				Name:      pkg.Name,
+				Installed: pkg.Installed,
+				Fixed:     pkg.Fixed,
+				Available: pkg.Available,
+				Advisory:  pkg.Advisory,
+				Cves:      pkg.Cves,
+			}
+			printPkgs = append(printPkgs, outPkg)
+		}
+	}
+
+	outJson, err := json.Marshal(printables)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal json")
+	}
+
+	packagesJson, err := json.Marshal(printPkgs)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal json")
+	}
+
+	out := "{" +
+		"\"platform\": " +
+		string(outJson) +
+		"," +
+		"\"packages\": " +
+		string(packagesJson) +
+		"}"
+
+	return out
+}

--- a/cli/reporter/json_vuln_test.go
+++ b/cli/reporter/json_vuln_test.go
@@ -1,0 +1,29 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
+)
+
+func TestJsonConverter(t *testing.T) {
+	reportRaw, err := os.ReadFile("./testdata/mondoo-debug-vulnReport.json")
+	require.NoError(t, err)
+
+	report := &mvd.VulnReport{}
+	err = json.Unmarshal(reportRaw, report)
+	require.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	writer := shared.IOWriter{Writer: &buf}
+	err = VulnReportToJSON("index.docker.io/ubutnu:focal-20220113", report, &writer)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "\"cves\":[\"CVE-2021-43618\"]")
+}

--- a/cli/reporter/print_vuln.go
+++ b/cli/reporter/print_vuln.go
@@ -1,0 +1,39 @@
+package reporter
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/muesli/termenv"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/cli/theme"
+	"go.mondoo.com/cnquery/upstream/mvd"
+)
+
+type defaultVulnReporter struct {
+	*Reporter
+	isCompact bool
+	isSummary bool
+	target    string
+	out       io.Writer
+	data      *mvd.VulnReport
+}
+
+func (r *defaultVulnReporter) print() error {
+	// catch case where the scan was not successful and no bundle was fetched from server
+	if r.data == nil {
+		log.Debug().Msg("report does not contain any data")
+		return nil
+	}
+
+	header := fmt.Sprintf("\nTarget:     %s\n", r.target)
+	r.out.Write([]byte(termenv.String(header).Foreground(theme.DefaultTheme.Colors.Primary).String()))
+	summaryDivider := strings.Repeat("=", utf8.RuneCountInString(header))
+	r.out.Write([]byte(termenv.String(summaryDivider + "\n\n").Foreground(theme.DefaultTheme.Colors.Secondary).String()))
+	r.out.Write([]byte(RenderVulnerabilityStats(r.data)))
+	r.out.Write([]byte(RenderVulnReport(r.data)))
+	fmt.Println(r.out)
+	return nil
+}

--- a/cli/reporter/print_vuln.go
+++ b/cli/reporter/print_vuln.go
@@ -33,7 +33,8 @@ func (r *defaultVulnReporter) print() error {
 	summaryDivider := strings.Repeat("=", utf8.RuneCountInString(header))
 	r.out.Write([]byte(termenv.String(summaryDivider + "\n\n").Foreground(theme.DefaultTheme.Colors.Secondary).String()))
 	r.out.Write([]byte(RenderVulnerabilityStats(r.data)))
-	r.out.Write([]byte(RenderVulnReport(r.data)))
-	fmt.Println(r.out)
+	if !r.isSummary {
+		r.out.Write([]byte(RenderVulnReportDetailed(r.data, !r.isCompact)))
+	}
 	return nil
 }

--- a/cli/reporter/render_advisory_policy.go
+++ b/cli/reporter/render_advisory_policy.go
@@ -272,6 +272,10 @@ func RenderVulnerabilityStats(vulnReport *mvd.VulnReport) string {
 }
 
 func RenderVulnReport(vulnReport *mvd.VulnReport) string {
+	return RenderVulnReportDetailed(vulnReport, false)
+}
+
+func RenderVulnReportDetailed(vulnReport *mvd.VulnReport, detailed bool) string {
 	var b bytes.Buffer
 	if vulnReport == nil || vulnReport.Stats == nil || vulnReport.Stats.Advisories.Total == 0 {
 		color := components.DefaultRatingColors.Color(policy.ScoreRating_aPlus)
@@ -284,6 +288,9 @@ func RenderVulnReport(vulnReport *mvd.VulnReport) string {
 	} else {
 		// render advisory table
 		renderer := components.NewAdvisoryResultTable()
+		if detailed {
+			renderer.DetailedPackageRisks = true
+		}
 		output, err := renderer.Render(vulnReport)
 		if err != nil {
 			return err.Error()

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -140,6 +140,20 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 			target:    target,
 		}
 		return rr.print()
+	case YAML:
+		raw := bytes.Buffer{}
+		writer := shared.IOWriter{Writer: &raw}
+		err := VulnReportCollectionToJSON(target, data, &writer)
+		if err != nil {
+			return err
+		}
+
+		json, err := yaml.JSONToYAML(raw.Bytes())
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(json)
+		return err
 	case JSON:
 		writer := shared.IOWriter{Writer: out}
 		return VulnReportCollectionToJSON(target, data, &writer)

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/cli/printer"
 	"go.mondoo.com/cnquery/cli/theme/colors"
 	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/executor"
 	"sigs.k8s.io/yaml"
@@ -107,4 +108,43 @@ func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
 	default:
 		return errors.New("unknown reporter type, don't recognize this Format")
 	}
+}
+
+func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string) error {
+	switch r.Format {
+	case Compact:
+		rr := &defaultVulnReporter{
+			Reporter:  r,
+			isCompact: true,
+			out:       out,
+			data:      data,
+			target:    target,
+		}
+		return rr.print()
+	case Summary:
+		rr := &defaultVulnReporter{
+			Reporter:  r,
+			isCompact: true,
+			isSummary: true,
+			out:       out,
+			data:      data,
+			target:    target,
+		}
+		return rr.print()
+	case Full:
+		rr := &defaultVulnReporter{
+			Reporter:  r,
+			isCompact: false,
+			out:       out,
+			data:      data,
+			target:    target,
+		}
+		return rr.print()
+	case JSON:
+		writer := shared.IOWriter{Writer: out}
+		return VulnReportCollectionToJSON(target, data, &writer)
+	default:
+		return errors.New("unknown reporter type, don't recognize this Format")
+	}
+	return nil
 }

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -146,5 +146,4 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 	default:
 		return errors.New("unknown reporter type, don't recognize this Format")
 	}
-	return nil
 }

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -140,19 +140,10 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 			target:    target,
 		}
 		return rr.print()
-		/*
-			case Report:
-				rr := &reportRenderer{
-					printer:  r.Printer,
-					pager:    r.Pager,
-					usePager: r.UsePager,
-					out:      out,
-					data:     data,
-				}
-				return rr.print()
-		*/
+	case Report:
+		return errors.New("'report' is not supported for vuln reports, please use one of the other formats")
 	case JUnit:
-		return errors.New("junit is not supported for vuln reports, please use one of the other formats")
+		return errors.New("'junit' is not supported for vuln reports, please use one of the other formats")
 	case CSV:
 		writer := shared.IOWriter{Writer: out}
 		return VulnReportCollectionToCSV(data, &writer)

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -140,6 +140,9 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 			target:    target,
 		}
 		return rr.print()
+	case CSV:
+		writer := shared.IOWriter{Writer: out}
+		return VulnReportCollectionToCSV(data, &writer)
 	case YAML:
 		raw := bytes.Buffer{}
 		writer := shared.IOWriter{Writer: &raw}

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -140,6 +140,19 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 			target:    target,
 		}
 		return rr.print()
+		/*
+			case Report:
+				rr := &reportRenderer{
+					printer:  r.Printer,
+					pager:    r.Pager,
+					usePager: r.UsePager,
+					out:      out,
+					data:     data,
+				}
+				return rr.print()
+		*/
+	case JUnit:
+		return errors.New("junit is not supported for vuln reports, please use one of the other formats")
 	case CSV:
 		writer := shared.IOWriter{Writer: out}
 		return VulnReportCollectionToCSV(data, &writer)

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -146,11 +146,11 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 		return errors.New("'junit' is not supported for vuln reports, please use one of the other formats")
 	case CSV:
 		writer := shared.IOWriter{Writer: out}
-		return VulnReportCollectionToCSV(data, &writer)
+		return VulnReportToCSV(data, &writer)
 	case YAML:
 		raw := bytes.Buffer{}
 		writer := shared.IOWriter{Writer: &raw}
-		err := VulnReportCollectionToJSON(target, data, &writer)
+		err := VulnReportToJSON(target, data, &writer)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, out io.Writer, target string
 		return err
 	case JSON:
 		writer := shared.IOWriter{Writer: out}
-		return VulnReportCollectionToJSON(target, data, &writer)
+		return VulnReportToJSON(target, data, &writer)
 	default:
 		return errors.New("unknown reporter type, don't recognize this Format")
 	}

--- a/cli/reporter/reporter_test.go
+++ b/cli/reporter/reporter_test.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/cli/printer"
 	"go.mondoo.com/cnquery/cli/theme/colors"
 	"go.mondoo.com/cnquery/shared"
+	"go.mondoo.com/cnquery/upstream/mvd"
 	"go.mondoo.com/cnspec/policy"
 )
 
@@ -44,4 +45,52 @@ func TestJunitConverter(t *testing.T) {
 	assert.Contains(t, buf.String(), "! Error:        Set")
 	assert.Contains(t, buf.String(), "✓ Pass:  A 100  Ensure")
 	assert.Contains(t, buf.String(), "✕ Fail:  F   0  Ensure")
+}
+
+func TestVulnReporter(t *testing.T) {
+	reportRaw, err := os.ReadFile("./testdata/mondoo-debug-vulnReport.json")
+	require.NoError(t, err)
+
+	report := &mvd.VulnReport{}
+	err = json.Unmarshal(reportRaw, report)
+	require.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	writer := shared.IOWriter{Writer: &buf}
+
+	r, err := New("summary")
+	require.NoError(t, err)
+
+	target := "index.docker.io/library/ubuntu@669e010b58ba"
+	err = r.PrintVulns(report, &writer, target)
+	require.NoError(t, err)
+
+	r, err = New("compact")
+	require.NoError(t, err)
+
+	err = r.PrintVulns(report, &writer, target)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "5.5    libblkid1       2.34-0.1ubuntu9.1")
+	assert.NotContains(t, buf.String(), "USN-5279-1")
+
+	r, err = New("full")
+	require.NoError(t, err)
+
+	err = r.PrintVulns(report, &writer, target)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "5.5    libblkid1       2.34-0.1ubuntu9.1")
+	assert.Contains(t, buf.String(), "USN-5279-1")
+
+	r, err = New("yaml")
+	require.NoError(t, err)
+
+	err = r.PrintVulns(report, &writer, target)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "score: 5.5")
+	assert.Contains(t, buf.String(), "package: libblkid1")
+	assert.Contains(t, buf.String(), "installed: 2.34-0.1ubuntu9.1")
+	assert.Contains(t, buf.String(), "advisory: USN-5279-1")
 }

--- a/cli/reporter/testdata/mondoo-debug-vulnReport.json
+++ b/cli/reporter/testdata/mondoo-debug-vulnReport.json
@@ -1,0 +1,3383 @@
+{
+  "platform": {
+    "name": "ubuntu",
+    "release": "20.04",
+    "title": "Ubuntu 20.04.3 LTS, Docker Image"
+  },
+  "packages": [
+    {
+      "name": "bash",
+      "version": "5.0-6ubuntu1.1",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "5.0-6ubuntu1.2",
+      "namespace": "ubuntu:20.04",
+      "score": 72,
+      "affected": true
+    },
+    {
+      "name": "dpkg",
+      "version": "1.19.7ubuntu3",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "1.19.7ubuntu3.2",
+      "namespace": "ubuntu:20.04",
+      "score": 75,
+      "affected": true
+    },
+    {
+      "name": "e2fsprogs",
+      "version": "1.45.5-2ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "1.45.5-2ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "fdisk",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "gpgv",
+      "version": "2.2.19-3ubuntu2.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "gnupg2",
+      "available": "2.2.19-3ubuntu2.2",
+      "namespace": "ubuntu:20.04",
+      "score": 58,
+      "affected": true
+    },
+    {
+      "name": "gzip",
+      "version": "1.10-0ubuntu4",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "1.10-0ubuntu4.1",
+      "namespace": "ubuntu:20.04",
+      "score": 88,
+      "affected": true
+    },
+    {
+      "name": "libblkid1",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libc6",
+      "version": "2.31-0ubuntu9.2",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "glibc",
+      "available": "2.31-0ubuntu9.9",
+      "namespace": "ubuntu:20.04",
+      "score": 78,
+      "affected": true
+    },
+    {
+      "name": "libcom-err2",
+      "version": "1.45.5-2ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "e2fsprogs",
+      "available": "1.45.5-2ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "libext2fs2",
+      "version": "1.45.5-2ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "e2fsprogs",
+      "available": "1.45.5-2ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "libfdisk1",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libgmp10",
+      "version": "2:6.2.0+dfsg-4",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "gmp",
+      "available": "2:6.2.0+dfsg-4ubuntu0.1",
+      "namespace": "ubuntu:20.04",
+      "score": 50,
+      "affected": true
+    },
+    {
+      "name": "libgnutls30",
+      "version": "3.6.13-2ubuntu1.6",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "gnutls28",
+      "available": "3.6.13-2ubuntu1.8",
+      "namespace": "ubuntu:20.04",
+      "score": 75,
+      "affected": true
+    },
+    {
+      "name": "liblzma5",
+      "version": "5.2.4-1ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "xz-utils",
+      "available": "5.2.4-1ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 88,
+      "affected": true
+    },
+    {
+      "name": "libmount1",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libpam-modules",
+      "version": "1.3.1-5ubuntu4.3",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "pam",
+      "available": "1.3.1-5ubuntu4.6",
+      "namespace": "ubuntu:20.04",
+      "score": 98,
+      "affected": true
+    },
+    {
+      "name": "libpcre2-8-0",
+      "version": "10.34-7",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "pcre2",
+      "available": "10.34-7ubuntu0.1",
+      "namespace": "ubuntu:20.04",
+      "score": 64,
+      "affected": true
+    },
+    {
+      "name": "libpcre3",
+      "version": "2:8.39-12build1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "pcre3",
+      "available": "2:8.39-12ubuntu0.1",
+      "namespace": "ubuntu:20.04",
+      "score": 50,
+      "affected": true
+    },
+    {
+      "name": "libsepol1",
+      "version": "3.0-1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "libsepol",
+      "available": "3.0-1ubuntu0.1",
+      "namespace": "ubuntu:20.04",
+      "score": 21,
+      "affected": true
+    },
+    {
+      "name": "libsmartcols1",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libss2",
+      "version": "1.45.5-2ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "e2fsprogs",
+      "available": "1.45.5-2ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "libsystemd0",
+      "version": "245.4-4ubuntu3.15",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "systemd",
+      "available": "245.4-4ubuntu3.21",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libudev1",
+      "version": "245.4-4ubuntu3.15",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "systemd",
+      "available": "245.4-4ubuntu3.21",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "libuuid1",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "login",
+      "version": "1:4.8.1-1ubuntu5.20.04.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "shadow",
+      "available": "1:4.8.1-1ubuntu5.20.04.4",
+      "namespace": "ubuntu:20.04",
+      "score": 33,
+      "affected": true
+    },
+    {
+      "name": "logsave",
+      "version": "1.45.5-2ubuntu1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "e2fsprogs",
+      "available": "1.45.5-2ubuntu1.1",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "mount",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "util-linux",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "passwd",
+      "version": "1:4.8.1-1ubuntu5.20.04.1",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "shadow",
+      "available": "1:4.8.1-1ubuntu5.20.04.4",
+      "namespace": "ubuntu:20.04",
+      "score": 33,
+      "affected": true
+    },
+    {
+      "name": "perl-base",
+      "version": "5.30.0-9ubuntu0.2",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "perl",
+      "available": "5.30.0-9ubuntu0.3",
+      "namespace": "ubuntu:20.04",
+      "score": 68,
+      "affected": true
+    },
+    {
+      "name": "tar",
+      "version": "1.30+dfsg-7ubuntu0.20.04.1",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "1.30+dfsg-7ubuntu0.20.04.3",
+      "namespace": "ubuntu:20.04",
+      "score": 78,
+      "affected": true
+    },
+    {
+      "name": "util-linux",
+      "version": "2.34-0.1ubuntu9.1",
+      "arch": "amd64",
+      "format": "deb",
+      "available": "2.34-0.1ubuntu9.3",
+      "namespace": "ubuntu:20.04",
+      "score": 55,
+      "affected": true
+    },
+    {
+      "name": "zlib1g",
+      "version": "1:1.2.11.dfsg-2ubuntu1.2",
+      "arch": "amd64",
+      "format": "deb",
+      "origin": "zlib",
+      "available": "1:1.2.11.dfsg-2ubuntu1.5",
+      "namespace": "ubuntu:20.04",
+      "score": 98,
+      "affected": true
+    }
+  ],
+  "advisories": [
+    {
+      "ID": "USN-5825-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5825-1",
+      "title": "PAM vulnerability",
+      "description": "It was discovered that PAM did not correctly restrict login from an IP\naddress that is not resolvable via DNS. An attacker could possibly use this\nissue to bypass authentication.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libpam-modules/version/1.3.1-5ubuntu4.4/arch//namespace/ubuntu:20.04",
+          "name": "libpam-modules",
+          "version": "1.3.1-5ubuntu4.4",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libpam-modules",
+          "version": "1.3.1-5ubuntu4.3",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "pam",
+          "available": "1.3.1-5ubuntu4.6",
+          "namespace": "ubuntu:20.04",
+          "score": 98,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-28321",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-28321",
+          "summary": "The Linux-PAM package before 1.5.2-6.1 for openSUSE Tumbleweed allows authentication bypass for SSH logins. The pam_access.so module doesn't correctly restrict login if a user tries to connect from an IP address that is not resolvable via DNS. In such conditions, a user with denied access to a machine can still get access. NOTE: the relevance of this issue is largely limited to openSUSE Tumbleweed and openSUSE Factory; it does not affect Linux-PAM upstream.",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            }
+          ],
+          "cwe": "CWE-863",
+          "published": "2022-09-19T22:15:00Z",
+          "modified": "2022-09-22T14:52:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28321"
+        }
+      ],
+      "score": 98,
+      "worstScore": {
+        "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 9.8
+      },
+      "published": "2023-01-25T09:38:40Z",
+      "modified": "2023-01-25T09:38:40Z"
+    },
+    {
+      "ID": "USN-5825-2",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5825-2",
+      "title": "PAM regressions",
+      "description": "USN-5825-1 fixed vulnerabilities in PAM. Unfortunately that update was\nincomplete and could introduce a regression. This update fixes the problem.\n\nWe apologize for the inconvenience.\n\nOriginal advisory details:\n\n It was discovered that PAM did not correctly restrict login from an IP\n address that is not resolvable via DNS. An attacker could possibly use this\n issue to bypass authentication.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libpam-modules/version/1.3.1-5ubuntu4.6/arch//namespace/ubuntu:20.04",
+          "name": "libpam-modules",
+          "version": "1.3.1-5ubuntu4.6",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libpam-modules",
+          "version": "1.3.1-5ubuntu4.3",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "pam",
+          "available": "1.3.1-5ubuntu4.6",
+          "namespace": "ubuntu:20.04",
+          "score": 98,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-28321",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-28321",
+          "summary": "The Linux-PAM package before 1.5.2-6.1 for openSUSE Tumbleweed allows authentication bypass for SSH logins. The pam_access.so module doesn't correctly restrict login if a user tries to connect from an IP address that is not resolvable via DNS. In such conditions, a user with denied access to a machine can still get access. NOTE: the relevance of this issue is largely limited to openSUSE Tumbleweed and openSUSE Factory; it does not affect Linux-PAM upstream.",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            }
+          ],
+          "cwe": "CWE-863",
+          "published": "2022-09-19T22:15:00Z",
+          "modified": "2022-09-22T14:52:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-28321"
+        }
+      ],
+      "score": 98,
+      "worstScore": {
+        "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 9.8
+      },
+      "published": "2023-02-06T03:06:11Z",
+      "modified": "2023-02-06T03:06:11Z"
+    },
+    {
+      "ID": "USN-5570-2",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5570-2",
+      "title": "zlib vulnerability",
+      "description": "USN-5570-1 fixed a vulnerability in zlib. This update provides the\ncorresponding update for Ubuntu 22.04 LTS and Ubuntu 20.04 LTS.\n\nOriginal advisory details:\n\n Evgeny Legerov discovered that zlib incorrectly handled memory when\n performing certain inflate operations. An attacker could use this issue\n to cause zlib to crash, resulting in a denial of service, or possibly\n execute arbitrary code.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/zlib1g/version/1:1.2.11.dfsg-2ubuntu1.5/arch//namespace/ubuntu:20.04",
+          "name": "zlib1g",
+          "version": "1:1.2.11.dfsg-2ubuntu1.5",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "zlib1g",
+          "version": "1:1.2.11.dfsg-2ubuntu1.2",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "zlib",
+          "available": "1:1.2.11.dfsg-2ubuntu1.5",
+          "namespace": "ubuntu:20.04",
+          "score": 98,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-37434",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-37434",
+          "summary": "zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field. NOTE: only applications that call inflateGetHeader are affected. Some common applications bundle the affected zlib source code but may be unable to call inflateGetHeader (e.g., see the nodejs/node reference).",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat:7",
+              "score": 7
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat:9",
+              "score": 7
+            },
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat",
+              "score": 7
+            },
+            {
+              "vector": "7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7
+            }
+          ],
+          "cwe": "CWE-787",
+          "published": "2022-08-05T07:15:00Z",
+          "modified": "2023-01-09T16:44:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-37434"
+        }
+      ],
+      "score": 98,
+      "worstScore": {
+        "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 9.8
+      },
+      "published": "2022-10-17T18:37:50Z",
+      "modified": "2022-10-17T18:37:50Z"
+    },
+    {
+      "ID": "USN-5378-2",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5378-2",
+      "title": "XZ Utils vulnerability",
+      "description": "Cleemy Desu Wayo discovered that XZ Utils incorrectly handled certain\nfilenames. If a user or automated system were tricked into performing\nxzgrep operations with specially crafted filenames, a remote attacker could\noverwrite arbitrary files.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/xz-utils/version/5.2.4-1ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "xz-utils",
+          "version": "5.2.4-1ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "liblzma5",
+          "version": "5.2.4-1ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "xz-utils",
+          "available": "5.2.4-1ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 88,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-1271",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1271",
+          "summary": "An arbitrary file write vulnerability was found in GNU gzip's zgrep utility. When zgrep is applied on the attacker's chosen file name (for example, a crafted file name), this can overwrite an attacker's content to an arbitrary attacker-selected file. This flaw occurs due to insufficient validation when processing filenames with two or more newlines where selected content and the target file names are embedded in crafted multi-line file names. This flaw allows a remote, low privileged attacker to force zgrep to write arbitrary files on the system.",
+          "score": 8.8,
+          "worstScore": {
+            "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 8.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:7",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:8",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:9",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat",
+              "score": 8.8
+            }
+          ],
+          "cwe": "CWE-20",
+          "published": "2022-08-31T16:15:00Z",
+          "modified": "2022-10-07T14:14:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1271"
+        }
+      ],
+      "score": 88,
+      "worstScore": {
+        "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 8.8
+      },
+      "published": "2022-04-13T12:45:29Z",
+      "modified": "2022-04-13T12:45:29Z"
+    },
+    {
+      "ID": "USN-5378-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5378-1",
+      "title": "Gzip vulnerability",
+      "description": "Cleemy Desu Wayo discovered that Gzip incorrectly handled certain\nfilenames. If a user or automated system were tricked into performing zgrep\noperations with specially crafted filenames, a remote attacker could\noverwrite arbitrary files.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/gzip/version/1.10-0ubuntu4.1/arch//namespace/ubuntu:20.04",
+          "name": "gzip",
+          "version": "1.10-0ubuntu4.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "gzip",
+          "version": "1.10-0ubuntu4",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "1.10-0ubuntu4.1",
+          "namespace": "ubuntu:20.04",
+          "score": 88,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-1271",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1271",
+          "summary": "An arbitrary file write vulnerability was found in GNU gzip's zgrep utility. When zgrep is applied on the attacker's chosen file name (for example, a crafted file name), this can overwrite an attacker's content to an arbitrary attacker-selected file. This flaw occurs due to insufficient validation when processing filenames with two or more newlines where selected content and the target file names are embedded in crafted multi-line file names. This flaw allows a remote, low privileged attacker to force zgrep to write arbitrary files on the system.",
+          "score": 8.8,
+          "worstScore": {
+            "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 8.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:7",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:8",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:9",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 8.8
+            },
+            {
+              "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat",
+              "score": 8.8
+            }
+          ],
+          "cwe": "CWE-20",
+          "published": "2022-08-31T16:15:00Z",
+          "modified": "2022-10-07T14:14:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1271"
+        }
+      ],
+      "score": 88,
+      "worstScore": {
+        "vector": "8.8/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 8.8
+      },
+      "published": "2022-04-13T12:37:06Z",
+      "modified": "2022-04-13T12:37:06Z"
+    },
+    {
+      "ID": "USN-5310-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5310-1",
+      "title": "GNU C Library vulnerabilities",
+      "description": "Jan Engelhardt, Tavis Ormandy, and others discovered that the GNU C Library\niconv feature incorrectly handled certain input sequences. An attacker\ncould possibly use this issue to cause the GNU C Library to hang or crash,\nresulting in a denial of service. This issue only affected Ubuntu 18.04 LTS\nand Ubuntu 20.04 LTS. (CVE-2016-10228, CVE-2019-25013, CVE-2020-27618,\nCVE-2020-29562, CVE-2021-3326)\n\nJason Royes and Samuel Dytrych discovered that the GNU C Library\nincorrectly handled signed comparisons on ARMv7 targets. A remote attacker\ncould use this issue to cause the GNU C Library to crash, resulting in a\ndenial of service, or possibly execute arbitrary code. This issue only\naffected Ubuntu 18.04 LTS and Ubuntu 20.04 LTS. (CVE-2020-6096)\n\nIt was discovered that the GNU C Library nscd daemon incorrectly handled\ncertain netgroup lookups. An attacker could possibly use this issue to\ncause the GNU C Library to crash, resulting in a denial of service. This\nissue only affected Ubuntu 20.04 LTS. (CVE-2021-27645)\n\nIt was discovered that the GNU C Library wordexp function incorrectly\nhandled certain patterns. An attacker could use this issue to cause the\nGNU C Library to crash, resulting in a denial of service, or possibly\nobtain sensitive information. This issue only affected Ubuntu 18.04 LTS and\nUbuntu 20.04 LTS. (CVE-2021-35942)\n\nIt was discovered that the GNU C Library realpath function incorrectly\nhandled return values. An attacker could possibly use this issue to obtain\nsensitive information. This issue only affected Ubuntu 21.10.\n(CVE-2021-3998)\n\nIt was discovered that the GNU C library getcwd function incorrectly\nhandled buffers. An attacker could use this issue to cause the GNU C\nLibrary to crash, resulting in a denial of service, or possibly execute\narbitrary code. (CVE-2021-3999)\n\nIt was discovered that the GNU C Library sunrpc module incorrectly handled\nbuffer lengths. An attacker could possibly use this issue to cause the GNU\nC Library to crash, resulting in a denial of service. (CVE-2022-23218,\nCVE-2022-23219)\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libc6/version/2.31-0ubuntu9.7/arch//namespace/ubuntu:20.04",
+          "name": "libc6",
+          "version": "2.31-0ubuntu9.7",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libc6",
+          "version": "2.31-0ubuntu9.2",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "glibc",
+          "available": "2.31-0ubuntu9.9",
+          "namespace": "ubuntu:20.04",
+          "score": 78,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2016-10228",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2016-10228",
+          "summary": "The iconv program in the GNU C Library (aka glibc or libc6) 2.31 and earlier, when invoked with multiple suffixes in the destination encoding (TRANSLATE or IGNORE) along with the -c option, enters an infinite loop when processing invalid multi-byte input sequences, leading to a denial of service.",
+          "score": 5.9,
+          "worstScore": {
+            "vector": "5.9/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2016",
+            "score": 5.9
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "3.3/CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 3.3
+            },
+            {
+              "vector": "5.9/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2016",
+              "score": 5.9
+            },
+            {
+              "vector": "4.3/AV:N/AC:M/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2016",
+              "score": 4.3
+            },
+            {
+              "vector": "3.3/CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2017",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-20",
+          "published": "2017-03-02T01:59:00Z",
+          "modified": "2022-10-17T18:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-10228"
+        },
+        {
+          "ID": "CVE-2020-6096",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2020-6096",
+          "summary": "An exploitable signed comparison vulnerability exists in the ARMv7 memcpy() implementation of GNU glibc 2.30.9000. Calling memcpy() (on ARMv7 targets that utilize the GNU glibc implementation) with a negative value for the 'num' parameter results in a signed comparison vulnerability. If an attacker underflows the 'num' parameter to memcpy(), this vulnerability could lead to undefined behavior such as writing to out-of-bounds memory and potentially remote code execution. Furthermore, this memcpy() implementation allows for program execution to continue in scenarios where a segmentation fault or crash should have occurred. The dangers occur in that subsequent execution and iterations of this code will be executed with this corrupted data.",
+          "score": 8.1,
+          "worstScore": {
+            "vector": "8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2020",
+            "score": 8.1
+          },
+          "cvss": [
+            {
+              "vector": "8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2020",
+              "score": 8.1
+            },
+            {
+              "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2020",
+              "score": 6.8
+            },
+            {
+              "vector": "8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2020",
+              "score": 8.1
+            }
+          ],
+          "cwe": "CWE-195",
+          "published": "2020-04-01T22:15:00Z",
+          "modified": "2022-11-21T19:39:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-6096"
+        },
+        {
+          "ID": "CVE-2020-27618",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2020-27618",
+          "summary": "The iconv function in the GNU C Library (aka glibc or libc6) 2.32 and earlier, when processing invalid multi-byte input sequences in IBM1364, IBM1371, IBM1388, IBM1390, and IBM1399 encodings, fails to advance the input state, which could lead to an infinite loop in applications, resulting in a denial of service, a different vulnerability from CVE-2016-10228.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2020",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2020",
+              "score": 5.5
+            },
+            {
+              "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2020",
+              "score": 2.1
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2020",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 5.5
+            }
+          ],
+          "cwe": "CWE-835",
+          "published": "2021-02-26T23:15:00Z",
+          "modified": "2022-10-28T20:06:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-27618"
+        },
+        {
+          "ID": "CVE-2020-29562",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2020-29562",
+          "summary": "The iconv function in the GNU C Library (aka glibc or libc6) 2.30 to 2.32, when converting UCS4 text containing an irreversible character, fails an assertion in the code path and aborts the program, potentially resulting in a denial of service.",
+          "score": 4.8,
+          "worstScore": {
+            "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2020",
+            "score": 4.8
+          },
+          "cvss": [
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2020",
+              "score": 4.8
+            },
+            {
+              "vector": "2.1/AV:N/AC:H/Au:S/C:N/I:N/A:P",
+              "source": "cve://nvd/2020",
+              "score": 2.1
+            },
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2020",
+              "score": 4.8
+            }
+          ],
+          "cwe": "CWE-617",
+          "published": "2020-12-04T07:15:00Z",
+          "modified": "2021-03-19T18:41:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-29562"
+        },
+        {
+          "ID": "CVE-2019-25013",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2019-25013",
+          "summary": "The iconv feature in the GNU C Library (aka glibc or libc6) through 2.32, when processing invalid multi-byte input sequences in the EUC-KR encoding, may have a buffer over-read.",
+          "score": 5.9,
+          "worstScore": {
+            "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2019",
+            "score": 5.9
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:7",
+              "score": 4.8
+            },
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 4.8
+            },
+            {
+              "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2019",
+              "score": 5.9
+            },
+            {
+              "vector": "7.1/AV:N/AC:M/Au:N/C:N/I:N/A:C",
+              "source": "cve://nvd/2019",
+              "score": 7.1
+            },
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2019",
+              "score": 4.8
+            },
+            {
+              "vector": "4.8/CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 4.8
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2021-01-04T18:15:00Z",
+          "modified": "2022-11-03T19:37:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-25013"
+        },
+        {
+          "ID": "CVE-2021-3326",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-3326",
+          "summary": "The iconv function in the GNU C Library (aka glibc or libc6) 2.32 and earlier, when processing invalid input sequences in the ISO-2022-JP-3 encoding, fails an assertion in the code path and aborts the program, potentially resulting in a denial of service.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 7.5
+            },
+            {
+              "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2021",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-617",
+          "published": "2021-01-27T20:15:00Z",
+          "modified": "2022-11-04T20:07:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3326"
+        },
+        {
+          "ID": "CVE-2021-27645",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-27645",
+          "summary": "The nameserver caching daemon (nscd) in the GNU C Library (aka glibc or libc6) 2.29 through 2.33, when processing a request for netgroup lookup, may crash due to a double-free, potentially resulting in degraded service or Denial of Service on the local system. This is related to netgroupcache.c.",
+          "score": 2.5,
+          "worstScore": {
+            "vector": "2.5/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2021",
+            "score": 2.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "2.5/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 2.5
+            },
+            {
+              "vector": "2.5/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2021",
+              "score": 2.5
+            },
+            {
+              "vector": "1.9/AV:L/AC:M/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 1.9
+            },
+            {
+              "vector": "2.5/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 2.5
+            },
+            {
+              "vector": "2.5/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 2.5
+            }
+          ],
+          "cwe": "CWE-415",
+          "published": "2021-02-24T15:15:00Z",
+          "modified": "2022-11-04T20:06:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-27645"
+        },
+        {
+          "ID": "CVE-2021-35942",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-35942",
+          "summary": "The wordexp function in the GNU C Library (aka glibc) through 2.33 may crash or read arbitrary memory in parse_param (in posix/wordexp.c) when called with an untrusted, crafted pattern, potentially resulting in a denial of service or disclosure of information. This occurs because atoi was used but strtoul should have been used to ensure correct calculations.",
+          "score": 9.1,
+          "worstScore": {
+            "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 9.1
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 9.1
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 9.1
+            },
+            {
+              "vector": "6.4/AV:N/AC:L/Au:N/C:P/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 6.4
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "cve://redhat/2021",
+              "score": 9.1
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 9.1
+            }
+          ],
+          "cwe": "CWE-190",
+          "published": "2021-07-22T18:15:00Z",
+          "modified": "2022-11-08T13:29:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-35942"
+        },
+        {
+          "ID": "CVE-2021-3998",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-3998",
+          "summary": "A flaw was found in glibc. The realpath() function can mistakenly return an unexpected value, potentially leading to information leakage and disclosure of sensitive data.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "source": "cve://nvd/2021",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "source": "cve://redhat/2022",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "source": "cve://nvd/2021",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2022-08-24T16:15:00Z",
+          "modified": "2023-02-12T23:43:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3998"
+        },
+        {
+          "ID": "CVE-2021-3999",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-3999",
+          "summary": "A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.",
+          "score": 7.8,
+          "worstScore": {
+            "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2021",
+            "score": 7.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.4
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2021",
+              "score": 7.8
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat",
+              "score": 7.4
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7.4
+            }
+          ],
+          "cwe": "CWE-193",
+          "published": "2022-08-24T16:15:00Z",
+          "modified": "2023-02-12T23:43:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3999"
+        },
+        {
+          "ID": "CVE-2022-23218",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-23218",
+          "summary": "The deprecated compatibility function svcunix_create in the sunrpc module of the GNU C Library (aka glibc) through 2.34 copies its path argument on the stack without validating its length, which may result in a buffer overflow, potentially resulting in a denial of service or (if an application is not built with a stack protector enabled) arbitrary code execution.",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7
+            },
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2022",
+              "score": 7.5
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat",
+              "score": 7
+            },
+            {
+              "vector": "7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7
+            }
+          ],
+          "cwe": "CWE-120",
+          "published": "2022-01-14T07:15:00Z",
+          "modified": "2022-11-08T13:37:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23218"
+        },
+        {
+          "ID": "CVE-2022-23219",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-23219",
+          "summary": "The deprecated compatibility function clnt_create in the sunrpc module of the GNU C Library (aka glibc) through 2.34 copies its hostname argument on the stack without validating its length, which may result in a buffer overflow, potentially resulting in a denial of service or (if an application is not built with a stack protector enabled) arbitrary code execution.",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7
+            },
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2022",
+              "score": 7.5
+            },
+            {
+              "vector": "7.0/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "advisories://redhat",
+              "score": 7
+            },
+            {
+              "vector": "7/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:H",
+              "source": "cve://redhat/2017",
+              "score": 7
+            }
+          ],
+          "cwe": "CWE-120",
+          "published": "2022-01-14T07:15:00Z",
+          "modified": "2022-11-08T13:32:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23219"
+        }
+      ],
+      "score": 78,
+      "worstScore": {
+        "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2021",
+        "score": 7.8
+      },
+      "published": "2022-03-01T15:09:40Z",
+      "modified": "2022-03-01T15:09:40Z"
+    },
+    {
+      "ID": "USN-5900-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5900-1",
+      "title": "tar vulnerability",
+      "description": "It was discovered that tar incorrectly handled certain files.\nAn attacker could possibly use this issue to expose sensitive information\nor cause a crash.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/tar/version/1.30+dfsg-7ubuntu0.20.04.3/arch//namespace/ubuntu:20.04",
+          "name": "tar",
+          "version": "1.30+dfsg-7ubuntu0.20.04.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "tar",
+          "version": "1.30+dfsg-7ubuntu0.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "1.30+dfsg-7ubuntu0.20.04.3",
+          "namespace": "ubuntu:20.04",
+          "score": 78,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-48303",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-48303",
+          "summary": "GNU Tar through 1.34 has a one-byte out-of-bounds read that results in use of uninitialized memory for a conditional jump. Exploitation to change the flow of control has not been demonstrated. The issue occurs in from_header in list.c via a V7 archive in which mtime has approximately 11 whitespace characters.",
+          "score": 7.8,
+          "worstScore": {
+            "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 7.8
+          },
+          "cvss": [
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 7.8
+            },
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:9",
+              "score": 7.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat",
+              "score": 7.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7.8
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2023-01-30T04:15:00Z",
+          "modified": "2023-03-27T00:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-48303"
+        }
+      ],
+      "score": 78,
+      "worstScore": {
+        "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+        "source": "cve://nvd/2022",
+        "score": 7.8
+      },
+      "published": "2023-02-28T17:15:54Z",
+      "modified": "2023-02-28T17:15:54Z"
+    },
+    {
+      "ID": "USN-5550-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5550-1",
+      "title": "GnuTLS vulnerabilities",
+      "description": "It was discovered that GnuTLS incorrectly handled certain memory\noperations. A remote attacker could possibly use this issue to cause GnuTLS\nto crash, resulting in a denial of service. This issue only affected Ubuntu\n18.04 LTS, and Ubuntu 20.04 LTS. (CVE-2021-4209)\n\nIt was discovered that GnuTLS incorrectly handled the verification of\ncertain pkcs7 signatures. A remote attacker could use this issue to cause\nGnuTLS to crash, resulting in a denial of service, or possibly execute\narbitrary code. (CVE-2022-2509)\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libgnutls30/version/3.6.13-2ubuntu1.7/arch//namespace/ubuntu:20.04",
+          "name": "libgnutls30",
+          "version": "3.6.13-2ubuntu1.7",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libgnutls30",
+          "version": "3.6.13-2ubuntu1.6",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "gnutls28",
+          "available": "3.6.13-2ubuntu1.8",
+          "namespace": "ubuntu:20.04",
+          "score": 75,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2021-4209",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-4209",
+          "summary": "A NULL pointer dereference flaw was found in GnuTLS. As Nettle's hash update functions internally call memcpy, providing zero-length input may cause undefined behavior. This flaw leads to a denial of service after authentication in rare circumstances.",
+          "score": 6.5,
+          "worstScore": {
+            "vector": "6.5/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 6.5
+          },
+          "cvss": [
+            {
+              "vector": "6.5/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 6.5
+            },
+            {
+              "vector": "6.5/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2021",
+              "score": 6.5
+            }
+          ],
+          "cwe": "CWE-476",
+          "published": "2022-08-24T16:15:00Z",
+          "modified": "2022-10-27T16:57:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-4209"
+        },
+        {
+          "ID": "CVE-2022-2509",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-2509",
+          "summary": "A vulnerability found in gnutls. This security flaw happens because of a double free error occurs during verification of pkcs7 signatures in gnutls_pkcs7_verify function.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2022",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:9",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2022",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-415",
+          "published": "2022-08-01T14:15:00Z",
+          "modified": "2022-08-19T12:10:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-2509"
+        }
+      ],
+      "score": 75,
+      "worstScore": {
+        "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "source": "cve://nvd/2022",
+        "score": 7.5
+      },
+      "published": "2022-08-04T16:07:06Z",
+      "modified": "2022-08-04T16:07:06Z"
+    },
+    {
+      "ID": "USN-5446-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5446-1",
+      "title": "dpkg vulnerability",
+      "description": "Max Justicz discovered that dpkg incorrectly handled unpacking certain\nsource packages. If a user or an automated system were tricked into\nunpacking a specially crafted source package, a remote attacker could\nmodify files outside the target unpack directory, leading to a denial of\nservice or potentially gaining access to the system.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/dpkg/version/1.19.7ubuntu3.2/arch//namespace/ubuntu:20.04",
+          "name": "dpkg",
+          "version": "1.19.7ubuntu3.2",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "dpkg",
+          "version": "1.19.7ubuntu3",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "1.19.7ubuntu3.2",
+          "namespace": "ubuntu:20.04",
+          "score": 75,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-1664",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1664",
+          "summary": "Dpkg::Source::Archive in dpkg, the Debian package management system, before version 1.21.8, 1.20.10, 1.19.8, 1.18.26 is prone to a directory traversal vulnerability. When extracting untrusted source packages in v2 and v3 source package formats that include a debian.tar, the in-place extraction can lead to directory traversal situations on specially crafted orig.tar and debian.tar tarballs.",
+          "score": 9.8,
+          "worstScore": {
+            "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.8
+          },
+          "cvss": [
+            {
+              "vector": "9.8/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.8
+            },
+            {
+              "vector": "7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2022",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-22",
+          "published": "2022-05-26T14:15:00Z",
+          "modified": "2022-12-03T02:19:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1664"
+        }
+      ],
+      "score": 75,
+      "worstScore": {
+        "vector": "7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P",
+        "source": "cve://nvd/2022",
+        "score": 7.5
+      },
+      "published": "2022-05-26T11:16:17Z",
+      "modified": "2022-05-26T11:16:17Z"
+    },
+    {
+      "ID": "USN-5901-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5901-1",
+      "title": "GnuTLS vulnerability",
+      "description": "Hubert Kario discovered that GnuTLS had a timing side-channel when handling\ncertain RSA messages. A remote attacker could possibly use this issue to\nrecover sensitive information.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libgnutls30/version/3.6.13-2ubuntu1.8/arch//namespace/ubuntu:20.04",
+          "name": "libgnutls30",
+          "version": "3.6.13-2ubuntu1.8",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libgnutls30",
+          "version": "3.6.13-2ubuntu1.6",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "gnutls28",
+          "available": "3.6.13-2ubuntu1.8",
+          "namespace": "ubuntu:20.04",
+          "score": 75,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2023-0361",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2023-0361",
+          "summary": "A timing side-channel in the handling of RSA ClientKeyExchange messages was discovered in GnuTLS. This side-channel can be sufficient to recover the key encrypted in the RSA ciphertext across a network in a Bleichenbacher style attack. To achieve a successful decryption the attacker would need to send a large amount of specially crafted messages to the vulnerable server. By recovering the secret from the ClientKeyExchange message, the attacker would be able to decrypt the application data exchanged over that connection.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "source": "cve://nvd/2023",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "source": "cve://nvd/2023",
+              "score": 7.5
+            },
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+              "source": "advisories://redhat:9",
+              "score": 7.4
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+              "source": "advisories://redhat",
+              "score": 7.4
+            },
+            {
+              "vector": "7.4/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+              "source": "cve://redhat/2023",
+              "score": 7.4
+            }
+          ],
+          "cwe": "CWE-203",
+          "published": "2023-02-15T18:15:00Z",
+          "modified": "2023-03-24T16:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0361"
+        }
+      ],
+      "score": 75,
+      "worstScore": {
+        "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "source": "cve://nvd/2023",
+        "score": 7.5
+      },
+      "published": "2023-02-28T14:05:47Z",
+      "modified": "2023-02-28T14:05:47Z"
+    },
+    {
+      "ID": "USN-5380-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5380-1",
+      "title": "Bash vulnerability",
+      "description": "It was discovered that Bash did not properly drop privileges\nwhen the binary had the setuid bit enabled. An attacker could\npossibly use this issue to escalate privileges.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/bash/version/5.0-6ubuntu1.2/arch//namespace/ubuntu:20.04",
+          "name": "bash",
+          "version": "5.0-6ubuntu1.2",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "bash",
+          "version": "5.0-6ubuntu1.1",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "5.0-6ubuntu1.2",
+          "namespace": "ubuntu:20.04",
+          "score": 72,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2019-18276",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2019-18276",
+          "summary": "An issue was discovered in disable_priv_mode in shell.c in GNU Bash through 5.0 patch 11. By default, if Bash is run with its effective UID not equal to its real UID, it will drop privileges by setting its effective UID to its real UID. However, it does so incorrectly. On Linux and other systems that support \"saved UID\" functionality, the saved UID is not dropped. An attacker with command execution in the shell can use \"enable -f\" for runtime loading of a new builtin, which can be a shared object that calls setuid() and therefore regains privileges. However, binaries running with an effective UID of 0 are unaffected.",
+          "score": 7.8,
+          "worstScore": {
+            "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2019",
+            "score": 7.8
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2019",
+              "score": 7.8
+            },
+            {
+              "vector": "7.2/AV:L/AC:L/Au:N/C:C/I:C/A:C",
+              "source": "cve://nvd/2019",
+              "score": 7.2
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2019",
+              "score": 7.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "source": "advisories://redhat",
+              "score": 7.8
+            },
+            {
+              "vector": "3.6/CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N",
+              "source": "cve://redhat/2019",
+              "score": 3.6
+            }
+          ],
+          "cwe": "CWE-273",
+          "published": "2019-11-28T01:15:00Z",
+          "modified": "2022-06-07T18:41:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276"
+        }
+      ],
+      "score": 72,
+      "worstScore": {
+        "vector": "7.2/AV:L/AC:L/Au:N/C:C/I:C/A:C",
+        "source": "cve://nvd/2019",
+        "score": 7.2
+      },
+      "published": "2022-04-20T07:41:07Z",
+      "modified": "2022-04-20T07:41:07Z"
+    },
+    {
+      "ID": "USN-5689-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5689-1",
+      "title": "Perl vulnerability",
+      "description": "It was discovered that Perl incorrectly handled certain signature verification.\nAn remote attacker could possibly use this issue to bypass signature verification.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/perl/version/5.30.0-9ubuntu0.3/arch//namespace/ubuntu:20.04",
+          "name": "perl",
+          "version": "5.30.0-9ubuntu0.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "perl-base",
+          "version": "5.30.0-9ubuntu0.2",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "perl",
+          "available": "5.30.0-9ubuntu0.3",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2020-16156",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2020-16156",
+          "summary": "CPAN 2.28 allows Signature Verification Bypass.",
+          "score": 7.8,
+          "worstScore": {
+            "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "source": "cve://nvd/2020",
+            "score": 7.8
+          },
+          "cvss": [
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://nvd/2020",
+              "score": 7.8
+            },
+            {
+              "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2020",
+              "score": 6.8
+            },
+            {
+              "vector": "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2021",
+              "score": 7.8
+            }
+          ],
+          "cwe": "CWE-347",
+          "published": "2021-12-13T18:15:00Z",
+          "modified": "2022-04-01T13:26:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-16156"
+        }
+      ],
+      "score": 68,
+      "worstScore": {
+        "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+        "source": "cve://nvd/2020",
+        "score": 6.8
+      },
+      "published": "2022-10-19T11:10:27Z",
+      "modified": "2022-10-19T11:10:27Z"
+    },
+    {
+      "ID": "USN-5464-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5464-1",
+      "title": "e2fsprogs vulnerability",
+      "description": "Nils Bars discovered that e2fsprogs incorrectly handled certain file\nsystems. A local attacker could use this issue with a crafted file\nsystem image to possibly execute arbitrary code.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/e2fsprogs/version/1.45.5-2ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/e2fsprogs/version/1.45.5-2ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/e2fsprogs/version/1.45.5-2ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/e2fsprogs/version/1.45.5-2ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/e2fsprogs/version/1.45.5-2ubuntu1.1/arch//namespace/ubuntu:20.04",
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "e2fsprogs",
+          "version": "1.45.5-2ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "1.45.5-2ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        },
+        {
+          "name": "libcom-err2",
+          "version": "1.45.5-2ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "e2fsprogs",
+          "available": "1.45.5-2ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        },
+        {
+          "name": "libext2fs2",
+          "version": "1.45.5-2ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "e2fsprogs",
+          "available": "1.45.5-2ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        },
+        {
+          "name": "libss2",
+          "version": "1.45.5-2ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "e2fsprogs",
+          "available": "1.45.5-2ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        },
+        {
+          "name": "logsave",
+          "version": "1.45.5-2ubuntu1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "e2fsprogs",
+          "available": "1.45.5-2ubuntu1.1",
+          "namespace": "ubuntu:20.04",
+          "score": 68,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-1304",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1304",
+          "worstScore": {
+            "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "source": "cve://nvd/2022",
+            "score": 6.8
+          },
+          "cvss": [
+            {
+              "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+              "source": "cve://nvd/2022",
+              "score": 6.8
+            }
+          ]
+        }
+      ],
+      "score": 68,
+      "worstScore": {
+        "vector": "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P",
+        "source": "cve://nvd/2022",
+        "score": 6.8
+      },
+      "published": "2022-06-07T18:36:50Z",
+      "modified": "2022-06-07T18:36:50Z"
+    },
+    {
+      "ID": "USN-5627-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5627-1",
+      "title": "PCRE vulnerabilities",
+      "description": "It was discovered that PCRE incorrectly handled memory when \nhandling certain regular expressions. An attacker could possibly\nuse this issue to cause applications using PCRE to expose\nsensitive information.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libpcre2-8-0/version/10.34-7ubuntu0.1/arch//namespace/ubuntu:20.04",
+          "name": "libpcre2-8-0",
+          "version": "10.34-7ubuntu0.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libpcre2-8-0",
+          "version": "10.34-7",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "pcre2",
+          "available": "10.34-7ubuntu0.1",
+          "namespace": "ubuntu:20.04",
+          "score": 64,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-1586",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1586",
+          "summary": "An out-of-bounds read vulnerability was discovered in the PCRE2 library in the compile_xclass_matchingpath() function of the pcre2_jit_compile.c file. This involves a unicode property matching issue in JIT-compiled regular expressions. The issue occurs because the character was not fully read in case-less matching within JIT.",
+          "score": 9.1,
+          "worstScore": {
+            "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.1
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.1
+            },
+            {
+              "vector": "6.4/AV:N/AC:L/Au:N/C:P/I:N/A:P",
+              "source": "cve://nvd/2022",
+              "score": 6.4
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:9",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2022-05-16T21:15:00Z",
+          "modified": "2023-03-16T05:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1586"
+        },
+        {
+          "ID": "CVE-2022-1587",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-1587",
+          "summary": "An out-of-bounds read vulnerability was discovered in the PCRE2 library in the get_recurse_data_length() function of the pcre2_jit_compile.c file. This issue affects recursions in JIT-compiled regular expressions caused by duplicate data transfers.",
+          "score": 9.1,
+          "worstScore": {
+            "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+            "source": "cve://nvd/2022",
+            "score": 9.1
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "9.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+              "source": "cve://nvd/2022",
+              "score": 9.1
+            },
+            {
+              "vector": "6.4/AV:N/AC:L/Au:N/C:P/I:N/A:P",
+              "source": "cve://nvd/2022",
+              "score": 6.4
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:9",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2022-05-16T21:15:00Z",
+          "modified": "2023-03-16T05:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-1587"
+        }
+      ],
+      "score": 64,
+      "worstScore": {
+        "vector": "6.4/AV:N/AC:L/Au:N/C:P/I:N/A:P",
+        "source": "cve://nvd/2022",
+        "score": 6.4
+      },
+      "published": "2022-09-22T08:11:36Z",
+      "modified": "2022-09-22T08:11:36Z"
+    },
+    {
+      "ID": "USN-5503-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5503-1",
+      "title": "GnuPG vulnerability",
+      "description": "Demi Marie Obenour discovered that GnuPG incorrectly handled injection in\nthe status message. A remote attacker could possibly use this issue to\nforge signatures.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/gnupg2/version/2.2.19-3ubuntu2.2/arch//namespace/ubuntu:20.04",
+          "name": "gnupg2",
+          "version": "2.2.19-3ubuntu2.2",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "gpgv",
+          "version": "2.2.19-3ubuntu2.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "gnupg2",
+          "available": "2.2.19-3ubuntu2.2",
+          "namespace": "ubuntu:20.04",
+          "score": 58,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-34903",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-34903",
+          "summary": "GnuPG through 2.3.6, in unusual situations where an attacker possesses any secret-key information from a victim's keyring and other constraints (e.g., use of GPGME) are met, allows signature forgery via injection into the status line.",
+          "score": 6.5,
+          "worstScore": {
+            "vector": "6.5/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N",
+            "source": "cve://nvd/2022",
+            "score": 6.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "source": "advisories://redhat:8",
+              "score": 5.9
+            },
+            {
+              "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "source": "advisories://redhat:9",
+              "score": 5.9
+            },
+            {
+              "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "source": "cve://redhat/2022",
+              "score": 5.9
+            },
+            {
+              "vector": "5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "source": "advisories://redhat",
+              "score": 5.9
+            },
+            {
+              "vector": "6.5/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N",
+              "source": "cve://nvd/2022",
+              "score": 6.5
+            },
+            {
+              "vector": "5.8/AV:N/AC:M/Au:N/C:P/I:P/A:N",
+              "source": "cve://nvd/2022",
+              "score": 5.8
+            }
+          ],
+          "cwe": "CWE-74",
+          "published": "2022-07-01T22:15:00Z",
+          "modified": "2022-09-09T20:40:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-34903"
+        }
+      ],
+      "score": 58,
+      "worstScore": {
+        "vector": "5.8/AV:N/AC:M/Au:N/C:P/I:P/A:N",
+        "source": "cve://nvd/2022",
+        "score": 5.8
+      },
+      "published": "2022-07-05T13:18:15Z",
+      "modified": "2022-07-05T13:18:15Z"
+    },
+    {
+      "ID": "USN-5279-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5279-1",
+      "title": "util-linux vulnerabilities",
+      "description": "It was discovered that util-linux incorrectly handled unmounting FUSE\nfilesystems. A local attacker could possibly use this issue to unmount\nFUSE filesystems belonging to other users.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/mount/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "mount",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/util-linux/version/2.34-0.1ubuntu9.3/arch//namespace/ubuntu:20.04",
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "mount",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "fdisk",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libblkid1",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libfdisk1",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libmount1",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libsmartcols1",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libuuid1",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "mount",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "util-linux",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "util-linux",
+          "version": "2.34-0.1ubuntu9.1",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "2.34-0.1ubuntu9.3",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2021-3995",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-3995",
+          "summary": "A logic error was found in the libmount library of util-linux in the function that allows an unprivileged user to unmount a FUSE filesystem. This flaw allows an unprivileged local attacker to unmount FUSE filesystems that belong to certain other users who have a UID that is a prefix of the UID of the attacker in its string form. An attacker may use this flaw to cause a denial of service to applications that use the affected filesystems.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 5.5
+            },
+            {
+              "vector": "4.7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 4.7
+            }
+          ],
+          "cwe": "CWE-552",
+          "published": "2022-08-23T20:15:00Z",
+          "modified": "2023-02-03T23:30:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3995"
+        },
+        {
+          "ID": "CVE-2021-3996",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-3996",
+          "summary": "A logic error was found in the libmount library of util-linux in the function that allows an unprivileged user to unmount a FUSE filesystem. This flaw allows a local user on a vulnerable system to unmount other users' filesystems that are either world-writable themselves (like /tmp) or mounted in a world-writable directory. An attacker may use this flaw to cause a denial of service to applications that use the affected filesystems.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 5.5
+            }
+          ],
+          "cwe": "CWE-552",
+          "published": "2022-08-23T20:15:00Z",
+          "modified": "2023-01-26T20:38:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-3996"
+        }
+      ],
+      "score": 55,
+      "worstScore": {
+        "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+        "source": "cve://nvd/2021",
+        "score": 5.5
+      },
+      "published": "2022-02-09T13:26:34Z",
+      "modified": "2022-02-09T13:26:34Z"
+    },
+    {
+      "ID": "USN-5928-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5928-1",
+      "title": "systemd vulnerabilities",
+      "description": "It was discovered that systemd did not properly validate the time and\naccuracy values provided to the format_timespan() function. An attacker\ncould possibly use this issue to cause a buffer overrun, leading to a\ndenial of service attack. This issue only affected Ubuntu 14.04 ESM, Ubuntu\n16.04 ESM, Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, and Ubuntu 22.04 LTS.\n(CVE-2022-3821)\n\nIt was discovered that systemd did not properly manage the fs.suid_dumpable\nkernel configurations. A local attacker could possibly use this issue to\nexpose sensitive information. This issue only affected Ubuntu 20.04 LTS,\nUbuntu 22.04 LTS, and Ubuntu 22.10. (CVE-2022-4415)\n\nIt was discovered that systemd did not properly manage a crash with long\nbacktrace data. A local attacker could possibly use this issue to cause a\ndeadlock, leading to a denial of service attack. This issue only affected\nUbuntu 22.10. (CVE-2022-45873)\n",
+      "fixed": [
+        {
+          "ID": "deb://name/systemd/version/245.4-4ubuntu3.20/arch//namespace/ubuntu:20.04",
+          "name": "systemd",
+          "version": "245.4-4ubuntu3.20",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/systemd/version/245.4-4ubuntu3.20/arch//namespace/ubuntu:20.04",
+          "name": "systemd",
+          "version": "245.4-4ubuntu3.20",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libsystemd0",
+          "version": "245.4-4ubuntu3.15",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "systemd",
+          "available": "245.4-4ubuntu3.21",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        },
+        {
+          "name": "libudev1",
+          "version": "245.4-4ubuntu3.15",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "systemd",
+          "available": "245.4-4ubuntu3.21",
+          "namespace": "ubuntu:20.04",
+          "score": 55,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2022-3821",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-3821",
+          "summary": "An off-by-one Error issue was discovered in Systemd in format_timespan() function of time-util.c. An attacker could supply specific values for time and accuracy that leads to buffer overrun in format_timespan(), leading to a Denial of Service.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2022",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:9",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2022",
+              "score": 5.5
+            }
+          ],
+          "cwe": "CWE-193",
+          "published": "2022-11-08T22:15:00Z",
+          "modified": "2022-12-02T22:45:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3821"
+        },
+        {
+          "ID": "CVE-2022-45873",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-45873",
+          "summary": "systemd 250 and 251 allows local users to achieve a systemd-coredump deadlock by triggering a crash that has a long backtrace. This occurs in parse_elf_object in shared/elf-util.c. The exploitation methodology is to crash a binary calling the same function recursively, and put it in a deeply nested directory to make its backtrace large enough to cause the deadlock. This must be done 16 times when MaxConnections=16 is set for the systemd/units/systemd-coredump.socket file.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2022",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:9",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2022",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2022",
+              "score": 5.5
+            }
+          ],
+          "cwe": "CWE-400",
+          "published": "2022-11-23T23:15:00Z",
+          "modified": "2023-03-01T14:27:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-45873"
+        },
+        {
+          "ID": "CVE-2022-4415",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2022-4415",
+          "summary": "A vulnerability was found in systemd. This security flaw can cause a local information leak due to systemd-coredump not respecting the fs.suid_dumpable kernel setting.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "source": "cve://nvd/2022",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "advisories://redhat:8",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "advisories://redhat:9",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "cve://redhat/2022",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "advisories://redhat",
+              "score": 5.5
+            },
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+              "source": "cve://nvd/2022",
+              "score": 5.5
+            }
+          ],
+          "cwe": "NVD-CWE-noinfo",
+          "published": "2023-01-11T15:15:00Z",
+          "modified": "2023-02-02T16:19:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-4415"
+        }
+      ],
+      "score": 55,
+      "worstScore": {
+        "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+        "source": "cve://nvd/2022",
+        "score": 5.5
+      },
+      "published": "2023-03-07T07:35:51Z",
+      "modified": "2023-03-07T07:35:51Z"
+    },
+    {
+      "ID": "USN-5425-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5425-1",
+      "title": "PCRE vulnerabilities",
+      "description": "Yunho Kim discovered that PCRE incorrectly handled memory when \nhandling certain regular expressions. An attacker could possibly use\nthis issue to cause applications using PCRE to expose sensitive\ninformation. This issue only affects Ubuntu 18.04 LTS, \nUbuntu 20.04 LTS, Ubuntu 21.10 and Ubuntu 22.04 LTS. (CVE-2019-20838)\n\nIt was discovered that PCRE incorrectly handled memory when \nhandling certain regular expressions. An attacker could possibly use\nthis issue to cause applications using PCRE to have unexpected \nbehavior. This issue only affects Ubuntu 14.04 ESM, Ubuntu 16.04 ESM,\nUbuntu 18.04 LTS and Ubuntu 20.04 LTS. (CVE-2020-14155)\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libpcre3/version/2:8.39-12ubuntu0.1/arch//namespace/ubuntu:20.04",
+          "name": "libpcre3",
+          "version": "2:8.39-12ubuntu0.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libpcre3",
+          "version": "2:8.39-12build1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "pcre3",
+          "available": "2:8.39-12ubuntu0.1",
+          "namespace": "ubuntu:20.04",
+          "score": 50,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2020-14155",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2020-14155",
+          "summary": "libpcre in PCRE before 8.44 allows an integer overflow via a large number after a (?C substring.",
+          "score": 5.3,
+          "worstScore": {
+            "vector": "5.3/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2020",
+            "score": 5.3
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "5.3/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 5.3
+            },
+            {
+              "vector": "5.3/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2020",
+              "score": 5.3
+            },
+            {
+              "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2020",
+              "score": 5
+            },
+            {
+              "vector": "5.3/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2020",
+              "score": 5.3
+            },
+            {
+              "vector": "5.3/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 5.3
+            }
+          ],
+          "cwe": "CWE-190",
+          "published": "2020-06-15T17:15:00Z",
+          "modified": "2022-12-03T03:00:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-14155"
+        },
+        {
+          "ID": "CVE-2019-20838",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2019-20838",
+          "summary": "libpcre in PCRE before 8.43 allows a subject buffer over-read in JIT when UTF is disabled, and \\X or \\R has more than one fixed quantifier, a related issue to CVE-2019-20454.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2019",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat:8",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2019",
+              "score": 7.5
+            },
+            {
+              "vector": "4.3/AV:N/AC:M/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2019",
+              "score": 4.3
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2020",
+              "score": 7.5
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "advisories://redhat",
+              "score": 7.5
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2020-06-15T17:15:00Z",
+          "modified": "2021-09-22T14:22:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-20838"
+        }
+      ],
+      "score": 50,
+      "worstScore": {
+        "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+        "source": "cve://nvd/2020",
+        "score": 5
+      },
+      "published": "2022-05-17T15:31:52Z",
+      "modified": "2022-05-17T15:31:52Z"
+    },
+    {
+      "ID": "USN-5355-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5355-1",
+      "title": "zlib vulnerability",
+      "description": "Danilo Ramos discovered that zlib incorrectly handled memory when\nperforming certain deflating operations. An attacker could use this issue\nto cause zlib to crash, resulting in a denial of service, or possibly\nexecute arbitrary code.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/zlib1g/version/1:1.2.11.dfsg-2ubuntu1.3/arch//namespace/ubuntu:20.04",
+          "name": "zlib1g",
+          "version": "1:1.2.11.dfsg-2ubuntu1.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "zlib1g",
+          "version": "1:1.2.11.dfsg-2ubuntu1.2",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "zlib",
+          "available": "1:1.2.11.dfsg-2ubuntu1.5",
+          "namespace": "ubuntu:20.04",
+          "score": 98,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2018-25032",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2018-25032",
+          "summary": "zlib before 1.2.12 allows memory corruption when deflating (i.e., when compressing) if the input has many distant matches.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2018",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat:6",
+              "score": 8.2
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat:7",
+              "score": 8.2
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat:8",
+              "score": 8.2
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat:9",
+              "score": 8.2
+            },
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2018",
+              "score": 7.5
+            },
+            {
+              "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2018",
+              "score": 5
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "advisories://redhat",
+              "score": 8.2
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "cve://redhat/2018",
+              "score": 8.2
+            },
+            {
+              "vector": "8.2/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H",
+              "source": "cve://redhat/2022",
+              "score": 8.2
+            }
+          ],
+          "cwe": "CWE-787",
+          "published": "2022-03-25T09:15:00Z",
+          "modified": "2023-02-11T17:44:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-25032"
+        }
+      ],
+      "score": 50,
+      "worstScore": {
+        "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+        "source": "cve://nvd/2018",
+        "score": 5
+      },
+      "published": "2022-03-30T14:24:46Z",
+      "modified": "2022-03-30T14:24:46Z"
+    },
+    {
+      "ID": "USN-5672-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5672-1",
+      "title": "GMP vulnerability",
+      "description": "It was discovered that GMP did not properly manage memory\non 32-bit platforms when processing a specially crafted\ninput. An attacker could possibly use this issue to cause\napplications using GMP to crash, resulting in a denial of\nservice.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libgmp10/version/2:6.2.0+dfsg-4ubuntu0.1/arch//namespace/ubuntu:20.04",
+          "name": "libgmp10",
+          "version": "2:6.2.0+dfsg-4ubuntu0.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libgmp10",
+          "version": "2:6.2.0+dfsg-4",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "gmp",
+          "available": "2:6.2.0+dfsg-4ubuntu0.1",
+          "namespace": "ubuntu:20.04",
+          "score": 50,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2021-43618",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-43618",
+          "summary": "GNU Multiple Precision Arithmetic Library (GMP) through 6.2.1 has an mpz/inp_raw.c integer overflow and resultant buffer overflow via crafted input, leading to a segmentation fault on 32-bit platforms.",
+          "score": 7.5,
+          "worstScore": {
+            "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 7.5
+          },
+          "cvss": [
+            {
+              "vector": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 7.5
+            },
+            {
+              "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 5
+            },
+            {
+              "vector": "6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "source": "cve://redhat/2021",
+              "score": 6.2
+            }
+          ],
+          "cwe": "CWE-190",
+          "published": "2021-11-15T04:15:00Z",
+          "modified": "2022-12-08T22:15:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43618"
+        }
+      ],
+      "score": 50,
+      "worstScore": {
+        "vector": "5/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+        "source": "cve://nvd/2021",
+        "score": 5
+      },
+      "published": "2022-10-12T12:54:58Z",
+      "modified": "2022-10-12T12:54:58Z"
+    },
+    {
+      "ID": "USN-5329-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5329-1",
+      "title": "tar vulnerability",
+      "description": "It was discovered that tar incorrectly handled certain files.\nAn attacker could possibly use this issue to cause tar to crash,\nresulting in a denial of service.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/tar/version/1.30+dfsg-7ubuntu0.20.04.2/arch//namespace/ubuntu:20.04",
+          "name": "tar",
+          "version": "1.30+dfsg-7ubuntu0.20.04.2",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "tar",
+          "version": "1.30+dfsg-7ubuntu0.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "available": "1.30+dfsg-7ubuntu0.20.04.3",
+          "namespace": "ubuntu:20.04",
+          "score": 78,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2021-20193",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-20193",
+          "summary": "A flaw was found in the src/list.c of tar 1.33 and earlier. This flaw allows an attacker who can submit a crafted input file to tar to cause uncontrolled consumption of memory. The highest threat from this vulnerability is to system availability.",
+          "score": 5.5,
+          "worstScore": {
+            "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "source": "cve://nvd/2021",
+            "score": 5.5
+          },
+          "cvss": [
+            {
+              "vector": "5.5/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+              "source": "cve://nvd/2021",
+              "score": 5.5
+            },
+            {
+              "vector": "4.3/AV:N/AC:M/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 4.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2021-03-26T17:15:00Z",
+          "modified": "2021-06-03T18:53:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193"
+        }
+      ],
+      "score": 43,
+      "worstScore": {
+        "vector": "4.3/AV:N/AC:M/Au:N/C:N/I:N/A:P",
+        "source": "cve://nvd/2021",
+        "score": 4.3
+      },
+      "published": "2022-03-15T17:52:56Z",
+      "modified": "2022-03-15T17:52:56Z"
+    },
+    {
+      "ID": "USN-5745-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5745-1",
+      "title": "shadow vulnerability",
+      "description": "Florian Weimer discovered that shadow was not properly copying and removing\nuser directory trees, which could lead to a race condition. A local attacker\ncould possibly use this issue to setup a symlink attack and alter or remove\ndirectories without authorization.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/passwd/version/1:4.8.1-1ubuntu5.20.04.3/arch//namespace/ubuntu:20.04",
+          "name": "passwd",
+          "version": "1:4.8.1-1ubuntu5.20.04.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/login/version/1:4.8.1-1ubuntu5.20.04.3/arch//namespace/ubuntu:20.04",
+          "name": "login",
+          "version": "1:4.8.1-1ubuntu5.20.04.3",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "passwd",
+          "version": "1:4.8.1-1ubuntu5.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "shadow",
+          "available": "1:4.8.1-1ubuntu5.20.04.4",
+          "namespace": "ubuntu:20.04",
+          "score": 33,
+          "affected": true
+        },
+        {
+          "name": "login",
+          "version": "1:4.8.1-1ubuntu5.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "shadow",
+          "available": "1:4.8.1-1ubuntu5.20.04.4",
+          "namespace": "ubuntu:20.04",
+          "score": 33,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2013-4235",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2013-4235",
+          "summary": "shadow: TOCTOU (time-of-check time-of-use) race condition when copying and removing directory trees",
+          "score": 4.7,
+          "worstScore": {
+            "vector": "4.7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "source": "cve://nvd/2013",
+            "score": 4.7
+          },
+          "cvss": [
+            {
+              "vector": "4.7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+              "source": "cve://nvd/2013",
+              "score": 4.7
+            },
+            {
+              "vector": "3.3/AV:L/AC:M/Au:N/C:N/I:P/A:P",
+              "source": "cve://nvd/2013",
+              "score": 3.3
+            },
+            {
+              "vector": "4.4/CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:H/A:N",
+              "source": "cve://redhat/2015",
+              "score": 4.4
+            },
+            {
+              "vector": "3.7/AV:L/AC:H/Au:N/C:P/I:P/A:P",
+              "source": "cve://redhat/2015",
+              "score": 3.7
+            },
+            {
+              "vector": "6.7/CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2015",
+              "score": 6.7
+            }
+          ],
+          "cwe": "CWE-367",
+          "published": "2019-12-03T15:15:00Z",
+          "modified": "2023-02-13T00:28:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235"
+        }
+      ],
+      "score": 33,
+      "worstScore": {
+        "vector": "3.3/AV:L/AC:M/Au:N/C:N/I:P/A:P",
+        "source": "cve://nvd/2013",
+        "score": 3.3
+      },
+      "published": "2022-11-28T14:28:11Z",
+      "modified": "2022-11-28T14:28:11Z"
+    },
+    {
+      "ID": "USN-5745-2",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5745-2",
+      "title": "shadow regression",
+      "description": "USN-5745-1 fixed vulnerabilities in shadow. Unfortunately that update\nintroduced a regression that caused useradd to behave incorrectly in Ubuntu\n14.04 ESM, Ubuntu 16.04 ESM, Ubuntu 18.04 LTS and Ubuntu 20.04 LTS. This\nupdate reverts the security fix pending further investigation.\n\nWe apologize for the inconvenience.\n\nOriginal advisory details:\n\n Florian Weimer discovered that shadow was not properly copying and removing\n user directory trees, which could lead to a race condition. A local attacker\n could possibly use this issue to setup a symlink attack and alter or remove\n directories without authorization.\n",
+      "fixed": [
+        {
+          "ID": "deb://name/login/version/1:4.8.1-1ubuntu5.20.04.4/arch//namespace/ubuntu:20.04",
+          "name": "login",
+          "version": "1:4.8.1-1ubuntu5.20.04.4",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        },
+        {
+          "ID": "deb://name/passwd/version/1:4.8.1-1ubuntu5.20.04.4/arch//namespace/ubuntu:20.04",
+          "name": "passwd",
+          "version": "1:4.8.1-1ubuntu5.20.04.4",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "login",
+          "version": "1:4.8.1-1ubuntu5.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "shadow",
+          "available": "1:4.8.1-1ubuntu5.20.04.4",
+          "namespace": "ubuntu:20.04",
+          "score": 33,
+          "affected": true
+        },
+        {
+          "name": "passwd",
+          "version": "1:4.8.1-1ubuntu5.20.04.1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "shadow",
+          "available": "1:4.8.1-1ubuntu5.20.04.4",
+          "namespace": "ubuntu:20.04",
+          "score": 33,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2013-4235",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2013-4235",
+          "summary": "shadow: TOCTOU (time-of-check time-of-use) race condition when copying and removing directory trees",
+          "score": 4.7,
+          "worstScore": {
+            "vector": "4.7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "source": "cve://nvd/2013",
+            "score": 4.7
+          },
+          "cvss": [
+            {
+              "vector": "4.7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+              "source": "cve://nvd/2013",
+              "score": 4.7
+            },
+            {
+              "vector": "3.3/AV:L/AC:M/Au:N/C:N/I:P/A:P",
+              "source": "cve://nvd/2013",
+              "score": 3.3
+            },
+            {
+              "vector": "4.4/CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:N/I:H/A:N",
+              "source": "cve://redhat/2015",
+              "score": 4.4
+            },
+            {
+              "vector": "3.7/AV:L/AC:H/Au:N/C:P/I:P/A:P",
+              "source": "cve://redhat/2015",
+              "score": 3.7
+            },
+            {
+              "vector": "6.7/CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+              "source": "cve://redhat/2015",
+              "score": 6.7
+            }
+          ],
+          "cwe": "CWE-367",
+          "published": "2019-12-03T15:15:00Z",
+          "modified": "2023-02-13T00:28:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235"
+        }
+      ],
+      "score": 33,
+      "worstScore": {
+        "vector": "3.3/AV:L/AC:M/Au:N/C:N/I:P/A:P",
+        "source": "cve://nvd/2013",
+        "score": 3.3
+      },
+      "published": "2022-11-29T17:23:51Z",
+      "modified": "2022-11-29T17:23:51Z"
+    },
+    {
+      "ID": "USN-5391-1",
+      "Mrn": "//vadvisor.api.mondoo.app/advisories/USN-5391-1",
+      "title": "libsepol vulnerabilities",
+      "description": "Nicolas Iooss discovered that libsepol incorrectly handled memory\nwhen handling policies. An attacker could possibly use this issue\nto cause a crash, resulting in a denial of service, or possibly\nexecute arbitrary code. (CVE-2021-36084)\n\nIt was discovered that libsepol incorrectly handled memory when\nhandling policies. An attacker could possibly use this issue to cause\na crash, resulting in a denial of service, or possibly execute\narbitrary code. (CVE-2021-36085)\n\nIt was discovered that libsepol incorrectly handled memory when\nhandling policies. An attacker could possibly use this issue to cause\na crash, resulting in a denial of service, or possibly execute\narbitrary code. This issue only affects Ubuntu 18.04 LTS, \nUbuntu 20.04 LTS and Ubuntu 21.10. (CVE-2021-36086)\n\nIt was discovered that libsepol incorrectly validated certain data,\nleading to a heap overflow. An attacker could possibly use this issue\nto cause a crash, resulting in a denial of service, or possibly execute\narbitrary code. (CVE-2021-36087)\n",
+      "fixed": [
+        {
+          "ID": "deb://name/libsepol1/version/3.0-1ubuntu0.1/arch//namespace/ubuntu:20.04",
+          "name": "libsepol1",
+          "version": "3.0-1ubuntu0.1",
+          "format": "deb",
+          "namespace": "ubuntu:20.04"
+        }
+      ],
+      "affected": [
+        {
+          "name": "libsepol1",
+          "version": "3.0-1",
+          "arch": "amd64",
+          "format": "deb",
+          "origin": "libsepol",
+          "available": "3.0-1ubuntu0.1",
+          "namespace": "ubuntu:20.04",
+          "score": 21,
+          "affected": true
+        }
+      ],
+      "cves": [
+        {
+          "ID": "CVE-2021-36084",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-36084",
+          "summary": "The CIL compiler in SELinux 3.2 has a use-after-free in __cil_verify_classperms (called from __cil_verify_classpermission and __cil_pre_verify_helper).",
+          "score": 3.3,
+          "worstScore": {
+            "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2021",
+            "score": 3.3
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 2.1
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-416",
+          "published": "2021-07-01T03:15:00Z",
+          "modified": "2021-11-17T03:16:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-36084"
+        },
+        {
+          "ID": "CVE-2021-36085",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-36085",
+          "summary": "The CIL compiler in SELinux 3.2 has a use-after-free in __cil_verify_classperms (called from __verify_map_perm_classperms and hashtab_map).",
+          "score": 3.3,
+          "worstScore": {
+            "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2021",
+            "score": 3.3
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 2.1
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-416",
+          "published": "2021-07-01T03:15:00Z",
+          "modified": "2021-11-17T03:26:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-36085"
+        },
+        {
+          "ID": "CVE-2021-36086",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-36086",
+          "summary": "The CIL compiler in SELinux 3.2 has a use-after-free in cil_reset_classpermission (called from cil_reset_classperms_set and cil_reset_classperms_list).",
+          "score": 3.3,
+          "worstScore": {
+            "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2021",
+            "score": 3.3
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 2.1
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-416",
+          "published": "2021-07-01T03:15:00Z",
+          "modified": "2021-11-17T03:27:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-36086"
+        },
+        {
+          "ID": "CVE-2021-36087",
+          "Mrn": "//vadvisor.api.mondoo.app/cves/CVE-2021-36087",
+          "summary": "The CIL compiler in SELinux 3.2 has a heap-based buffer over-read in ebitmap_match_any (called indirectly from cil_check_neverallow). This occurs because there is sometimes a lack of checks for invalid statements in an optional block.",
+          "score": 3.3,
+          "worstScore": {
+            "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "source": "cve://nvd/2021",
+            "score": 3.3
+          },
+          "cvss": [
+            {
+              "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat"
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat:8",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://nvd/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+              "source": "cve://nvd/2021",
+              "score": 2.1
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "cve://redhat/2021",
+              "score": 3.3
+            },
+            {
+              "vector": "3.3/CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+              "source": "advisories://redhat",
+              "score": 3.3
+            }
+          ],
+          "cwe": "CWE-125",
+          "published": "2021-07-01T03:15:00Z",
+          "modified": "2021-11-17T14:05:00Z",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-36087"
+        }
+      ],
+      "score": 21,
+      "worstScore": {
+        "vector": "2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P",
+        "source": "cve://nvd/2021",
+        "score": 2.1
+      },
+      "published": "2022-04-27T09:32:18Z",
+      "modified": "2022-04-27T09:32:18Z"
+    }
+  ],
+  "stats": {
+    "score": 98,
+    "affected": true,
+    "advisories": {
+      "total": 24,
+      "critical": 3,
+      "high": 8,
+      "medium": 10,
+      "low": 3
+    },
+    "cves": {
+      "total": 41,
+      "critical": 8,
+      "high": 13,
+      "medium": 15,
+      "low": 5
+    },
+    "packages": {
+      "total": 92,
+      "affected": 32,
+      "critical": 2,
+      "high": 7,
+      "medium": 20,
+      "low": 3
+    },
+    "exploits": {}
+  },
+  "published": "2023-04-26T15:50:32Z"
+}


### PR DESCRIPTION
This adds the following output formatters to `cnspec vuln`:
- summary
- full
- json
- yaml
- csv

`cnspec vuln` does not support `junit` and `report`. It will return an error message instead.

Fixes #366 