### PR TITLE
🧹 Change how controls are scored

### DIFF
--- a/policy/executor/internal/builder.go
+++ b/policy/executor/internal/builder.go
@@ -405,6 +405,7 @@ func (ge *GraphExecutor) addReportingJobNode(assetMrn string, reportingJobID str
 	nodeData := &ReportingJobNodeData{
 		queryID:               queryID,
 		isQuery:               isQuery,
+		rjType:                rj.Type,
 		childScores:           map[string]*reportingJobResult{},
 		datapoints:            map[string]*reportingJobDatapoint{},
 		featureFlagFailErrors: ge.featureFlagFailErrors,

--- a/policy/executor/internal/nodes_test.go
+++ b/policy/executor/internal/nodes_test.go
@@ -1101,6 +1101,90 @@ func TestReportingJobNode(t *testing.T) {
 					})
 				})
 
+				t.Run("when is control", func(t *testing.T) {
+					t.Run("error converted to fail", func(t *testing.T) {
+						nodeData := newNodeData()
+						nodeData.rjType = policy.ReportingJob_CONTROL
+						nodeData.childScores = map[NodeID]*reportingJobResult{
+							nodeData.queryID: {},
+						}
+
+						nodeData.initialize()
+						nodeData.recalculate()
+
+						nodeData.consume(NodeID(nodeData.queryID), &envelope{
+							score: &policy.Score{
+								QrId:            nodeData.queryID,
+								Type:            policy.ScoreType_Error,
+								Value:           0,
+								ScoreCompletion: 100,
+							},
+						})
+						data := nodeData.recalculate()
+
+						assert.Equal(t, "testqueryid", data.score.QrId)
+						assert.Equal(t, policy.ScoreType_Result, data.score.Type)
+						assert.Equal(t, 0, int(data.score.Value))
+						assert.Equal(t, 100, int(data.score.ScoreCompletion))
+						assert.Equal(t, 100, int(data.score.DataCompletion))
+						assert.Equal(t, 0, int(data.score.DataTotal))
+					})
+					t.Run("unscored converted to pass", func(t *testing.T) {
+						nodeData := newNodeData()
+						nodeData.rjType = policy.ReportingJob_CONTROL
+						nodeData.childScores = map[NodeID]*reportingJobResult{
+							nodeData.queryID: {},
+						}
+
+						nodeData.initialize()
+						nodeData.recalculate()
+
+						nodeData.consume(NodeID(nodeData.queryID), &envelope{
+							score: &policy.Score{
+								QrId:            nodeData.queryID,
+								Type:            policy.ScoreType_Unscored,
+								Value:           0,
+								ScoreCompletion: 100,
+							},
+						})
+						data := nodeData.recalculate()
+
+						assert.Equal(t, "testqueryid", data.score.QrId)
+						assert.Equal(t, policy.ScoreType_Result, data.score.Type)
+						assert.Equal(t, 100, int(data.score.Value))
+						assert.Equal(t, 100, int(data.score.ScoreCompletion))
+						assert.Equal(t, 100, int(data.score.DataCompletion))
+						assert.Equal(t, 0, int(data.score.DataTotal))
+					})
+					t.Run("skip converted to pass", func(t *testing.T) {
+						nodeData := newNodeData()
+						nodeData.rjType = policy.ReportingJob_CONTROL
+						nodeData.childScores = map[NodeID]*reportingJobResult{
+							nodeData.queryID: {},
+						}
+
+						nodeData.initialize()
+						nodeData.recalculate()
+
+						nodeData.consume(NodeID(nodeData.queryID), &envelope{
+							score: &policy.Score{
+								QrId:            nodeData.queryID,
+								Type:            policy.ScoreType_Skip,
+								Value:           0,
+								ScoreCompletion: 100,
+							},
+						})
+						data := nodeData.recalculate()
+
+						assert.Equal(t, "testqueryid", data.score.QrId)
+						assert.Equal(t, policy.ScoreType_Result, data.score.Type)
+						assert.Equal(t, 100, int(data.score.Value))
+						assert.Equal(t, 100, int(data.score.ScoreCompletion))
+						assert.Equal(t, 100, int(data.score.DataCompletion))
+						assert.Equal(t, 0, int(data.score.DataTotal))
+					})
+				})
+
 				t.Run("when not isQuery", func(t *testing.T) {
 					t.Run("when score", func(t *testing.T) {
 						nodeData := newNodeData()


### PR DESCRIPTION
Any child of a control that errors is converted into a fail. Any child that is skipped or unscored is converted to pass. This way, controls always have a result