### PR TITLE
🐛 Fix serve panics if splay is zero.

### DIFF
--- a/apps/cnspec/cmd/backgroundjob/serve_unix.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_unix.go
@@ -49,7 +49,11 @@ func Serve(timer time.Duration, splay time.Duration, handler JobRunner) {
 				if err != nil {
 					log.Error().Err(err).Send()
 				}
-				nextRun := timer + time.Duration(rand.Int63n(int64(splay)))
+				splayDur := time.Duration(0)
+				if splay > 0 {
+					splayDur = time.Duration(rand.Int63n(int64(splay)))
+				}
+				nextRun := timer + splayDur
 				log.Info().Msgf("next scan in %v", nextRun)
 				t.Reset(nextRun)
 			case <-shutdownChannel:

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -80,7 +80,11 @@ loop:
 			default:
 				log.Error().Msg("scan not started. may be stuck")
 			}
-			nextRun := m.Timer + time.Duration(rand.Int63n(int64(m.Splay)))
+			splayDur := time.Duration(0)
+			if m.Splay > 0 {
+				splayDur = time.Duration(rand.Int63n(int64(m.Splay)))
+			}
+			nextRun := m.Timer + splayDur
 			log.Info().Msgf("next scan in %v", nextRun)
 			t.Reset(nextRun)
 		case c := <-r:


### PR DESCRIPTION
Running `cnspec serve` with the following config (relevant bits only included):
```
scan_interval:
  timer: 60
```

panics as the splay is 0. This PR adds a safeguard to ensure cnspec doesn't panic if it's only the timer that has been set