### PR TITLE
🧹 improve cnspec bundle lint output

### DIFF
--- a/internal/bundle/lint_results_cli.go
+++ b/internal/bundle/lint_results_cli.go
@@ -27,6 +27,11 @@ func (s SortResults) Less(i, j int) bool {
 }
 
 func (r *Results) ToCli() []byte {
+	// lets not render the result table if no findings are present
+	if r == nil || len(r.Entries) == 0 {
+		return []byte{}
+	}
+
 	sort.Sort(SortResults(r.Entries))
 
 	// render platform advisories


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnspec/issues/615

**before**

```bash
cnspec bundle lint examples/example.mql.yaml
→ lint policy bundle file=examples/example.mql.yaml
  RULE ID  LEVEL  FILE  LINE  MESSAGE  
→ valid policy bundle
```

**after**

```bash
cnspec bundle lint examples/example.mql.yaml
→ lint policy bundle file=examples/example.mql.yaml
→ valid policy bundle
```