### PR TITLE
🐛 fix risk factors missing in inmemory w/ upstream

### DIFF
--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -316,6 +316,14 @@ func (db *Db) invalidateFrameworkAndBundleAncestors(ctx context.Context, wrap *w
 	return nil
 }
 
+func (db *Db) getRiskFactor(ctx context.Context, mrn string) (*policy.RiskFactor, error) {
+	found, ok := db.cache.Get(dbIDRiskFactor + mrn)
+	if !ok {
+		return nil, errors.New("risk factor " + mrn + " not found")
+	}
+	return found.(*policy.RiskFactor), nil
+}
+
 func (db *Db) SetRiskFactor(ctx context.Context, riskFactor *policy.RiskFactor) error {
 	db.cache.Set(dbIDRiskFactor+riskFactor.Mrn, riskFactor, 1)
 	return nil


### PR DESCRIPTION
When running against upstream policies, we don't get risk factors from the policy bundle, since we generally don't need the bundle to run the scan. However, we do require basic risk factor info to help score everything before we send data up.

In this change we pull risk info from the resolved policy and inject it into the inmemory datastore before the scan is started (unless the risk factor exists for any reason, like prior policy bundles). It has enough information for scoring.

For any later reporting step we may still inject all risk factor metadata into the inmemory store before printing the output.