### PR TITLE
🐛 fix cicd detection

### DIFF
--- a/apps/cnspec/cmd/config/config.go
+++ b/apps/cnspec/cmd/config/config.go
@@ -23,7 +23,7 @@ type CliConfig struct {
 
 	// Asset Category
 	Category               string `json:"category,omitempty" mapstructure:"category"`
-	AutoDetectCICDCategory bool   `json:"detect_cicd,omitempty" mapstructure:"detect_cicd"`
+	AutoDetectCICDCategory bool   `json:"detect-cicd,omitempty" mapstructure:"detect-cicd"`
 
 	// Configure report sharing
 	ShareReport *bool `json:"share_report,omitempty" mapstructure:"share_report"`


### PR DESCRIPTION
Detecting CI/CD environments has been broken since the release of v8.8.0 The root cause is that this flag has been renamed here https://github.com/mondoohq/cnspec/pull/543/files#diff-ed60d4b046d856a7d97de76331f9a47e1556bd4443a2efeda3558eb90390080fR26

```
KUBERNETES_ADMISSION_CONTROLLER=1 ./cnspec scan container image redis 
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ using service account credentials
→ discover related assets for 1 asset(s)
```

This fixes PR fixes the problem:
```
KUBERNETES_ADMISSION_CONTROLLER=1 ./cnspec scan container image redis  
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ detected ci-cd environment <-- THE IMPORTANT BIT
→ using service account credentials
→ discover related assets for 1 asset(s)
```