### PR TITLE
🐛 Do not exit if annotations not defined in scan/vuln cmd.

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -215,6 +215,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}
 
+	// annotations are user-added, editable labels for assets and are optional, therefore we do not need to check for err
 	annotations, _ := cmd.Flags().GetStringToString("annotation")
 	// merge the config and the user-provided annotations with the latter having precedence
 	optAnnotations := opts.Annotations

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -215,11 +215,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}
 
-	annotations, err := cmd.Flags().GetStringToString("annotation")
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to parse annotations")
-	}
-
+	annotations, _ := cmd.Flags().GetStringToString("annotation")
 	// merge the config and the user-provided annotations with the latter having precedence
 	optAnnotations := opts.Annotations
 	if optAnnotations == nil {


### PR DESCRIPTION
Fixes #840 