### PR TITLE
🧹 do not log error when checkin cannot be initialized

### DIFF
--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -80,7 +80,7 @@ var serveCmd = &cobra.Command{
 
 			checkin, err := backgroundjob.NewCheckinPinger(ctx, client.HttpClient, client.ApiEndpoint, scanConf.AgentMrn, scanConf.runtime.UpstreamConfig, 2*time.Hour)
 			if err != nil {
-				log.Error().Err(err).Msg("could not initialize upstream check-in")
+				log.Debug().Err(err).Msg("could not initialize upstream check-in")
 			} else {
 				checkin.Start()
 				defer checkin.Stop()


### PR DESCRIPTION
We are now printing an error message if agent MRN isn't set. That isn't an error because we can run `cnspec serve` without an agent MRN. I changed the level to debug