### PR TITLE
🐛 Use 100 for the default value of impact

### DIFF
--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -500,8 +500,8 @@ func (c *bandedScoreCalculator) Add(score *Score, impact *explorer.Impact) {
 		c.scoreCompletion += score.ScoreCompletion
 
 		if score.ScoreCompletion != 0 && score.Weight != 0 {
-			category := score.Value
-			if impact != nil {
+			category := uint32(0)
+			if impact != nil && impact.Value != nil {
 				category = 100 - uint32(impact.Value.Value)
 			}
 

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -276,6 +276,23 @@ func TestBandedScores(t *testing.T) {
 			},
 			out: &Score{Value: 9, ScoreCompletion: 100, DataCompletion: 66, Weight: 20, Type: ScoreType_Result},
 		},
+		{
+			in: []*Score{
+				// 10 critical checks (9ok, 1not)
+				{Value: 0, ScoreCompletion: 100, DataCompletion: 80, DataTotal: 5, Weight: 1, Type: ScoreType_Result},
+				{Value: 100, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 9, Type: ScoreType_Result},
+				// 10 high checks (ok)
+				{Value: 100, ScoreCompletion: 100, DataCompletion: 33, DataTotal: 3, Weight: 10, Type: ScoreType_Result},
+			},
+			impacts: []*explorer.Impact{
+				// 10 critical checks
+				{Value: &explorer.ImpactValue{Value: 100}},
+				{Value: nil},
+				// 10 high checks
+				{Value: &explorer.ImpactValue{Value: 80}},
+			},
+			out: &Score{Value: 45, ScoreCompletion: 100, DataCompletion: 66, Weight: 20, Type: ScoreType_Result},
+		},
 	})
 }
 


### PR DESCRIPTION
It's possible for impact to be be nil, in which case we should use the default value which is 100. Using the score value doesn't make sense. It would mean that the category would change based on if it passed or failed in cases where impact was not defined.