### PR TITLE
🐛 use resolved asset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,7 +69,18 @@
       }
     },
     {
-      "name": "serve",
+      "name": "Serve",
+      "type": "go",
+      "request": "launch",
+      "program": "${workspaceRoot}/apps/cnspec/cnspec.go",
+      "cwd": "${workspaceRoot}/",
+      "args": [
+        "serve",
+        // "--verbose"
+      ]
+    },
+    {
+      "name": "serve-api",
       "type": "go",
       "request": "launch",
       "program": "${workspaceRoot}/apps/cnspec/cnspec.go",

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -232,15 +232,14 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 
 	// we connect and perform discovery for each asset in the job inventory
 	for i := range assetList {
-		asset := assetList[i]
-		resolvedAsset, err := im.ResolveAsset(asset)
+		resolvedAsset, err := im.ResolveAsset(assetList[i])
 		if err != nil {
 			return nil, false, err
 		}
 
-		runtime, err := providers.Coordinator.RuntimeFor(asset, providers.DefaultRuntime())
+		runtime, err := providers.Coordinator.RuntimeFor(resolvedAsset, providers.DefaultRuntime())
 		if err != nil {
-			log.Error().Err(err).Str("asset", asset.Name).Msg("unable to create runtime for asset")
+			log.Error().Err(err).Str("asset", resolvedAsset.Name).Msg("unable to create runtime for asset")
 			continue
 		}
 		runtime.SetRecording(s.recording)


### PR DESCRIPTION
After https://github.com/mondoohq/cnspec/pull/782
After https://github.com/mondoohq/cnquery/pull/2021

During the resolution, if we only use the (old) asset object, we miss
the part where cnquery fixes the `Backend` field. See: https://github.com/mondoohq/cnquery/pull/2021