### PR TITLE
🐛 Set maximum retries for systemd

### DIFF
--- a/scripts/pkg/debian/cnspec.service
+++ b/scripts/pkg/debian/cnspec.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=cnspec Service
 After=network-online.target
-StartLimitIntervalSec=10
+StartLimitIntervalSec=280
 
 [Service]
 Type=simple
@@ -9,10 +9,9 @@ WorkingDirectory=/etc/opt/mondoo/
 ExecStart=/usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
 KillMode=process
 Restart=on-failure
-RestartSec=90
 RestartPreventExitStatus=78
 StartLimitBurst=3
-RestartSec=3
+RestartSec=90
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/pkg/debian/cnspec.service
+++ b/scripts/pkg/debian/cnspec.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=cnspec Service
 After=network-online.target
+StartLimitIntervalSec=10
 
 [Service]
 Type=simple
@@ -10,6 +11,8 @@ KillMode=process
 Restart=on-failure
 RestartSec=90
 RestartPreventExitStatus=78
+StartLimitBurst=3
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -13,6 +13,7 @@ KillMode=process
 Restart=on-failure
 RestartSec=90
 RestartPreventExitStatus=78
+StartLimitBurst=3
 RestartSec=3
 
 [Install]

--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -3,6 +3,7 @@ Description=cnspec Service
 After=network-online.target
 ConditionPathExists=/etc/opt/mondoo/
 ConditionFileNotEmpty=/etc/opt/mondoo/mondoo.yml
+StartLimitIntervalSec=10
 
 [Service]
 Type=simple
@@ -12,6 +13,7 @@ KillMode=process
 Restart=on-failure
 RestartSec=90
 RestartPreventExitStatus=78
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/pkg/linux/cnspec.service
+++ b/scripts/pkg/linux/cnspec.service
@@ -3,7 +3,7 @@ Description=cnspec Service
 After=network-online.target
 ConditionPathExists=/etc/opt/mondoo/
 ConditionFileNotEmpty=/etc/opt/mondoo/mondoo.yml
-StartLimitIntervalSec=10
+StartLimitIntervalSec=280
 
 [Service]
 Type=simple
@@ -11,10 +11,9 @@ WorkingDirectory=/etc/opt/mondoo/
 ExecStart=/usr/bin/cnspec --config /etc/opt/mondoo/mondoo.yml serve
 KillMode=process
 Restart=on-failure
-RestartSec=90
 RestartPreventExitStatus=78
 StartLimitBurst=3
-RestartSec=3
+RestartSec=90
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* RestartLimitBurst defines how many times to retry
* StartLimitIntervalSec > StartLimitBurst*RestartSec

If the number of reboots `RestartLimitBurst` in `RestartLimitIntervalSec` is reached, systemd will stop to restart.


https://github.com/mondoohq/installer/issues/376