### PR TITLE
🧹 improve linter for variants

### DIFF
--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -29,7 +29,7 @@ func TestLintPass(t *testing.T) {
 	assert.True(t, len(data) > 0)
 }
 
-func TestLintComplexPass(t *testing.T) {
+func TestLintPassComplex(t *testing.T) {
 	file := "../../examples/complex.mql.yaml"
 	rootDir := "../../examples"
 	results, err := Lint(file)


### PR DESCRIPTION
fixes #526

With the new v8 and variants we support queries to have their own asset filter. Therefore policy groups do not necessarily need an asset filter anymore. We still need to see how this shapes out long term but it definitely makes sense not to show the warning when variants are uses since they need to have an asset filter.