### PR TITLE
Do not report scores for frameworks without any controls implemented

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1603,11 +1603,10 @@ func (s *LocalServices) jobsToControls(cache *frameworkResolverCache, framework 
 			// if the framework has no children reporting, i.e. it has no controls implemented
 			// skip it. also delete it from all other jobs that have it as a child job (other frameworks)
 			if len(children) == 0 {
-				delete(framework.Nodes, mrn)
-				j := job.ReportingJobs[cache.relativeChecksum(mrn)]
-				for _, p := range j.Notify {
+				rj := job.ReportingJobs[cache.relativeChecksum(mrn)]
+				for _, p := range rj.Notify {
 					pj := job.ReportingJobs[p]
-					delete(pj.ChildJobs, j.Uuid)
+					delete(pj.ChildJobs, rj.Uuid)
 				}
 				delete(job.ReportingJobs, cache.relativeChecksum(mrn))
 			}

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -367,6 +367,7 @@ frameworks:
 - uid: parent-framework
   dependencies:
   - mrn: ` + frameworkMrn("framework1") + `
+  - mrn: ` + frameworkMrn("framework2") + `
 
 framework_maps:
 - uid: framework-map1
@@ -427,6 +428,9 @@ framework_maps:
 		// control3 had no checks, so it should not have a reporting job.
 		// TODO: is that the desired behavior?
 		require.Nil(t, rjTester.queryIdToReportingJob[controlMrn("control3")])
+		// framework 2 has no implemented controls, so it should not have a reporting job.
+		require.Nil(t, rjTester.queryIdToReportingJob[frameworkMrn("framework2")])
+
 		rjTester.requireReportsTo(mrnToQueryId[queryMrn("check-pass-1")], queryMrn("check-pass-1"))
 		rjTester.requireReportsTo(mrnToQueryId[queryMrn("check-pass-2")], queryMrn("check-pass-2"))
 		rjTester.requireReportsTo(mrnToQueryId[queryMrn("check-fail")], queryMrn("check-fail"))


### PR DESCRIPTION
If the framework has no children, remove it from the reporting jobs. This ensures we do not report framework scores for frameworks that have 0 controls reporting.