### PR TITLE
🐛 Fix adding ignored checks in the resolver

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -891,9 +891,8 @@ func (s *LocalServices) policyGroupToJobs(ctx context.Context, group *PolicyGrou
 			continue
 		}
 
-		validUntil := time.Unix(group.EndDate, 0).Format(time.RFC3339)
 		if check.Action == explorer.Action_IGNORE {
-			stillValid := CheckValidUntil(validUntil, check.Mrn)
+			stillValid := CheckValidUntil(group.EndDate, check.Mrn)
 			if !stillValid {
 				// the exception is no longer valid => score the check
 				check.Action = explorer.Action_ACTIVATE
@@ -908,7 +907,6 @@ func (s *LocalServices) policyGroupToJobs(ctx context.Context, group *PolicyGrou
 		if check.Action == explorer.Action_IGNORE {
 			impact.Scoring = explorer.ScoringSystem_IGNORE_SCORE
 			impact.Action = explorer.Action_IGNORE
-			check.Action = explorer.Action_IGNORE
 		}
 
 		cache.global.propsCache.Add(check.Props...)
@@ -1399,13 +1397,9 @@ func ensureControlJob(cache *frameworkResolverCache, jobs map[string]*ReportingJ
 	// If we ignore this control, we have to transfer this info to the impact var,
 	// which is used to inform how to aggregate the results of all child jobs.
 	impact := &explorer.Impact{}
-	validUntil := ""
 	if frameworkGroup, ok := frameworkGroupByControlMrn[controlMrn]; ok {
 		if frameworkGroup.Type == GroupType_IGNORED {
-			if frameworkGroup.EndDate != 0 {
-				validUntil = time.Unix(frameworkGroup.EndDate, 0).Format(time.RFC3339)
-			}
-			stillIgnore := CheckValidUntil(validUntil, controlMrn)
+			stillIgnore := CheckValidUntil(frameworkGroup.EndDate, controlMrn)
 			if stillIgnore {
 				impact.Scoring = explorer.ScoringSystem_IGNORE_SCORE
 				impact.Action = explorer.Action_IGNORE
@@ -1689,25 +1683,19 @@ func (s *LocalServices) updateAssetJobs(ctx context.Context, assetMrn string, as
 	return s.DataLake.SetAssetResolvedPolicy(ctx, assetMrn, resolvedPolicy, V2Code)
 }
 
-// CheckValidUntil returns whether the given time is lying in the future or not.
-// Specialcase is an empty string, which is treated as forever.
-func CheckValidUntil(validUntil string, mrn string) bool {
+// CheckValidUntil returns whether the given time is laying in the future or not.
+// Special case is a unix ts of 0, which is treated as forever.
+func CheckValidUntil(validUntil int64, mrn string) bool {
 	stillIgnore := false
-	// empty validUntil means ignore forever
-	if validUntil == "" {
+	// 0 validUntil means ignore forever
+	if validUntil == 0 {
 		stillIgnore = true
 		log.Debug().Str("mrn", mrn).Msg("control is ignored forever")
 	} else {
-		validTime, err := time.Parse(time.RFC3339, validUntil)
-		if err != nil {
-			// user wanted an exception, but something went wrong with the date
-			// should we bubble up the error?
-			log.Error().Err(err).Str("mrn", mrn).Msg("failed to parse validUntil")
-		} else {
-			if validTime.After(time.Now()) {
-				stillIgnore = true
-				log.Debug().Str("mrn", mrn).Msg("is ignored for now because of validUntil timestamp")
-			}
+		validTime := time.Unix(validUntil, 0)
+		if validTime.After(time.Now()) {
+			stillIgnore = true
+			log.Debug().Str("mrn", mrn).Msg("is ignored for now because of validUntil timestamp")
 		}
 	}
 	return stillIgnore

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1687,7 +1687,7 @@ func (s *LocalServices) updateAssetJobs(ctx context.Context, assetMrn string, as
 // Special case is a unix ts of 0, which is treated as forever.
 func CheckValidUntil(validUntil int64, mrn string) bool {
 	stillIgnore := false
-	// 0 validUntil means ignore forever
+	// empty validUntil means ignore forever
 	if validUntil == 0 {
 		stillIgnore = true
 		log.Debug().Str("mrn", mrn).Msg("control is ignored forever")

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -235,11 +235,6 @@ func TestResolve_DisabledQuery(t *testing.T) {
 	b := parseBundle(t, `
 owner_mrn: //test.sth
 policies:
-- owner_mrn: //test.sth
-  mrn: //test.sth
-  groups:
-  - policies:
-    - uid: policy-1
 - uid: policy-1
   owner_mrn: //test.sth
   groups:
@@ -255,20 +250,18 @@ policies:
 		{asset: "asset1", policies: []string{policyMrn("policy-1")}},
 	}, []*policy.Bundle{b})
 
-	t.Run("resolve with disabled query", func(t *testing.T) {
-		rp, err := srv.Resolve(context.Background(), &policy.ResolveReq{
-			PolicyMrn:    "//test.sth",
-			AssetFilters: []*explorer.Mquery{{Mql: "true"}},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, rp)
-		require.Len(t, rp.CollectorJob.ReportingJobs, 2)
-		for _, rj := range rp.CollectorJob.ReportingJobs {
-			if rj.Type == policy.ReportingJob_CHECK {
-				require.Fail(t, "expected no check reporting job")
-			}
-		}
+	rp, err := srv.Resolve(context.Background(), &policy.ResolveReq{
+		PolicyMrn:    "asset1",
+		AssetFilters: []*explorer.Mquery{{Mql: "true"}},
 	})
+	require.NoError(t, err)
+	require.NotNil(t, rp)
+	require.Len(t, rp.CollectorJob.ReportingJobs, 2)
+	for _, rj := range rp.CollectorJob.ReportingJobs {
+		if rj.Type == policy.ReportingJob_CHECK {
+			require.Fail(t, "expected no check reporting job")
+		}
+	}
 }
 
 func TestResolve_ExpiredGroups(t *testing.T) {


### PR DESCRIPTION
Previously, we used to annotate ignored checks with the `MODIFY` action, we now have a `IGNORE` action too. Clean up of all v7 deprecated code, related to the scoring spec and add a test for a disabled query.

I still need to write a test for a policy with an ignored query