### PR TITLE
🧹 make sure all asset runtime are shut down after job

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -289,6 +289,20 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		// assets = append(assets, runtime.Provider.Connection.Asset)
 	}
 
+	// For each asset candidate, we initialize a new runtime and connect to it.
+	// Within this process, we set up a catch-all deferred function, that shuts
+	// down all runtimes, in case we exit early. The list of assets only gets
+	// set in the block below this deferred function.
+	defer func() {
+		for i := range assets {
+			asset := assets[i]
+			// we can call close multiple times and it will only execute once
+			if asset.runtime != nil {
+				asset.runtime.Close()
+			}
+		}
+	}()
+
 	// for each asset candidate, we initialize a new runtime and connect to it.
 	for i := range assetCandidates {
 		candidate := assetCandidates[i]


### PR DESCRIPTION
On distributeJob, we create runtimes but only shut them down at the end of the execution. However, it is possible to exit this function before all runtimes have been executed, i.e. before they all have a chance to shut down properly. With this deferred function we make sure all new runtimes are terminated.

See https://github.com/mondoohq/cnquery/pull/2387