### PR TITLE
✨ variants inherit missing fields from parents

### DIFF
--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,22 @@ func TestPolicyBundleSort(t *testing.T) {
 	assert.Equal(t, "//policy.api.mondoo.app/policies/debian-10-level-1-server", policies[0].Mrn)
 	assert.Equal(t, "//captain.api.mondoo.app/spaces/adoring-moore-542492", policies[1].Mrn)
 	assert.Equal(t, "//assets.api.mondoo.app/spaces/adoring-moore-542492/assets/1dKBiOi5lkI2ov48plcowIy8WEl", policies[2].Mrn)
+}
+
+func TestBundleCompile(t *testing.T) {
+	bundle, err := BundleFromPaths("../examples/complex.mql.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+
+	bundlemap, err := bundle.Compile(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, bundlemap)
+
+	base := bundlemap.Queries["//local.cnspec.io/run/local-execution/queries/uname"]
+	require.NotNil(t, base, "variant base cannot be nil")
+
+	variant1 := bundlemap.Queries["//local.cnspec.io/run/local-execution/queries/unix-uname"]
+	require.NotNil(t, variant1, "variant cannot be nil")
+
+	assert.Equal(t, base.Title, variant1.Title)
 }


### PR DESCRIPTION
Allow variant queries to pull common fields from their parents, if they have not been specified. For example: title, descriptions, and properties.