### PR TITLE
🧹 Do not log full asset.

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -406,7 +406,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 				asset := batch[i].Asset
 				runtime := batch[i].Runtime
 
-				log.Debug().Interface("asset", asset).Msg("start scan")
+				log.Debug().Interface("platform", asset.Platform).Str("name", asset.Name).Msg("start scan")
 
 				// Make sure the context has not been canceled in the meantime. Note that this approach works only for single threaded execution. If we have more than 1 thread calling this function,
 				// we need to solve this at a different level.


### PR DESCRIPTION
Do not log the full asset when starting a scan as this may log sensitive data such as credentials, stored in the asset's connnection.