### PR TITLE
🧹 batch sync assets

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -410,7 +410,9 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	scanGroups.Add(1)
 	go func() {
 		defer scanGroups.Done()
-		multiprogress.Open()
+		if err := multiprogress.Open(); err != nil {
+			log.Error().Err(err).Msg("failed to open progress bar")
+		}
 	}()
 
 	assetBatches := batch(assets, 10)


### PR DESCRIPTION
Instead of calling `SynchronizeAssets` once for all discovered assets, we create batches. This makes sure that if we have discovered a huge amount of assets, the call would still succeed. 

I intentionally put a low number for the batch size because with this implementation, batches are scanned in parallel, which also decreases the total scan time.

Downside of this approach is that the progress bar results ordering is no longer deterministic. However, since this is a progress bar, I don't think ordering should matter