### PR TITLE
🧹 remove trailing dot for short cmd description

### DIFF
--- a/apps/cnspec/cmd/bundle.go
+++ b/apps/cnspec/cmd/bundle.go
@@ -45,7 +45,8 @@ func init() {
 
 var policyInitDeprecatedCmd = &cobra.Command{
 	Use:        "init [path]",
-	Short:      "Create an example policy bundle that you can use as a starting point. If you don't provide a filename, cnspec uses `example-policy.mql.yml`.",
+	Short:      "Create an example policy bundle",
+	Long:       "Create an example policy bundle that you can use as a starting point. If you don't provide a filename, cnspec uses `example-policy.mql.yml`.",
 	Aliases:    []string{"new"},
 	Hidden:     true,
 	Deprecated: "use `cnspec policy init` instead",
@@ -58,7 +59,7 @@ var policyFmtDeprecatedCmd = &cobra.Command{
 	Aliases:    []string{"fmt"},
 	Hidden:     true,
 	Deprecated: "use `cnspec policy fmt` instead",
-	Short:      "Apply style formatting to one or more policy bundles.",
+	Short:      "Apply style formatting to one or more policy bundles",
 	Args:       cobra.MinimumNArgs(1),
 	Run:        runPolicyFmt,
 }
@@ -77,7 +78,7 @@ var policyBundlesCmd = &cobra.Command{
 	Use:        "bundle",
 	Hidden:     true,
 	Deprecated: "use `cnspec policy` instead",
-	Short:      "Manage policy bundles.",
+	Short:      "Manage policy bundles",
 }
 
 var policyLintDeprecatedCmd = &cobra.Command{
@@ -85,7 +86,7 @@ var policyLintDeprecatedCmd = &cobra.Command{
 	Aliases:    []string{"validate"},
 	Hidden:     true,
 	Deprecated: "use `cnspec policy lint` instead",
-	Short:      "Lint a policy bundle.",
+	Short:      "Lint a policy bundle",
 	Args:       cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
@@ -99,7 +100,7 @@ var policyPublishCmd = &cobra.Command{
 	Aliases:    []string{"upload"},
 	Hidden:     true,
 	Deprecated: "use `cnspec policy upload` instead",
-	Short:      "Add a user-owned policy to the Mondoo Security Registry.",
+	Short:      "Add a user-owned policy to the Mondoo Security Registry",
 	Args:       cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("policy-version", cmd.Flags().Lookup("policy-version"))
@@ -202,7 +203,7 @@ var policyDocsDeprecatedCmd = &cobra.Command{
 	Aliases:    []string{},
 	Hidden:     true,
 	Deprecated: "use `cnspec policy docs` instead",
-	Short:      "Retrieve only the docs for a bundle.",
+	Short:      "Retrieve only the docs for a bundle",
 	Args:       cobra.MinimumNArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("no-ids", cmd.Flags().Lookup("no-ids"))

--- a/apps/cnspec/cmd/migrate.go
+++ b/apps/cnspec/cmd/migrate.go
@@ -11,7 +11,7 @@ import (
 // migrateCmd helps to migrate user config to the latest version
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "Migrate cnspec CLI configuration to the latest version.",
+	Short: "Migrate cnspec CLI configuration to the latest version",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info().Msg("No migration needed.")
 	},

--- a/apps/cnspec/cmd/policy.go
+++ b/apps/cnspec/cmd/policy.go
@@ -75,12 +75,12 @@ func init() {
 
 var policyCmd = &cobra.Command{
 	Use:   "policy",
-	Short: "Manage local and upstream policies.",
+	Short: "Manage local and upstream policies",
 }
 
 var policyListCmd = &cobra.Command{
 	Use:   "list [-f bundle]",
-	Short: "List enabled policies in the connected space.",
+	Short: "List enabled policies in the connected space",
 	Args:  cobra.MaximumNArgs(0),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := viper.BindPFlag("file", cmd.Flags().Lookup("file")); err != nil {
@@ -152,7 +152,7 @@ var policyListCmd = &cobra.Command{
 
 var policyUploadCmd = &cobra.Command{
 	Use:   "upload my.mql.yaml",
-	Short: "Upload a policy to the connected space.",
+	Short: "Upload a policy to the connected space",
 	Args:  cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := viper.BindPFlag("policy-version", cmd.Flags().Lookup("policy-version")); err != nil {
@@ -260,7 +260,7 @@ var policyUploadCmd = &cobra.Command{
 
 var policyDeleteCmd = &cobra.Command{
 	Use:   "delete UID/MRN",
-	Short: "Delete a policy from the connected space.",
+	Short: "Delete a policy from the connected space",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, err := config.Read()
@@ -324,7 +324,7 @@ var policyDeleteCmd = &cobra.Command{
 
 var policyInfoCmd = &cobra.Command{
 	Use:     "info UID/MRN",
-	Short:   "Show more info about a policy from the connected space.",
+	Short:   "Show more info about a policy from the connected space",
 	Aliases: []string{"show"},
 	Args:    cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -441,7 +441,7 @@ var policyInfoCmd = &cobra.Command{
 
 var policyDownloadCmd = &cobra.Command{
 	Use:   "download UID/MRN",
-	Short: "download a policy to a local bundle file.",
+	Short: "download a policy to a local bundle file",
 	Args:  cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := viper.BindPFlag("file", cmd.Flags().Lookup("file")); err != nil {
@@ -496,7 +496,7 @@ var policyDownloadCmd = &cobra.Command{
 
 var policyEnableCmd = &cobra.Command{
 	Use:   "enable UID/MRN",
-	Short: "Enables a policy in the connected space.",
+	Short: "Enables a policy in the connected space",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, err := config.Read()
@@ -532,7 +532,7 @@ var policyEnableCmd = &cobra.Command{
 
 var policyDisableCmd = &cobra.Command{
 	Use:   "disable UID/MRN",
-	Short: "Disables a policy in the connected space.",
+	Short: "Disables a policy in the connected space",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, err := config.Read()
@@ -571,7 +571,8 @@ var embedPolicyTemplate []byte
 
 var policyInitCmd = &cobra.Command{
 	Use:     "init [path]",
-	Short:   "Create an example policy bundle that you can use as a starting point. If you don't provide a filename, cnspec uses `example-policy.mql.yml`.",
+	Short:   "Create an example policy bundle",
+	Long:    "Create an example policy bundle that you can use as a starting point. If you don't provide a filename, cnspec uses `example-policy.mql.yml`.",
 	Aliases: []string{"new"},
 	Args:    cobra.MaximumNArgs(1),
 	Run:     runPolicyInit,
@@ -598,7 +599,7 @@ func runPolicyInit(cmd *cobra.Command, args []string) {
 var policyFmtCmd = &cobra.Command{
 	Use:     "format [path]",
 	Aliases: []string{"fmt"},
-	Short:   "Apply style formatting to one or more policy bundles.",
+	Short:   "Apply style formatting to one or more policy bundles",
 	Args:    cobra.MinimumNArgs(1),
 	Run:     runPolicyFmt,
 }
@@ -621,7 +622,7 @@ func runPolicyFmt(cmd *cobra.Command, args []string) {
 var policyLintCmd = &cobra.Command{
 	Use:     "lint [path]",
 	Aliases: []string{"validate"},
-	Short:   "Lint a policy bundle.",
+	Short:   "Lint a policy bundle",
 	Args:    cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := viper.BindPFlag("output", cmd.Flags().Lookup("output")); err != nil {
@@ -688,7 +689,7 @@ func runPolicyLint(cmd *cobra.Command, args []string) {
 var policyDocsCmd = &cobra.Command{
 	Use:     "docs [path]",
 	Aliases: []string{},
-	Short:   "Retrieve only the docs for a bundle.",
+	Short:   "Retrieve only the docs for a bundle",
 	Args:    cobra.MinimumNArgs(1),
 	Hidden:  true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -67,7 +67,7 @@ func init() {
 
 var scanCmd = &cobra.Command{
 	Use:   "scan",
-	Short: "Scan assets with one or more policies.",
+	Short: "Scan assets with one or more policies",
 	Long: `
 This command scans an asset using a policy. For example, you can scan
 the local system with its pre-configured policies:

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -41,7 +41,7 @@ func init() {
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Start cnspec in background mode.",
+	Short: "Start cnspec in background mode",
 
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_ = viper.BindPFlag("scan_interval.timer", cmd.Flags().Lookup("timer"))

--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -36,7 +36,7 @@ func init() {
 var serveApiCmd = &cobra.Command{
 	Use:    "serve-api",
 	Hidden: true,
-	Short:  "EXPERIMENTAL: Serve a REST API for running scans.",
+	Short:  "EXPERIMENTAL: Serve a REST API for running scans",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("port", cmd.Flags().Lookup("port"))
 		viper.BindPFlag("address", cmd.Flags().Lookup("address"))

--- a/apps/cnspec/cmd/shell.go
+++ b/apps/cnspec/cmd/shell.go
@@ -23,7 +23,7 @@ func init() {
 
 var shellCmd = &cobra.Command{
 	Use:   "shell",
-	Short: "Interactive query shell for MQL.",
+	Short: "Interactive query shell for MQL",
 	Long:  `Allows the interactive exploration of MQL queries.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))

--- a/apps/cnspec/cmd/version.go
+++ b/apps/cnspec/cmd/version.go
@@ -13,7 +13,7 @@ import (
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Display the cnspec version.",
+	Short: "Display the cnspec version",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(cnspec.Info())
 	},

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -37,7 +37,7 @@ func init() {
 
 var vulnCmd = &cobra.Command{
 	Use:   "vuln",
-	Short: "Scans a target for Vulnerabilities",
+	Short: "Scans a target for vulnerabilities",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// for all assets
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -37,7 +37,7 @@ func init() {
 
 var vulnCmd = &cobra.Command{
 	Use:   "vuln",
-	Short: "Scans a target for Vulnerabilities.",
+	Short: "Scans a target for Vulnerabilities",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// for all assets
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	go.mondoo.com/cnquery/v10 v10.0.0-beta2
+	go.mondoo.com/cnquery/v10 v10.0.0-beta2.0.20240116170322-692b9d61c6cd
 	go.mondoo.com/mondoo-go v0.0.0-20240103050411-fa7e920c6784
 	go.mondoo.com/ranger-rpc v0.5.3
 	go.opentelemetry.io/otel v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -1115,6 +1115,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/cnquery/v10 v10.0.0-beta2 h1:193KxYu1DREhRgCR03Dx6YDQTHRWx8faJsSi7nS+mls=
 go.mondoo.com/cnquery/v10 v10.0.0-beta2/go.mod h1:KrUZGsoWraETSaWqJNnURzpQQRpwpx7rcOW14bmgfxM=
+go.mondoo.com/cnquery/v10 v10.0.0-beta2.0.20240116170322-692b9d61c6cd h1:ZazyBEnnQUlPvnVT0aOGeFJOeBj7Kg2RnkUvX8QjC5o=
+go.mondoo.com/cnquery/v10 v10.0.0-beta2.0.20240116170322-692b9d61c6cd/go.mod h1:KrUZGsoWraETSaWqJNnURzpQQRpwpx7rcOW14bmgfxM=
 go.mondoo.com/mondoo-go v0.0.0-20240103050411-fa7e920c6784 h1:k6Z9Fax2ELkspDozxy3Skkqe1eaHRSqRS16InEspMHg=
 go.mondoo.com/mondoo-go v0.0.0-20240103050411-fa7e920c6784/go.mod h1:elugDWMp6Tnk1tSpTf/7HHewkb0ORjMA2ubeFLI+FwQ=
 go.mondoo.com/ranger-rpc v0.5.3 h1:914JOFTrxWFtBu1qrvuTyTyMibuT7g1GAX3HaUcbFqI=

--- a/test/cli/testdata/cnspec.ct
+++ b/test/cli/testdata/cnspec.ct
@@ -13,19 +13,18 @@ Usage:
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
-  login       Register with Mondoo Platform.
-  logout      Log out from Mondoo Platform.
+  login       Register with Mondoo Platform
+  logout      Log out from Mondoo Platform
   migrate     Migrate cnspec CLI configuration to the latest version
   policy      Manage local and upstream policies
-  providers   Providers add connectivity to all assets.
-  run         Run an MQL query.
+  providers   Providers add connectivity to all assets
+  run         Run an MQL query
   scan        Scan assets with one or more policies
   serve       Start cnspec in background mode
   shell       Interactive query shell for MQL
-  status      Verify access to Mondoo Platform.
-  vault       Manage vault environments.
+  status      Verify access to Mondoo Platform
+  vault       Manage vault environments
   version     Display the cnspec version
-  vuln        Scans a target for Vulnerabilities
 
 Flags:
       --api-proxy string   Set proxy for communications with Mondoo API
@@ -34,5 +33,8 @@ Flags:
   -h, --help               help for cnspec
       --log-level string   Set log level: error, warn, info, debug, trace (default "info")
   -v, --verbose            Enable verbose output
+
+Additional help topics:
+  cnspec vuln       Scans a target for vulnerabilities
 
 Use "cnspec [command] --help" for more information about a command.

--- a/test/cli/testdata/cnspec.ct
+++ b/test/cli/testdata/cnspec.ct
@@ -15,16 +15,17 @@ Available Commands:
   help        Help about any command
   login       Register with Mondoo Platform.
   logout      Log out from Mondoo Platform.
-  migrate     Migrate cnspec CLI configuration to the latest version.
-  policy      Manage local and upstream policies.
+  migrate     Migrate cnspec CLI configuration to the latest version
+  policy      Manage local and upstream policies
   providers   Providers add connectivity to all assets.
   run         Run an MQL query.
-  scan        Scan assets with one or more policies.
-  serve       Start cnspec in background mode.
-  shell       Interactive query shell for MQL.
+  scan        Scan assets with one or more policies
+  serve       Start cnspec in background mode
+  shell       Interactive query shell for MQL
   status      Verify access to Mondoo Platform.
   vault       Manage vault environments.
-  version     Display the cnspec version.
+  version     Display the cnspec version
+  vuln        Scans a target for Vulnerabilities
 
 Flags:
       --api-proxy string   Set proxy for communications with Mondoo API
@@ -33,8 +34,5 @@ Flags:
   -h, --help               help for cnspec
       --log-level string   Set log level: error, warn, info, debug, trace (default "info")
   -v, --verbose            Enable verbose output
-
-Additional help topics:
-  cnspec vuln       Scans a target for Vulnerabilities.
 
 Use "cnspec [command] --help" for more information about a command.

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -13,7 +13,14 @@ Usage:
   cnspec scan [command]
 
 Available Commands:
+  container   Scan a running container or container image
+  docker      Scan a running Docker container or Docker image
+  filesystem  Scan a mounted file system target
+  local       Scan your local system
   mock        Scan use a recording without an active connection
+  ssh         Scan a remote system via SSH
+  vagrant     Scan a Vagrant host
+  winrm       Scan a remote system via WinRM
 
 Flags:
       --annotation stringToString   Add an annotation to the asset. (default [])

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -13,14 +13,7 @@ Usage:
   cnspec scan [command]
 
 Available Commands:
-  container   Scan a running container or container image
-  docker      Scan a running Docker container or Docker image
-  filesystem  Scan a mounted file system target
-  local       Scan your local system
   mock        Scan use a recording without an active connection
-  ssh         Scan a remote system via SSH
-  vagrant     Scan a Vagrant host
-  winrm       Scan a remote system via WinRM
 
 Flags:
       --annotation stringToString   Add an annotation to the asset. (default [])

--- a/test/cli/testdata/cnspec_vault.ct
+++ b/test/cli/testdata/cnspec_vault.ct
@@ -1,12 +1,12 @@
 $ cnspec vault
-Manage vault environments.
+Manage vault environments
 
 Usage:
   cnspec vault [command]
 
 Available Commands:
-  add-secret  Store a secret in a vault.
-  configure   Configure a vault environment.
+  add-secret  Store a secret in a vault
+  configure   Configure a vault environment
 
 Flags:
   -h, --help   help for vault


### PR DESCRIPTION
This PR simplifies the short descriptions and does not end with trailing dots

- [x] cnquery dependency needs to be updated to cover the missing trailing dot messages https://github.com/mondoohq/cnquery/pull/3033