### PR TITLE
🏃🏻‍♂️ retrieve space bundle instead of asset bundle for upstream scans

### DIFF
--- a/policy/scan/scan.go
+++ b/policy/scan/scan.go
@@ -32,6 +32,7 @@ type AssetJob struct {
 	UpstreamConfig   *upstream.UpstreamConfig
 	Asset            *inventory.Asset
 	Bundle           *policy.Bundle
+	SpaceBundleMap   *policy.PolicyBundleMap
 	PolicyFilters    []string
 	Props            map[string]string
 	Ctx              context.Context


### PR DESCRIPTION
We don't need the asset bundle when we run upstream scans. All we need is the space bundle, which already contains all queries, controls, policies and frameworks. This speeds up scans significantly. 

The more policies/frameworks are enabled in a space, the more this change will speed up the scans when compared to the latest cnspec release

I tested this with a sample space and a fresh minikube instance (11 assets). Total scan duration:
  - Old: 24s
  - New: 16s