### PR TITLE
🐛 fix reporting when policies are fetched from public registry

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -274,29 +274,22 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	}
 
 	var serviceAccount *upstream.ServiceAccountCredentials
-	if !conf.IsIncognito {
-		serviceAccount = opts.GetServiceCredential()
-		if serviceAccount != nil {
-			// TODO: determine if this needs migrating
-			// // determine information about the client
-			// sysInfo, err := sysinfo.GatherSystemInfo()
-			// if err != nil {
-			// 	log.Warn().Err(err).Msg("could not gather client information")
-			// }
-			// plugins = append(plugins, defaultRangerPlugins(sysInfo, opts.GetFeatures())...)
 
-			log.Info().Msg("using service account credentials")
-			conf.runtime.UpstreamConfig = &upstream.UpstreamConfig{
-				SpaceMrn:    opts.GetParentMrn(),
-				ApiEndpoint: opts.UpstreamApiEndpoint(),
-				ApiProxy:    opts.APIProxy,
-				Incognito:   conf.IsIncognito,
-				Creds:       serviceAccount,
-			}
-		} else {
-			log.Warn().Msg("No credentials provided. Switching to --incognito mode.")
-			conf.IsIncognito = true
+	serviceAccount = opts.GetServiceCredential()
+	// NOTE: even if we have incognito, we want to set the upstream config. Otherwise we would not be able to
+	// use the policies that are defined in Mondoo Platform
+	if serviceAccount != nil {
+		log.Info().Msg("using service account credentials")
+		conf.runtime.UpstreamConfig = &upstream.UpstreamConfig{
+			SpaceMrn:    opts.GetParentMrn(),
+			ApiEndpoint: opts.UpstreamApiEndpoint(),
+			ApiProxy:    opts.APIProxy,
+			Incognito:   conf.IsIncognito,
+			Creds:       serviceAccount,
 		}
+	} else {
+		log.Warn().Msg("No credentials provided. Switching to --incognito mode.")
+		conf.IsIncognito = true
 	}
 
 	if len(conf.PolicyPaths) > 0 && !conf.IsIncognito {

--- a/policy/scan/fetcher.go
+++ b/policy/scan/fetcher.go
@@ -38,11 +38,11 @@ func (f *fetcher) fetchBundles(ctx context.Context, conf mqlc.CompilerConfig, ur
 		if err != nil {
 			return nil, err
 		}
+		cur.ConvertQuerypacks()
 
 		// need to generate MRNs for everything
 		if _, err := cur.CompileExt(ctx, policy.BundleCompileConf{
 			CompilerConfig: conf,
-			Library:        nil,
 			RemoveFailing:  true,
 		}); err != nil {
 			return nil, errors.Wrap(err, "failed to compile fetched bundle")

--- a/policy/scan/reporter.go
+++ b/policy/scan/reporter.go
@@ -16,8 +16,14 @@ type AssetReport struct {
 }
 
 type Reporter interface {
+	// AddBundle adds the policy bundle to the reporter which includes more information about the policies
+	AddBundle(bundle *policy.Bundle)
+	// AddReport adds the scan results to the reporter
 	AddReport(asset *inventory.Asset, results *AssetReport)
+	// AddVulnReport adds the vulnerability scan results to the reporter
 	AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport)
+	// AddScanError adds the scan error to the reporter
 	AddScanError(asset *inventory.Asset, err error)
+	// Reports returns the scan results
 	Reports() *ScanResult
 }

--- a/policy/scan/reporter_aggregate.go
+++ b/policy/scan/reporter_aggregate.go
@@ -22,15 +22,22 @@ type AggregateReporter struct {
 	worstScore       *policy.Score
 }
 
-func NewAggregateReporter(bundle *policy.Bundle) *AggregateReporter {
+func NewAggregateReporter() *AggregateReporter {
 	return &AggregateReporter{
 		assets:           make(map[string]*inventory.Asset),
 		assetReports:     map[string]*policy.Report{},
 		assetErrors:      map[string]error{},
 		resolvedPolicies: map[string]*policy.ResolvedPolicy{},
 		assetVulnReports: map[string]*mvd.VulnReport{},
-		bundle:           bundle,
 	}
+}
+
+func (r *AggregateReporter) AddBundle(bundle *policy.Bundle) {
+	if r.bundle == nil {
+		r.bundle = bundle
+		return
+	}
+	r.bundle = policy.Merge(r.bundle, bundle)
 }
 
 func (r *AggregateReporter) AddReport(asset *inventory.Asset, results *AssetReport) {

--- a/policy/scan/reporter_aggregate_test.go
+++ b/policy/scan/reporter_aggregate_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnspec/v10/policy"
+)
+
+func TestAggregateReport(t *testing.T) {
+
+	b := &policy.Bundle{
+		Policies: []*policy.Policy{
+			{
+				Uid:  "policy1",
+				Name: "Policy 1",
+			},
+		},
+	}
+
+	r := NewAggregateReporter()
+	r.AddBundle(b)
+	assert.Equal(t, r.bundle, b)
+
+	b2 := &policy.Bundle{
+		Policies: []*policy.Policy{
+			{
+				Uid:  "policy2",
+				Name: "Policy 2",
+			},
+		},
+	}
+
+	r.AddBundle(b2)
+	assert.Equal(t, r.bundle, policy.Merge(b, b2))
+}

--- a/policy/scan/reporter_error.go
+++ b/policy/scan/reporter_error.go
@@ -30,6 +30,8 @@ func (r *ErrorReporter) AddReport(asset *inventory.Asset, results *AssetReport) 
 	}
 }
 
+func (r *ErrorReporter) AddBundle(bundle *policy.Bundle) {}
+
 func (r *ErrorReporter) AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport) {
 }
 

--- a/policy/scan/reporter_noop.go
+++ b/policy/scan/reporter_noop.go
@@ -6,6 +6,7 @@ package scan
 import (
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream/gql"
+	"go.mondoo.com/cnspec/v10/policy"
 )
 
 type NoOpReporter struct{}
@@ -13,6 +14,8 @@ type NoOpReporter struct{}
 func NewNoOpReporter() Reporter {
 	return &NoOpReporter{}
 }
+
+func (r *NoOpReporter) AddBundle(bundle *policy.Bundle) {}
 
 func (r *NoOpReporter) AddReport(asset *inventory.Asset, results *AssetReport) {
 }


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnspec/issues/1071

When we run scans we have 3 different cases we need to handle:

1. use local bundle
2. public registry, which is default when not authenticated with Mondoo platoform and no local bundle was provided
3. authenticated with Mondoo platform with upstream reporting
4. authenticated with Mondoo platform in incognito mode but with upstream policies

Before this PR we did different ways of handling. We harmonize the fetching of the bundles for the reported now. We always use the services.GetBundle() independently of the cases above. This simplifies the code base.

It is also important to note that having a configuration does not mean that it includes upstream config. A simple config could be:

```yaml
auto_update: true
log-level: info
```

TODO:

- [x] For reporting we want to fetch the bundle only once when we are authenticated
