### PR TITLE
🩹 fix executor memory issue

### DIFF
--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"time"
 
@@ -95,6 +96,10 @@ func (em *executionManager) Start() {
 					}
 					return
 				}
+				// FIXME: Run the garbage collector after each query execution because we alloc a
+				// lot of objects. The objects are stacking and spike the memory usage. We should
+				// come back to this and address the underlying cause.
+				runtime.GC()
 			case <-em.stopChan:
 				return
 			}


### PR DESCRIPTION
It seems like the executor does too many allocations and the GC cannot keep up with cleaning them up. For assets where we execute many queries, the memory can spike a lot for this reason. Now that we force the GC to run, the memory stays low. 

This is a temporary fix and we should come back and make sure we address the underlying issue instead of calling the GC manually

Discussed with @arlimus 