### PR TITLE
🐛 fix inverted risk factor evaluation

### DIFF
--- a/examples/risk.mql.yaml
+++ b/examples/risk.mql.yaml
@@ -27,7 +27,7 @@ policies:
 
           - uid: sshd-02
             title: Prevent weaker CBC ciphers from being used
-            mql: sshd.config.ciphers.all( /cbc/ )
+            mql: sshd.config.ciphers.none( /128/ )
             impact: 80
 
             # Here we use a referenced query. You can put multiple policies
@@ -41,9 +41,10 @@ policies:
       - uid: sshd-service
         title: SSHd Service running
         docs:
-          active: The SSH service is running and can expose security issues in SSH or the asset to outside attackers.
+          active: The SSH service is running and can expose security issues to outside attackers.
           inactive: The SSH service is not running, which reduces the attack surface on the asset.
         magnitude: 0.7
+        is_absolute: true
         software:
           - name: openssh-server
           - type: alpm

--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -105,7 +105,7 @@ func (c *BufferedCollector) consumeRisk(score *policy.Score, risks map[string]bo
 	}
 
 	for _, riskMRN := range riskMRNs {
-		isDetected := score.Value != 100
+		isDetected := score.Value == 100
 		risks[riskMRN] = risks[riskMRN] || isDetected
 	}
 	return true


### PR DESCRIPTION
The logic on the risk factors examples had been inverted by accident.