### PR TITLE
🐛 make filter queries optional

### DIFF
--- a/examples/example.mql.yaml
+++ b/examples/example.mql.yaml
@@ -50,7 +50,7 @@ policies:
           # Here is an example of a query that uses embedded properties. 
           # These allow you to fine-tune the policy.
           - uid: home-info
-            mql: file(props.home) { * }
+            mql: file(props.home) { path basename user group }
             title: Gather info about the user's home
             props:
               - uid: home


### PR DESCRIPTION
Currently filter queries that error during the compile stage will cause the execution to fail. However, with the new providers model, certain contents are now optional, thus the local compiler (given locally available schemas) will throw errors. We simply eliminate these filters from the result list.

Example use-case: Have a scanner that only scans github. When it encounters filters, it will get a long list of technologies that are unsupported (like clouds and k8s). These can now simply be eliminated and moved on.