### PR TITLE
Remove the release hook which is failing

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -163,13 +163,3 @@ jobs:
           event-type: update
           client-payload: '{"version": "${{ github.ref_name }}"}'
 
-  release-installer:
-    name: Trigger installer release
-    runs-on: ubuntu-latest
-    if: ${{ ! inputs.skip-publish }}
-    needs: goreleaser
-    steps:
-      - name: Run installer release workfow
-        env:
-          GH_TOKEN: ${{ secrets.REPO_API_TOKEN }}
-        run: gh workflow run release.yml --repo "mondoohq/installer" --field version=${{ github.ref_name }}


### PR DESCRIPTION
This was part of a refactor by Sam that was rolled back, however this hook was left in place.  Removing it will allow the gorelease job to finish green.  We will plan to come back and complete the automation between cnspec and installer in the future.