### PR TITLE
🧹 Allow re-running the goreleaser job

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -371,3 +371,5 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:latest-arm64v8-rootless
       - mondoo/{{ .ProjectName }}:latest-armv6-rootless
       - mondoo/{{ .ProjectName }}:latest-armv7-rootless
+release:
+  replace_existing_artifacts: true


### PR DESCRIPTION
With this change, it can override the existing release files. This can help in case something goes wrong.