### PR TITLE
🐛 Find variant checks by parent MRN

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -99,6 +99,11 @@ func BundleExecutionChecksum(policy *Policy, framework *Framework) string {
 	if framework != nil {
 		res = res.Add(framework.GraphExecutionChecksum)
 	}
+	// So far the checksum only includes the policy and the framework
+	// It does not change if any of the jobs changes, only if the policy or the framework changes
+	// To update the resolved policy, when we change how it is generated, change the incoporated version of the resolver
+	res = res.Add(RESOLVER_VERSION)
+
 	return res.String()
 }
 

--- a/policy/reportingjob.go
+++ b/policy/reportingjob.go
@@ -37,5 +37,14 @@ func (r *ReportingJob) RefreshChecksum() {
 			checksum = checksum.Add(notify[i])
 		}
 	}
+
+	{
+		mrns := make([]string, len(r.Mrns))
+		copy(mrns, r.Mrns)
+		sort.Strings(mrns)
+		for i := range mrns {
+			checksum = checksum.Add(mrns[i])
+		}
+	}
 	r.Checksum = checksum.String()
 }

--- a/policy/reportingjob.go
+++ b/policy/reportingjob.go
@@ -38,13 +38,5 @@ func (r *ReportingJob) RefreshChecksum() {
 		}
 	}
 
-	{
-		mrns := make([]string, len(r.Mrns))
-		copy(mrns, r.Mrns)
-		sort.Strings(mrns)
-		for i := range mrns {
-			checksum = checksum.Add(mrns[i])
-		}
-	}
 	r.Checksum = checksum.String()
 }

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"math/rand"
+	"slices"
 	"sort"
 	"time"
 
@@ -1160,10 +1161,21 @@ func (cache *policyResolverCache) addCheckJob(ctx context.Context, check *explor
 			Type:       ReportingJob_CHECK,
 			Mrns:       []string{},
 		}
-		// We don't track the MRNs for variant queries through the cachem, since variant queries
+		// We don't track the MRNs for variant queries through the cache, since variant queries
 		// have no MQL, meaning they get the same code ID
 		if len(check.Variants) == 0 {
 			cache.global.codeIdToMrn[check.CodeId] = append(cache.global.codeIdToMrn[check.CodeId], check.Mrn)
+			// Because we have no variants, we might have to add the MRN of the parent job
+			if ownerJob != nil && ownerJob.Type == ReportingJob_CHECK && len(ownerJob.Mrns) > 0 {
+				// We might have variants, where multiple variant queries apply
+				// Don't save the same MRNs multiple times
+				for _, mrn := range ownerJob.Mrns {
+					if slices.Contains(cache.global.codeIdToMrn[check.CodeId], mrn) {
+						continue
+					}
+					cache.global.codeIdToMrn[check.CodeId] = append(cache.global.codeIdToMrn[check.CodeId], mrn)
+				}
+			}
 		}
 		cache.global.reportingJobsByUUID[uuid] = rj
 		cache.global.reportingJobsByMsum[check.Checksum] = append(cache.global.reportingJobsByMsum[check.Checksum], rj)
@@ -1183,12 +1195,14 @@ func (cache *policyResolverCache) addCheckJob(ctx context.Context, check *explor
 	rj.Notify = append(rj.Notify, ownerJob.Uuid)
 
 	if len(check.Variants) != 0 {
+		// Add parent MRN, so we can later also query the result by the variants parent MRN
+		// //.../queries/parent-check
+		// //.../queries/variant-1
+		rj.Mrns = []string{check.Mrn}
 		err := cache.addCheckJobVariants(ctx, check, rj)
 		if err != nil {
 			log.Error().Err(err).Str("checkMrn", check.Mrn).Msg("failed to add data query variants")
 		}
-		// If this is avariant query, its MRN is only the MRN of the check.
-		rj.Mrns = []string{check.Mrn}
 	} else {
 		// we set a placeholder for the execution query, just to indicate it will be added
 		cache.global.executionQueries[check.Checksum] = nil
@@ -1255,6 +1269,17 @@ func (cache *policyResolverCache) addDataQueryJob(ctx context.Context, query *ex
 		// have no MQL, meaning they get the same code ID
 		if len(query.Variants) == 0 {
 			cache.global.codeIdToMrn[query.CodeId] = append(cache.global.codeIdToMrn[query.CodeId], query.Mrn)
+			// Because we have no variants, we might have to add the MRN of the parent job
+			if ownerJob != nil && ownerJob.Type == ReportingJob_DATA_QUERY && len(ownerJob.Mrns) > 0 {
+				// We might have variants, where multiple variant queries apply
+				// Don't save the same MRNs multiple times
+				for _, mrn := range ownerJob.Mrns {
+					if slices.Contains(cache.global.codeIdToMrn[query.CodeId], mrn) {
+						continue
+					}
+					cache.global.codeIdToMrn[query.CodeId] = append(cache.global.codeIdToMrn[query.CodeId], mrn)
+				}
+			}
 		}
 		cache.global.reportingJobsByUUID[uuid] = rj
 		cache.global.reportingJobsByMsum[query.Checksum] = append(cache.global.reportingJobsByMsum[query.Checksum], rj)
@@ -1272,11 +1297,14 @@ func (cache *policyResolverCache) addDataQueryJob(ctx context.Context, query *ex
 		ownerJob.ChildJobs[rj.Uuid] = query.Impact
 	}
 	if len(query.Variants) != 0 {
+		// Add parent MRN, so we can later also query the result by the variants parent MRN
+		// //.../queries/parent-check
+		// //.../queries/variant-1
+		rj.Mrns = []string{query.Mrn}
 		err := cache.addDataQueryVariants(ctx, query, rj)
 		if err != nil {
 			log.Error().Err(err).Str("queryMrn", query.Mrn).Msg("failed to add data query variants")
 		}
-		rj.Mrns = []string{query.Mrn}
 	} else {
 		// we set a placeholder for the execution query, just to indicate it will be added
 		cache.global.executionQueries[query.Checksum] = nil

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -662,15 +662,8 @@ func (s *LocalServices) tryResolve(ctx context.Context, bundleMrn string, assetF
 		rj.RefreshChecksum()
 	}
 
-	// resolvedPolicyExecutionChecksum is the GraphExceutionChecksum of the policy and the framework
-	// it does not change if any of the jobs changes, only if the policy or the framework changes
-	// To update the resolved policy, when we change how it is generated, change the incoporated version of the resolver
-	rpChecksumInclVersion := checksums.New
-	rpChecksumInclVersion = rpChecksumInclVersion.Add(resolvedPolicyExecutionChecksum)
-	rpChecksumInclVersion = rpChecksumInclVersion.Add(RESOLVER_VERSION)
-
 	resolvedPolicy := ResolvedPolicy{
-		GraphExecutionChecksum: rpChecksumInclVersion.String(),
+		GraphExecutionChecksum: resolvedPolicyExecutionChecksum,
 		Filters:                matchingFilters,
 		FiltersChecksum:        assetFiltersChecksum,
 		ExecutionJob:           executionJob,

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -234,9 +234,9 @@ policies:
 		require.NoError(t, err)
 		require.NotNil(t, rp)
 		require.Len(t, rp.CollectorJob.ReportingJobs, 5)
-		ignoreJob := rp.CollectorJob.ReportingJobs["8Sis0SvMbtI="]
+		ignoreJob := rp.CollectorJob.ReportingJobs["q7gxFtwx4zg="]
 		require.NotNil(t, ignoreJob)
-		childJob := ignoreJob.ChildJobs["YCeU4NjbMe0="]
+		childJob := ignoreJob.ChildJobs["GhqR9OVIDVM="]
 		require.NotNil(t, childJob)
 		require.Equal(t, explorer.ScoringSystem_IGNORE_SCORE, childJob.Scoring)
 	})
@@ -291,12 +291,12 @@ policies:
 		require.NoError(t, err)
 		require.NotNil(t, rp)
 		require.Len(t, rp.CollectorJob.ReportingJobs, 5)
-		ignoreJob := rp.CollectorJob.ReportingJobs["WVDbd6CWW30="]
+		ignoreJob := rp.CollectorJob.ReportingJobs["gqNWe4GO+UA="]
 		require.NotNil(t, ignoreJob)
-		childJob := ignoreJob.ChildJobs["7Q8ymKH8W5c="]
+		childJob := ignoreJob.ChildJobs["LrvWHNnWZNQ="]
 		require.NotNil(t, childJob)
 		require.Equal(t, explorer.ScoringSystem_IGNORE_SCORE, childJob.Scoring)
-		activeJob := rp.CollectorJob.ReportingJobs["/w4u/z6FEsI="]
+		activeJob := rp.CollectorJob.ReportingJobs["+KeXN9zwDzA="]
 		require.NotNil(t, activeJob)
 		require.Equal(t, explorer.ScoringSystem_BANDED, activeJob.ScoringSystem)
 	})

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -1709,13 +1709,15 @@ queries:
 		}
 		// scoring queries report by code id
 		require.NotNil(t, qrIdToRj[b.Queries[1].CodeId])
-		require.Len(t, qrIdToRj[b.Queries[1].CodeId].Mrns, 2)
+		require.Len(t, qrIdToRj[b.Queries[1].CodeId].Mrns, 3)
 		require.Equal(t, queryMrn("variant1"), qrIdToRj[b.Queries[1].CodeId].Mrns[0])
-		require.Equal(t, queryMrn("variant2"), qrIdToRj[b.Queries[1].CodeId].Mrns[1])
+		require.Equal(t, queryMrn("check-variants"), qrIdToRj[b.Queries[1].CodeId].Mrns[1])
+		require.Equal(t, queryMrn("variant2"), qrIdToRj[b.Queries[1].CodeId].Mrns[2])
 
-		require.Len(t, qrIdToRj[b.Queries[2].CodeId].Mrns, 2)
+		require.Len(t, qrIdToRj[b.Queries[2].CodeId].Mrns, 3)
 		require.Equal(t, queryMrn("variant1"), qrIdToRj[b.Queries[2].CodeId].Mrns[0])
-		require.Equal(t, queryMrn("variant2"), qrIdToRj[b.Queries[2].CodeId].Mrns[1])
+		require.Equal(t, queryMrn("check-variants"), qrIdToRj[b.Queries[2].CodeId].Mrns[1])
+		require.Equal(t, queryMrn("variant2"), qrIdToRj[b.Queries[2].CodeId].Mrns[2])
 	})
 }
 
@@ -1881,7 +1883,10 @@ queries:
 
 		rj = qrIdToRj["//test.sth/queries/windows-uname"]
 		require.NotNil(t, rj)
-		assert.ElementsMatch(t, []string{"//test.sth/queries/windows-uname"}, rj.Mrns)
+		assert.ElementsMatch(t, []string{
+			"//test.sth/queries/windows-uname",
+			"//test.sth/queries/uname",
+		}, rj.Mrns)
 	})
 
 	t.Run("resolve variant checks", func(t *testing.T) {
@@ -1891,6 +1896,9 @@ queries:
 
 		rj = qrIdToRj["eUdVwVDNIGA="]
 		require.NotNil(t, rj)
-		assert.ElementsMatch(t, []string{"//test.sth/queries/check-os-windows"}, rj.Mrns)
+		assert.ElementsMatch(t, []string{
+			"//test.sth/queries/check-os-windows",
+			"//test.sth/queries/check-os",
+		}, rj.Mrns)
 	})
 }


### PR DESCRIPTION
Compliance only knows about parent MRNs and not variant MRNs. To allow a mapping from compliance control to executed check, we need to store the check with it's parent MRN.

