### PR TITLE
🧹 harmonize the version handling for mondoo.version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,8 @@ builds:
       - -tags="production netgo"
     ldflags:
       - "-extldflags=-static"
-      - -s -w -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
+      - -s -w
+      - -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
       - -X go.mondoo.com/cnquery/v10.Version={{.Version}} -X go.mondoo.com/cnquery/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v10.Date={{.Date}}
   - id: macos
     main: ./apps/cnspec/cnspec.go
@@ -39,7 +40,8 @@ builds:
     flags: -tags production
     ldflags:
       # clang + macos does not support static: - -extldflags "-static"
-      - -s -w -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
+      - -s -w
+      - -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
       - -X go.mondoo.com/cnquery/v10.Version={{.Version}} -X go.mondoo.com/cnquery/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v10.Date={{.Date}}
     hooks:
       post:
@@ -58,7 +60,8 @@ builds:
     flags: -tags production -buildmode exe
     ldflags:
       - "-extldflags -static"
-      - -s -w -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
+      - -s -w
+      - -X go.mondoo.com/cnspec/v10.Version={{.Version}} -X go.mondoo.com/cnspec/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnspec/v10.Date={{.Date}}
       - -X go.mondoo.com/cnquery/v10.Version={{.Version}} -X go.mondoo.com/cnquery/v10.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v10.Date={{.Date}}
     hooks:
       post:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION=${LATEST_VERSION_TAG}+$(shell git rev-list --count HEAD)
 endif
 
 LDFLAGS=-ldflags "-s -w -X go.mondoo.com/cnspec/v10.Version=${VERSION} -X go.mondoo.com/cnspec/v10.Build=${TAG}" # -linkmode external -extldflags=-static
-LDFLAGSDIST=-tags production -ldflags "-s -w -X go.mondoo.com/cnspec/v10.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnspec/v10.Build=${TAG} -s -w"
+LDFLAGSDIST=-tags production -ldflags "-s -w -X go.mondoo.com/cnquery/v10.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnquery/v10.Build=${TAG} -X go.mondoo.com/cnspec/v10.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnspec/v10.Build=${TAG} -s -w"
 
 .PHONY: info/ldflags
 info/ldflags:

--- a/apps/cnspec/cmd/shell.go
+++ b/apps/cnspec/cmd/shell.go
@@ -7,11 +7,9 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.mondoo.com/cnquery/v10"
 	cnquery_app "go.mondoo.com/cnquery/v10/apps/cnquery/cmd"
 	"go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnspec/v10"
 )
 
 func init() {
@@ -33,13 +31,6 @@ var shellCmd = &cobra.Command{
 var shellRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
 	shellConf := cnquery_app.ParseShellConfig(cmd, cliRes)
 	shellConf.WelcomeMessage = cnspecLogo
-
-	// FIXME: workaround for `mondoo.version` in case of builtin providers
-	// (which is how the core provider is set up by default)
-	if cnquery.Version == "" {
-		cnquery.Version = cnspec.Version
-	}
-
 	if err := cnquery_app.StartShell(runtime, shellConf); err != nil {
 		log.Fatal().Err(err).Msg("failed to run query")
 	}


### PR DESCRIPTION
The problem was that we have not set the cnquery version variables properly. The shell had special handling which I removed to ensure we have consistent results. This has not affected prod builds, just dev builds.

**before**

```
±> cnspec run -c "mondoo.version"
mondoo.version: "unstable"
±> cnspec shell -c "mondoo.version"
→ connected to macOS
  ___ _ __  ___ _ __   ___  ___ 
 / __| '_ \/ __| '_ \ / _ \/ __|
| (__| | | \__ \ |_) |  __/ (__ 
 \___|_| |_|___/ .__/ \___|\___|
   mondoo™     |_|              
mondoo.version: "v10.3.4"
```

**after**

```
±> cnspec run -c "mondoo.version"
mondoo.version: "v10.3.4"
±> cnspec shell -c "mondoo.version"
→ connected to macOS
  ___ _ __  ___ _ __   ___  ___ 
 / __| '_ \/ __| '_ \ / _ \/ __|
| (__| | | \__ \ |_) |  __/ (__ 
 \___|_| |_|___/ .__/ \___|\___|
   mondoo™     |_|              
mondoo.version: "v10.3.4"
```