### PR TITLE
🌈 add additional output options

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -96,7 +96,7 @@ To manually configure a policy, use this:
 		// don't have a target connection or provider.
 		output, _ := cmd.Flags().GetString("output")
 		if output == "help" {
-			fmt.Println("Available output formats: " + reporter.AllFormats())
+			fmt.Println(reporter.AllAvailableOptions())
 			os.Exit(0)
 		}
 
@@ -284,7 +284,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	// print them before executing the scan
 	output, _ := cmd.Flags().GetString("output")
 	if output == "help" {
-		fmt.Println("Available output formats: " + reporter.AllFormats())
+		fmt.Println(reporter.AllAvailableOptions())
 		os.Exit(0)
 	}
 

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -58,6 +56,11 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	conf.PolicyPaths = nil
 	conf.Bundle = policy.FromQueryPackBundle(pb)
 	conf.IsIncognito = true
+
+	printConf, err := reporter.ParseConfig(conf.OutputFormat)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to parse config for reporter")
+	}
 
 	report, err := RunScan(conf)
 	if err != nil {
@@ -131,7 +134,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	}
 
 	// print the output using the specified output format
-	r := reporter.NewReporter(reporter.Formats[strings.ToLower(conf.OutputFormat)], false)
+	r := reporter.NewReporter(printConf, false)
 	logger.DebugDumpJSON("vulnReport", report)
 	if err := r.PrintVulns(vulnReport, bom.Asset.Name); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")

--- a/cli/reporter/file_handler.go
+++ b/cli/reporter/file_handler.go
@@ -13,8 +13,8 @@ import (
 )
 
 type localFileHandler struct {
-	file   string
-	format Format
+	file string
+	conf *PrintConfig
 }
 
 // we reuse the already implemented Reporter's WriteReport method by simply pointing the writer
@@ -26,7 +26,7 @@ func (h *localFileHandler) WriteReport(ctx context.Context, report *policy.Repor
 		return err
 	}
 	defer f.Close() //nolint: errcheck
-	reporter := NewReporter(h.format, false)
+	reporter := NewReporter(h.conf, false)
 	reporter.out = f
 	err = reporter.WriteReport(ctx, report)
 	if err != nil {

--- a/cli/reporter/json_test.go
+++ b/cli/reporter/json_test.go
@@ -29,8 +29,10 @@ func TestJsonOutput(t *testing.T) {
 	buf := bytes.Buffer{}
 	writer := shared.IOWriter{Writer: &buf}
 
+	conf := defaultPrintConfig()
+	conf.format = FormatJSONv1
 	r := &Reporter{
-		Format:  FormatJSONv1,
+		Conf:    conf,
 		Printer: &printer.DefaultPrinter,
 		Colors:  &colors.DefaultColorTheme,
 		out:     &writer,
@@ -56,8 +58,10 @@ func TestJsonOutputOnlyErrors(t *testing.T) {
 	buf := bytes.Buffer{}
 	writer := shared.IOWriter{Writer: &buf}
 
+	conf := defaultPrintConfig()
+	conf.format = FormatJSONv1
 	r := &Reporter{
-		Format:  FormatJSONv1,
+		Conf:    conf,
 		Printer: &printer.DefaultPrinter,
 		Colors:  &colors.DefaultColorTheme,
 		out:     &writer,

--- a/cli/reporter/print_test.go
+++ b/cli/reporter/print_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		conf string
+		f    func(t *testing.T, conf *PrintConfig)
+	}{
+		{"", func(t *testing.T, conf *PrintConfig) {
+			assert.Equal(t, defaultPrintConfig(), conf)
+		}},
+		{"compact", func(t *testing.T, conf *PrintConfig) {
+			assert.Equal(t, defaultPrintConfig(), conf)
+		}},
+		{"summary", func(t *testing.T, conf *PrintConfig) {
+			expect := defaultPrintConfig()
+			expect.format = FormatSummary
+			expect.printData = false
+			expect.printVulnerabilities = false
+			expect.printControls = false
+			expect.printChecks = false
+			expect.printRisks = false
+			assert.Equal(t, expect, conf)
+		}},
+		{"summary,checks,DATA,vulns", func(t *testing.T, conf *PrintConfig) {
+			expect := defaultPrintConfig()
+			expect.format = FormatSummary
+			expect.printControls = false
+			expect.printRisks = false
+			assert.Equal(t, expect, conf)
+		}},
+		{"full", func(t *testing.T, conf *PrintConfig) {
+			expect := defaultPrintConfig()
+			expect.format = FormatFull
+			expect.isCompact = false
+			assert.Equal(t, expect, conf)
+		}},
+		{"nodata,noVuln,noRiSks", func(t *testing.T, conf *PrintConfig) {
+			expect := defaultPrintConfig()
+			expect.printData = false
+			expect.printVulnerabilities = false
+			expect.printRisks = false
+			assert.Equal(t, expect, conf)
+		}},
+	}
+
+	for i := range tests {
+		cur := tests[i]
+		t.Run(cur.conf, func(t *testing.T) {
+			res, err := ParseConfig(cur.conf)
+			require.NoError(t, err)
+			cur.f(t, res)
+		})
+	}
+
+	t.Run("unknown options", func(t *testing.T) {
+		_, err := ParseConfig("notknown")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown terms entered: notknown")
+		assert.Contains(t, err.Error(), "Available output formats: compact, csv, ")
+		assert.Contains(t, err.Error(), "Available options: [no]checks, [no]controls, ")
+	})
+}


### PR DESCRIPTION
This introduces a series of new optios for the default CLI output printer. These give far greater control over which sections are printed (or rather not printed).

As a follow-up, we should enabled these for the other output formats as well.

For all options, run:

```
> cnspec scan -o help
Available output formats: compact, csv, full, json, json-v1, json-v2, junit, report, summary, yaml, yaml-v1, yaml-v2.
Available options: [no]checks, [no]controls, [no]data, [no]vulns.
Combine with commas, example: compact,nodata,nocontrols
```

Example usage (from this help):
```bash
> cnspec scan -o compact,nodata,nocontrols
```