### PR TITLE
:sparkles: Add a new linter case to catch `'// not implemented yet'`

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -590,19 +590,16 @@ func lintQuery(query *Mquery, file string, globalQueriesUids map[string]int, ass
 	}
 
 	if query.Mql == "// not implemented yet" {
-		_, hasParent := variantMapping[query.Uid]
-		if !hasParent {
-			res.Entries = append(res.Entries, Entry{
-				RuleID:  queryMqlMissing,
-				Message: fmt.Sprintf("query %s does not define a mql field", uid),
-				Level:   levelError,
-				Location: []Location{{
-					File:   file,
-					Line:   query.FileContext.Line,
-					Column: query.FileContext.Column,
-				}},
-			})
-		}
+		res.Entries = append(res.Entries, Entry{
+			RuleID:  queryMqlMissing,
+			Message: fmt.Sprintf("query %s does not define a mql field", uid),
+			Level:   levelError,
+			Location: []Location{{
+				File:   file,
+				Line:   query.FileContext.Line,
+				Column: query.FileContext.Column,
+			}},
+		})
 	}
 
 	// check if query id was used already

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -589,7 +589,8 @@ func lintQuery(query *Mquery, file string, globalQueriesUids map[string]int, ass
 		}
 	}
 
-	if query.Mql == "// not implemented yet" {
+	reNotImplemented := regexp.MustCompile(`\/\/\snot\simplemented\syet`)
+	if reNotImplemented.MatchString(query.Mql) {
 		res.Entries = append(res.Entries, Entry{
 			RuleID:  queryMqlMissing,
 			Message: fmt.Sprintf("query %s does not define a mql field", uid),

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -589,12 +589,12 @@ func lintQuery(query *Mquery, file string, globalQueriesUids map[string]int, ass
 		}
 	}
 
-	if query.Mql == "// not implemented yet" || query.Mql == "" {
+	if query.Mql == "// not implemented yet" {
 		_, hasParent := variantMapping[query.Uid]
-		if hasParent {
+		if !hasParent {
 			res.Entries = append(res.Entries, Entry{
 				RuleID:  queryMqlMissing,
-				Message: fmt.Sprintf("query %s does not define a mql field ", uid),
+				Message: fmt.Sprintf("query %s does not define a mql field", uid),
 				Level:   levelError,
 				Location: []Location{{
 					File:   file,

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -32,6 +32,7 @@ const (
 	policyWrongVersion         = "policy-wrong-version"
 	queryUid                   = "query-uid"
 	queryTitle                 = "query-name"
+	queryMqlMissing            = "query-missing-mql"
 	queryUidUnique             = "query-uid-unique"
 	queryUnassigned            = "query-unassigned"
 	queryUsedAsDifferentTypes  = "query-used-as-different-types"
@@ -108,6 +109,11 @@ var LinterRules = []Rule{
 		ID:          queryTitle,
 		Name:        "Missing query title",
 		Description: "Every query needs to have a `title: My Query Title` field",
+	},
+	{
+		ID:          queryMqlMissing,
+		Name:        "Missing query mql",
+		Description: "Every query that isn't a parent query needs to have a valid `mql:` field",
 	},
 	{
 		ID:          queryUidUnique,
@@ -573,6 +579,22 @@ func lintQuery(query *Mquery, file string, globalQueriesUids map[string]int, ass
 			res.Entries = append(res.Entries, Entry{
 				RuleID:  queryTitle,
 				Message: fmt.Sprintf("query %s does not define a title", uid),
+				Level:   levelError,
+				Location: []Location{{
+					File:   file,
+					Line:   query.FileContext.Line,
+					Column: query.FileContext.Column,
+				}},
+			})
+		}
+	}
+
+	if query.Mql == "// not implemented yet" || query.Mql == "" {
+		_, hasParent := variantMapping[query.Uid]
+		if hasParent {
+			res.Entries = append(res.Entries, Entry{
+				RuleID:  queryMqlMissing,
+				Message: fmt.Sprintf("query %s does not define a mql field ", uid),
 				Level:   levelError,
 				Location: []Location{{
 					File:   file,

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -593,7 +593,7 @@ func lintQuery(query *Mquery, file string, globalQueriesUids map[string]int, ass
 	if reNotImplemented.MatchString(query.Mql) {
 		res.Entries = append(res.Entries, Entry{
 			RuleID:  queryMqlMissing,
-			Message: fmt.Sprintf("query %s does not define a mql field", uid),
+			Message: fmt.Sprintf("query %s is '// not implemented yet'", uid),
 			Level:   levelError,
 			Location: []Location{{
 				File:   file,

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -106,7 +106,7 @@ func TestLintFail_MissingMQLVariant(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.BundleLocations))
-	assert.Equal(t, 2, len(results.Entries))
+	assert.Equal(t, 1, len(results.Entries))
 	assert.True(t, results.HasError())
 
 	entry := results.Entries[0]

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -111,5 +111,5 @@ func TestLintFail_MissingMQL(t *testing.T) {
 
 	entry := results.Entries[0]
 	assert.Equal(t, "query-missing-mql", entry.RuleID)
-	assert.Equal(t, "query cis-apple-macos-15-benchmark--1.1 does not define a mql field", entry.Message)
+	assert.Equal(t, "query mql-missing--1.1 does not define a mql field", entry.Message)
 }

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -100,6 +100,20 @@ func TestLintFail_MixQueries(t *testing.T) {
 	assert.Equal(t, "query sshd-sshd-01 is used as a check and data query", entry.Message)
 }
 
+func TestLintFail_MissingMQLVariant(t *testing.T) {
+	file := "./testdata/missing-mql-variants.mql.yaml"
+	results, err := bundle.Lint(schema, file)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(results.BundleLocations))
+	assert.Equal(t, 2, len(results.Entries))
+	assert.True(t, results.HasError())
+
+	entry := results.Entries[0]
+	assert.Equal(t, "query-missing-mql", entry.RuleID)
+	assert.Equal(t, "query mql-missing--foo does not define a mql field", entry.Message)
+}
+
 func TestLintFail_MissingMQL(t *testing.T) {
 	file := "./testdata/missing-mql.mql.yaml"
 	results, err := bundle.Lint(schema, file)

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -114,6 +114,20 @@ func TestLintFail_MissingMQLVariant(t *testing.T) {
 	assert.Equal(t, "query mql-missing--foo does not define a mql field", entry.Message)
 }
 
+func TestLintPass_MissingMQLVariant(t *testing.T) {
+	file := "./testdata/missing-mql-variants-pass.mql.yaml"
+	results, err := bundle.Lint(schema, file)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(results.BundleLocations))
+	assert.Equal(t, 0, len(results.Entries))
+	assert.False(t, results.HasError())
+
+	// entry := results.Entries[0]
+	// assert.Equal(t, "query-missing-mql", entry.RuleID)
+	// assert.Equal(t, "query mql-missing--foo does not define a mql field", entry.Message)
+}
+
 func TestLintFail_MissingMQL(t *testing.T) {
 	file := "./testdata/missing-mql.mql.yaml"
 	results, err := bundle.Lint(schema, file)

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -111,7 +111,7 @@ func TestLintFail_MissingMQLVariant(t *testing.T) {
 
 	entry := results.Entries[0]
 	assert.Equal(t, "query-missing-mql", entry.RuleID)
-	assert.Equal(t, "query mql-missing--foo does not define a mql field", entry.Message)
+	assert.Equal(t, "query mql-missing--foo is '// not implemented yet'", entry.Message)
 }
 
 func TestLintPass_MissingMQLVariant(t *testing.T) {
@@ -122,10 +122,6 @@ func TestLintPass_MissingMQLVariant(t *testing.T) {
 	assert.Equal(t, 1, len(results.BundleLocations))
 	assert.Equal(t, 0, len(results.Entries))
 	assert.False(t, results.HasError())
-
-	// entry := results.Entries[0]
-	// assert.Equal(t, "query-missing-mql", entry.RuleID)
-	// assert.Equal(t, "query mql-missing--foo does not define a mql field", entry.Message)
 }
 
 func TestLintFail_MissingMQL(t *testing.T) {
@@ -139,5 +135,5 @@ func TestLintFail_MissingMQL(t *testing.T) {
 
 	entry := results.Entries[0]
 	assert.Equal(t, "query-missing-mql", entry.RuleID)
-	assert.Equal(t, "query mql-missing--1.1 does not define a mql field", entry.Message)
+	assert.Equal(t, "query mql-missing--1.1 is '// not implemented yet'", entry.Message)
 }

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -99,3 +99,17 @@ func TestLintFail_MixQueries(t *testing.T) {
 	assert.Equal(t, "query-used-as-different-types", entry.RuleID)
 	assert.Equal(t, "query sshd-sshd-01 is used as a check and data query", entry.Message)
 }
+
+func TestLintFail_MissingMQL(t *testing.T) {
+	file := "./testdata/missing-mql.mql.yaml"
+	results, err := bundle.Lint(schema, file)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(results.BundleLocations))
+	assert.Equal(t, 1, len(results.Entries))
+	assert.True(t, results.HasError())
+
+	entry := results.Entries[0]
+	assert.Equal(t, "query-missing-mql", entry.RuleID)
+	assert.Equal(t, "query cis-apple-macos-15-benchmark--1.1 does not define a mql field", entry.Message)
+}

--- a/internal/bundle/testdata/missing-mql-variants-pass.mql.yaml
+++ b/internal/bundle/testdata/missing-mql-variants-pass.mql.yaml
@@ -1,0 +1,24 @@
+policies:
+  - uid: mql-missing-l1
+    name: Missing MQL Checks
+    version: "0.9"
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    groups:
+      - uid: mql-missing-l1--1
+        title: Missing MQL Checks
+        filters: |
+          asset.platform == "macos"
+          asset.version == /^15\./
+        checks:
+          - uid: mql-missing--1.1
+    scoring_system: highest impact
+queries:
+  - uid: mql-missing--1.1
+    title: Missing MQL 1
+    variants:
+      - uid: mql-missing--foo
+  - uid: mql-missing--foo
+    mql: |
+      asset.name == "test"

--- a/internal/bundle/testdata/missing-mql-variants.mql.yaml
+++ b/internal/bundle/testdata/missing-mql-variants.mql.yaml
@@ -1,0 +1,27 @@
+policies:
+  - uid: mql-missing-l1
+    name: Missing MQL Checks
+    version: "0.9"
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    groups:
+      - uid: mql-missing-l1--1
+        title: Missing MQL Checks
+        filters: |
+          asset.platform == "macos"
+          asset.version == /^15\./
+        checks:
+          - uid: mql-missing--1.1
+    scoring_system: highest impact
+queries:
+  - uid: mql-missing--1.1
+    title: Missing MQL 1
+    variants:
+      - uid: mql-missing--foo
+      - uid: mql-missing--bar
+
+  - uid: mql-missing--foo
+    mql: "// not implemented yet"
+  - uid: mql-missing--bar
+    mql: "// not implemented yet"

--- a/internal/bundle/testdata/missing-mql-variants.mql.yaml
+++ b/internal/bundle/testdata/missing-mql-variants.mql.yaml
@@ -19,9 +19,6 @@ queries:
     title: Missing MQL 1
     variants:
       - uid: mql-missing--foo
-      - uid: mql-missing--bar
-
   - uid: mql-missing--foo
-    mql: "// not implemented yet"
-  - uid: mql-missing--bar
-    mql: "// not implemented yet"
+    mql: |
+      // not implemented yet

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -17,4 +17,4 @@ policies:
 queries:
   - uid: mql-missing--1.1
     title: Missing MQL 1
-    mql: "// not implemented yet"
+    mql: // not implemented yet

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -1,20 +1,13 @@
 policies:
   - uid: mql-missing-l1
-    name: CIS Apple macOS 15.0 Sequoia Draft - Level 1
+    name: Missing MQL Checks
     version: "0.9"
-    tags:
-      mondoo.com/category: compliance
-      mondoo.com/platform: macos:15
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    docs:
-      desc: |-
-        This is a draft for the upcoming CIS Apple macOS 15.0 Sequoia Benchmark Level 1 policy.
-        It is based on the CIS Apple macOS 14.0 Sonoma Benchmark policy.
     groups:
       - uid: mql-missing-l1--1
-        title: Install Updates, Patches and Additional Security Software
+        title: Missing MQL Checks
         filters: |
           asset.platform == "macos"
           asset.version == /^15\./

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -16,6 +16,5 @@ policies:
     scoring_system: highest impact
 queries:
   - uid: mql-missing--1.1
-    title: Ensure All Apple-provided Software Is Current
-    mql: |
-      // not implemented yet
+    title: Missing MQL 1
+    mql: "// not implemented yet"

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -1,5 +1,5 @@
 policies:
-  - uid: cis-apple-macos-15-benchmark-l1
+  - uid: mql-missing-l1
     name: CIS Apple macOS 15.0 Sequoia Draft - Level 1
     version: "0.9"
     tags:
@@ -13,16 +13,16 @@ policies:
         This is a draft for the upcoming CIS Apple macOS 15.0 Sequoia Benchmark Level 1 policy.
         It is based on the CIS Apple macOS 14.0 Sonoma Benchmark policy.
     groups:
-      - uid: cis-apple-macos-15-benchmark-l1--1
+      - uid: mql-missing-l1--1
         title: Install Updates, Patches and Additional Security Software
         filters: |
           asset.platform == "macos"
           asset.version == /^15\./
         checks:
-          - uid: cis-apple-macos-15-benchmark--1.1
+          - uid: mql-missing--1.1
     scoring_system: highest impact
 queries:
-  - uid: cis-apple-macos-15-benchmark--1.1
+  - uid: mql-missing--1.1
     title: Ensure All Apple-provided Software Is Current
     mql: |
       // not implemented yet

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -1,0 +1,30 @@
+policies:
+  - uid: cis-apple-macos-15-benchmark-l1
+    name: CIS Apple macOS 15.0 Sequoia Draft - Level 1
+    version: "0.9"
+    tags:
+      mondoo.com/category: compliance
+      mondoo.com/platform: macos:15
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    docs:
+      desc: |-
+        This is a draft for the upcoming CIS Apple macOS 15.0 Sequoia Benchmark Level 1 policy.
+        It is based on the CIS Apple macOS 14.0 Sonoma Benchmark policy.
+    groups:
+      - uid: cis-apple-macos-15-benchmark-l1--1
+        title: Install Updates, Patches and Additional Security Software
+        filters: |
+          asset.platform == "macos"
+          asset.version == /^15\./
+        checks:
+          - uid: cis-apple-macos-15-benchmark--1.1
+    scoring_system: highest impact
+queries:
+  - uid: cis-apple-macos-15-benchmark--1.1
+    title: Ensure All Apple-provided Software Is Current
+    tags:
+      cisecurity.org/recommendation: "1.1"
+    mql: |
+      // not implemented yet

--- a/internal/bundle/testdata/missing-mql.mql.yaml
+++ b/internal/bundle/testdata/missing-mql.mql.yaml
@@ -24,7 +24,5 @@ policies:
 queries:
   - uid: cis-apple-macos-15-benchmark--1.1
     title: Ensure All Apple-provided Software Is Current
-    tags:
-      cisecurity.org/recommendation: "1.1"
     mql: |
       // not implemented yet


### PR DESCRIPTION
Reference only. 
@chris-rock highlights that the compile phase should catch this already.