### PR TITLE
🧹 Add sortContents to yac bundle struct. Simplify formatting.

### DIFF
--- a/internal/bundle/bundle_ext.yac.go
+++ b/internal/bundle/bundle_ext.yac.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package bundle
 
 import "sort"

--- a/internal/bundle/bundle_ext.yac.go
+++ b/internal/bundle/bundle_ext.yac.go
@@ -1,0 +1,49 @@
+package bundle
+
+import "sort"
+
+// Sorts the queries, policies and queries' variants in the bundle.
+func (p *Bundle) SortContents() {
+	sort.SliceStable(p.Queries, func(i, j int) bool {
+		if p.Queries[i].Mrn == "" || p.Queries[j].Mrn == "" {
+			return p.Queries[i].Uid < p.Queries[j].Uid
+		}
+		return p.Queries[i].Mrn < p.Queries[j].Mrn
+	})
+
+	sort.SliceStable(p.Policies, func(i, j int) bool {
+		if p.Policies[i].Mrn == "" || p.Policies[j].Mrn == "" {
+			return p.Policies[i].Uid < p.Policies[j].Uid
+		}
+		return p.Policies[i].Mrn < p.Policies[j].Mrn
+	})
+
+	for _, q := range p.Queries {
+		sort.SliceStable(q.Variants, func(i, j int) bool {
+			if q.Variants[i].Mrn == "" || q.Variants[j].Mrn == "" {
+				return q.Variants[i].Uid < q.Variants[j].Uid
+			}
+			return q.Variants[i].Mrn < q.Variants[j].Mrn
+		})
+	}
+	for _, pl := range p.Policies {
+		for _, g := range pl.Groups {
+			for _, q := range g.Queries {
+				sort.SliceStable(q.Variants, func(i, j int) bool {
+					if q.Variants[i].Mrn == "" || q.Variants[j].Mrn == "" {
+						return q.Variants[i].Uid < q.Variants[j].Uid
+					}
+					return q.Variants[i].Mrn < q.Variants[j].Mrn
+				})
+			}
+			for _, c := range g.Checks {
+				sort.SliceStable(c.Variants, func(i, j int) bool {
+					if c.Variants[i].Mrn == "" || c.Variants[j].Mrn == "" {
+						return c.Variants[i].Uid < c.Variants[j].Uid
+					}
+					return c.Variants[i].Mrn < c.Variants[j].Mrn
+				})
+			}
+		}
+	}
+}

--- a/internal/bundle/fmt.go
+++ b/internal/bundle/fmt.go
@@ -74,26 +74,16 @@ func FormatFile(filename string, sort bool) error {
 	if err != nil {
 		return err
 	}
-
-	if sort {
-		b, err := policy.BundleFromYAML(data)
-		if err != nil {
-			return err
-		}
-
-		b.SortContents()
-		data, err = b.ToYAML()
-		if err != nil {
-			return err
-		}
+	yacB, err := ParseYaml(data)
+	if err != nil {
+		return err
 	}
-
-	data, err = FormatBundleData(data)
+	fmtData, err := FormatBundle(yacB, sort)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(filename, data, 0o644)
+	err = os.WriteFile(filename, fmtData, 0o644)
 	if err != nil {
 		return err
 	}
@@ -101,13 +91,8 @@ func FormatFile(filename string, sort bool) error {
 	return nil
 }
 
-// Format formats the .mql.yaml bundle
-func FormatBundleData(data []byte) ([]byte, error) {
-	b, err := ParseYaml(data)
-	if err != nil {
-		return nil, err
-	}
-
+// Format formats the ßbundle
+func FormatBundle(b *Bundle, sort bool) ([]byte, error) {
 	// to improve the formatting we need to remove the whitespace at the end of the lines
 	for i := range b.Queries {
 		query := b.Queries[i]
@@ -136,6 +121,10 @@ func FormatBundleData(data []byte) ([]byte, error) {
 				}
 			}
 		}
+	}
+
+	if sort {
+		b.SortContents()
 	}
 
 	return Format(b)

--- a/internal/bundle/fmt.go
+++ b/internal/bundle/fmt.go
@@ -74,11 +74,11 @@ func FormatFile(filename string, sort bool) error {
 	if err != nil {
 		return err
 	}
-	yacB, err := ParseYaml(data)
+	b, err := ParseYaml(data)
 	if err != nil {
 		return err
 	}
-	fmtData, err := FormatBundle(yacB, sort)
+	fmtData, err := FormatBundle(b, sort)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func FormatFile(filename string, sort bool) error {
 	return nil
 }
 
-// Format formats the ßbundle
+// Format formats the Bundle
 func FormatBundle(b *Bundle, sort bool) ([]byte, error) {
 	// to improve the formatting we need to remove the whitespace at the end of the lines
 	for i := range b.Queries {

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -43,6 +43,7 @@ queries:
 `
 
 	b, err := ParseYaml([]byte(data))
+	require.NoError(t, err)
 	formatted, err := FormatBundle(b, false)
 	require.NoError(t, err)
 

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnspec/v9/policy"
 )
 
 func TestBundleFormatter(t *testing.T) {
@@ -43,7 +42,8 @@ queries:
     title: Ensure Secure Boot is enabled
 `
 
-	formatted, err := FormatBundleData([]byte(data))
+	b, err := ParseYaml([]byte(data))
+	formatted, err := FormatBundle(b, false)
 	require.NoError(t, err)
 
 	expected := `policies:
@@ -128,12 +128,9 @@ queries:
     title: Ensure Secure Boot is enabled
 `
 
-	b, err := policy.BundleFromYAML([]byte(data))
+	b, err := ParseYaml([]byte(data))
 	require.NoError(t, err)
-	b.SortContents()
-	byteData, err := b.ToYAML()
-	require.NoError(t, err)
-	formatted, err := FormatBundleData(byteData)
+	formatted, err := FormatBundle(b, true)
 	require.NoError(t, err)
 	expected := `policies:
   - uid: sshd-server-policy

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestBundleFormatter(t *testing.T) {
 	data := `
+# This is a comment
 policies:
   - uid: sshd-server-policy
     authors:
@@ -47,7 +48,8 @@ queries:
 	formatted, err := FormatBundle(b, false)
 	require.NoError(t, err)
 
-	expected := `policies:
+	expected := `# This is a comment
+policies:
   - uid: sshd-server-policy
     name: SSH Server Policy
     version: 1.0.0


### PR DESCRIPTION
The yac bundle holds extra properties (file context, comments). To avoid losing those we add a `SortContents` function to the yac `Bundle` struct 