### PR TITLE
🧹 AdjustRiskScore to not adjust base score

### DIFF
--- a/policy/risk_factor.go
+++ b/policy/risk_factor.go
@@ -12,6 +12,11 @@ import (
 	"go.mondoo.com/cnquery/v10/utils/multierr"
 )
 
+type ScoredRiskInfo struct {
+	*RiskFactor
+	*ScoredRiskFactor
+}
+
 func (r *RiskFactor) RefreshMRN(ownerMRN string) error {
 	nu, err := RefreshMRN(ownerMRN, r.Mrn, MRN_RESOURCE_RISK, r.Uid)
 	if err != nil {
@@ -76,17 +81,17 @@ func (r *RiskFactor) RefreshChecksum(conf mqlc.CompilerConfig) error {
 	return nil
 }
 
-func (r *RiskFactor) AdjustScore(score *Score, isDetected bool) {
+func (r *RiskFactor) AdjustRiskScore(score *Score, isDetected bool) {
 	// Absolute risk factors only play a role when they are detected.
 	if r.IsAbsolute {
 		if isDetected {
-			nu := int(score.Value) - int(r.Magnitude*100)
+			nu := int(score.RiskScore) - int(r.Magnitude*100)
 			if nu < 0 {
-				score.Value = 0
+				score.RiskScore = 0
 			} else if nu > 100 {
-				score.Value = 100
+				score.RiskScore = 100
 			} else {
-				score.Value = uint32(nu)
+				score.RiskScore = uint32(nu)
 			}
 
 			if score.RiskFactors == nil {
@@ -105,7 +110,7 @@ func (r *RiskFactor) AdjustScore(score *Score, isDetected bool) {
 
 	if r.Magnitude < 0 {
 		if isDetected {
-			score.Value = uint32(100 - float32(100-score.Value)*(1+r.Magnitude))
+			score.RiskScore = uint32(100 - float32(100-score.RiskScore)*(1+r.Magnitude))
 			if score.RiskFactors == nil {
 				score.RiskFactors = &ScoredRiskFactors{}
 			}
@@ -135,7 +140,7 @@ func (r *RiskFactor) AdjustScore(score *Score, isDetected bool) {
 		return
 	}
 
-	score.Value = uint32(100 - float32(100-score.Value)*(1-r.Magnitude))
+	score.RiskScore = uint32(100 - float32(100-score.RiskScore)*(1-r.Magnitude))
 	if score.RiskFactors == nil {
 		score.RiskFactors = &ScoredRiskFactors{}
 	}

--- a/policy/risk_factor_test.go
+++ b/policy/risk_factor_test.go
@@ -14,7 +14,7 @@ func risks(risks ...*ScoredRiskFactor) *ScoredRiskFactors {
 	return &ScoredRiskFactors{Items: risks}
 }
 
-func TestRiskFactor_AdjustScore(t *testing.T) {
+func TestRiskFactor_AdjustRiskScore(t *testing.T) {
 	tests := []struct {
 		risk     RiskFactor
 		score    Score
@@ -24,78 +24,78 @@ func TestRiskFactor_AdjustScore(t *testing.T) {
 		// Relative, increase risk
 		{
 			risk:     RiskFactor{Magnitude: 0.4},
-			score:    Score{Value: 40},
-			onDetect: Score{Value: 40, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.4})},
-			onFail:   Score{Value: 64, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
+			score:    Score{RiskScore: 40},
+			onDetect: Score{RiskScore: 40, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.4})},
+			onFail:   Score{RiskScore: 64, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
 		},
 		{
 			risk:     RiskFactor{Mrn: "internet-facing", Magnitude: 0.4},
-			score:    Score{Value: 10},
-			onDetect: Score{Value: 10, RiskFactors: risks(&ScoredRiskFactor{Mrn: "internet-facing", Risk: 0.4})},
-			onFail:   Score{Value: 45, RiskFactors: risks(&ScoredRiskFactor{Mrn: "internet-facing", Risk: -0.4})},
+			score:    Score{RiskScore: 10},
+			onDetect: Score{RiskScore: 10, RiskFactors: risks(&ScoredRiskFactor{Mrn: "internet-facing", Risk: 0.4})},
+			onFail:   Score{RiskScore: 45, RiskFactors: risks(&ScoredRiskFactor{Mrn: "internet-facing", Risk: -0.4})},
 		},
 		{
 			risk:     RiskFactor{Magnitude: 0.4},
-			score:    Score{Value: 90},
-			onDetect: Score{Value: 90, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.4})},
-			onFail:   Score{Value: 94, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
+			score:    Score{RiskScore: 90},
+			onDetect: Score{RiskScore: 90, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.4})},
+			onFail:   Score{RiskScore: 94, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
 		},
 		// Absolute, decrease risk
 		{
 			risk:     RiskFactor{Magnitude: -0.4},
-			score:    Score{Value: 40},
-			onDetect: Score{Value: 64, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
-			onFail:   Score{Value: 40},
+			score:    Score{RiskScore: 40},
+			onDetect: Score{RiskScore: 64, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
+			onFail:   Score{RiskScore: 40},
 		},
 		{
 			risk:     RiskFactor{Magnitude: -0.4},
-			score:    Score{Value: 10},
-			onDetect: Score{Value: 45, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
-			onFail:   Score{Value: 10},
+			score:    Score{RiskScore: 10},
+			onDetect: Score{RiskScore: 45, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
+			onFail:   Score{RiskScore: 10},
 		},
 		{
 			risk:     RiskFactor{Magnitude: -0.4},
-			score:    Score{Value: 90},
-			onDetect: Score{Value: 94, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
-			onFail:   Score{Value: 90},
+			score:    Score{RiskScore: 90},
+			onDetect: Score{RiskScore: 94, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.4})},
+			onFail:   Score{RiskScore: 90},
 		},
 		// Absolute, increase risk
 		{
 			risk:     RiskFactor{Magnitude: 0.2, IsAbsolute: true},
-			score:    Score{Value: 40},
-			onDetect: Score{Value: 20, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 40},
+			score:    Score{RiskScore: 40},
+			onDetect: Score{RiskScore: 20, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 40},
 		},
 		{
 			risk:     RiskFactor{Magnitude: 0.2, IsAbsolute: true},
-			score:    Score{Value: 10},
-			onDetect: Score{Value: 0, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 10},
+			score:    Score{RiskScore: 10},
+			onDetect: Score{RiskScore: 0, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 10},
 		},
 		{
 			risk:     RiskFactor{Magnitude: 0.2, IsAbsolute: true},
-			score:    Score{Value: 90},
-			onDetect: Score{Value: 70, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 90},
+			score:    Score{RiskScore: 90},
+			onDetect: Score{RiskScore: 70, RiskFactors: risks(&ScoredRiskFactor{Risk: 0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 90},
 		},
 		// Absolute, decrease risk
 		{
 			risk:     RiskFactor{Magnitude: -0.2, IsAbsolute: true},
-			score:    Score{Value: 40},
-			onDetect: Score{Value: 60, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 40},
+			score:    Score{RiskScore: 40},
+			onDetect: Score{RiskScore: 60, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 40},
 		},
 		{
 			risk:     RiskFactor{Magnitude: -0.2, IsAbsolute: true},
-			score:    Score{Value: 10},
-			onDetect: Score{Value: 30, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 10},
+			score:    Score{RiskScore: 10},
+			onDetect: Score{RiskScore: 30, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 10},
 		},
 		{
 			risk:     RiskFactor{Magnitude: -0.2, IsAbsolute: true},
-			score:    Score{Value: 90},
-			onDetect: Score{Value: 100, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
-			onFail:   Score{Value: 90},
+			score:    Score{RiskScore: 90},
+			onDetect: Score{RiskScore: 100, RiskFactors: risks(&ScoredRiskFactor{Risk: -0.2, IsAbsolute: true})},
+			onFail:   Score{RiskScore: 90},
 		},
 	}
 
@@ -104,11 +104,11 @@ func TestRiskFactor_AdjustScore(t *testing.T) {
 			cur := tests[i]
 
 			okScore := cur.score
-			cur.risk.AdjustScore(&okScore, true)
+			cur.risk.AdjustRiskScore(&okScore, true)
 			assert.Equal(t, cur.onDetect, okScore, "ok scores match")
 
 			nokScore := cur.score
-			cur.risk.AdjustScore(&nokScore, false)
+			cur.risk.AdjustRiskScore(&nokScore, false)
 			assert.Equal(t, cur.onFail, nokScore, "fail scores match")
 		})
 	}


### PR DESCRIPTION
This keeps the computation separate between the risk score and the base score.

@chris-rock FYI for the vulnerability score. The best way to use this is to set the 

```
score.RiskScore = score.Value
``` 

to get started. The add all risk factors to the score:

```
for i := range risks {
       risks[i].AdjustRiskScore(score, isDetected)
}
```

This prevents any changes to the base `Value` of the score, so that we always have access to it.