### PR TITLE
🐛 Try to make mquery checksums stable

### DIFF
--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -185,6 +185,23 @@ func TestBundleCompile_FromQueryPackBundle(t *testing.T) {
 	require.Equal(t, 2, len(converted.Policies[0].Groups))
 }
 
+func TestStableMqueryChecksum(t *testing.T) {
+	bundle, err := policy.BundleFromPaths("../examples/complex.mql.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+
+	bundlemap, err := bundle.Compile(context.Background(), schema, nil)
+	require.NoError(t, err)
+	require.NotNil(t, bundlemap)
+
+	for _, m := range bundlemap.Queries {
+		initialChecksum := m.Checksum
+		err := m.RefreshChecksum(context.Background(), schema, explorer.QueryMap(bundlemap.Queries).GetQuery)
+		require.NoError(t, err)
+		assert.Equal(t, initialChecksum, m.Checksum, "checksum for %s changed", m.Mrn)
+	}
+}
+
 func TestBundleCompile_RemoveFailingQueries(t *testing.T) {
 	bundleStr := `
   owner_mrn: //test.sth


### PR DESCRIPTION
- We cannot change a value of the mquery before its stored. This causes the checksum to change. Its better we do this before we calculate checksums. I've made this happen when the bundle is compiled
- The queries variants refer to need to have their checksums before we checksum it. So we need to topologically sort the queries before compiling such that all dependent queries have been compiled and checksummed before compiling the depending query.
