### PR TITLE
🐛 fix url error in printcompact

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@v1.1.2
+        with:
+          version: v0.16.4
 
       - name: Check Header Compliance
         run: copywrite headers --plan

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -172,10 +172,12 @@ func (r *defaultReporter) printSummary(orderedAssets []assetMrnName) {
 				// when runnin inside cicd, we create an url for the cicd project
 				spaceUrlRegexp := regexp.MustCompile(`^(http.*)/inventory/[a-zA-Z0-9-]+(\?.+)$`)
 				m := spaceUrlRegexp.FindStringSubmatch(assetUrl)
-				if projectId != "" {
-					url = m[1] + "/cicd/jobs" + m[2] + "&projectId=" + projectId
-				} else {
-					url = m[1] + "/inventory" + m[2]
+				if len(m) > 0 {
+					if projectId != "" {
+						url = m[1] + "/cicd/jobs" + m[2] + "&projectId=" + projectId
+					} else {
+						url = m[1] + "/inventory" + m[2]
+					}
 				}
 
 			} else {


### PR DESCRIPTION
```

Score Distribution		Asset Distribution
------------------		------------------
A   0 assets      		Azure Subscription   2
B   0 assets
C   0 assets
D   2 assets
F   0 assets

panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
go.mondoo.com/cnspec/cli/reporter.(*defaultReporter).printSummary(0x14000969978, {0x140053cdd00, 0x2, 0x140005c1860?})
	/Users/vj/go/src/go.mondoo.io/cnspec/cli/reporter/print_compact.go:178 +0xbe0
	```