### PR TITLE
🐛 support empty policy with only risk factors

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -738,7 +738,7 @@ func (s *LocalServices) policyToJobs(ctx context.Context, policyMrn string, owne
 		return errors.New("cannot find policy '" + policyMrn + "' while resolving")
 	}
 
-	if len(policyObj.Groups) == 0 {
+	if len(policyObj.Groups) == 0 && len(policyObj.RiskFactors) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
this would routinely drop through the filter on the resolution step. With the support of empty policies with risk factors a dependency chain works as intended again.