### PR TITLE
🐛 Collect package format for the vuln report

### DIFF
--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -88,7 +88,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Error().Err(err).Msg("failed to initialize cnspec shell")
 	}
 
-	packagesQuery := "packages{ name version origin }"
+	packagesQuery := "packages { name version origin format }"
 	packagesDatapointChecksum := executor.MustGetOneDatapoint(executor.MustCompile(packagesQuery))
 	codeBundle, results, err := sh.RunOnce(packagesQuery)
 	if err != nil {


### PR DESCRIPTION
This is needed to match the correct versions when an advisory contains the multiple formats