### PR TITLE
🧹 Don't unnecessarily recalculate framework dep checksums

### DIFF
--- a/policy/framework.go
+++ b/policy/framework.go
@@ -246,8 +246,10 @@ func (f *Framework) updateGraphChecksums(
 			depObj.FrameworkMaps = frameworkMaps
 		}
 
-		if err := depObj.UpdateChecksums(ctx, getFramework, getFrameworkMaps, bundle); err != nil {
-			return err
+		if depObj.LocalExecutionChecksum == "" || depObj.LocalContentChecksum == "" || depObj.GraphExecutionChecksum == "" || depObj.GraphContentChecksum == "" {
+			if err := depObj.UpdateChecksums(ctx, getFramework, getFrameworkMaps, bundle); err != nil {
+				return err
+			}
 		}
 
 		graphExecutionChecksum = graphExecutionChecksum.


### PR DESCRIPTION
This causes us to load frameworks to calculate checksums we already have. If checksums need to be recalculated, they get cleared first