### PR TITLE
🐛 Fix bug where cnspec panics on missing variants

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -517,6 +518,9 @@ func (p *bundleCache) ensureNoCyclesInVariants(queries []*explorer.Mquery) error
 	// Gather all top-level queries with variants
 	queriesMap := map[string]*explorer.Mquery{}
 	for _, q := range queries {
+		if q == nil {
+			continue
+		}
 		if q.Mrn == "" {
 			// This should never happen. This function is called after all
 			// queries have their MRNs set.
@@ -906,7 +910,7 @@ func (c *bundleCache) precompileQuery(query *explorer.Mquery, policy *Policy) *e
 	// note: must happen after all MRNs (including variants) are computed
 	if policy != nil {
 		if err := policy.ComputedFilters.AddQueryFilters(query, c.lookupQuery); err != nil {
-			c.errors = append(c.errors, errors.New("failed to register filters for query "+query.Mrn))
+			c.errors = append(c.errors, fmt.Errorf("failed to register filters for query %s: %v", query.Mrn, err))
 			return nil
 		}
 	}


### PR DESCRIPTION
Test example:
```
policies:
    - uid: greetings
      name: Another policy
      version: "1.0.0"
      groups:
      - checks:
        - uid: hello-os
          variants:
          - uid: ubuntu
          - uid: rhel

queries:
  - uid: ubuntu
    title: Hello Ubuntu
    mql: platform.name == 'ubuntu'
    filters: platform.name == 'ubuntu'

  - uid: centos
    title: Hello Centos
    mql: platform.name == 'centos'
    filters: platform.name == 'centos'
```

Previous output:
```
❯ go run apps/cnspec/cnspec.go scan local -f ./variants.mql.yaml
→ loaded configuration from /home/jaym/.config/mondoo/mondoo.yml using source default
→ using service account credentials
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x82e24de]

goroutine 1 [running]:
go.mondoo.com/cnspec/policy.(*bundleCache).ensureNoCyclesInVariants(0xc001a03ad0?, {0xc000894b08, 0x1, 0x9db3260?})
	/home/jaym/workspace/mondoo/cnspec/policy/bundle.go:520 +0xbe
go.mondoo.com/cnspec/policy.(*bundleCache).compileQueries(0xc001a03ad0, {0xc0001458a0, 0x1, 0x9?}, 0x7f5ff83ec1d8?)
	/home/jaym/workspace/mondoo/cnspec/policy/bundle.go:814 +0xa6
go.mondoo.com/cnspec/policy.(*Bundle).Compile(0xc000ab52c0, {0xb338a50, 0xc0000ba0b0}, {0x0?, 0x0})
	/home/jaym/workspace/mondoo/cnspec/policy/bundle.go:705 +0xaff
go.mondoo.com/cnspec/apps/cnspec/cmd.(*scanConfig).loadPolicies(0xc00352ea00)
	/home/jaym/workspace/mondoo/cnspec/apps/cnspec/cmd/scan.go:618 +0x69
go.mondoo.com/cnspec/apps/cnspec/cmd.glob..func22(0x0?, {0xc000f12b00?, 0x0?, 0x0?}, 0x0?, 0x0?)
	/home/jaym/workspace/mondoo/cnspec/apps/cnspec/cmd/scan.go:388 +0x9a
go.mondoo.com/cnquery/apps/cnquery/cmd/builder.localProviderCmd.func1(0xc00328d200?, {0xc000f12b00?, 0x2?, 0x2?})
	/home/jaym/workspace/mondoo/cnquery/apps/cnquery/cmd/builder/builder.go:185 +0x2b
github.com/spf13/cobra.(*Command).execute(0xc00328d200, {0xc000f12ae0, 0x2, 0x2})
	/home/jaym/workspace/godev/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0x1001e460)
	/home/jaym/workspace/godev/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/jaym/workspace/godev/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
go.mondoo.com/cnspec/apps/cnspec/cmd.Execute()
	/home/jaym/workspace/mondoo/cnspec/apps/cnspec/cmd/root.go:80 +0x25
main.main()
	/home/jaym/workspace/mondoo/cnspec/apps/cnspec/cnspec.go:6 +0x17
exit status 2
```

New output:
```
❯ go run apps/cnspec/cnspec.go scan local -f ./variants.mql.yaml
→ loaded configuration from /home/jaym/.config/mondoo/mondoo.yml using source default
→ using service account credentials
FTL failed to resolve policies error="failed to compile bundle: failed to register filters for query //local.cnspec.io/run/local-execution/queries/hello-os: cannot find query variant //local.cnspec.io/run/local-execution/queries/rhel: query not found\n"
exit status 1
```

Fixes #564 