### PR TITLE
🧹 Modify logger for serve instead of logging timestamps manually.

### DIFF
--- a/apps/cnspec/cmd/backgroundjob/serve_unix.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_unix.go
@@ -18,8 +18,8 @@ import (
 )
 
 func Serve(timer time.Duration, splay time.Duration, handler JobRunner) {
-	log.Info().Time("now", time.Now().UTC()).Msg("start cnspec background service")
-	log.Info().Time("now", time.Now().UTC()).Msgf("scan interval is %d minute(s) with a splay of %d minutes(s)", int(timer.Minutes()), int(splay.Minutes()))
+	log.Info().Msg("start cnspec background service")
+	log.Info().Msgf("scan interval is %d minute(s) with a splay of %d minutes(s)", int(timer.Minutes()), int(splay.Minutes()))
 
 	quitChannel := make(chan os.Signal)
 	signal.Notify(quitChannel, syscall.SIGINT, syscall.SIGTERM)
@@ -38,14 +38,14 @@ func Serve(timer time.Duration, splay time.Duration, handler JobRunner) {
 			// Give shutdown priority
 			select {
 			case <-shutdownChannel:
-				log.Info().Time("now", time.Now().UTC()).Msg("stop worker")
+				log.Info().Msg("stop worker")
 				return
 			default:
 			}
 
 			select {
 			case <-t.C:
-				log.Info().Time("now", time.Now().UTC()).Msg("starting background scan")
+				log.Info().Msg("starting background scan")
 				err := handler()
 				if err != nil {
 					log.Error().Err(err).Send()
@@ -55,11 +55,10 @@ func Serve(timer time.Duration, splay time.Duration, handler JobRunner) {
 					splayDur = time.Duration(rand.Int63n(int64(splay)))
 				}
 				nextRun := timer + splayDur
-				n := time.Now().UTC()
-				log.Info().Time("now", n).Time("next scan", n.Add(nextRun)).Msgf("next scan in %v", nextRun)
+				log.Info().Time("next scan", time.Now().Add(nextRun)).Msgf("next scan in %v", nextRun)
 				t.Reset(nextRun)
 			case <-shutdownChannel:
-				log.Info().Time("now", time.Now().UTC()).Msg("stop worker")
+				log.Info().Msg("stop worker")
 				return
 			}
 		}

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -62,12 +62,12 @@ func (m *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, chan
 		// that's not possible right now and requires wiring through
 		// context throughout the execution.
 		for range runChan {
-			log.Info().Time("now", time.Now().UTC()).Msg("starting background scan")
+			log.Info().Msg("starting background scan")
 			err := m.Handler()
 			if err != nil {
 				log.Error().Err(err).Send()
 			} else {
-				log.Info().Time("now", time.Now().UTC()).Msg("scan completed")
+				log.Info().Msg("scan completed")
 			}
 		}
 	}()
@@ -85,15 +85,14 @@ loop:
 				splayDur = time.Duration(rand.Int63n(int64(m.Splay)))
 			}
 			nextRun := m.Timer + splayDur
-			n := time.Now().UTC()
-			log.Info().Time("now", n).Time("next scan", n.Add(nextRun)).Msgf("next scan in %v", nextRun)
+			log.Info().Time("next scan", time.Now().Add(nextRun)).Msgf("next scan in %v", nextRun)
 			t.Reset(nextRun)
 		case c := <-r:
 			switch c.Cmd {
 			case svc.Interrogate:
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				log.Info().Time("now", time.Now().UTC()).Msg("stopping cnspec service")
+				log.Info().Msg("stopping cnspec service")
 				break loop
 			default:
 				log.Error().Msgf("unexpected control request #%d", c)
@@ -108,7 +107,7 @@ loop:
 func runService(isDebug bool, timer time.Duration, splay time.Duration, handler JobRunner) {
 	var err error
 
-	log.Info().Time("now", time.Now().UTC()).Msgf("starting %s service", SvcName)
+	log.Info().Msgf("starting %s service", SvcName)
 	run := svc.Run
 	if isDebug {
 		run = debug.Run
@@ -122,5 +121,5 @@ func runService(isDebug bool, timer time.Duration, splay time.Duration, handler 
 		log.Info().Msgf("%s service failed: %v", SvcName, err)
 		return
 	}
-	log.Info().Time("now", time.Now().UTC()).Msgf("%s service stopped", SvcName)
+	log.Info().Msgf("%s service stopped", SvcName)
 }

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -13,10 +13,12 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/v10"
 	"go.mondoo.com/cnquery/v10/cli/config"
+
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
 	"go.mondoo.com/cnquery/v10/cli/execruntime"
 	"go.mondoo.com/cnquery/v10/cli/inventoryloader"
 	"go.mondoo.com/cnquery/v10/cli/prof"
+	"go.mondoo.com/cnquery/v10/logger"
 	"go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
@@ -47,6 +49,7 @@ var serveCmd = &cobra.Command{
 		_ = viper.BindPFlag("scan_interval.timer", cmd.Flags().Lookup("timer"))
 		_ = viper.BindPFlag("scan_interval.splay", cmd.Flags().Lookup("splay"))
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
+		logger.StandardZerologLogger()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prof.InitProfiler()


### PR DESCRIPTION
Mimic `serve-api` and do not log timestamps manually