### PR TITLE
🐛 Use agent MRN to check in upstream

### DIFF
--- a/apps/cnspec/cmd/backgroundjob/checkin.go
+++ b/apps/cnspec/cmd/backgroundjob/checkin.go
@@ -30,16 +30,19 @@ type checkinPinger struct {
 	creds      *upstream.ServiceAccountCredentials
 }
 
-func NewCheckinPinger(ctx context.Context, httpClient *http.Client, endpoint string, config *upstream.UpstreamConfig, interval time.Duration) *checkinPinger {
+func NewCheckinPinger(ctx context.Context, httpClient *http.Client, endpoint string, agentMrn string, config *upstream.UpstreamConfig, interval time.Duration) (*checkinPinger, error) {
+	if agentMrn == "" {
+		return nil, errors.New("could not determine agent MRN")
+	}
 	return &checkinPinger{
 		ctx:        ctx,
 		interval:   interval,
 		quit:       make(chan struct{}),
 		endpoint:   endpoint,
 		httpClient: httpClient,
-		mrn:        config.Creds.Mrn,
+		mrn:        agentMrn,
 		creds:      config.Creds,
-	}
+	}, nil
 }
 
 func (c *checkinPinger) Start() {

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -195,6 +195,7 @@ type scanConfig struct {
 	ScoreThreshold int
 
 	DoRecord bool
+	AgentMrn string
 }
 
 func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) (*scanConfig, error) {
@@ -243,6 +244,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		ScoreThreshold: viper.GetInt("score-threshold"),
 		Props:          props,
 		runtime:        runtime,
+		AgentMrn:       opts.AgentMrn,
 	}
 
 	// if users want to get more information on available output options,

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -80,9 +80,14 @@ var serveCmd = &cobra.Command{
 				return cli_errors.NewCommandError(errors.Wrap(err, "could not initialize upstream client"), 1)
 			}
 
-			checkin := backgroundjob.NewCheckinPinger(ctx, client.HttpClient, client.ApiEndpoint, conf.runtime.UpstreamConfig, 2*time.Hour)
-			checkin.Start()
-			defer checkin.Stop()
+			checkin, err := backgroundjob.NewCheckinPinger(ctx, client.HttpClient, client.ApiEndpoint, conf.AgentMrn, conf.runtime.UpstreamConfig, 2*time.Hour)
+			if err != nil {
+				log.Error().Err(err).Msg("could not initialize upstream check-in")
+			} else {
+				checkin.Start()
+				defer checkin.Stop()
+			}
+
 		}
 
 		bj, err := backgroundjob.New()
@@ -136,6 +141,7 @@ func getServeConfig() (*scanConfig, error) {
 		ReportType: scan.ReportType_ERROR,
 		Output:     "",
 		runtime:    runtime,
+		AgentMrn:   opts.AgentMrn,
 	}
 
 	// detect CI/CD runs and read labels from runtime and apply them to all assets in the inventory


### PR DESCRIPTION
Previously, I used the serivceaccount MRN. That does not work on all cases. We need to use the agent MRN.