### PR TITLE
🧹 don't add snoozed score type

### DIFF
--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -550,10 +550,6 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 				if c.impact.GetScoring() == explorer.ScoringSystem_DISABLED {
 					s.Type = policy.ScoreType_Disabled
 				} else if s.Type == policy.ScoreType_Result {
-					// If the impact is ignore, then the score type should be Snoozed
-					if c.impact.GetScoring() == explorer.ScoringSystem_IGNORE_SCORE {
-						s.Type = policy.ScoreType_Snoozed
-					}
 					// We cant just forward the score if impact is set and we have a result.
 					// We still need to apply impact to the score
 					if c.impact != nil {

--- a/policy/score.go
+++ b/policy/score.go
@@ -16,7 +16,6 @@ const (
 	ScoreType_Unscored
 	ScoreType_OutOfScope
 	ScoreType_Disabled
-	ScoreType_Snoozed
 )
 
 // TypeLabel prints the score's type in a human-readable way
@@ -36,8 +35,6 @@ func (s *Score) TypeLabel() string {
 		return "out of scope"
 	case ScoreType_Disabled:
 		return "disabled"
-	case ScoreType_Snoozed:
-		return "snoozed"
 	default:
 		return "unknown type"
 	}


### PR DESCRIPTION
If we add a Snoozed type we potentially hide error scores. Instead of adding a new score type, we will solve the issue differently on the backend