### PR TITLE
🧹 Fix deprecated/removed/moved parameters for golangci

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -4,11 +4,12 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
-  skip-dirs:
-  skip-files:
+  modules-download-mode: readonly
+
+issues:
+  exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
-  modules-download-mode: readonly
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,12 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
-  skip-dirs:
-  skip-files:
+  modules-download-mode: readonly
+
+issues:
+  exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
-  modules-download-mode: readonly
 
 linters:
   disable-all: true


### PR DESCRIPTION
This fixes https://github.com/mondoohq/cnspec/actions/runs/13894237360/job/38871321104\?pr\=1603

These are the same fixes as for cnquery.