### PR TITLE
🐛 set default logger to info

### DIFF
--- a/apps/cnspec/cmd/root.go
+++ b/apps/cnspec/cmd/root.go
@@ -117,7 +117,7 @@ func init() {
 	// since the log instance is already initialized, replace default zerolog color output with our own
 	// use color logger by default
 	logger.CliCompactLogger(logger.LogOutputWriter)
-	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	config.DefaultConfigFile = "mondoo.yml"
 


### PR DESCRIPTION
This is in line with cnquery. Additionally, users are missing helpful information if this is set to Warn only, like installation of providers is hidden from them. With this setting active, you get the following output again:

```
> cnspec run gcp project something-1234
→ installing provider gcp version=9.0.1
...
```