### PR TITLE
🐛 fix policy scoring with exceptions

### DIFF
--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -113,13 +113,17 @@ func AddDataScore(calculator ScoreCalculator, totalDeps int, finishedDeps int) {
 
 func (c *averageScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 	switch score.Type {
-	case ScoreType_Skip:
+	case ScoreType_Skip, ScoreType_Disabled, ScoreType_OutOfScope:
 		return
 	case ScoreType_Unscored:
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 
 	case ScoreType_Result:
+		if impact != nil && (impact.Action == explorer.Action_IGNORE || impact.Action == explorer.Action_DEACTIVATE) {
+			return
+		}
+
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 		c.weight += score.Weight
@@ -226,13 +230,17 @@ func (c *weightedScoreCalculator) Init() {
 
 func (c *weightedScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 	switch score.Type {
-	case ScoreType_Skip:
+	case ScoreType_Skip, ScoreType_Disabled, ScoreType_OutOfScope:
 		return
 	case ScoreType_Unscored:
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 
 	case ScoreType_Result:
+		if impact != nil && (impact.Action == explorer.Action_IGNORE || impact.Action == explorer.Action_DEACTIVATE) {
+			return
+		}
+
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 		c.weight += score.Weight
@@ -332,13 +340,17 @@ func (c *worstScoreCalculator) Init() {
 
 func (c *worstScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 	switch score.Type {
-	case ScoreType_Skip:
+	case ScoreType_Skip, ScoreType_Disabled, ScoreType_OutOfScope:
 		return
 	case ScoreType_Unscored:
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 
 	case ScoreType_Result:
+		if impact != nil && (impact.Action == explorer.Action_IGNORE || impact.Action == explorer.Action_DEACTIVATE) {
+			return
+		}
+
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 		c.weight += score.Weight
@@ -452,13 +464,17 @@ func (c *bandedScoreCalculator) Init() {
 
 func (c *bandedScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 	switch score.Type {
-	case ScoreType_Skip:
+	case ScoreType_Skip, ScoreType_OutOfScope, ScoreType_Disabled:
 		return
 	case ScoreType_Unscored:
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 
 	case ScoreType_Result:
+		if impact != nil && (impact.Action == explorer.Action_IGNORE || impact.Action == explorer.Action_DEACTIVATE) {
+			return
+		}
+
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 		c.weight += score.Weight
@@ -623,13 +639,17 @@ func (c *decayedScoreCalculator) Init() {
 
 func (c *decayedScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 	switch score.Type {
-	case ScoreType_Skip:
+	case ScoreType_Skip, ScoreType_OutOfScope, ScoreType_Disabled:
 		return
 	case ScoreType_Unscored:
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 
 	case ScoreType_Result:
+		if impact != nil && (impact.Action == explorer.Action_IGNORE || impact.Action == explorer.Action_DEACTIVATE) {
+			return
+		}
+
 		c.dataCompletion += score.DataCompletion * score.DataTotal
 		c.dataTotal += score.DataTotal
 		c.weight += score.Weight

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -71,6 +71,10 @@ func TestAverageScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+			},
+			impacts: []*explorer.Impact{
+				nil, nil, nil, nil, nil, {Action: explorer.Action_IGNORE},
 			},
 			out: &Score{Value: 60, ScoreCompletion: 40, DataCompletion: 59, DataTotal: 10, Weight: 6, Type: ScoreType_Result},
 		},
@@ -114,6 +118,10 @@ func TestWeightedScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+			},
+			impacts: []*explorer.Impact{
+				nil, nil, nil, nil, nil, {Action: explorer.Action_IGNORE},
 			},
 			out: &Score{Value: 68, ScoreCompletion: 40, DataCompletion: 59, Weight: 6, Type: ScoreType_Result},
 		},
@@ -157,6 +165,10 @@ func TestWorstScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+			},
+			impacts: []*explorer.Impact{
+				nil, nil, nil, nil, nil, {Action: explorer.Action_IGNORE},
 			},
 			out: &Score{Value: 20, ScoreCompletion: 40, DataCompletion: 59, Weight: 6, Type: ScoreType_Result},
 		},
@@ -198,6 +210,7 @@ func TestBandedScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 8, Type: ScoreType_Result},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
 			},
 			impacts: []*explorer.Impact{
 				// 2 critical checks
@@ -207,6 +220,7 @@ func TestBandedScores(t *testing.T) {
 				{Value: &explorer.ImpactValue{Value: 20}},
 				{Value: &explorer.ImpactValue{Value: 100}},
 				{Value: &explorer.ImpactValue{Value: 100}},
+				{Action: explorer.Action_IGNORE},
 			},
 			out: &Score{Value: 25, ScoreCompletion: 100, DataCompletion: 66, Weight: 10, Type: ScoreType_Result},
 		},
@@ -262,6 +276,7 @@ func TestDecayedScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 8, Type: ScoreType_Result},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
 				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
 			},
 			impacts: []*explorer.Impact{
 				// 2 critical checks
@@ -271,6 +286,7 @@ func TestDecayedScores(t *testing.T) {
 				{Value: &explorer.ImpactValue{Value: 20}},
 				{Value: &explorer.ImpactValue{Value: 100}},
 				{Value: &explorer.ImpactValue{Value: 100}},
+				{Action: explorer.Action_IGNORE},
 			},
 			out: &Score{Value: 61, ScoreCompletion: 100, DataCompletion: 66, Weight: 10, Type: ScoreType_Result},
 		},

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -69,6 +69,8 @@ func TestAverageScores(t *testing.T) {
 				{Value: 0, ScoreCompletion: 0, DataCompletion: 80, DataTotal: 5, Weight: 1, Type: ScoreType_Result},
 				{Value: 20, ScoreCompletion: 20, DataCompletion: 50, DataTotal: 2, Weight: 2, Type: ScoreType_Result},
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
 			},
 			out: &Score{Value: 60, ScoreCompletion: 40, DataCompletion: 59, DataTotal: 10, Weight: 6, Type: ScoreType_Result},
 		},
@@ -110,6 +112,8 @@ func TestWeightedScores(t *testing.T) {
 				{Value: 0, ScoreCompletion: 0, DataCompletion: 80, DataTotal: 5, Weight: 1, Type: ScoreType_Result},
 				{Value: 20, ScoreCompletion: 20, DataCompletion: 50, DataTotal: 2, Weight: 2, Type: ScoreType_Result},
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
 			},
 			out: &Score{Value: 68, ScoreCompletion: 40, DataCompletion: 59, Weight: 6, Type: ScoreType_Result},
 		},
@@ -151,6 +155,8 @@ func TestWorstScores(t *testing.T) {
 				{Value: 0, ScoreCompletion: 0, DataCompletion: 80, DataTotal: 5, Weight: 1, Type: ScoreType_Result},
 				{Value: 20, ScoreCompletion: 20, DataCompletion: 50, DataTotal: 2, Weight: 2, Type: ScoreType_Result},
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Result},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
 			},
 			out: &Score{Value: 20, ScoreCompletion: 40, DataCompletion: 59, Weight: 6, Type: ScoreType_Result},
 		},
@@ -190,6 +196,8 @@ func TestBandedScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result},
 				// 8 low checks (ok)
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 8, Type: ScoreType_Result},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
 			},
 			impacts: []*explorer.Impact{
 				// 2 critical checks
@@ -197,6 +205,8 @@ func TestBandedScores(t *testing.T) {
 				{Value: &explorer.ImpactValue{Value: 100}},
 				// 8 low checks
 				{Value: &explorer.ImpactValue{Value: 20}},
+				{Value: &explorer.ImpactValue{Value: 100}},
+				{Value: &explorer.ImpactValue{Value: 100}},
 			},
 			out: &Score{Value: 25, ScoreCompletion: 100, DataCompletion: 66, Weight: 10, Type: ScoreType_Result},
 		},
@@ -250,6 +260,8 @@ func TestDecayedScores(t *testing.T) {
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result},
 				// 8 low checks (ok)
 				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 8, Type: ScoreType_Result},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_Disabled},
+				{Value: 30, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 3, Type: ScoreType_OutOfScope},
 			},
 			impacts: []*explorer.Impact{
 				// 2 critical checks
@@ -257,6 +269,8 @@ func TestDecayedScores(t *testing.T) {
 				{Value: &explorer.ImpactValue{Value: 100}},
 				// 8 low checks
 				{Value: &explorer.ImpactValue{Value: 20}},
+				{Value: &explorer.ImpactValue{Value: 100}},
+				{Value: &explorer.ImpactValue{Value: 100}},
 			},
 			out: &Score{Value: 61, ScoreCompletion: 100, DataCompletion: 66, Weight: 10, Type: ScoreType_Result},
 		},


### PR DESCRIPTION
We ignore all scores that are out of scope, disabled or ignored from the policy score calculation