### PR TITLE
🧹 fix asset filter of the example policy

### DIFF
--- a/apps/cnspec/cmd/policy-example.mql.yaml
+++ b/apps/cnspec/cmd/policy-example.mql.yaml
@@ -13,7 +13,7 @@ policies:
       - name: Jane Doe
         email: jane@example.com
     groups:
-      - filters: platform.family.contains(_ == 'unix')
+      - filters: asset.family.contains("unix")
         checks:
           - uid: sshd-score-01
 queries:


### PR DESCRIPTION
this fix the cnspec lint run on the example policy


the lint run of the example policy produce a error

```bash
cnspec bundle lint example-policy.mql.yaml                                                                    x1 16h27m main[bf56f98]
→ lint policy bundle file=example-policy.mql.yaml
  RULE ID               LEVEL  FILE                     LINE  MESSAGE
  bundle-compile-error  error  example-policy.mql.yaml  1     could not compile
                                                              policy bundle:failed
                                                              to validate policy:
                                                              failed to compile query
                                                              'platform.family.contains(_
                                                              == 'unix')': cannot find field
                                                              'family' in platform
FTL invalid policy bundle
```