### PR TITLE
🧹 revert GC change in execution manager

### DIFF
--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -5,7 +5,6 @@ package internal
 
 import (
 	"errors"
-	"runtime"
 	"sync"
 	"time"
 
@@ -96,10 +95,6 @@ func (em *executionManager) Start() {
 					}
 					return
 				}
-				// FIXME: Run the garbage collector after each query execution because we alloc a
-				// lot of objects. The objects are stacking and spike the memory usage. We should
-				// come back to this and address the underlying cause.
-				runtime.GC()
 			case <-em.stopChan:
 				return
 			}


### PR DESCRIPTION
this is causing a large spike in CPU usage making scans really slow in environments with insufficient CPU. We need to find a better way to fix this issue