### PR TITLE
:broom: Set correct filter for `cnspec bundle init` policy

### DIFF
--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -23,7 +23,7 @@ policies:
     name: SSH Server Policy
     specs:
       - asset_filter:
-          query: asset.family.contains(_ == 'unix')
+          query: asset.family.contains('unix')
         scoring_queries:
           query1:
     version: "1.0.0"
@@ -58,7 +58,7 @@ queries:
       - name: Jane Doe
         email: jane@example.com
     groups:
-      - filters: asset.family.contains(_ == 'unix')
+      - filters: asset.family.contains('unix')
         checks:
           - uid: query1
     scoring_system: 2

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -58,7 +58,7 @@ queries:
       - name: Jane Doe
         email: jane@example.com
     groups:
-      - filters: platform.family.contains(_ == 'unix')
+      - filters: asset.family.contains(_ == 'unix')
         checks:
           - uid: query1
     scoring_system: 2

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -23,7 +23,7 @@ policies:
     name: SSH Server Policy
     specs:
       - asset_filter:
-          query: platform.family.contains(_ == 'unix')
+          query: asset.family.contains(_ == 'unix')
         scoring_queries:
           query1:
     version: "1.0.0"


### PR DESCRIPTION
From `platform.` to `asset.`

Not sure if that's the right place.

I want to modify the `example-policy.mql.yml` created when using `cnspec bundle init`