### PR TITLE
Add asset platform to cnspec output when displaying asset

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -337,7 +337,7 @@ func (r *defaultReporter) printAssetSections(orderedAssets []assetMrnName) {
 			target = assetMrn
 		}
 
-		r.out(r.Printer.H2("Asset: " + target))
+		r.out(r.Printer.H2("Asset: (" + getPlatformNameForAsset(asset) + ") " + target))
 
 		errorMsg, ok := r.data.Errors[assetMrn]
 		if ok {


### PR DESCRIPTION
Adds the platform name to the asset name header in the asset section.

```
Asset: planetexpress
--------------------
```
becomes

```
Asset: (Arch Linux) planetexpress
---------------------------------
```

Fixes #1534