### PR TITLE
⭐️ Score errors as failures

### DIFF
--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -30,6 +30,10 @@ func ExecuteResolvedPolicy(schema *resources.Schema, runtime *resources.Runtime,
 		builder.WithProgressReporter(progressReporter)
 	}
 
+	if features.IsActive(cnquery.ErrorsAsFailures) {
+		builder.WithFeatureFlagFailErrors()
+	}
+
 	ge, err := builder.Build(schema, runtime, assetMrn)
 	if err != nil {
 		return err

--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -61,6 +61,8 @@ type GraphExecutor struct {
 	executionManager *executionManager
 	resultChan       chan *llx.RawResult
 	doneChan         chan struct{}
+
+	featureFlagFailErrors bool
 }
 
 // Execute executes the graph

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -424,6 +424,8 @@ type ReportingJobNodeData struct {
 	datapoints  map[NodeID]*reportingJobDatapoint
 	completed   bool
 	invalidated bool
+
+	featureFlagFailErrors bool
 }
 
 func (nodeData *ReportingJobNodeData) initialize() {
@@ -530,7 +532,11 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 		return s, nil
 	}
 
-	calculator, err := policy.NewScoreCalculator(nodeData.scoringSystem)
+	scoreCalculatorOptions := []policy.ScoreCalculatorOption{}
+	if nodeData.featureFlagFailErrors {
+		scoreCalculatorOptions = append(scoreCalculatorOptions, policy.WithScoreCalculatorFeatureFlagFailErrors())
+	}
+	calculator, err := policy.NewScoreCalculator(nodeData.scoringSystem, scoreCalculatorOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/executor/internal/nodes_test.go
+++ b/policy/executor/internal/nodes_test.go
@@ -1154,6 +1154,40 @@ func TestReportingJobNode(t *testing.T) {
 						assert.Equal(t, 95, int(data.score.DataCompletion))
 						assert.Equal(t, 20, int(data.score.DataTotal))
 					})
+
+					t.Run("when score with error", func(t *testing.T) {
+						nodeData := newNodeData()
+
+						nodeData.childScores = map[NodeID]*reportingJobResult{
+							"rjID1": {
+								score: &policy.Score{
+									QrId:            "qrid1",
+									Type:            policy.ScoreType_Result,
+									Value:           100,
+									ScoreCompletion: 100,
+									DataTotal:       100,
+									DataCompletion:  100,
+								},
+							},
+							"rjID2": {
+								score: &policy.Score{
+									QrId:            "qrid2",
+									Type:            policy.ScoreType_Error,
+									Value:           50,
+									ScoreCompletion: 100,
+								},
+							},
+						}
+						nodeData.featureFlagFailErrors = true
+						nodeData.initialize()
+						data := nodeData.recalculate()
+
+						assert.Equal(t, "testqueryid", data.score.QrId)
+						assert.Equal(t, policy.ScoreType_Result, data.score.Type)
+						assert.Equal(t, 75, int(data.score.Value))
+						assert.Equal(t, 100, int(data.score.ScoreCompletion))
+					})
+
 					t.Run("when result", func(t *testing.T) {
 						nodeData := newNodeData()
 


### PR DESCRIPTION
This changes the way checks get scored when they're errored. Instead of ignoring them as part of the policy score, they will be scored no different than if they were failing.

This is behind a feature flag "ErrorsAsFailures".

Example policy `errors.yaml`:
```
policies:
  - uid: test-pol
    name: Errors as Failures Test
    specs:
      - asset_filter:
          query: platform.family.contains(_ == 'unix')
        scoring_queries:
          my-test1:
          my-test2:
queries:
  - uid: my-test1
    title: erroring check with sev 50
    severity: 50
    query: |
      file("/doesnotexit").content != ""
  - uid: my-test2
    title: /etc exists
    severity: 100
    query: |
      file("/etc").exists == true
```

```
❯ MONDOO_FEATURES="ErrorsAsFailures" go run apps/cnspec/cnspec.go scan local -f errors.yaml
```

```
Asset: mars
-----------

Checks:
! Error: erroring check with sev 50
✓ Pass:  A 100  /etc exists

Scanned 1 assets

Arch Linux
    B mars
```