### PR TITLE
🏃🏻‍♂️ benchmark serve api

### DIFF
--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -96,6 +98,7 @@ var serveApiCmd = &cobra.Command{
 		log.Info().Str("url", "/Scan/").Msg("enable Scanner API")
 		mux.Handle("/Scan/", server)
 
+		go http.ListenAndServe("localhost:8081", nil)
 		if err := bindHTTP(mux, uri); err != nil {
 			log.Fatal().Err(err).Msg("failed to bind http server")
 		}


### PR DESCRIPTION
This PR is just for describing how to benchmark the scan API. It adds a profiler to the `serve-api` command that is gathering go runtime statistics and is exposing them via HTTP.

To generate a profile:
1. run `cnspec serve-api`
2. trigger a scan. We need a scan that discovers multiple assets and the easiest way to get that is to scan a k8s cluster:
  this can be done with the following inventory:
  ```json
  {
      "reportType": 1,
      "inventory": {
          "spec": {
              "assets": [
                  {
                      "connections": [
                          {
                              "type": "k8s",
                              "discover": {
                                  "targets": ["auto"]
                              }
                          }
                      ]
                  }
              ]
          }
      }
  }
  ```
  it should be posted to `http://127.0.0.1:8080/Scan/Run`
3. monitor the memory with a process monitor. When the memory spikes, grab a heap snapshot: `curl -s http://127.0.0.1:8081/debug/pprof/heap > ./test.out`
4. visualize the snapshot using pprof: `go tool pprof -http=:8082 ./test.out`

To view the allocations and space used flame graphs:
1. go to `View` -> `Flame Graph (new)`
2. then select `Sample` -> `inuse_space` or `inuse_objects` depending on what you are looking for