### PR TITLE
⭐️ Add conditions to the systemd unit file

### DIFF
--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=cnspec Service
 After=network-online.target
+ConditionPathExists=/etc/opt/mondoo/
+ConditionFileNotEmpty=/etc/opt/mondoo/mondoo.yml
 
 [Service]
 Type=simple


### PR DESCRIPTION
This is in response to https://github.com/mondoohq/installer/issues/279

Adding these conditions will cause the systemd unit to fail is a more elegant way than simply failing because the files aren't present, in the case that the service wasn't registered.  Because we install the unit file with the packages there isn't a direct interface to the user to instruct them to register before instantiating the service.