### PR TITLE
🧹 Add err to the reporter if we cant connect to an asset.

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -249,6 +249,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			Asset:    resolvedAsset,
 			Upstream: upstream,
 		}); err != nil {
+			reporter.AddScanError(resolvedAsset, err)
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
@@ -292,6 +293,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			Upstream: upstream,
 		})
 		if err != nil {
+			reporter.AddScanError(candidate.asset, err)
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
@@ -302,7 +304,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	}
 
 	if len(assets) == 0 {
-		return nil, false, nil
+		return reporter.Reports(), false, nil
 	}
 
 	runtimeEnv := execruntime.Detect()


### PR DESCRIPTION
This is an attempt at getting better insight into scan errors. Until now, we ignore errors if we cant connect to an asset. Those errors are now logged into the reporter which is then returned if no assets are present instead of returning `nil, false, nil`

