### PR TITLE
Preserve the framework dependencies in the reporting structure

### DIFF
--- a/policy/framework.go
+++ b/policy/framework.go
@@ -24,8 +24,6 @@ type ResolvedFramework struct {
 	// E.g. ReportSources[controlA] = [check123, check45]
 	// E.g. ReportSources[frameworkX] = [controlA, ...]
 	ReportSources map[string][]string
-
-	Frameworks map[string]*Framework
 }
 
 // Compile takes a framework and prepares it to be stored and further
@@ -408,18 +406,20 @@ func ResolveFramework(mrn string, frameworks map[string]*Framework) *ResolvedFra
 		Mrn:           mrn,
 		ReportTargets: map[string][]string{},
 		ReportSources: map[string][]string{},
-		Frameworks:    map[string]*Framework{},
 	}
 
 	for _, framework := range frameworks {
 		for i := range framework.FrameworkMaps {
 			fmap := framework.FrameworkMaps[i]
 
-			for j := range fmap.Controls {
-				ctl := fmap.Controls[j]
+			for _, ctl := range fmap.Controls {
 				res.addReportLink(framework.Mrn, ctl.Mrn)
 				res.addControl(ctl)
 			}
+		}
+		// FIXME: why do these not show up in the framework map
+		for _, depFramework := range framework.Dependencies {
+			res.addReportLink(framework.Mrn, depFramework.Mrn)
 		}
 	}
 

--- a/policy/framework.go
+++ b/policy/framework.go
@@ -24,6 +24,8 @@ type ResolvedFramework struct {
 	// E.g. ReportSources[controlA] = [check123, check45]
 	// E.g. ReportSources[frameworkX] = [controlA, ...]
 	ReportSources map[string][]string
+
+	Frameworks map[string]*Framework
 }
 
 // Compile takes a framework and prepares it to be stored and further
@@ -406,6 +408,7 @@ func ResolveFramework(mrn string, frameworks map[string]*Framework) *ResolvedFra
 		Mrn:           mrn,
 		ReportTargets: map[string][]string{},
 		ReportSources: map[string][]string{},
+		Frameworks:    map[string]*Framework{},
 	}
 
 	for _, framework := range frameworks {

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -576,6 +576,16 @@ func (s *LocalServices) tryResolve(ctx context.Context, bundleMrn string, assetF
 			Str("bundle", bundleMrn).
 			Msg("resolver> phase 5: internal error, trying to attach controls to resolved policy [ok]")
 	}
+
+	for _, rj := range collectorJob.ReportingJobs {
+		if rj.Type == ReportingJob_FRAMEWORK && len(rj.Notify) == 0 {
+			rj.Notify = append(rj.Notify, reportingJob.Uuid)
+			reportingJob.ChildJobs[rj.Uuid] = &explorer.Impact{
+				Scoring: explorer.ScoringSystem_IGNORE_SCORE,
+			}
+		}
+	}
+
 	logCtx.Debug().
 		Str("bundle", bundleMrn).
 		Msg("resolver> phase 5: resolve controls [ok]")


### PR DESCRIPTION
There are major changes here:

First, compliance frameworks were not connected to the root reporting job. On the backend, we iterate from the root reporting job to figure out all reporting jobs that get saved. Without this, we don't save the compliance frameworks or controls

Second change is the structure of the framework dependencies is preserved in the reporting jobs. For example, asset frameworks point to the space framework which point to the global framework which point to some actual frameworks. This keeps it consistent with the way handle policies.

One issue I ran into was that we have space/asset frameworks and space/asset policies. I chose to not create separate reporting jobs for those because having multiple reporting jobs with the same query is likely to break something. Instead, the policies would just get attached to the existing policy jobs, but the impact is set to unscored

![reporting_structure](https://github.com/mondoohq/cnspec/assets/27443/3a8ade88-86b7-4b26-bd5e-5df42c26bf26)
