### PR TITLE
🧹 Add bytes reporter to support the packer plugin

### DIFF
--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -101,6 +101,13 @@ func NewReporter(format Format, incognito bool) *Reporter {
 	}
 }
 
+// This allows the packer-plugin-cnspec to set the output writer directly
+// The plugin needs this to work the the packer output
+func (r *Reporter) WithOutput(out io.Writer) *Reporter {
+	r.out = out
+	return r
+}
+
 func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollection) error {
 	switch r.Format {
 	case Compact:

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -101,8 +101,7 @@ func NewReporter(format Format, incognito bool) *Reporter {
 	}
 }
 
-// This allows the packer-plugin-cnspec to set the output writer directly
-// The plugin needs this to work the the packer output
+// This allows to set the output writer directly
 func (r *Reporter) WithOutput(out io.Writer) *Reporter {
 	r.out = out
 	return r

--- a/cli/reporter/file_handler.go
+++ b/cli/reporter/file_handler.go
@@ -27,9 +27,6 @@ func (h *localFileHandler) WriteReport(ctx context.Context, report *policy.Repor
 	}
 	defer f.Close() //nolint: errcheck
 	reporter := NewReporter(h.format, false)
-	if err != nil {
-		return err
-	}
 	reporter.out = f
 	err = reporter.WriteReport(ctx, report)
 	if err != nil {


### PR DESCRIPTION
This adds a reporter which allows to access the rendered report as bytes.Buffer. This is needed, so we can output it inside the packer plugin.

For reference: https://github.com/mondoohq/packer-plugin-cnspec/pull/170