### PR TITLE
🛑 switch to json v2 output format

### DIFF
--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -40,7 +40,7 @@ var Formats = map[string]Format{
 	"yml":     FormatYAMLv2,
 	"json-v1": FormatJSONv1,
 	"json-v2": FormatJSONv2,
-	"json":    FormatJSONv1,
+	"json":    FormatJSONv2,
 	"junit":   FormatJUnit,
 	"csv":     FormatCSV,
 }


### PR DESCRIPTION
after https://github.com/mondoohq/cnspec/pull/1244

This PR enables the v2 json format as standard. The new format is accessible via:

```
cnspec scan local --json
```

or 

```
cnspec scan local --output json
```

For backwards-compatibility, the old format is available via:

```
cnspec scan local --output json-v1
```