### PR TITLE
⭐️ Improve compliance framework evidence generation.

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -183,26 +183,12 @@ func (p *Bundle) ConvertQuerypacks() {
 
 func (b *Bundle) ConvertEvidence() {
 	for _, f := range b.Frameworks {
-		policies := []*Policy{}
-		cmaps := []*ControlMap{}
-		for _, g := range f.Groups {
-			for _, c := range g.Controls {
-				evidencePolicies := c.GenerateEvidencePolicies(f.Uid)
-				policies = append(policies, evidencePolicies...)
-				controlMap := c.GenerateEvidenceControlMap()
-				// if the control has evidence, we add the control map
-				if controlMap != nil {
-					cmaps = append(cmaps, controlMap)
-				}
-			}
+		pol, fm := f.GenerateEvidenceObjects()
+		if pol != nil {
+			b.Policies = append(b.Policies, pol)
 		}
-		// we only want a new framework map if there's at least one control map
-		if len(cmaps) > 0 {
-			frameworkMap := GenerateFrameworkMap(cmaps, f, policies)
-			b.FrameworkMaps = append(b.FrameworkMaps, frameworkMap)
-		}
-		if len(policies) > 0 {
-			b.Policies = append(b.Policies, policies...)
+		if fm != nil {
+			b.FrameworkMaps = append(b.FrameworkMaps, fm)
 		}
 	}
 }

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -324,11 +324,11 @@ func TestBundle_ConvertEvidence(t *testing.T) {
 	// the framework in this bundle contains 2 controls with 2 evidences per control
 	bundle.ConvertEvidence()
 
-	// assert that we now have a policy per evidence and one frameworkmap to tie them together
-	require.Equal(t, 4, len(bundle.Policies))
+	// assert that we now have a policy per framework and one frameworkmap to tie them together
+	require.Equal(t, 1, len(bundle.Policies))
 	require.Equal(t, 1, len(bundle.FrameworkMaps))
 	require.Equal(t, 2, len(bundle.FrameworkMaps[0].Controls))
-	require.Equal(t, 4, len(bundle.FrameworkMaps[0].PolicyDependencies))
+	require.Equal(t, 1, len(bundle.FrameworkMaps[0].PolicyDependencies))
 	require.Equal(t, 1, len(bundle.Frameworks))
 }
 


### PR DESCRIPTION
This is a follow-up to #1246 
 * Generate one policy per framework. Evidences are now pulled into policy groups rather than separate policies.  This means  we do not have to deal with multiple policies, specially for larger frameworks.
 * Add `GenerateEvidenceObjects` onto a framework which will pull out the evidence and return both a policy and a framework map.
 * Pull out generation code entirely into `evidence.go`. This makes it fully testable, the bundle now only calls `GenerateEvidenceObjects`.
 * Improve tests