### PR TITLE
🧹 Debug dependabot auto-approve PRs

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -88,10 +88,19 @@ jobs:
           name: test-results
           path: report.xml
 
+  debug:
+    runs-on: ubuntu-latest
+    needs: go-test
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
   go-auto-approve:
     runs-on: ubuntu-latest
     needs: go-test
-    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && needs.go-test.outputs.outcome == 'success' }}
+    if: ${{ github.actor == 'dependabot[bot]' && needs.go-test.outputs.outcome == 'success' }}
     permissions:
       contents: write
       pull-requests: write
@@ -101,15 +110,17 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
-        # For now, we only auto approve and merge go dep PRs because we have tests for this in place.
-        if: ${{ steps.dependabot-metadata.outputs.package-ecosystem == 'go' }}
-        # Settings the comment will auto merge the PR after all tests passed
-        # https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands
-        run: gh pr review --comment "@dependabot squash and merge" --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Debug metadata
+        run: echo "${{ steps.metadata.outputs }}"
+      # - name: Approve a PR
+      #   # For now, we only auto approve and merge go dep PRs because we have tests for this in place.
+      #   if: ${{ steps.dependabot-metadata.outputs.package-ecosystem == 'go' }}
+      #   # Settings the comment will auto merge the PR after all tests passed
+      #   # https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands
+      #   run: gh pr review --comment "@dependabot squash and merge" --approve "$PR_URL"
+      #   env:
+      #     PR_URL: ${{github.event.pull_request.html_url}}
+      #     GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   event_file:
     name: "Store event file"


### PR DESCRIPTION
Currently the auto-approve job is skipped:
https://github.com/mondoohq/cnspec/actions/runs/10662782067/job/29550833769?pr=1414

The workflow is triggered by a push event and not a pull_request event. I need to figure out how to use the metadata step, with a push event.

All the examples work on a pull_request: https://github.com/dependabot/fetch-metadata