### PR TITLE
🧹 increase dqueue max size

### DIFF
--- a/policy/scan/disk_queue.go
+++ b/policy/scan/disk_queue.go
@@ -24,7 +24,7 @@ type diskQueueConfig struct {
 var defaultDqueConfig = diskQueueConfig{
 	dir:      "/tmp/cnspec-queue", // TODO: consider configurable path
 	filename: "disk-queue",
-	maxSize:  500,
+	maxSize:  50000,
 	sync:     false,
 }
 


### PR DESCRIPTION
The current size is too small. We are scanning clusters with dqueue and 500 entries is just not enough. There are cases where we queue all the objects in the cluster to be scanned sequentially... The actual thing that gets stored on the disk is the inventory file to be scanned, which is not large. I increased the limit significantly 