### PR TITLE
🐛 Fix missing platform

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -249,6 +249,7 @@ func createAssetCandidateList(ctx context.Context, job *Job, upstream *upstream.
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
+		resolvedAsset = runtime.Provider.Connection.Asset // to ensure we get all the information the connect call gave us
 
 		// for all discovered assets, we apply mondoo-specific labels and annotations that come from the root asset
 		for _, a := range runtime.Provider.Connection.GetInventory().GetSpec().GetAssets() {
@@ -345,6 +346,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
+		candidate.asset = runtime.Provider.Connection.Asset // to ensure we get all the information the connect call gave us
 
 		if candidate.asset.GetPlatform() == nil {
 			log.Error().Msgf("unable to detect platform for asset " + candidate.asset.Name)


### PR DESCRIPTION
This fixes the error:
'unable to detect platform for asset ...'

I came across this with container image discovery.