### PR TITLE
🐛 fix CI test

### DIFF
--- a/test/providers/scan_flags_test.go
+++ b/test/providers/scan_flags_test.go
@@ -55,7 +55,7 @@ func TestScanFlags(t *testing.T) {
 		assert.NotNil(t, r.Stderr())
 
 		assert.Contains(t, string(r.Stderr()),
-			"app-private-key is required for GitHub App authentication", // expected! it means we loaded the flags
+			"could not parse private key", // expected! it means we loaded the flags
 		)
 	})
 	t.Run("github scan WITH all required flags for app auth", func(t *testing.T) {


### PR DESCRIPTION
This changed since the `github` provider changed.

We still want to test that flags are loaded, so I am updating the test and not removing it.