### PR TITLE
✨ re-use provider instance for all assets when scanning k8s

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -281,9 +281,17 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	for i := range assetCandidates {
 		candidate := assetCandidates[i]
 
-		runtime, err := providers.Coordinator.EphemeralRuntimeFor(candidate.asset)
-		if err != nil {
-			return nil, false, err
+		var runtime *providers.Runtime
+		if candidate.asset.Connections[0].Type == "k8s" {
+			runtime, err = providers.Coordinator.RuntimeFor(candidate.asset, providers.DefaultRuntime())
+			if err != nil {
+				return nil, false, err
+			}
+		} else {
+			runtime, err = providers.Coordinator.EphemeralRuntimeFor(candidate.asset)
+			if err != nil {
+				return nil, false, err
+			}
 		}
 
 		err = runtime.Connect(&plugin.ConnectReq{
@@ -443,7 +451,9 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			})
 
 			// shut down all ephemeral runtimes
-			runtime.Close()
+			if asset.Connections[0].Type != "k8s" {
+				runtime.Close()
+			}
 		}
 		finished = true
 	}()

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -451,9 +451,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			})
 
 			// shut down all ephemeral runtimes
-			if asset.Connections[0].Type != "k8s" {
-				runtime.Close()
-			}
+			runtime.Close()
 		}
 		finished = true
 	}()


### PR DESCRIPTION
do not use ephemeral runtimes for discovered k8s assets. Needed to optimize the memory usage for k8s since we scan hundreds of assets there