### PR TITLE
🐛 Print asset MRN only if StoreResourcesData is enabled.

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -165,7 +165,9 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create an output handler")
 	}
-	if err := outputHandler.WriteReport(ctx, report); err != nil {
+
+	fCtx := cnquery.SetFeatures(ctx, conf.Features)
+	if err := outputHandler.WriteReport(fCtx, report); err != nil {
 		log.Fatal().Err(err).Msg("failed to write report to output target")
 	}
 

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -108,30 +108,34 @@ func (r *Reporter) WithOutput(out io.Writer) *Reporter {
 }
 
 func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollection) error {
+	features := cnquery.GetFeatures(ctx)
 	switch r.Format {
 	case FormatCompact:
 		rr := &defaultReporter{
-			Reporter:  r,
-			isCompact: true,
-			output:    r.out,
-			data:      data,
+			Reporter:                r,
+			isCompact:               true,
+			output:                  r.out,
+			data:                    data,
+			isStoreResourcesEnabled: features.IsActive(cnquery.StoreResourcesData),
 		}
 		return rr.print()
 	case FormatSummary:
 		rr := &defaultReporter{
-			Reporter:  r,
-			isCompact: true,
-			isSummary: true,
-			output:    r.out,
-			data:      data,
+			Reporter:                r,
+			isCompact:               true,
+			isSummary:               true,
+			output:                  r.out,
+			data:                    data,
+			isStoreResourcesEnabled: features.IsActive(cnquery.StoreResourcesData),
 		}
 		return rr.print()
 	case FormatFull:
 		rr := &defaultReporter{
-			Reporter:  r,
-			isCompact: false,
-			output:    r.out,
-			data:      data,
+			Reporter:                r,
+			isCompact:               false,
+			output:                  r.out,
+			data:                    data,
+			isStoreResourcesEnabled: features.IsActive(cnquery.StoreResourcesData),
 		}
 		return rr.print()
 	case FormatReport:

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -37,6 +37,9 @@ type defaultReporter struct {
 	output    io.Writer
 	data      *policy.ReportCollection
 
+	// indicates if the StoreResourcesData cnquery feature is enabled
+	isStoreResourcesEnabled bool
+
 	// vv the items below will be automatically filled
 	bundle *policy.PolicyBundleMap
 }
@@ -194,7 +197,7 @@ func (r *defaultReporter) printSummary(orderedAssets []assetMrnName) {
 			r.out("See more scan results and asset relationships on the Mondoo Console: ")
 			r.out(url + NewLineCharacter)
 
-			if len(orderedAssets) == 1 && orderedAssets[0].Mrn != "" {
+			if len(orderedAssets) == 1 && orderedAssets[0].Mrn != "" && r.isStoreResourcesEnabled {
 				r.out("Asset MRN: " + orderedAssets[0].Mrn + NewLineCharacter)
 			}
 		}


### PR DESCRIPTION
Fixes #1228
Aligns the display of the asset MRN with the `StoreResourcesData` feature flag