### PR TITLE
🐛 report asset errors

### DIFF
--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -97,10 +97,11 @@ func TestCreateAssetList(t *testing.T) {
 				},
 			},
 		}
-		assetList, candidates, err := createAssetCandidateList(context.TODO(), job, nil, providers.NullRecording{})
+		assetList, candidates, assetErrors, err := createAssetCandidateList(context.TODO(), job, nil, providers.NullRecording{})
 		require.NoError(t, err)
 		require.Len(t, assetList, 1)
 		require.Len(t, candidates, 3)
+		require.Len(t, assetErrors, 0)
 		require.Equal(t, "mondoo-operator-123", candidates[0].asset.ManagedBy)
 		require.Equal(t, "mondoo-operator-123", candidates[1].asset.ManagedBy)
 		require.Equal(t, "mondoo-operator-123", candidates[2].asset.ManagedBy)


### PR DESCRIPTION
This implements the same [behavior](https://github.com/mondoohq/cnquery/pull/3152) we added for cnquery to cnspec.

When cnspec was executed in a pipeline and a connect error happened, we never collected that error and returned a non-zero exit code. That can lead to silent errors.

We always prepared the report structure to collect the errors. This change handles asset errors now.

**before**

```shell
> cnspec scan ssh user@host.com
x unable to connect to asset error="rpc error: code = Unknown desc = dial tcp 104.21.31.241:22: connect: operation timed 
> echo $?
0
```


**after**

```shell
> cnspec scan ssh user@host.com
x unable to connect to asset error="rpc error: code = Unknown desc = dial tcp 104.21.31.241:22: connect: operation timed out"
Asset: 
-------

error: rpc error: code = Unknown desc = dial tcp 104.21.31.241:22: connect: operation timed out


Scanned 1 asset

> echo $?
1
```