### PR TITLE
fix #1532, add missing azure permission

### DIFF
--- a/internal/onboarding/azure.go
+++ b/internal/onboarding/azure.go
@@ -63,6 +63,7 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 				"Microsoft.Compute/virtualMachines/runCommands/read",
 				"Microsoft.Compute/virtualMachines/runCommands/write",
 				"Microsoft.Compute/virtualMachines/runCommands/delete",
+				"Microsoft.Compute/virtualMachines/runCommand/action",
 			},
 			// not_actions = []
 			// data_actions = []


### PR DESCRIPTION
This fixes Mondoo not being able to scan VMs on Azure.