### PR TITLE
🐛 Fix the gh cli command

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Approve a PR
         # Settings the comment will auto merge the PR after all tests passed
         # https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands
-        run: gh pr review --comment "@dependabot squash and merge" --approve "$PR_URL"
+        run: gh pr review "$PR_URL" --approve --body "@dependabot squash and merge"
         env:
           PR_URL: ${{ steps.pr.outputs.url }}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The command failed here: https://github.com/mondoohq/cnspec/actions/runs/10701181061/job/29666754075?pr=1419

> gh pr review --comment "@dependabot squash and merge" --approve "$PR_URL"
...
accepts at most 1 arg(s), received 2
Error: Process completed with exit code 1.

Giving the docs another try, I think, this might be the correct syntax.