### PR TITLE
🧹 ensure example pass our own lint requirements

### DIFF
--- a/examples/compliance.mql.yaml
+++ b/examples/compliance.mql.yaml
@@ -4,6 +4,7 @@
 policies:
 - uid: ssh-policy
   name: SSH Policy
+  version: 1.0.0
   groups:
   - filters: return true
     checks:

--- a/examples/directory/example1.mql.yaml
+++ b/examples/directory/example1.mql.yaml
@@ -9,7 +9,7 @@ policies:
       - name: Mondoo
         email: hello@mondoo.com
     groups:
-      - filters: platform.family.contains('unix')
+      - filters: asset.family.contains('unix')
         checks:
           - uid: sshd-01
           - uid: sshd-02

--- a/examples/directory/example2.mql.yaml
+++ b/examples/directory/example2.mql.yaml
@@ -6,7 +6,7 @@ policies:
     name: Another policy
     version: 1.0.0
     groups:
-      - filters: platform.family.contains('unix')
+      - filters: asset.family.contains('unix')
         checks:
           - uid: linux-1
         policies:

--- a/examples/lint_test.go
+++ b/examples/lint_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package examples
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10/providers"
+	"go.mondoo.com/cnspec/v10/internal/bundle"
+	"os"
+	"testing"
+)
+
+func ensureProviders(ids []string) error {
+	for _, id := range ids {
+		_, err := providers.EnsureProvider(providers.ProviderLookup{ID: id}, true, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	dir := ".lint-providers"
+	providers.CustomProviderPath = dir
+	providers.DefaultPath = dir
+
+	err := ensureProviders([]string{
+		"go.mondoo.com/cnquery/providers/os",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	exitVal := m.Run()
+
+	// cleanup custom provider path to ensure no leftovers and other tests are not affected
+	err = os.RemoveAll(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(exitVal)
+}
+
+func TestExampleLint(t *testing.T) {
+	files := []string{
+		"./complex.mql.yaml",
+		"./example.mql.yaml",
+		"./props.mql.yaml",
+	}
+
+	runtime := providers.DefaultRuntime()
+	result, err := bundle.Lint(runtime.Schema(), files...)
+	require.NoError(t, err)
+	assert.False(t, result.HasError())
+}

--- a/examples/props.mql.yaml
+++ b/examples/props.mql.yaml
@@ -23,26 +23,27 @@ policies:
 
 queries:
   - uid: variant-check
+    title: Variant check
     variants:
-      - uid: var1
-      - uid: var2
-      - uid: var3
+      - uid: variant-1
+      - uid: variant-2
+      - uid: variant-3
 
-  - uid: var1
+  - uid: variant-1
     mql: props.home + " on 1"
     filters: asset.family.contains("unix")
     props:
       - uid: home
         mql: return "p1"
 
-  - uid: var2
+  - uid: variant-2
     mql: props.home + " on 2"
     filters: asset.family.contains("unix")
     props:
       - uid: home
         mql: return "p2"
 
-  - uid: var3
+  - uid: variant-3
     mql: props.homeDir + " on 3"
     filters: asset.family.contains("unix")
     props:


### PR DESCRIPTION
Use our lint requirements to validate our examples. To make this work, we temporarily install the required providers and remove them afterwards. This ensures that other tests like cli tests are not affected by the providers we need here.