### PR TITLE
🧹 set minimum go version to 1.20.4

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20.4"
           cache: false
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20.4"
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: ">=1.20.4"
 
 jobs:
   # Check if there is any dirty change for go mod tidy


### PR DESCRIPTION
just like we did in cnquery, https://github.com/mondoohq/cnquery/pull/1258/files