### PR TITLE
🐛 fix bundle lint panic

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -460,8 +460,8 @@ func hasVariants(group *PolicyGroup, queryMap map[string]*Mquery) bool {
 		}
 
 		// check referenced query
-		q := queryMap[check.Uid]
-		if q.Variants != nil {
+		q, ok := queryMap[check.Uid]
+		if ok && q.Variants != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
If there are no global queries defined, then `q` is nil, hence the panic

Fixes #553 