### PR TITLE
🧹use custom provider directory for pipeline

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set provider env
         run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
-      - name: Display Provider PAth
+      - name: Display Provider Path
         run: echo $PROVIDERS_PATH
 
       - run: make test/go/plain-ci

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -67,6 +68,12 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
+      - name: Set provider env
+        run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
+      - name: Display Provider PAth
+        run: echo $PROVIDERS_PATH
+
       - run: make test/go/plain-ci
       - uses: actions/upload-artifact@v4  # upload test results
         if: success() || failure()        # run this step even if previous step failed


### PR DESCRIPTION
This makes sure different runs use different provider install directories. It shields PRs better and makes sure we test properly.