### PR TITLE
Report a score for disabled queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.15.1
-	go.mondoo.com/cnquery/v11 v11.33.0
+	go.mondoo.com/cnquery/v11 v11.33.1-0.20241203152108-75141bf91344
 	go.mondoo.com/mondoo-go v0.0.0-20241118222255-5299c9adc97c
 	go.mondoo.com/ranger-rpc v0.6.4
 	go.opentelemetry.io/otel v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -998,6 +998,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/cnquery/v11 v11.33.0 h1:lXLEPwt+7D3GW2hKMNmHlQlD6YhEd3izGnmHIo2a3Kg=
 go.mondoo.com/cnquery/v11 v11.33.0/go.mod h1:ynuOojMFVuwUAq7nC0Dk6Ut/2MS9T/R+hHmWQdP491Q=
+go.mondoo.com/cnquery/v11 v11.33.1-0.20241203152108-75141bf91344 h1:WAhzalrXYL7vJDi2tC0UHPl1T5M5GGI8vFhg+A1R0wk=
+go.mondoo.com/cnquery/v11 v11.33.1-0.20241203152108-75141bf91344/go.mod h1:ynuOojMFVuwUAq7nC0Dk6Ut/2MS9T/R+hHmWQdP491Q=
 go.mondoo.com/mondoo-go v0.0.0-20241118222255-5299c9adc97c h1:0u12icLFjeTLzNQHjPs8Mw65VG1Wl8LxHoGRihwaSmg=
 go.mondoo.com/mondoo-go v0.0.0-20241118222255-5299c9adc97c/go.mod h1:VTTbqYTjin1hKSnwKHVYeOTEyJrAZarNlf1I8M2rlpM=
 go.mondoo.com/ranger-rpc v0.6.4 h1:q01kjESvF2HSnbFO+TjpUQSiI2IM8JWGJLH3u0vNxZA=

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -547,13 +547,17 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 			} else {
 				s = proto.Clone(c.score).(*policy.Score)
 				s.QrId = nodeData.queryID
-				if s.Type == policy.ScoreType_Result {
+				if c.impact.GetScoring() == explorer.ScoringSystem_DISABLED {
+					s.Type = policy.ScoreType_Disabled
+				} else if s.Type == policy.ScoreType_Result {
 					// We cant just forward the score if impact is set and we have a result.
 					// We still need to apply impact to the score
-					if c.impact != nil && c.impact.Value != nil {
-						floor := 100 - uint32(c.impact.Value.Value)
-						if floor > s.Value {
-							s.Value = floor
+					if c.impact != nil {
+						if c.impact.Value != nil {
+							floor := 100 - uint32(c.impact.Value.Value)
+							if floor > s.Value {
+								s.Value = floor
+							}
 						}
 					}
 				}

--- a/policy/resolved_policy_builder.go
+++ b/policy/resolved_policy_builder.go
@@ -871,7 +871,7 @@ func (b *resolvedPolicyBuilder) addQuery(query *explorer.Mquery) (string, bool) 
 		// Add node for query
 		b.addNode(&rpBuilderGenericQueryNode{queryMrn: query.Mrn, selectedCodeId: b.disabledQuery.CodeId, queryType: queryType})
 		// Add edge from execution query to query
-		b.addEdge(b.disabledQuery.CodeId, query.Mrn, &explorer.Impact{Scoring: explorer.ScoringSystem_IGNORE_SCORE})
+		b.addEdge(b.disabledQuery.CodeId, query.Mrn, &explorer.Impact{Scoring: explorer.ScoringSystem_DISABLED})
 		return b.disabledQuery.CodeId, true
 	}
 

--- a/policy/resolved_policy_builder.go
+++ b/policy/resolved_policy_builder.go
@@ -29,6 +29,17 @@ func buildResolvedPolicy(ctx context.Context, bundleMrn string, bundle *Bundle, 
 	policyObj := bundleMap.Policies[bundleMrn]
 	frameworkObj := bundleMap.Frameworks[bundleMrn]
 
+	disabledQuery := &explorer.Mquery{
+		Mql: `// Disabled
+		if(false) { return false }`,
+		CodeId: "",
+	}
+	cb, err := disabledQuery.Compile(nil, compilerConf)
+	if err != nil {
+		return nil, err
+	}
+	disabledQuery.CodeId = cb.GetCodeV2().GetId()
+
 	builder := &resolvedPolicyBuilder{
 		bundleMrn:            bundleMrn,
 		bundleMap:            bundleMap,
@@ -43,6 +54,7 @@ func buildResolvedPolicy(ctx context.Context, bundleMrn string, bundle *Bundle, 
 		propsCache:           explorer.NewPropsCache(),
 		queryTypes:           map[string]queryType{},
 		now:                  now,
+		disabledQuery:        disabledQuery,
 	}
 
 	builder.gatherGlobalInfoFromPolicy(policyObj)
@@ -224,6 +236,11 @@ type resolvedPolicyBuilder struct {
 	propsCache explorer.PropsCache
 	// now is the time that the resolved policy is being built
 	now time.Time
+	// disabledQuery represents a query that is disabled. We need to inject this for disabled queries
+	// because we want to report a score of U for them. We cannot just insert a reporting job without
+	// a query because there is a bug in the clients that expects those reporting jobs to be connected
+	// to a query that runs
+	disabledQuery *explorer.Mquery
 }
 
 type edgeImpact struct {
@@ -846,7 +863,16 @@ func (b *resolvedPolicyBuilder) addQuery(query *explorer.Mquery) (string, bool) 
 	queryType := b.queryTypes[query.Mrn]
 
 	if !canRun(action) {
-		return "", false
+		if !b.anyFilterMatches(query.Filters) {
+			return "", false
+		}
+		// Add node for execution query
+		b.addNode(&rpBuilderExecutionQueryNode{query: b.disabledQuery})
+		// Add node for query
+		b.addNode(&rpBuilderGenericQueryNode{queryMrn: query.Mrn, selectedCodeId: b.disabledQuery.CodeId, queryType: queryType})
+		// Add edge from execution query to query
+		b.addEdge(b.disabledQuery.CodeId, query.Mrn, &explorer.Impact{Scoring: explorer.ScoringSystem_IGNORE_SCORE})
+		return b.disabledQuery.CodeId, true
 	}
 
 	if len(query.Variants) != 0 {

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -33,7 +33,7 @@ const (
 	// This can be updated, e.g., when we change how the report jobs are generated
 	// A change of this string will force an update of all the stored resolved policies
 	RESOLVER_VERSION    = "v2024-08-29"
-	RESOLVER_VERSION_NG = "v2024-11-25"
+	RESOLVER_VERSION_NG = "v2024-12-02"
 )
 
 type AssetMutation struct {


### PR DESCRIPTION
This reports them as skipped for old clients, disabled for new clients. It does this by injecting a query which always reports a skipped score. Doing so allows us to know if an asset didn't run a query that would have because it is disabled