### PR TITLE
✨ Trigger cnspec bump in dependant repos

### DIFF
--- a/.github/workflows/bump-cnspec-in-deps.yaml
+++ b/.github/workflows/bump-cnspec-in-deps.yaml
@@ -1,0 +1,23 @@
+name: Trigger cnspec bump in dependant repositories
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-cnspec:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: [packer-plugin-cnspec]
+    steps:
+      - name: Trigger cnspec bump in server
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
+          repository: "mondoohq/${{ matrix.repo }}"
+          event-type: update-cnspec
+          client-payload: '{
+              "version": "${{  github.ref_name }}"
+            }'


### PR DESCRIPTION
This trigger a PR creating in the dependant repos:
- packer-plugin-cnspec

These repo will then create a PR to get the submitted cnspec version.