### PR TITLE
🐛 Set upstream for ephemeral runtimes

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -301,6 +301,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 				return nil, false, err
 			}
 		}
+		runtime.UpstreamConfig = upstream
 
 		err = runtime.Connect(&plugin.ConnectReq{
 			Features: config.Features,


### PR DESCRIPTION
The upstream config is needed to fetch vuln reports.