### PR TITLE
🧹 use error reporter when running serve command

### DIFF
--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -102,7 +102,7 @@ var serveCmd = &cobra.Command{
 				log.Error().Err(err).Msg("could not update providers")
 			}
 			// TODO: check in every 5 min via timer, init time in Background job
-			result, err := RunScan(scanConf, scan.DisableProgressBar())
+			result, err := RunScan(scanConf, scan.DisableProgressBar(), scan.WithReportType(scan.ReportType_ERROR))
 			if err != nil {
 				return cli_errors.NewCommandError(errors.Wrap(err, "could not successfully complete scan"), 1)
 			}


### PR DESCRIPTION
this will make sure we aren't calling `GetBundle` when running in `cnspec serve` mode. We don't really need it, since we only care about the errors