### PR TITLE
✨ extend policy linter to enforce no unknown fields in yaml

### DIFF
--- a/examples/complex.mql.yaml
+++ b/examples/complex.mql.yaml
@@ -17,17 +17,17 @@ policies:
           - uid: sshd-01
             title: Set the port to 22
             query: sshd.config.params.Port == 22
-            severity: 30
+            impact: 30
 
           - uid: sshd-02
             title: Configure the address family
             query: sshd.config.params.AddressFamily == /inet|inet6|any/
-            severity: 40
+            impact: 40
 
           - uid: sshd-03
             title: Enable strict mode
             query: sshd.config.params.StrictModes == "yes"
-            severity: 70
+            impact: 70
 
   # This is a second policy in the same bundle
   - uid: example2

--- a/internal/bundle/fmt.go
+++ b/internal/bundle/fmt.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v11/policy"
 	"gopkg.in/yaml.v3"
-	k8sYaml "sigs.k8s.io/yaml"
 )
 
 // Formats the given bundle to a yaml string
@@ -53,22 +52,9 @@ func FormatRecursive(mqlBundlePath string, sort bool) error {
 
 // ParseYaml loads a yaml file and parse it into the go struct
 func ParseYaml(data []byte) (*Bundle, error) {
-	// This will generate errors if the yaml contains fields that are not
-	// known in the policy.Bundle struct
-	err := k8sYaml.UnmarshalStrict(data, &policy.Bundle{})
-	if err != nil {
-		return nil, err
-	}
-
 	baseline := Bundle{}
 
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true) // Enforce strict field mapping
-
-	err = decoder.Decode(&baseline)
-	if err != nil {
-		return nil, err
-	}
+	err := yaml.Unmarshal([]byte(data), &baseline)
 	return &baseline, err
 }
 

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -100,6 +100,32 @@ func TestLintFail_MixQueries(t *testing.T) {
 	assert.Equal(t, "query sshd-sshd-01 is used as a check and data query", entry.Message)
 }
 
+func TestLintFail_UnknownFieds(t *testing.T) {
+	file := "./testdata/unknown-field.mql.yaml"
+	rootDir := "./testdata"
+	results, err := bundle.Lint(schema, file)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(results.BundleLocations))
+	assert.Equal(t, 1, len(results.Entries))
+	assert.True(t, results.HasError())
+
+	entry := results.Entries[0]
+	assert.Equal(t, "bundle-unknown-field", entry.RuleID)
+	assert.Equal(t, "bundle contains unknown fields unknown-field.mql.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"unknown_field\"", entry.Message)
+
+	report, err := results.SarifReport(rootDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(report.Runs))
+	assert.Equal(t, len(bundle.LinterRules), len(report.Runs[0].Tool.Driver.Rules))
+	assert.Equal(t, 1, len(report.Runs[0].Results))
+
+	data, err := results.ToSarif(rootDir)
+	require.NoError(t, err)
+	assert.True(t, len(data) > 0)
+}
+
 func TestLintWarn_NoFilterGroupCheck(t *testing.T) {
 	file := "./testdata/fail_noFiltersGroupAndCheck.mql.yaml"
 	results, err := bundle.Lint(schema, file)

--- a/internal/bundle/testdata/unknown-field.mql.yaml
+++ b/internal/bundle/testdata/unknown-field.mql.yaml
@@ -3,14 +3,14 @@ policies:
     name: Test data SSH Policy
     version: "1.0.0"
     owner_mrn: ""
+    # A field that does not exist in the bundle struct
+    unknown_field: "This is an unknown field" 
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
     groups:
       - title: group 01
         checks:
-          - uid: sshd-sshd-01
-        queries:
           - uid: sshd-sshd-01
         filters: |
           asset.family.contains(_ == 'unix')


### PR DESCRIPTION
We found issues where remediations are not correctly set in policies. Seems like our linter does not enforce no unknown fileds to be present in the bundle. This PR changes that so now we can get:
```
cnspec policy lint mondoo-aws-security.mql.yaml
→ lint policy bundle file=mondoo-aws-security.mql.yaml
  RULE ID         LEVEL  FILE                          LINE  MESSAGE                         
  bundle-invalid  error  mondoo-aws-security.mql.yaml  1     cannot parse the yaml file      
                                                             mondoo-aws-security.mql.yaml:   
                                                             error unmarshaling JSON: while  
                                                             decoding JSON: json: unknown    
                                                             field "remediation"             
FTL invalid policy bundle
```

One limitation of this approach is that we do not get the exact line of the issue. This is better than nothing. A better solution that would yield the correct line numbers would be to use yamlv3. However, for that we need to re-implement all the custom unmarshallers we have for existing types to work with yamlv3.