### PR TITLE
🐛 Fix creation of reporting job for missing or non-matching data queries.

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1594,8 +1594,12 @@ func (s *LocalServices) jobsToControls(cache *frameworkResolverCache, framework 
 				continue
 			}
 
-			// the query must exist, since validation happens earlier
+			// the query may not be active and therefore not part of the bundle
+			// there is a similar guard for checks where we verify if there's a rj with the check's mrn
 			mquery := cache.bundleMap.Queries[mrn]
+			if mquery == nil {
+				continue
+			}
 			execQuery := cache.executionQueries[mquery.Checksum]
 			uuid := cache.relativeChecksum(mquery.Mrn)
 			queryJob := &ReportingJob{

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1601,6 +1601,11 @@ func (s *LocalServices) jobsToControls(cache *frameworkResolverCache, framework 
 				continue
 			}
 			execQuery := cache.executionQueries[mquery.Checksum]
+			// the data query may be part of the bundle, but it may not match the curent asset,
+			// which means it will not be part of the execution
+			if execQuery == nil {
+				continue
+			}
 			uuid := cache.relativeChecksum(mquery.Mrn)
 			queryJob := &ReportingJob{
 				Uuid:      uuid,


### PR DESCRIPTION
This PRs fixes 2 issues:
 1. If we have a framework that references a query but that query is not part of the bundle because the pack or policy are not activated, it will not be present during execution. Add a guard + test to ensure we only add reporting jobs for present queries
 2. If there's an active query but it does not match the asset (wrong asset filters), it will not be part of the execution queries. Note it is still part of the bundle, since the pack or policy is active but its not a query that the asset will run. Add a guard + test 