### PR TITLE
⭐️ configurable report sharing

### DIFF
--- a/apps/cnspec/cmd/config/config.go
+++ b/apps/cnspec/cmd/config/config.go
@@ -23,5 +23,8 @@ type CliConfig struct {
 
 	// Asset Category
 	Category               string `json:"category,omitempty" mapstructure:"category"`
-	AutoDetectCICDCategory bool   `json:"detect-cicd,omitempty" mapstructure:"detect-cicd"`
+	AutoDetectCICDCategory bool   `json:"detect_cicd,omitempty" mapstructure:"detect_cicd"`
+
+	// Configure report sharing
+	ShareReport *bool `json:"share_report,omitempty" mapstructure:"share_report"`
 }


### PR DESCRIPTION
Users can now simply share a report via:

```
cnspec scan --share-report
```

If that is not set then the user is asked:

```
Do you want to view or share this report results via Mondoo's reporting service in a browser? [Y/n]
```

To disable the the sharing and not being asked, users either

- use the `--share-report=false` flag
- set the config with the following settings

```
share_report: false # only applicable if used unauthenticated 
```

When a user runs `cnspec scan --share-report` and has disabled the reporting in the config, the cli flag has precedence and therefore the report will be shared.