### PR TITLE
🧹 Use average scoring for frameworks

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1467,7 +1467,7 @@ func (s *LocalServices) jobsToFrameworksInner(cache *frameworkResolverCache, res
 					Uuid:          uuid,
 					QrId:          childFramework.Mrn,
 					ChildJobs:     map[string]*explorer.Impact{},
-					ScoringSystem: explorer.ScoringSystem_WORST,
+					ScoringSystem: explorer.ScoringSystem_AVERAGE,
 					Type:          ReportingJob_FRAMEWORK,
 				}
 			}
@@ -1478,7 +1478,7 @@ func (s *LocalServices) jobsToFrameworksInner(cache *frameworkResolverCache, res
 				// overwrite it as that would change the scoring system
 				impact := &explorer.Impact{}
 				if parent.Type == ReportingJob_FRAMEWORK {
-					impact.Scoring = explorer.ScoringSystem_WORST
+					impact.Scoring = explorer.ScoringSystem_AVERAGE
 				} else {
 					impact.Scoring = explorer.ScoringSystem_IGNORE_SCORE
 				}

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -500,6 +500,7 @@ func (tester *frameworkReportingJobTester) requireReportsTo(childQueryId string,
 
 	if isFramework(parentQueryId) {
 		require.Equal(tester.t, policy.ReportingJob_FRAMEWORK, parentRj.Type)
+		require.Equal(tester.t, explorer.ScoringSystem_AVERAGE, parentRj.ScoringSystem)
 	} else if isControl(parentQueryId) {
 		require.Equal(tester.t, policy.ReportingJob_CONTROL, parentRj.Type)
 	} else if isPolicy(parentQueryId) || parentQueryId == "root" {
@@ -515,6 +516,7 @@ func (tester *frameworkReportingJobTester) requireReportsTo(childQueryId string,
 		require.Equal(tester.t, policy.ReportingJob_CONTROL, childRj.Type)
 	} else if isFramework(childQueryId) {
 		require.Equal(tester.t, policy.ReportingJob_FRAMEWORK, childRj.Type)
+		require.Equal(tester.t, explorer.ScoringSystem_AVERAGE, childRj.ScoringSystem)
 	} else if isPolicy(childQueryId) {
 		require.Equal(tester.t, policy.ReportingJob_POLICY, childRj.Type)
 	} else {


### PR DESCRIPTION
Frameworks get controls. Controls are pass or fail (0 or 100). By changing the scoring system to average, the value of the framework score is the completion