### PR TITLE
🐛 fix merging of `for`-referenced props + add example

### DIFF
--- a/examples/props.mql.yaml
+++ b/examples/props.mql.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# This bundle contains two policies
+policies:
+  - uid: example1
+    name: Example policy 1
+    version: "1.0.0"
+    authors:
+      - name: Mondoo
+        email: hello@mondoo.com
+    groups:
+      - title: group1
+        filters: asset.family.contains("unix")
+        queries:
+          - uid: variant-check
+    props:
+      - uid: userHome
+        for:
+          - uid: home
+          - uid: homeDir
+        mql: return "ex"
+
+queries:
+  - uid: variant-check
+    variants:
+      - uid: var1
+      - uid: var2
+      - uid: var3
+
+  - uid: var1
+    mql: props.home + " on 1"
+    filters: asset.family.contains("unix")
+    props:
+      - uid: home
+        mql: return "p1"
+
+  - uid: var2
+    mql: props.home + " on 2"
+    filters: asset.family.contains("unix")
+    props:
+      - uid: home
+        mql: return "p2"
+
+  - uid: var3
+    mql: props.homeDir + " on 3"
+    filters: asset.family.contains("unix")
+    props:
+      - uid: homeDir
+        mql: return "p3"
+  

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -1115,11 +1115,22 @@ func (c *bundleCache) compileProp(prop *explorer.Property) error {
 
 	if prop.Mrn == "" {
 		uid := prop.Uid
+		forUids := make([]string, len(prop.For))
+		for i := range prop.For {
+			forUids[i] = prop.For[i].Uid
+		}
+
 		if err := prop.RefreshMRN(c.ownerMrn); err != nil {
 			return err
 		}
+
 		if uid != "" {
 			c.uid2mrn[uid] = prop.Mrn
+		}
+		for i := range forUids {
+			if forUids[i] != "" {
+				c.uid2mrn[forUids[i]] = prop.For[i].Mrn
+			}
 		}
 
 		// TODO: uid's can be namespaced, extract the name


### PR DESCRIPTION
Note: Please update cnquery to latest post https://github.com/mondoohq/cnquery/pull/2973 and this should work

1. The `for` field is used to specify what a prop is meant to set. Unfortunately it was not used during resolution, so it was effectively ignored so far.

2. Properties have been hard to use because they lack documentation. This PR adds a full example on how properties work and how they can be used across properties.

Given the new example, we can now run:

```bash
cnspec scan -f examples/props.mql.yaml
```

```
Data queries:
home.+: "ex on 1"
home.+: "ex on 2"
homeDir.+: "ex on 3"
```

It also now supports overrides:

```bash
cnspec scan -f examples/props.mql.yaml --props userHome="'nya'"
```

```
Data queries:
home.+: "nya on 1"
home.+: "nya on 2"
homeDir.+: "nya on 3"
```