### PR TITLE
🐛 fix scanning assets

### DIFF
--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/logger"
+	"go.mondoo.com/cnquery/providers"
 	"go.mondoo.com/cnquery/providers-sdk/v1/upstream"
 	cnspec_config "go.mondoo.com/cnspec/apps/cnspec/cmd/config"
 	"go.mondoo.com/cnspec/policy/scan"
@@ -71,6 +72,7 @@ var serveApiCmd = &cobra.Command{
 		scanner := scan.NewLocalScanner(
 			scan.WithUpstream(&upstreamConfig),
 			scan.DisableProgressBar(),
+			scan.WithRecording(providers.NullRecording{}),
 		)
 		if err := scanner.EnableQueue(); err != nil {
 			log.Fatal().Err(err).Msg("could not enable scan queue")

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -254,15 +254,13 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
-		inventorySpec := runtime.Provider.Connection
-		if inventorySpec.Inventory != nil &&
-			inventorySpec.Inventory.Spec != nil &&
-			inventorySpec.Inventory.Spec.Assets != nil {
-			log.Debug().Msgf("adding %d discovered asset(s)", len(runtime.Provider.Connection.Inventory.Spec.Assets))
-			assetCandidates = append(assetCandidates, inventorySpec.Inventory.Spec.Assets...)
-		} else {
-			assetCandidates = append(assetCandidates, runtime.Provider.Connection.Asset)
+
+		processedAssets, err := providers.ProcessAssetCandidates(runtime, runtime.Provider.Connection, upstream, "")
+		if err != nil {
+			return nil, false, err
 		}
+		assetCandidates = append(assetCandidates, processedAssets...)
+
 		// TODO: we want to keep better track of errors, since there may be
 		// multiple assets coming in. It's annoying to abort the scan if we get one
 		// error at this stage.
@@ -304,6 +302,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 
 	justAssets := []*inventory.Asset{}
 	for _, asset := range assets {
+		asset.asset.KindString = asset.asset.GetPlatform().Kind
 		justAssets = append(justAssets, asset.asset)
 	}
 


### PR DESCRIPTION
Uses similar scan flow as in `cnquery`