### PR TITLE
⭐️ add help for new gcp instance scanshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ upstream/generate:
 cnspec/build:
 	go build -o cnspec ${LDFLAGSDIST} apps/cnspec/cnspec.go
 
+.PHONY: cnspec/build/linux
+cnspec/build/linux:
+	GOOS=linux GOARCH=amd64 go build ${LDFLAGSDIST} apps/cnspec/cnspec.go
+
 .PHONY: cnspec/install
 cnspec/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnspec/cnspec.go

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -240,6 +240,9 @@ configure your Azure credentials and have SSH access to the virtual machines.`,
 			"gcp-compute-instance": {
 				Short: "Scan a Google Cloud Platform (GCP) VM instance.",
 			},
+			"gcp-compute-snapshot": {
+				Short: "Scan a Google Cloud Platform (GCP) VM snapshot.",
+			},
 			"oci": {
 				Short: "Scan a Oracle Cloud Infrastructure (OCI) tenancy.",
 			},

--- a/apps/cnspec/cmd/shell.go
+++ b/apps/cnspec/cmd/shell.go
@@ -187,6 +187,9 @@ configure your Azure credentials and have SSH access to the virtual machines.`,
 			"gcp-compute-instance": {
 				Short: "Connect to a Google Cloud Platform (GCP) VM instance.",
 			},
+			"gcp-compute-snapshot": {
+				Short: "Connect to a Google Cloud Platform (GCP) VM snapshot.",
+			},
 			"vsphere": {
 				Short: "Connect to a VMware vSphere API endpoint.",
 			},


### PR DESCRIPTION
This change works in combination with https://github.com/mondoohq/cnquery/pull/1314 and https://github.com/mondoohq/cnquery/pull/1315 to bring GCP compute instance snapshot scanning to cnspec.