### PR TITLE
🐛 re-add binding of record flag

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -358,6 +358,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		viper.BindPFlag("sudo.active", cmd.Flags().Lookup("sudo"))
 
 		viper.BindPFlag("score-threshold", cmd.Flags().Lookup("score-threshold"))
+		viper.BindPFlag("record", cmd.Flags().Lookup("record"))
 
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 		// the logic is that noPager takes precedence over pager if both are sent

--- a/apps/cnspec/cmd/shell.go
+++ b/apps/cnspec/cmd/shell.go
@@ -47,6 +47,7 @@ var shellCmd = builder.NewProviderCommand(builder.CommandOpts{
 		viper.BindPFlag("policies", cmd.Flags().Lookup("policy"))
 		viper.BindPFlag("sudo.active", cmd.Flags().Lookup("sudo"))
 
+		viper.BindPFlag("record", cmd.Flags().Lookup("record"))
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 
 		viper.BindPFlag("vault.name", cmd.Flags().Lookup("vault"))


### PR DESCRIPTION
re-adds the ability to record scans