### PR TITLE
🐛 Fix gh merge command

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Approve and merge a PR
         run: |
           gh pr review ${{ steps.pr.outputs.number }} --approve
-          gh pr merge ${{ steps.pr.outputs.number }} --squash --merge
+          gh pr merge ${{ steps.pr.outputs.number }} --squash
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
   event_file:


### PR DESCRIPTION
This should fix:
https://github.com/mondoohq/cnspec/actions/runs/12136947927/job/33839326646

> only one of --merge, --rebase, or --squash can be enabled