### PR TITLE
Avoid reviewing own PRs by auto-merging with bot token

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -135,13 +135,19 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           filterOutClosed: true
           filterOutDraft: true
-      - name: Approve and merge a PR
-        run: |
-          gh pr review ${{ steps.pr.outputs.number }} --approve
-          gh pr merge ${{ steps.pr.outputs.number }} --squash --merge
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
+      # fetch a token for the mondoo-mergebot app
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private_key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+      # automerge using bot token
+      - uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+          token: ${{ steps.generate-token.outputs.token }} 
   event_file:
     name: "Store event file"
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -138,10 +138,10 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
-          private_key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       # automerge using bot token
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -143,11 +143,12 @@ jobs:
           app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       # automerge using bot token
-      - uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
-          token: ${{ steps.generate-token.outputs.token }} 
+      - name: Approve and merge a PR
+        run: |
+          gh pr review ${{ steps.pr.outputs.number }} --approve
+          gh pr merge ${{ steps.pr.outputs.number }} --squash --merge
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
   event_file:
     name: "Store event file"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use `mondoo-mergebot` app token when approving/merging PRs in order to avoid scenarios where we are attempting to create and approve a PR with the same user.