### PR TITLE
🧹 decouple checkin from service startup

### DIFF
--- a/apps/cnspec/cmd/backgroundjob/checkin_pinger.go
+++ b/apps/cnspec/cmd/backgroundjob/checkin_pinger.go
@@ -43,7 +43,9 @@ func (c *checkinPinger) Start() {
 	}
 
 	// run check-in once on startup
-	runCheckIn()
+	go func() {
+		runCheckIn()
+	}()
 
 	jitter := time.Duration(rand.Int63n(int64(c.interval)))
 	ticker := time.NewTicker(c.interval + jitter)

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Serve(timer time.Duration, splay time.Duration, handler JobRunner) {
-	isIntSess, err := svc.IsAnInteractiveSession()
+	isIntSess, err := svc.IsWindowsService()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to determine if we are running in an interactive session")
 	}


### PR DESCRIPTION
Make sure the check-in is not blocking service startup. It now happens in the background