### PR TITLE
🚨 recover from panic's inside goroutines

### DIFF
--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream/health"
 	"go.mondoo.com/cnquery/v11/utils/iox"
+	"go.mondoo.com/cnspec/v11"
 	"go.mondoo.com/cnspec/v11/policy"
 	"google.golang.org/protobuf/proto"
 )
@@ -122,6 +124,7 @@ func (c *BufferedCollector) run() {
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
+		defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
 
 		done := false
 		results := []*llx.RawResult{}

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream/health"
+	"go.mondoo.com/cnspec/v11"
 )
 
 const MEM_DEBUG_ENV = "MEM_DEBUG"
@@ -63,6 +65,7 @@ func (em *executionManager) Start() {
 	em.wg.Add(1)
 	go func() {
 		defer em.wg.Done()
+		defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
 		for {
 			// Prioritize stopChan
 			select {

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -30,6 +30,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/recording"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream/gql"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream/health"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
 	"go.mondoo.com/cnquery/v11/utils/slicesx"
 	"go.mondoo.com/cnspec/v11"
@@ -314,6 +315,8 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	scanGroups.Add(1)
 	go func() {
 		defer scanGroups.Done()
+		defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
+
 		if err := multiprogress.Open(); err != nil {
 			log.Error().Err(err).Msg("failed to open progress bar")
 		}
@@ -415,6 +418,8 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
+
 			for i := range batch {
 				asset := batch[i].Asset
 				runtime := batch[i].Runtime


### PR DESCRIPTION
The main cnspec goroutine has already a `recover()` statement, though Go doesn't
share that between goroutines and since the calculation of the policies happen on
another thread, we were not reporting upstream.

<img src="https://media0.giphy.com/media/EEvaPhKOp7uphg148v/giphy.gif"/>