### PR TITLE
🐛 fix asset name for vuln command

### DIFF
--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -26,6 +26,7 @@ func init() {
 	vulnCmd.Flags().StringP("output", "o", "compact", "Set output format: "+reporter.AllFormats())
 	vulnCmd.Flags().BoolP("json", "j", false, "Run the query and return the object in a JSON structure.")
 	vulnCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
+	vulnCmd.Flags().String("asset-name", "", "User-override for the asset name")
 
 	vulnCmd.Flags().String("inventory-file", "", "Set the path to the inventory file.")
 	vulnCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible.")


### PR DESCRIPTION
#911 

Before:
```
./cnspec vuln container image ubuntu:focal-20220113 --log-level debug
DBG using provider os with connector container
DBG Started a new runtime (2 total)
DBG running provider plugin path=/home/marius/.config/mondoo/providers/os/os
DBG Started a new runtime (3 total)
→ no Mondoo configuration file provided, using defaults
FTL failed to parse asset-name error="flag accessed but not defined: asset-name"
```


After:
```
./cnspec vuln container image ubuntu:focal-20220113 --log-level debug
DBG using provider os with connector container
DBG Started a new runtime (2 total)
DBG running provider plugin path=/home/marius/.config/mondoo/providers/os/os
DBG Started a new runtime (3 total)
→ no Mondoo configuration file provided, using defaults
! No credentials provided. Switching to --incognito mode.
FTL vulnerability scan requires authentication, login with `cnspec login --token
```


Introduced in #885 - I was not aware that the vuln command also uses `getCobraScanConfig`