### PR TITLE
🏃🏻‍♂️ improve scan speed by not retrieving bundles for assets

### DIFF
--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -107,15 +107,6 @@ func (db *Db) GetRawPolicy(ctx context.Context, mrn string) (*policy.Policy, err
 
 // GetPolicyFilters retrieves the list of asset filters for a policy (fast)
 func (db *Db) GetPolicyFilters(ctx context.Context, mrn string) ([]*explorer.Mquery, error) {
-	// If there is an upstream set, we should prefer using that always.
-	if db.services.Upstream != nil {
-		mqueries, err := db.services.Upstream.GetPolicyFilters(ctx, &policy.Mrn{Mrn: mrn})
-		if err != nil {
-			return nil, err
-		}
-		return mqueries.Items, nil
-	}
-
 	r, err := db.GetRawPolicy(ctx, mrn)
 	if err != nil {
 		return nil, err

--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -107,6 +107,15 @@ func (db *Db) GetRawPolicy(ctx context.Context, mrn string) (*policy.Policy, err
 
 // GetPolicyFilters retrieves the list of asset filters for a policy (fast)
 func (db *Db) GetPolicyFilters(ctx context.Context, mrn string) ([]*explorer.Mquery, error) {
+	// If there is an upstream set, we should prefer using that always.
+	if db.services.Upstream != nil {
+		mqueries, err := db.services.Upstream.GetPolicyFilters(ctx, &policy.Mrn{Mrn: mrn})
+		if err != nil {
+			return nil, err
+		}
+		return mqueries.Items, nil
+	}
+
 	r, err := db.GetRawPolicy(ctx, mrn)
 	if err != nil {
 		return nil, err

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -297,6 +297,15 @@ func (s *LocalServices) GetPolicyFilters(ctx context.Context, mrn *Mrn) (*Mqueri
 		return nil, status.Error(codes.InvalidArgument, "policy mrn is required")
 	}
 
+	// If there is an upstream set, we should prefer using that always.
+	if s.Upstream != nil {
+		mqueries, err := s.Upstream.GetPolicyFilters(ctx, mrn)
+		if err != nil {
+			return nil, err
+		}
+		return mqueries, nil
+	}
+
 	filters, err := s.DataLake.GetPolicyFilters(ctx, mrn.Mrn)
 	if err != nil {
 		return nil, errors.New("failed to get policy filters: " + err.Error())

--- a/policy/scan/aggregate_reporter.go
+++ b/policy/scan/aggregate_reporter.go
@@ -22,13 +22,14 @@ type AggregateReporter struct {
 	worstScore       *policy.Score
 }
 
-func NewAggregateReporter() *AggregateReporter {
+func NewAggregateReporter(bundle *policy.Bundle) *AggregateReporter {
 	return &AggregateReporter{
 		assets:           make(map[string]*inventory.Asset),
 		assetReports:     map[string]*policy.Report{},
 		assetErrors:      map[string]error{},
 		resolvedPolicies: map[string]*policy.ResolvedPolicy{},
 		assetVulnReports: map[string]*mvd.VulnReport{},
+		bundle:           bundle,
 	}
 }
 
@@ -39,7 +40,6 @@ func (r *AggregateReporter) AddReport(asset *inventory.Asset, results *AssetRepo
 	r.assetReports[asset.Mrn] = results.Report
 	r.resolvedPolicies[asset.Mrn] = results.ResolvedPolicy
 
-	r.bundle = results.Bundle
 	if r.worstScore == nil || results.Report.Score.Value < r.worstScore.Value {
 		r.worstScore = results.Report.Score
 	}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1020,6 +1020,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	}
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> got policy filters")
 	logger.TraceJSON(rawFilters)
+	logger.DebugDumpYAML("policyFilters", rawFilters)
 
 	filters, err := s.UpdateFilters(&explorer.Mqueries{Items: rawFilters.Items}, 5*time.Second)
 	if err != nil {

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1002,7 +1002,17 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	var hub policy.PolicyHub = s.services
 	var resolver policy.PolicyResolver = s.services
 
-	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> request policies bundle for asset")
+	// If we run in debug mode, download the asset bundle and dump it to disk
+	if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
+		log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> request policies bundle for asset")
+		assetBundle, err := hub.GetBundle(s.job.Ctx, &policy.Mrn{Mrn: s.job.Asset.Mrn})
+		if err != nil {
+			return nil, err
+		}
+		log.Debug().Msg("client> got policy bundle")
+		logger.TraceJSON(assetBundle)
+		logger.DebugDumpYAML("assetBundle", assetBundle)
+	}
 
 	rawFilters, err := hub.GetPolicyFilters(s.job.Ctx, &policy.Mrn{Mrn: s.job.Asset.Mrn})
 	if err != nil {

--- a/policy/scan/reporter.go
+++ b/policy/scan/reporter.go
@@ -12,7 +12,6 @@ import (
 type AssetReport struct {
 	Mrn            string
 	ResolvedPolicy *policy.ResolvedPolicy
-	Bundle         *policy.Bundle
 	Report         *policy.Report
 }
 


### PR DESCRIPTION
After #1023 and some thoughts and discussions on this topic, I tried out something else. It turns out we don't need the bundle at all for execution and reporting results upstream. We only use it to print the CLI report. 

This PR makes sure we aren't pulling the bundle for every asset. It needs a small backend change that will allow agents to call `GetPolicyFilters` but apart from that it works exactly the same as the old code

Another benefit of this approach is that we will use significantly less network traffic. This has become a problem for big k8s cluster that result in many assets being scanned