### PR TITLE
🐛 Ensure that policy group checks are also properly cleaned if queries are missing

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -579,7 +579,8 @@ func (c *bundleCache) removeFailing(res *Bundle) {
 		for j := range policy.Groups {
 			group := policy.Groups[j]
 			group.Queries = explorer.FilterQueryMRNs(c.removeQueries, group.Queries)
-			if len(group.Queries) != 0 {
+			group.Checks = explorer.FilterQueryMRNs(c.removeQueries, group.Checks)
+			if len(group.Queries)+len(group.Checks) > 0 {
 				groups = append(groups, group)
 			}
 		}


### PR DESCRIPTION
We only were checking the `queries` part and not the `checks`, which mean that any policy grp w/o queries would have been skipped. Fixes #925 

- [x] I want to add a test for this