### PR TITLE
🧹 allow specifying custom http timeout for serve-api cmd

### DIFF
--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -28,6 +28,8 @@ import (
 func init() {
 	serveApiCmd.Flags().String("address", "127.0.0.1", "address to listen on")
 	serveApiCmd.Flags().Uint("port", 8080, "port to listen on")
+	serveApiCmd.Flags().Uint("http-timeout", 30, "timeout for http requests in seconds")
+	serveApiCmd.Flags().MarkHidden("http-timeout")
 	rootCmd.AddCommand(serveApiCmd)
 }
 
@@ -38,6 +40,7 @@ var serveApiCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("port", cmd.Flags().Lookup("port"))
 		viper.BindPFlag("address", cmd.Flags().Lookup("address"))
+		viper.BindPFlag("http-timeout", cmd.Flags().Lookup("http-timeout"))
 
 		logger.StandardZerologLogger()
 
@@ -75,6 +78,9 @@ var serveApiCmd = &cobra.Command{
 			log.Error().Err(err).Msg("error seting up http client")
 			os.Exit(cnquery_cmd.ConfigurationErrorCode)
 		}
+
+		httpTimeout := viper.GetUint("http-timeout")
+		httpClient.Timeout = time.Duration(httpTimeout) * time.Second
 		log.Info().Msg("using service account credentials")
 		upstreamConfig := resources.UpstreamConfig{
 			SpaceMrn:    opts.GetParentMrn(),


### PR DESCRIPTION
The default HTTP timeout is 30s but sometimes that's not enough. For example, if the mondoo-operator needs to clean thousands of assets, it might take more than 30s. The operator itself sets the timeout for its client to 50minutes or so but the scan API terminates the request on 30s.

Added a flag to allow extending this timeout when needed