### PR TITLE
🧹 make sure we set IsLastBatch only once

### DIFF
--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -86,11 +86,14 @@ func (c *BufferedCollector) run() {
 			}
 			c.lock.Unlock()
 
-			if len(results) > 0 || done {
-				c.collector.SinkData(results, done)
+			if len(results) > 0 {
+				c.collector.SinkData(results, false)
 			}
 
 			if len(scores) > 0 || done {
+				// Since scores are stored after data, we can send the IsLastBatch flag
+				// only here. We always need to notify the final batch has been sent once
+				// for each scan.
 				c.collector.SinkScore(scores, done)
 			}
 


### PR DESCRIPTION
Both `SinkData` and `SinkScore` are calling `StoreResults`. We need to make sure we call `StoreResults` with `IsLastBatch = true` only once for each scan. 

This PR changes the way we send scores and data. We now combine both in a single call. This makes the code easier to understand and reduces the amount of roundtrips we do per scan