### PR TITLE
⭐️ Add reporting jobs for data queries.

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1138,8 +1138,6 @@ func (s *LocalServices) jobsToQueries(ctx context.Context, policyMrn string, cac
 		Queries: map[string]*ExecutionQuery{},
 	}
 
-	// fill in all reporting jobs. we will remove the data query jobs and replace
-	// them with direct collections into their parent job later
 	for _, rj := range cache.reportingJobsByUUID {
 		collectorJob.ReportingJobs[rj.Uuid] = rj
 	}

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1044,6 +1044,8 @@ func (cache *policyResolverCache) addDataQueryJob(ctx context.Context, query *ex
 			ChildJobs:  map[string]*explorer.Impact{},
 			Datapoints: map[string]bool{},
 			Type:       ReportingJob_DATA_QUERY,
+			// FIXME: DEPRECATED, remove in v10.0 vv
+			DeprecatedV8IsData: true,
 		}
 		cache.global.codeIdToMrn[query.CodeId] = append(cache.global.codeIdToMrn[query.CodeId], query.Mrn)
 		cache.global.reportingJobsByUUID[uuid] = queryJob

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -222,7 +222,7 @@ policies:
 		})
 		require.NoError(t, err)
 		require.NotNil(t, rp)
-		require.Len(t, rp.CollectorJob.ReportingJobs, 4)
+		require.Len(t, rp.CollectorJob.ReportingJobs, 5)
 		ignoreJob := rp.CollectorJob.ReportingJobs["lTbmPQz/DwA="]
 		require.NotNil(t, ignoreJob)
 		childJob := ignoreJob.ChildJobs["DmPNGpL6IXo="]


### PR DESCRIPTION
Until now we had always deleted the data queries' reporting jobs and attached the datapoints to their parent RJs. With this change we instead attach the datapoints to the data queries' RJs and we do not delete them. 

This means that we now have scores coming in for data queries, even though those will always be of the unscored type.

This brings scoring and data queries a lot closer in terms of their behaviour in the resolver. For instance, we no longer need to do special handling for framework controls and data queries, those work just like the checks.

I need to write more tests for this but the code changes should be there

- [x] tests

