### PR TITLE
🧹 do not reorder queries and checks in a policy when updating checksums

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -444,6 +444,7 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 		}
 
 		// CHECKS (must be sorted)
+		// copy checks to keep the original order and only sort it for the purpose of checksum generation
 		checks := make([]*explorer.Mquery, len(group.Checks))
 		copy(checks, group.Checks)
 		sort.Slice(checks, func(i, j int) bool {
@@ -484,6 +485,7 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 		}
 
 		// DATA (must be sorted)
+		// copy checks to keep the original order and only sort it for the purpose of checksum generation
 		queries := make([]*explorer.Mquery, len(group.Queries))
 		copy(queries, group.Queries)
 		sort.Slice(queries, func(i, j int) bool {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -444,12 +444,14 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 		}
 
 		// CHECKS (must be sorted)
-		sort.Slice(group.Checks, func(i, j int) bool {
-			return group.Checks[i].Mrn < group.Checks[j].Mrn
+		checks := make([]*explorer.Mquery, len(group.Checks))
+		copy(checks, group.Checks)
+		sort.Slice(checks, func(i, j int) bool {
+			return checks[i].Mrn < checks[j].Mrn
 		})
 
-		for i := range group.Checks {
-			check := group.Checks[i]
+		for i := range checks {
+			check := checks[i]
 
 			if base, ok := bundle.Queries[check.Mrn]; ok {
 				check = check.Merge(base)
@@ -482,12 +484,14 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 		}
 
 		// DATA (must be sorted)
-		sort.Slice(group.Queries, func(i, j int) bool {
-			return group.Queries[i].Mrn < group.Queries[j].Mrn
+		queries := make([]*explorer.Mquery, len(group.Queries))
+		copy(queries, group.Queries)
+		sort.Slice(queries, func(i, j int) bool {
+			return queries[i].Mrn < queries[j].Mrn
 		})
 
-		for i := range group.Queries {
-			query := group.Queries[i]
+		for i := range queries {
+			query := queries[i]
 
 			if base, ok := bundle.Queries[query.Mrn]; ok {
 				query = query.Merge(base)


### PR DESCRIPTION
This PR makes sure we are not changing the orders of queries and checks when we update checksums