### PR TITLE
🧹 expose runtime on scanner

### DIFF
--- a/policy/hub.go
+++ b/policy/hub.go
@@ -38,7 +38,7 @@ func NewPolicyMrn(namespace string, uid string) string {
 
 // ValidateBundle and check queries, relationships, MRNs, and versions
 func (s *LocalServices) ValidateBundle(ctx context.Context, bundle *Bundle) (*Empty, error) {
-	_, err := bundle.Compile(ctx, s.runtime.Schema(), s.DataLake)
+	_, err := bundle.Compile(ctx, s.Runtime.Schema(), s.DataLake)
 	return globalEmpty, err
 }
 
@@ -46,7 +46,7 @@ func (s *LocalServices) ValidateBundle(ctx context.Context, bundle *Bundle) (*Em
 func (s *LocalServices) SetBundle(ctx context.Context, bundle *Bundle) (*Empty, error) {
 	// See https://gitlab.com/mondoolabs/mondoo/-/issues/595
 
-	bundleMap, err := bundle.Compile(ctx, s.runtime.Schema(), s.DataLake)
+	bundleMap, err := bundle.Compile(ctx, s.Runtime.Schema(), s.DataLake)
 	if err != nil {
 		return globalEmpty, err
 	}
@@ -96,7 +96,7 @@ func (s *LocalServices) PreparePolicy(ctx context.Context, policyObj *Policy, bu
 			s.DataLake.GetValidatedPolicy,
 			s.DataLake.GetQuery,
 			bundle,
-			s.runtime.Schema(),
+			s.Runtime.Schema(),
 		)
 		if err != nil {
 			return nil, nil, err

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -123,7 +123,7 @@ func (s *LocalServices) SetProps(ctx context.Context, req *explorer.PropsReq) (*
 	// validate that the queries compile and fill in checksums
 	for i := range req.Props {
 		prop := req.Props[i]
-		code, err := prop.RefreshChecksumAndType(s.runtime.Schema())
+		code, err := prop.RefreshChecksumAndType(s.Runtime.Schema())
 		if err != nil {
 			return nil, err
 		}
@@ -446,7 +446,7 @@ func (s *LocalServices) tryResolve(ctx context.Context, bundleMrn string, assetF
 
 	// phase 1: resolve asset filters and see if we can find a cached policy
 	// trying first with all asset filters
-	allFiltersChecksum, err := ChecksumAssetFilters(assetFilters, s.runtime.Schema())
+	allFiltersChecksum, err := ChecksumAssetFilters(assetFilters, s.Runtime.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +484,7 @@ func (s *LocalServices) tryResolve(ctx context.Context, bundleMrn string, assetF
 		assetFiltersMap[matchingFilters[i].CodeId] = struct{}{}
 	}
 
-	assetFiltersChecksum, err := ChecksumAssetFilters(matchingFilters, s.runtime.Schema())
+	assetFiltersChecksum, err := ChecksumAssetFilters(matchingFilters, s.Runtime.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -888,7 +888,7 @@ func (s *LocalServices) policyGroupToJobs(ctx context.Context, group *PolicyGrou
 		if base, ok := cache.global.bundleMap.Queries[check.Mrn]; ok {
 			check = check.Merge(base)
 			err := check.RefreshChecksum(ctx,
-				s.runtime.Schema(),
+				s.Runtime.Schema(),
 				explorer.QueryMap(cache.global.bundleMap.Queries).GetQuery,
 			)
 			if err != nil {
@@ -945,7 +945,7 @@ func (s *LocalServices) policyGroupToJobs(ctx context.Context, group *PolicyGrou
 		if base, ok := cache.global.bundleMap.Queries[query.Mrn]; ok {
 			query = query.Merge(base)
 			err := query.RefreshChecksum(ctx,
-				s.runtime.Schema(),
+				s.Runtime.Schema(),
 				explorer.QueryMap(cache.global.bundleMap.Queries).GetQuery,
 			)
 			if err != nil {
@@ -1211,7 +1211,7 @@ func (s *LocalServices) jobsToQueries(ctx context.Context, policyMrn string, cac
 					}
 				}
 
-				executionQuery, dataChecksum, err := mquery2executionQuery(prop, nil, map[string]string{}, collectorJob, false, s.runtime.Schema())
+				executionQuery, dataChecksum, err := mquery2executionQuery(prop, nil, map[string]string{}, collectorJob, false, s.Runtime.Schema())
 				if err != nil {
 					return nil, nil, errors.New("resolver> failed to compile query for MRN " + prop.Mrn + ": " + err.Error())
 				}
@@ -1226,7 +1226,7 @@ func (s *LocalServices) jobsToQueries(ctx context.Context, policyMrn string, cac
 			}
 		}
 
-		executionQuery, _, err := mquery2executionQuery(query, propTypes, propToChecksums, collectorJob, !isDataQuery, s.runtime.Schema())
+		executionQuery, _, err := mquery2executionQuery(query, propTypes, propToChecksums, collectorJob, !isDataQuery, s.Runtime.Schema())
 		if err != nil {
 			return nil, nil, errors.New("resolver> failed to compile query for MRN " + query.Mrn + ": " + err.Error())
 		}

--- a/policy/services.go
+++ b/policy/services.go
@@ -41,7 +41,7 @@ type LocalServices struct {
 	DataLake  DataLake
 	Upstream  *Services
 	Incognito bool
-	runtime   llx.Runtime
+	Runtime   llx.Runtime
 }
 
 // NewLocalServices initializes a reasonably configured local services struct
@@ -50,7 +50,7 @@ func NewLocalServices(datalake DataLake, uuid string, runtime llx.Runtime) *Loca
 		DataLake:  datalake,
 		Upstream:  nil,
 		Incognito: false,
-		runtime:   runtime,
+		Runtime:   runtime,
 	}
 }
 
@@ -80,5 +80,5 @@ func NewRemoteServices(addr string, auth []ranger.ClientPlugin, httpClient *http
 }
 
 func (l *LocalServices) Schema() llx.Schema {
-	return l.runtime.Schema()
+	return l.Runtime.Schema()
 }


### PR DESCRIPTION
Allow us to more easily reconfigure it when needed.