### PR TITLE
🧹 shutdown coordinator after scan

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -462,6 +462,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		multiprogress.Open()
 	}()
 	scanGroup.Wait()
+	providers.Coordinator.Shutdown()
 	return reporter.Reports(), finished, nil
 }
 


### PR DESCRIPTION
Make sure all providers are killed after scan finishes