### PR TITLE
🐛 Don't tie incorrect data to controls

### DIFF
--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1755,6 +1755,9 @@ func (s *LocalServices) jobsToControls(cache *frameworkResolverCache, framework 
 			queryMrns := cache.codeIdToMrn[rj.QrId]
 
 			for _, queryMrn := range queryMrns {
+				if queryMrn != mrn {
+					continue
+				}
 				uuid := cache.relativeChecksum(queryMrn)
 				queryJob := &ReportingJob{
 					Uuid:      uuid,

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -526,6 +526,9 @@ policies:
     - uid: active-query-2
       title: users length
       mql: users.length
+    - uid: check-overlap
+      title: overlaps with check
+      mql: 1 == 1
 - uid: policy-inactive
   groups:
   - filters: "false"
@@ -631,6 +634,11 @@ framework_maps:
 		// Check that there are no duplicates in the reporting job's notify list
 		for _, rj := range rp.CollectorJob.ReportingJobs {
 			requireUnique(t, rj.Notify)
+			for _, pRjUuid := range rj.Notify {
+				pRj := rp.CollectorJob.ReportingJobs[pRjUuid]
+				require.NotNil(t, pRj)
+				require.Contains(t, pRj.ChildJobs, rj.Uuid)
+			}
 		}
 
 		require.Len(t, rp.ExecutionJob.Queries, 5)


### PR DESCRIPTION
We have a case where an incorrect data query is being tied to a control by mrn. This happens when there is duplicate code ids for different mrns.

This is causing a resolved policy to be created where the child jobs are not consistent with notifies. When executed, things get scored as a U.