### PR TITLE
🧹 Dump resolved policy DOT file if TRACE env var is set.

### DIFF
--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -189,6 +189,7 @@ OUTER:
 
 func (ge *GraphExecutor) Debug() {
 	if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
+	} else if val, ok := os.LookupEnv("TRACE"); ok && (val == "1" || val == "true") {
 	} else {
 		return
 	}


### PR DESCRIPTION
Same as https://github.com/mondoohq/cnquery/pull/1742