### PR TITLE
🐛 fix reporting job score panic

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -977,6 +977,9 @@ func (cache *policyResolverCache) addCheckJob(ctx context.Context, check *explor
 		cache.global.reportingJobsByUUID[uuid] = queryJob
 		cache.global.reportingJobsByMsum[check.Checksum] = append(cache.global.reportingJobsByMsum[check.Checksum], queryJob)
 		cache.childJobsByMrn[check.Mrn] = append(cache.childJobsByMrn[check.Mrn], queryJob)
+	}
+
+	if ownerJob.ChildJobs[queryJob.Uuid] == nil {
 		ownerJob.ChildJobs[queryJob.Uuid] = impact
 	}
 

--- a/policy/scan/testdata/shared-query.mql.yaml
+++ b/policy/scan/testdata/shared-query.mql.yaml
@@ -1,0 +1,20 @@
+policies:
+  - uid: example1
+    name: Example policy 1
+    version: "1.0.0"
+    groups:
+      - filters: true == true
+        checks:
+          - uid: sshd-01
+  - uid: example2
+    name: Example policy 2
+    version: "1.0.0"
+    groups:
+      - filters: true == true
+        checks:
+          - uid: sshd-01
+
+queries:
+  - uid: sshd-01
+    title: Ensure the port is set to 22
+    mql: true == true


### PR DESCRIPTION
Fixes #960

I think this solves the problem we have seen in the issue above. I broke this in #943. There was even a discussion about that specific change https://github.com/mondoohq/cnspec/pull/943/files#r1392963805 The intention there was that we do not override scores if they already exist, since that was breaking the new exceptions logic. 

I think I messed it up because with the flow in that PR there are situation where the score would be completely missing from the reporting job and that causes panics. I re-wrote the code to only set the score if it's not already set. That works for exceptions and also fixes the panic