### PR TITLE
🧹 create a resilient v8 and v9+ vuln report

### DIFF
--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v9/explorer"
-	"go.mondoo.com/cnquery/v9/providers"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/cnquery/v9/shared"
@@ -164,18 +162,11 @@ func assetMvdTests(r *policy.ReportCollection, assetMrn string, assetObj *invent
 		return nil
 	}
 
-	schema := providers.DefaultRuntime().Schema()
-	vulnChecksum, err := defaultChecksum(vulnReport, schema)
-	if err != nil {
-		log.Debug().Err(err).Msg("could not determine vulnerability report checksum")
-	}
-
 	rawResults := results.RawResults()
-	value, ok := rawResults[vulnChecksum]
-	if !ok {
+	value, err := getVulnReport(rawResults)
+	if err != nil {
 		return nil
 	}
-
 	if value == nil || value.Data == nil {
 		return nil
 	}

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -18,7 +18,6 @@ import (
 	"go.mondoo.com/cnquery/v9/cli/components"
 	"go.mondoo.com/cnquery/v9/explorer"
 	"go.mondoo.com/cnquery/v9/llx"
-	"go.mondoo.com/cnquery/v9/providers"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/cnquery/v9/utils/stringx"
@@ -586,16 +585,9 @@ func (r *defaultReporter) printCheck(score *policy.Score, query *explorer.Mquery
 func (r *defaultReporter) printVulns(resolved *policy.ResolvedPolicy, report *policy.Report, results map[string]*llx.RawResult) {
 	print := r.Printer
 
-	schema := providers.DefaultRuntime().Schema()
-	vulnChecksum, err := defaultChecksum(vulnReport, schema)
+	value, err := getVulnReport(results)
 	if err != nil {
-		log.Debug().Err(err).Msg("could not determine vulnerability report checksum")
-		r.out.Write([]byte(print.Error("No vulnerabilities for this provider")))
-		return
-	}
-
-	value, ok := results[vulnChecksum]
-	if !ok {
+		r.out.Write([]byte(print.Error(err.Error())))
 		return
 	}
 

--- a/cli/reporter/render_advisory_policy.go
+++ b/cli/reporter/render_advisory_policy.go
@@ -36,21 +36,12 @@ func renderAdvisoryPolicy(print *printer.Printer, policyObj *policy.Policy, repo
 	// render mini score card
 	score := report.Scores[policyObj.Mrn]
 
-	schema := providers.DefaultRuntime().Schema()
-	vulnChecksum, err := defaultChecksum(vulnReport, schema)
-	if err != nil {
-		log.Debug().Err(err).Msg("could not determine vulnerability report checksum")
-		b.WriteString(print.Error("no vulnerabilities for this provider"))
-		return b.String()
-	}
-
 	results := report.Data
-	value, ok := results[vulnChecksum]
-	if !ok {
-		b.WriteString(print.Error("could not find advisory report" + NewLineCharacter + NewLineCharacter))
+	value, err := getVulnReport(results)
+	if err != nil {
+		b.WriteString(print.Error(err.Error()))
 		return b.String()
 	}
-
 	if value == nil || value.Data == nil {
 		b.WriteString(print.Error("could not load advisory report" + NewLineCharacter + NewLineCharacter))
 		return b.String()
@@ -96,6 +87,7 @@ func renderAdvisoryPolicy(print *printer.Printer, policyObj *policy.Policy, repo
 	}
 
 	// render additional information
+	schema := providers.DefaultRuntime().Schema()
 	kernelInstalledChecksum, err := defaultChecksum(kernelInstalled, schema)
 	if err != nil {
 		log.Debug().Err(err).Msg("could not determine installed kernel checksum")


### PR DESCRIPTION
We recently hotfixed an issue that caused the report not to show on v9+, because older v8 code-paths were taken: https://github.com/mondoohq/cnspec/pull/850

When the upstream reporting eventually switches over to use `asset` instead of `platform`, this hotfix will fail. This PR create a more resilient approach to the vulnerability report, supporting both v8 and v9+