### PR TITLE
🧹 Prevent nil panic when recording is not set

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -102,6 +102,10 @@ func NewLocalScanner(opts ...ScannerOption) *LocalScanner {
 		opts[i](ls)
 	}
 
+	if ls.recording == nil {
+		ls.recording = providers.NullRecording{}
+	}
+
 	return ls
 }
 

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -100,3 +100,12 @@ func TestCreateAssetList(t *testing.T) {
 		require.Equal(t, "mondoo-operator-123", candidates[2].asset.ManagedBy)
 	})
 }
+
+func TestDefaultConfig(t *testing.T) {
+	t.Run("without opts", func(t *testing.T) {
+		scanner := NewLocalScanner()
+		require.NotNil(t, scanner)
+
+		require.Equal(t, providers.NullRecording{}, scanner.recording)
+	})
+}


### PR DESCRIPTION
In case recording isn't specififed during scanner initialisation, set the NullRecording