### PR TITLE
🧹 only submit scores once we are done

### DIFF
--- a/policy/risk_factor.go
+++ b/policy/risk_factor.go
@@ -188,3 +188,10 @@ func (r *RiskFactor) AdjustRiskScore(score *Score, isDetected bool) {
 		Risk: -r.Magnitude,
 	})
 }
+
+func (s *ScoredRiskFactors) Add(other *ScoredRiskFactors) {
+	if other == nil {
+		return
+	}
+	s.Items = append(s.Items, other.Items...)
+}


### PR DESCRIPTION
We will wait to send scores to the server until all of them have been collected. This helps us to update all the scores with the available risks in the client before sending them.

Follow-up: We may want to batch up the number of scores we send and possibly split out the data from the remaining score upload if there is a lot to send. Ultimately, the last batch (which sets the scan to done) must contain all policies, which makes it easy to consume them in just one request.

We also restructure risks so that the list is only created when we are ready to store them. Once consumed the risk index is emptied out.