### PR TITLE
🧹 remove unused flag for report output

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -341,8 +341,6 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		// output rendering
 		cmd.Flags().StringP("output", "o", "compact", "Set output format: "+reporter.AllFormats())
 		cmd.Flags().BoolP("json", "j", false, "Set output to JSON (shorthand).")
-		cmd.Flags().Bool("no-pager", false, "Disable interactive scan output pagination.")
-		cmd.Flags().String("pager", "", "Enable scan output pagination with custom pagination command. The default is 'less -R'.")
 		cmd.Flags().Bool("share-report", false, "Overrides the prompt to share web-based reports when cnspec is unauthenticated. Defaults to true.")
 	},
 	CommonPreRun: func(cmd *cobra.Command, args []string) {
@@ -365,9 +363,6 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		viper.BindPFlag("record", cmd.Flags().Lookup("record"))
 
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
-		// the logic is that noPager takes precedence over pager if both are sent
-		viper.BindPFlag("no_pager", cmd.Flags().Lookup("no-pager"))
-		viper.BindPFlag("pager", cmd.Flags().Lookup("pager"))
 		viper.BindPFlag("share-report", cmd.Flags().Lookup("share-report"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
@@ -689,10 +684,7 @@ func printReports(report *policy.ReportCollection, conf *scanConfig, cmd *cobra.
 		log.Fatal().Msg(err.Error())
 	}
 
-	r.UsePager, _ = cmd.Flags().GetBool("pager")
-	r.Pager, _ = cmd.Flags().GetString("pager")
 	r.IsIncognito = conf.IsIncognito
-
 	if err = r.Print(report, os.Stdout); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")
 	}

--- a/cli/reporter/print_report.go
+++ b/cli/reporter/print_report.go
@@ -27,15 +27,12 @@ const (
 type policyRenderer func(print *printer.Printer, policyObj *policy.Policy, report *policy.Report, bundle *policy.PolicyBundleMap, resolvedPolicy *policy.ResolvedPolicy, data []reportRow) string
 
 type reportRenderer struct {
-	printer  *printer.Printer
-	pager    string
-	usePager bool
-	out      io.Writer
-	data     *policy.ReportCollection
+	printer *printer.Printer
+	out     io.Writer
+	data    *policy.ReportCollection
 }
 
 func (r *reportRenderer) print() error {
-	// TODO: render to a buffer and print later, to enable pager printing
 	// TODO: sort assets by reverse score
 
 	var res bytes.Buffer

--- a/cli/reporter/print_report.go
+++ b/cli/reporter/print_report.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/muesli/termenv"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/cli/pager"
 	"go.mondoo.com/cnquery/cli/printer"
 	"go.mondoo.com/cnquery/cli/theme/colors"
 	"go.mondoo.com/cnquery/explorer"
@@ -76,17 +75,7 @@ func (r *reportRenderer) print() error {
 		}
 	}
 
-	if r.usePager && pager.Supported(r.pager) {
-		err := pager.Display(res.String(), r.pager)
-		if err != nil {
-			log.Error().Err(err).Send()
-		}
-		// we print the summary again to make it visible after the pager is closed of the page
-		fmt.Fprintln(r.out, NewLineCharacter+scanSummary)
-	} else {
-		fmt.Fprintln(r.out, res.String())
-	}
-
+	fmt.Fprintln(r.out, res.String())
 	return nil
 }
 

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -21,10 +21,6 @@ var (
 )
 
 type Reporter struct {
-	// Pager set to true will use a pager for the output. Only relevant for all
-	// non-json/yaml/junit/csv reports (for now)
-	UsePager    bool
-	Pager       string
 	Format      Format
 	Printer     *printer.Printer
 	Colors      *colors.Theme
@@ -74,11 +70,9 @@ func (r *Reporter) Print(data *policy.ReportCollection, out io.Writer) error {
 		return rr.print()
 	case Report:
 		rr := &reportRenderer{
-			printer:  r.Printer,
-			pager:    r.Pager,
-			usePager: r.UsePager,
-			out:      out,
-			data:     data,
+			printer: r.Printer,
+			out:     out,
+			data:    data,
 		}
 		return rr.print()
 


### PR DESCRIPTION
The pager wasn't working as expecting and the new defaults with web reporting and compact view do not require us to have that anymore. Lets remove it.