### PR TITLE
⭐️ integrate preflight check: role assignments

### DIFF
--- a/apps/cnspec/cmd/integrate.go
+++ b/apps/cnspec/cmd/integrate.go
@@ -148,8 +148,11 @@ NOTE that --allow and --deny are mutually exclusive and can't be use together.`,
 				os.Exit(1)
 			}
 
-			// TODO ideally, we should verify that the user has the "Privileged Role Administrator" or "Global Administrator"
-			// => https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#privileged-role-administrator
+			// Verify that the user has the right role assignments to onboard an Azure environment
+			log.Info().Msg("verifying role assignments for the currently logged-in user")
+			if err := onboarding.VerifyUserRoleAssignments(); err != nil {
+				return errors.Wrap(err, "preflight verification failed")
+			}
 
 			// Generate HCL for azure deployment
 			log.Info().Msg("generating automation code")


### PR DESCRIPTION
This change adds a minimalistic preflight check where we verify that the user has the right role assignments to onboard an Azure environment.

We need one of "**Privileged Role Administrator**" or "**Global Administrator**"

https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#privileged-role-administrator

Note that we run Azure CLI commands directly so that `cnspec` doesn't have to import the entire Azure SDK which will make the binary much bigger, which today is unnecessary for the amount of checks we are running.

## Example Success

![Screenshot 2024-11-22 at 2 58 09 PM](https://github.com/user-attachments/assets/ddd74868-b0a1-400f-9702-e57e7ad3bacc)

## Example Failure

![Screenshot 2024-11-22 at 3 02 27 PM](https://github.com/user-attachments/assets/5b899dc9-7250-4525-9aeb-f5c10d31af8d)
