### PR TITLE
🐛 do not print error if vulns are not supported

### DIFF
--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -163,10 +163,7 @@ func assetMvdTests(r *policy.ReportCollection, assetMrn string, assetObj *invent
 	}
 
 	rawResults := results.RawResults()
-	value, err := getVulnReport(rawResults)
-	if err != nil {
-		return nil
-	}
+	value, _ := getVulnReport(rawResults)
 	if value == nil || value.Data == nil {
 		return nil
 	}
@@ -199,7 +196,7 @@ func assetMvdTests(r *policy.ReportCollection, assetMrn string, assetObj *invent
 		TagName:  "json",
 	}
 	decoder, _ := mapstructure.NewDecoder(cfg)
-	if err = decoder.Decode(rawData); err != nil {
+	if err := decoder.Decode(rawData); err != nil {
 		ts.Errors++
 		ts.Testcases = append(ts.Testcases, junit.Testcase{
 			Failure: &junit.Result{

--- a/cli/reporter/render_advisory_policy.go
+++ b/cli/reporter/render_advisory_policy.go
@@ -37,18 +37,12 @@ func renderAdvisoryPolicy(print *printer.Printer, policyObj *policy.Policy, repo
 	score := report.Scores[policyObj.Mrn]
 
 	results := report.Data
-	value, err := getVulnReport(results)
-	if err != nil {
-		b.WriteString(print.Error(err.Error()))
-		return b.String()
-	}
+	value, _ := getVulnReport(results)
 	if value == nil || value.Data == nil {
-		b.WriteString(print.Error("could not load advisory report" + NewLineCharacter + NewLineCharacter))
 		return b.String()
 	}
-
 	if value.Error != "" {
-		b.WriteString(print.Error("could not load advisory report: " + value.Error + NewLineCharacter + NewLineCharacter))
+		b.Write([]byte(print.Error("Could not load the advisory report: "+value.Error) + NewLineCharacter + NewLineCharacter))
 		return b.String()
 	}
 
@@ -61,7 +55,7 @@ func renderAdvisoryPolicy(print *printer.Printer, policyObj *policy.Policy, repo
 		TagName:  "json",
 	}
 	decoder, _ := mapstructure.NewDecoder(cfg)
-	if err = decoder.Decode(rawData); err != nil {
+	if err := decoder.Decode(rawData); err != nil {
 		b.WriteString(print.Error("could not decode advisory report" + NewLineCharacter + NewLineCharacter))
 		return b.String()
 	}


### PR DESCRIPTION
Many providers do not support vulnerability reports, eg: Anything that requests APIs or files like Terraform/K8s. We support it for things like OSs and OS-related targets.

Example OLD:

```bash
...
✕ Fail:         Verify shielded VM is enabled on compute instances
✓ Pass:         Legacy metadata endpoints enabled

Vulnerabilities:
error: Could not find the vulnerability report.

Scanned 1 asset

Terraform HCL
    C Terraform Static Analysis directory pass
```

Example NEW:

```bash
✓ Pass:         VM disk encryption keys should not be provided in plaintext
. Skipped:      Service accounts should not have roles assigned with excessive privileges


Scanned 1 asset

Terraform HCL
    C Terraform Static Analysis directory pass
```