### PR TITLE
🐛 Fix missing .git directory

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -126,6 +126,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       # figure out the PR for this commit
       - uses: cloudposse-github-actions/get-pr@v2.0.0
         id: pr


### PR DESCRIPTION
That should fix:
https://github.com/mondoohq/cnspec/actions/runs/11910492758/job/33190215560?pr=1483

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```