### PR TITLE
#498 BURP: Remove dispatch event for releases.mondoo.com

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -138,18 +138,6 @@ jobs:
         if: always()
         run: rm -f ${CERT_PATH}
 
-      - name: Publish Release to releases.mondoo.com
-        if: ${{ ! steps.skip-publish.outputs.skip-publish }}
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
-          repository: "mondoohq/releasr"
-          event-type: publish-release
-          client-payload: '{
-            "repository": "${{ github.event.repository.name }}",
-            "version":  "${{  github.ref_name }}"
-            }'
-
   trigger-installer-release:
     name: Trigger Installer Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove repository-dispatch event triggering a release to releases.mondoo.com. Releases will be entirely managed inside the [installer](https://github.com/mondoohq/installer/) repo in the future.