### PR TITLE
Allow props to be set on policy

### DIFF
--- a/policy/resolver_v2_test.go
+++ b/policy/resolver_v2_test.go
@@ -2004,3 +2004,54 @@ policies:
 		rpTester.doTest(t, rp)
 	})
 }
+
+func TestResolveV2_PropsDefinedAtPolicy(t *testing.T) {
+	ctx := context.Background()
+	b := parseBundle(t, `
+owner_mrn: //test.sth
+policies:
+- uid: policy1
+  props:
+  - uid: name
+    mql: return "definitely not the asset name"
+  groups:
+  - type: chapter
+    filters: "true"
+    checks:
+    - uid: check1
+      mql: asset.name == props.name
+      props:
+      - uid: name
+    queries:
+    - uid: query1
+      mql: asset{*}
+`)
+
+	srv := initResolver(t, []*testAsset{
+		{asset: "asset1", policies: []string{policyMrn("policy1")}},
+	}, []*policy.Bundle{b})
+
+	t.Run("resolve with correct filters", func(t *testing.T) {
+		rp, err := srv.Resolve(ctx, &policy.ResolveReq{
+			PolicyMrn:    policyMrn("policy1"),
+			AssetFilters: []*explorer.Mquery{{Mql: "true"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rp)
+		require.Len(t, rp.ExecutionJob.Queries, 3)
+		require.Len(t, rp.Filters, 1)
+		require.Len(t, rp.CollectorJob.ReportingJobs, 5)
+
+		rpTester := newResolvedPolicyTester(b, srv.NewCompilerConfig())
+		rpTester.ExecutesQuery(queryMrn("query1"))
+		rpTester.
+			ExecutesQuery(queryMrn("check1")).
+			WithProps(map[string]string{"name": `return "definitely not the asset name"`})
+		rpTester.CodeIdReportingJobForMrn(queryMrn("check1")).Notifies(queryMrn("check1"))
+		rpTester.CodeIdReportingJobForMrn(queryMrn("query1")).Notifies(queryMrn("query1"))
+		rpTester.ReportingJobByMrn(queryMrn("check1")).Notifies("root")
+		rpTester.ReportingJobByMrn(queryMrn("query1")).Notifies("root")
+
+		rpTester.doTest(t, rp)
+	})
+}


### PR DESCRIPTION
Makes the following example work. Not that you still need to declare you are going to use a property which is done by referencing the uid without any mql
```yaml
policies:
  - uid: example1
    name: Example policy 1
    version: "1.0.0"
    authors:
      - name: Mondoo
        email: hello@mondoo.com
    groups:
      - title: group1
        filters: asset.family.contains("unix")
        checks:
          - uid: check-4
    props:
      - uid: adminaccount
        mql: return "adminaccount"

queries:
  - uid: check-4
    title: check 4
    mql: props.adminaccount == "foo"
    filters: asset.family.contains("unix")
    props:
      - uid: adminaccount
```