### PR TITLE
🐛 fix junit reporter panic

### DIFF
--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -50,6 +50,10 @@ func ConvertToJunit(r *policy.ReportCollection, out shared.OutputHelper) error {
 			suites.Suites = append(suites.Suites, ts)
 		}
 
+		if r.Bundle == nil {
+			return fmt.Errorf("no policy bundle found")
+		}
+
 		bundle := r.Bundle.ToMap()
 		queries := bundle.QueryMap()
 


### PR DESCRIPTION
The bundle can be empty if cnspec encountered an error during scanning. In that case, we need to make sure we don't exit with a panic