### PR TITLE
🐛 add group type and review status to policy graph execution checksum

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -69,8 +69,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Make provider dir
+        run: mkdir -p ${PWD}/{{env.GITHUB_JOB}}/.providers
       - name: Set provider env
-        run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
+        run: echo "PROVIDERS_PATH=${PWD}/{{env.GITHUB_JOB}}/.providers" >> $GITHUB_ENV
       - name: Display Provider Path
         run: echo $PROVIDERS_PATH
 
@@ -104,6 +106,14 @@ jobs:
         with:
           go-version: ">=${{ env.golang-version }}"
           cache: false
+
+      - name: Make provider dir
+        run: mkdir -p ${PWD}/{{env.GITHUB_JOB}}/.providers
+      - name: Set provider env
+        run: echo "PROVIDERS_PATH=${PWD}/{{env.GITHUB_JOB}}/.providers" >> $GITHUB_ENV
+      - name: Display Provider Path
+        run: echo $PROVIDERS_PATH
+        
       - name: Run benchmark
         run: make benchmark/go | tee benchmark.txt
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -71,9 +71,9 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Make provider dir
-        run: mkdir -p ${PWD}/{{env.GITHUB_JOB}}/.providers
+        run: mkdir -p ${PWD}/${{GITHUB_JOB}}/.providers
       - name: Set provider env
-        run: echo "PROVIDERS_PATH=${PWD}/{{env.GITHUB_JOB}}/.providers" >> $GITHUB_ENV
+        run: echo "PROVIDERS_PATH=${PWD}/${{GITHUB_JOB}}/.providers" >> $GITHUB_ENV
       - name: Display Provider Path
         run: echo $PROVIDERS_PATH
 
@@ -109,9 +109,9 @@ jobs:
           cache: false
 
       - name: Make provider dir
-        run: mkdir -p ${PWD}/{{env.GITHUB_JOB}}/.providers
+        run: mkdir -p ${PWD}/${{GITHUB_JOB}}/.providers
       - name: Set provider env
-        run: echo "PROVIDERS_PATH=${PWD}/{{env.GITHUB_JOB}}/.providers" >> $GITHUB_ENV
+        run: echo "PROVIDERS_PATH=${PWD}/${{GITHUB_JOB}}/.providers" >> $GITHUB_ENV
       - name: Display Provider Path
         run: echo $PROVIDERS_PATH
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -7,6 +7,7 @@ on:
       - '**.go'
       - '**.mod'
       - 'go.sum'
+      - '.github/workflows/pr-test-lint.yml'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -113,7 +114,7 @@ jobs:
         run: echo "PROVIDERS_PATH=${PWD}/{{env.GITHUB_JOB}}/.providers" >> $GITHUB_ENV
       - name: Display Provider Path
         run: echo $PROVIDERS_PATH
-        
+
       - name: Run benchmark
         run: make benchmark/go | tee benchmark.txt
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -398,6 +398,8 @@ func (p *Policy) updateAllChecksums(ctx context.Context,
 			return group.Policies[i].Mrn < group.Policies[j].Mrn
 		})
 
+		executionChecksum = executionChecksum.AddUint(uint64(group.Type))
+		executionChecksum = executionChecksum.AddUint(uint64(group.ReviewStatus))
 		for i := range group.Policies {
 			ref := group.Policies[i]
 

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -232,9 +232,9 @@ policies:
 		require.NoError(t, err)
 		require.NotNil(t, rp)
 		require.Len(t, rp.CollectorJob.ReportingJobs, 5)
-		ignoreJob := rp.CollectorJob.ReportingJobs["lTbmPQz/DwA="]
+		ignoreJob := rp.CollectorJob.ReportingJobs["8Sis0SvMbtI="]
 		require.NotNil(t, ignoreJob)
-		childJob := ignoreJob.ChildJobs["DmPNGpL6IXo="]
+		childJob := ignoreJob.ChildJobs["YCeU4NjbMe0="]
 		require.NotNil(t, childJob)
 		require.Equal(t, explorer.ScoringSystem_IGNORE_SCORE, childJob.Scoring)
 	})


### PR DESCRIPTION
We need the group type and review status to be part of the policy graph execution checksum since these 2 fields can actually change the execution job (for exceptions)