### PR TITLE
⭐️ Randomize the start time of scanning in serve mode

### DIFF
--- a/apps/cnspec/cmd/backgroundjob/background.go
+++ b/apps/cnspec/cmd/backgroundjob/background.go
@@ -20,6 +20,9 @@ func New() (*BackgroundScanner, error) {
 type BackgroundScanner struct{}
 
 func (bs *BackgroundScanner) Run(runScanFn JobRunner) error {
-	Serve(time.Duration(viper.GetInt64("timer"))*time.Minute, runScanFn)
+	Serve(
+		time.Duration(viper.GetInt64("timer"))*time.Minute,
+		time.Duration(viper.GetInt64("splay"))*time.Minute,
+		runScanFn)
 	return nil
 }

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -36,7 +36,9 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	// background scan flags
 	serveCmd.Flags().Int("timer", 60, "scan interval in minutes")
+	serveCmd.Flags().Int("splay", 60, "randomize the timer by up to this many minutes")
 	serveCmd.Flags().MarkHidden("timer")
+	serveCmd.Flags().MarkHidden("splay")
 	// set inventory
 	serveCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
 }
@@ -47,6 +49,7 @@ var serveCmd = &cobra.Command{
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("timer", cmd.Flags().Lookup("timer"))
+		viper.BindPFlag("splay", cmd.Flags().Lookup("splay"))
 		viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This makes sure that scans get randomly distributed throughout the timer time in an effort to spread out load against the api server.