### PR TITLE
🧹 align asset scores in CLI report

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -272,8 +272,9 @@ func (r *defaultReporter) printAssetsByPlatform(assetsByPlatform map[string][]*i
 				assetScore = "X"
 			}
 
+			paddedAssetScore := fmt.Sprintf("%-9s", assetScore)
 			scoreColor := cnspecComponents.DefaultRatingColors.Color(assetScoreRating)
-			output := fmt.Sprintf("    %s   %s", termenv.String(assetScore).Foreground(scoreColor), assetsByPlatform[platform][i].Name)
+			output := fmt.Sprintf("    %s   %s", termenv.String(paddedAssetScore).Foreground(scoreColor), assetsByPlatform[platform][i].Name)
 			r.out(output + NewLineCharacter)
 		}
 	}


### PR DESCRIPTION
Before:
```
Scanned 13 assets

Kubernetes CronJob
    [45/100]   mondoo/restart-nexus

Kubernetes DaemonSet
    [45/100]   amazon-cloudwatch/fluent-bit
    [45/100]   kube-system/replace-gvisor-platform-flag

Kubernetes Deployment
    [45/100]   argocd-repo-server
    [50/100]   kueue-system/kueue-controller-manager
    [0/100]   mondoo-enterprise-operator/mondoo-enterprise-operator-controller-manager
    [45/100]   mondoo-operator/mondoo-operator-controller-manager
    [0/100]   mondoo/mondoo-job-runner-controller-manager
```

After:
```
Scanned 13 assets

Kubernetes CronJob
    [45/100]    mondoo/restart-nexus

Kubernetes DaemonSet
    [45/100]    amazon-cloudwatch/fluent-bit
    [45/100]    kube-system/replace-gvisor-platform-flag

Kubernetes Deployment
    [45/100]    argocd-repo-server
    [50/100]    kueue-system/kueue-controller-manager
    [0/100]     mondoo-enterprise-operator/mondoo-enterprise-operator-controller-manager
    [45/100]    mondoo-operator/mondoo-operator-controller-manager
    [0/100]     mondoo/mondoo-job-runner-controller-manager
```