### PR TITLE
🧹 only pull vuln report for AggregateReporter

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -514,7 +514,8 @@ func (s *LocalScanner) RunAssetJob(job *AssetJob) {
 	job.Reporter.AddReport(job.Asset, results)
 
 	upstream := s.upstreamServices(job.Ctx, job.UpstreamConfig)
-	if upstream != nil {
+	// The vuln report is relevant only when we have an aggregate reporter
+	if vulnReporter, isAggregateReporter := job.Reporter.(VulnReporter); upstream != nil && isAggregateReporter {
 		// get new gql client
 		mondooClient, err := gql.NewClient(job.UpstreamConfig, s._upstreamClient.HttpClient)
 		if err != nil {
@@ -526,7 +527,7 @@ func (s *LocalScanner) RunAssetJob(job *AssetJob) {
 			log.Error().Err(err).Msg("could not get vulnerability report")
 			return
 		}
-		job.Reporter.AddVulnReport(job.Asset, gqlVulnReport)
+		vulnReporter.AddVulnReport(job.Asset, gqlVulnReport)
 	}
 
 	// When the progress bar is disabled there's no feedback when an asset is done scanning. Adding this message

--- a/policy/scan/reporter.go
+++ b/policy/scan/reporter.go
@@ -15,13 +15,16 @@ type AssetReport struct {
 	Report         *policy.Report
 }
 
+type VulnReporter interface {
+	// AddVulnReport adds the vulnerability scan results to the reporter
+	AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport)
+}
+
 type Reporter interface {
 	// AddBundle adds the policy bundle to the reporter which includes more information about the policies
 	AddBundle(bundle *policy.Bundle)
 	// AddReport adds the scan results to the reporter
 	AddReport(asset *inventory.Asset, results *AssetReport)
-	// AddVulnReport adds the vulnerability scan results to the reporter
-	AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport)
 	// AddScanError adds the scan error to the reporter
 	AddScanError(asset *inventory.Asset, err error)
 	// Reports returns the scan results

--- a/policy/scan/reporter_aggregate.go
+++ b/policy/scan/reporter_aggregate.go
@@ -12,6 +12,8 @@ import (
 	"go.mondoo.com/cnspec/v10/policy"
 )
 
+var _ VulnReporter = &AggregateReporter{}
+
 type AggregateReporter struct {
 	assets           map[string]*inventory.Asset
 	assetReports     map[string]*policy.Report

--- a/policy/scan/reporter_error.go
+++ b/policy/scan/reporter_error.go
@@ -8,7 +8,6 @@ import (
 
 	"go.mondoo.com/cnquery/v10/cli/theme"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream/gql"
 	"go.mondoo.com/cnspec/v10/policy"
 	pbStatus "go.mondoo.com/ranger-rpc/status"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -31,9 +30,6 @@ func (r *ErrorReporter) AddReport(asset *inventory.Asset, results *AssetReport) 
 }
 
 func (r *ErrorReporter) AddBundle(bundle *policy.Bundle) {}
-
-func (r *ErrorReporter) AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport) {
-}
 
 func (c *ErrorReporter) AddScanError(asset *inventory.Asset, err error) {
 	if c.errors == nil {

--- a/policy/scan/reporter_noop.go
+++ b/policy/scan/reporter_noop.go
@@ -5,7 +5,6 @@ package scan
 
 import (
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream/gql"
 	"go.mondoo.com/cnspec/v10/policy"
 )
 
@@ -18,9 +17,6 @@ func NewNoOpReporter() Reporter {
 func (r *NoOpReporter) AddBundle(bundle *policy.Bundle) {}
 
 func (r *NoOpReporter) AddReport(asset *inventory.Asset, results *AssetReport) {
-}
-
-func (r *NoOpReporter) AddVulnReport(asset *inventory.Asset, vulnReport *gql.VulnReport) {
 }
 
 func (r *NoOpReporter) AddScanError(asset *inventory.Asset, err error) {


### PR DESCRIPTION
When we do not use the `AggregateReporter` we don't care about vulnerabilities at all. This change will make sure we aren't calling `GetVulnCompactReport` when running `cnspec serve` and `cnspec serve-api`