### PR TITLE
🐛 report error trace for plugin calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -471,7 +471,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.107.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/grpc v1.53.0 // indirect
+	google.golang.org/grpc v1.53.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect


### PR DESCRIPTION
We have been swallowing all errors for plugin calls, which made them impossible to debug. I ran into this while debugging https://github.com/mondoohq/cnspec/issues/585 and noticed that as a user, I wasn't able to simply run:

```bash
> cnspec run terraform example.tf -c "terraform.blocks{arguments}"
FTL failed to run query error="rpc error: code = Unavailable desc = error reading from server: EOF"
```

That error is no help.

With this change, we are:
1. exposing the full stack trace of the crashing plugin and
2. formatting a few well-known errors in a way that is more meaningful

Given the above example, I now get:

```
! unknown type *hclsyntax.ParenthesesExpr
panic: interface conversion: interface {} is nil, not string

goroutine 84 [running]:
go.mondoo.com/cnquery/resources/packs/terraform.getCtyValue({0xa7b3510?, 0xc000b6bd60?}, 0xc000a2d6b0?)
	/pub/go/src/go.mondoo.com/cnquery/resources/packs/terraform/hcl.go:394 +0xb31
...
	/pub/go/src/go.mondoo.com/cnquery/llx/llx.go:283 +0x59
go.mondoo.com/cnquery/mql/internal.(*executionManager).executeCodeBundle(0xc0002056d0, 0xc000b6be00, 0x0?, {0x0, 0x0})
	/pub/go/src/go.mondoo.com/cnquery/mql/internal/execution_manager.go:167 +0x51d
go.mondoo.com/cnquery/mql/internal.(*executionManager).Start.func1()
	/pub/go/src/go.mondoo.com/cnquery/mql/internal/execution_manager.go:85 +0x1cb
created by go.mondoo.com/cnquery/mql/internal.(*executionManager).Start
	/pub/go/src/go.mondoo.com/cnquery/mql/internal/execution_manager.go:54 +0x6a
FTL failed to run query error="cnquery plugin crashed, please report any stack trace you see with this error"
exit status 1
```

which is great, because we can work with the stack trace!