### PR TITLE
✨ show numeric score in cli for assets

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -254,14 +255,16 @@ func (r *defaultReporter) printAssetsByPlatform(assetsByPlatform map[string][]*i
 			assetScore := "U"
 			assetScoreRating := policy.ScoreRating_unrated
 			if r.data.Reports[assetsByPlatform[platform][i].Mrn] != nil {
-				assetScoreRating = r.data.Reports[assetsByPlatform[platform][i].Mrn].Score.Rating()
-				assetScore = assetScoreRating.Letter()
+				score := r.data.Reports[assetsByPlatform[platform][i].Mrn].Score
+				assetScoreRating = score.Rating()
+				assetScore = assetScoreRating.Letter() + " [" + strconv.Itoa(int(score.Value)) + "/100]"
 			} else {
 				assetScoreRating = policy.ScoreRating_error
 				assetScore = "X"
 			}
+
 			scoreColor := cnspecComponents.DefaultRatingColors.Color(assetScoreRating)
-			output := fmt.Sprintf("    %s %s", termenv.String(assetScore).Foreground(scoreColor), assetsByPlatform[platform][i].Name)
+			output := fmt.Sprintf("    %s   %s", termenv.String(assetScore).Foreground(scoreColor), assetsByPlatform[platform][i].Name)
 			r.out.Write([]byte(output + NewLineCharacter))
 		}
 	}


### PR DESCRIPTION
Instead of:

![image](https://github.com/mondoohq/cnspec/assets/1307529/45b9cc3d-672c-4932-b532-eb02a02ac26e)

Do:

![image](https://github.com/mondoohq/cnspec/assets/1307529/db9bdda9-0b76-48ab-9d3d-0dc3fd33d7f6)

We may abolish letter-grading in favor of criticality-grading in the future, but either way numeric scores should be visible to see meaningful changes.