### PR TITLE
🐛 fix RiskFactor Checksum with Magnitude field

### DIFF
--- a/policy/risk_factor.go
+++ b/policy/risk_factor.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -57,7 +58,7 @@ func (r *RiskFactor) RefreshMRN(ownerMRN string) error {
 func (r *RiskFactor) ExecutionChecksum(ctx context.Context, conf mqlc.CompilerConfig) (checksums.Fast, error) {
 	c := checksums.New.
 		AddUint(uint64(r.Scope)).
-		AddUint(uint64(r.Magnitude))
+		Add(strconv.FormatFloat(float64(r.Magnitude), 'f', -1, 64))
 
 	if r.IsAbsolute {
 		c = c.AddUint(1)


### PR DESCRIPTION
We ignored value changes in this field because the float was mapped (and rounded) to an integer before adding it to the checksum. Despite having a test for this case, the test didn't catch this case because other changes to the RiskFactor caused changes in the checksum.

We now have a standalone method for generating data for RiskFactor tests and additional validations that the generation produces unchanged data. (This approach is also more efficient than a deep-clone via proto)