### PR TITLE
📃 remove license header from cnspec policy init

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -13,5 +13,6 @@ project {
     "**/testdata/**",
     "**/*.pb.go",
     "**/*_string.go",
+    "apps/cnspec/cmd/policy-example.mql.yaml",
   ]
 }

--- a/apps/cnspec/cmd/policy-example.mql.yaml
+++ b/apps/cnspec/cmd/policy-example.mql.yaml
@@ -1,6 +1,3 @@
-# Copyright (c) Mondoo, Inc.
-# SPDX-License-Identifier: BUSL-1.1
-
 # Read more about the policy structure at https://mondoo.com/docs
 policies:
   - uid: sshd-server-policy


### PR DESCRIPTION
... otherwise this generates policy files that always have Mondoo copyright and license info in the header. This is a bit of overkill in most use-cases, so we can lighten it.