### PR TITLE
🐛 Assign the computed filters if recomputed

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -399,7 +399,17 @@ func (s *LocalServices) ComputeBundle(ctx context.Context, mpolicyObj *Policy) (
 				// However, we do this to avoid breaking the execution, while still
 				// logging the error.
 				log.Error().Str("new-policy-mrn", policy.Mrn).Str("caller", mpolicyObj.Mrn).Msg("received a policy with nil ComputedFilters; trying to refresh it")
-				nuPolicy.ComputeAssetFilters(ctx, s.DataLake.GetValidatedPolicy, s.DataLake.GetQuery, true)
+				filters, err := nuPolicy.ComputeAssetFilters(ctx, s.DataLake.GetValidatedPolicy, s.DataLake.GetQuery, true)
+				if err != nil {
+					return nil, err
+				}
+
+				nuPolicy.ComputedFilters = &explorer.Filters{
+					Items: make(map[string]*explorer.Mquery, len(filters)),
+				}
+				for _, f := range filters {
+					nuPolicy.ComputedFilters.Items[f.CodeId] = f
+				}
 			}
 
 			for k, v := range nuPolicy.ComputedFilters.Items {


### PR DESCRIPTION
This is causing panics:
```
go.mondoo.com/cnspec/policy.(*LocalServices).ComputeBundle(0xc020fd25a8, {0xd45b998, 0xc01c77c780}, 0xc020b5e780)
	/go/pkg/mod/go.mondoo.com/cnspec@v0.0.0-20230516164323-ea5aaaad968d/policy/hub.go:405 +0x8f4
```