### PR TITLE
🐛 The controlmap control uids also need to be cleared

### DIFF
--- a/policy/framework.go
+++ b/policy/framework.go
@@ -479,6 +479,7 @@ func (c *ControlMap) refreshMRNs(ownerMRN string, cache *bundleCache) error {
 		if !ok {
 			return errors.New("cannot find policy '" + control.Uid + "' in this bundle, which is referenced by control " + c.Mrn)
 		}
+		control.Uid = ""
 	}
 
 	return nil


### PR DESCRIPTION
Otherwise, you cannot compile a bundle twice. And when you run locally, the bundle gets compiled during validation and then when it gets set in the data store