### PR TITLE
✨ onboarding: azure allow subscriptions

### DIFF
--- a/internal/onboarding/azure.go
+++ b/internal/onboarding/azure.go
@@ -122,17 +122,6 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 				"owners":    []interface{}{dataADClientConfig.TraverseRef("object_id")},
 			}),
 		)
-		// TODO can we skip subscriptions if deny is provided
-		dataRMAllSubscriptions         = tfgen.NewDataSource("azurerm_subscriptions", "available")
-		resourceRMReaderRoleAssignment = tfgen.NewResource("azurerm_role_assignment", "reader",
-			tfgen.HclResourceWithAttributes(tfgen.Attributes{
-				"role_definition_name": "Reader",
-
-				"count":        tfgen.NewFuncCall("length", dataRMAllSubscriptions.TraverseRef("subscriptions")),
-				"scope":        dataRMAllSubscriptions.TraverseRef("subscriptions[count.index]", "id"),
-				"principal_id": resourceADServicePrincipal.TraverseRef("object_id"),
-			}),
-		)
 		// This is the way we avoid Grant Admin Consent issue.
 		//
 		// => https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers
@@ -160,14 +149,9 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 					tfgen.CreateSimpleTraversal(`"\n", [tls_self_signed_cert.credential.cert_pem, tls_private_key.credential.private_key_pem]`),
 				),
 			},
-			"depends_on": []interface{}{
-				resourceADServicePrincipal.TraverseRef(),
-				resourceRMReaderRoleAssignment.TraverseRef(),
-				resourceADApplicationCertificate.TraverseRef(),
-				resourceADReadersRoleAssignment.TraverseRef(),
-			},
 		}
 		// Custom role needed only when scanning VMs
+		dataRMAllSubscriptions         = tfgen.NewDataSource("azurerm_subscriptions", "available")
 		resourceRMCustomRoleDefinition = tfgen.NewResource("azurerm_role_definition", "mondoo_security",
 			tfgen.HclResourceWithAttributes(tfgen.Attributes{
 				"name":              "tf-mondoo-security-role",
@@ -189,18 +173,7 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 		)
 	)
 
-	// Allow and Deny are mutually exclusive and can't be added together
-	if len(integration.Allow) != 0 {
-		integrationAttributes["subscription_allow_list"] = integration.Allow
-	} else if len(integration.Deny) != 0 {
-		integrationAttributes["subscription_deny_list"] = integration.Deny
-	}
-
-	resourceMondooIntegration := tfgen.NewResource("mondoo_integration_azure", "this",
-		tfgen.HclResourceWithAttributes(integrationAttributes),
-	)
-
-	blocks, err := tfgen.ObjectsToBlocks(
+	dynamicObjects := []tfgen.Object{
 		providerMondoo,
 		providerAzureAD,
 		providerAzureRM,
@@ -212,11 +185,50 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 		resourceADServicePrincipal,
 		resourceAdApplication,
 		resourceADReadersDirectoryRole,
-		resourceRMReaderRoleAssignment,
 		resourceADReadersRoleAssignment,
 		resourceTimeSleep,
-		resourceMondooIntegration,
+	}
+	integrationDependsOn := []any{
+		resourceADServicePrincipal.TraverseRef(),
+		resourceADApplicationCertificate.TraverseRef(),
+		resourceADReadersRoleAssignment.TraverseRef(),
+	}
+
+	// Allow and Deny are mutually exclusive and can't be added together
+	if len(integration.Allow) != 0 {
+		// add the mondoo integration resource attribute
+		integrationAttributes["subscription_allow_list"] = integration.Allow
+		// grant reader role to only the allowed list of subscriptions
+		readerRoleAssignmentBlocks, dependencies := azureRMReaderRoleAssignmentBlocks(integration.Allow, resourceADServicePrincipal)
+		dynamicObjects = append(dynamicObjects, readerRoleAssignmentBlocks...)
+		integrationDependsOn = append(integrationDependsOn, dependencies...)
+	} else if len(integration.Deny) != 0 {
+		// add the mondoo integration resource attribute
+		integrationAttributes["subscription_deny_list"] = integration.Deny
+		// TODO can we skip subscriptions if deny is provided
+	} else {
+		// grant reader role to all subscriptions
+		resourceRMReaderRoleAssignment := tfgen.NewResource("azurerm_role_assignment", "reader",
+			tfgen.HclResourceWithAttributes(tfgen.Attributes{
+				"role_definition_name": "Reader",
+
+				"count":        tfgen.NewFuncCall("length", dataRMAllSubscriptions.TraverseRef("subscriptions")),
+				"scope":        dataRMAllSubscriptions.TraverseRef("subscriptions[count.index]", "id"),
+				"principal_id": resourceADServicePrincipal.TraverseRef("object_id"),
+			}),
+		)
+		dynamicObjects = append(dynamicObjects, resourceRMReaderRoleAssignment)
+		integrationDependsOn = append(integrationDependsOn, resourceRMReaderRoleAssignment.TraverseRef())
+	}
+
+	// add the main mondoo integration
+	integrationAttributes["depends_on"] = integrationDependsOn
+	resourceMondooIntegration := tfgen.NewResource("mondoo_integration_azure", "this",
+		tfgen.HclResourceWithAttributes(integrationAttributes),
 	)
+	dynamicObjects = append(dynamicObjects, resourceMondooIntegration)
+
+	blocks, err := tfgen.ObjectsToBlocks(dynamicObjects...)
 	if err != nil {
 		return "", err
 	}
@@ -234,6 +246,29 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 	}
 
 	return tfgen.CreateHclStringOutput(hclBlocks...), nil
+}
+
+// azureRMReaderRoleAssignmentBlocks creates role assignment blocks for a list of subscription IDs,
+// it returns the resources and the list of depends_on objects
+func azureRMReaderRoleAssignmentBlocks(subscriptionIDs []string, resourceADServicePrincipal *tfgen.HclResource) ([]tfgen.Object, []any) {
+	resources := []tfgen.Object{}
+	dependsOn := []any{}
+
+	for i, subscriptionID := range subscriptionIDs {
+		resource := tfgen.NewResource("azurerm_role_assignment", fmt.Sprintf("reader-%d", i),
+			tfgen.HclResourceWithAttributes(tfgen.Attributes{
+				"role_definition_name": "Reader",
+				// For scope format see:
+				// https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment
+				"scope":        fmt.Sprintf("/subscriptions/%s", subscriptionID),
+				"principal_id": resourceADServicePrincipal.TraverseRef("object_id"),
+			}),
+		)
+		resources = append(resources, resource)
+		dependsOn = append(dependsOn, resource.TraverseRef())
+	}
+
+	return resources, dependsOn
 }
 
 type AzAccount struct {

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package onboarding_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	subject "go.mondoo.com/cnspec/v11/internal/onboarding"
+)
+
+func TestGenerateAzureHCL(t *testing.T) {
+	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{})
+	assert.Nil(t, err)
+	expected := `terraform {
+  required_providers {
+    mondoo = {
+      source  = "mondoohq/mondoo"
+      version = "~> 0.19"
+    }
+  }
+}
+
+provider "mondoo" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+
+  features {
+  }
+}
+
+data "azuread_client_config" "current" {
+}
+
+data "azurerm_subscriptions" "available" {
+}
+
+resource "tls_private_key" "credential" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "credential" {
+  allowed_uses          = ["key_encipherment", "digital_signature", "data_encipherment", "cert_signing"]
+  early_renewal_hours   = 3
+  private_key_pem       = tls_private_key.credential.private_key_pem
+  validity_period_hours = 4096
+
+  subject {
+    common_name = "mondoo"
+  }
+}
+
+resource "azuread_application_certificate" "mondoo" {
+  application_id = azuread_application.mondoo.id
+  type           = "AsymmetricX509Cert"
+  value          = tls_self_signed_cert.credential.cert_pem
+}
+
+resource "azuread_service_principal" "mondoo" {
+  client_id = azuread_application.mondoo.client_id
+  owners    = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_application" "mondoo" {
+  display_name  = "mondoo_security"
+  marketing_url = "https://www.mondoo.com/"
+  owners        = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_directory_role" "readers" {
+  display_name = "Directory Readers"
+}
+
+resource "azuread_directory_role_assignment" "readers" {
+  depends_on          = [time_sleep.wait_time]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  role_id             = azuread_directory_role.readers.template_id
+}
+
+resource "time_sleep" "wait_time" {
+  create_duration = "60s"
+}
+
+resource "azurerm_role_assignment" "reader" {
+  count                = length(data.azurerm_subscriptions.available.subscriptions)
+  principal_id         = azuread_service_principal.mondoo.object_id
+  role_definition_name = "Reader"
+  scope                = data.azurerm_subscriptions.available.subscriptions[count.index].id
+}
+
+resource "mondoo_integration_azure" "this" {
+  client_id = azuread_application.mondoo.client_id
+  credentials = {
+    pem_file = join("\n", [tls_self_signed_cert.credential.cert_pem, tls_private_key.credential.private_key_pem])
+  }
+  depends_on = [azuread_service_principal.mondoo, azuread_application_certificate.mondoo, azuread_directory_role_assignment.readers, azurerm_role_assignment.reader]
+  name       = "subscription-"
+  scan_vms   = false
+  tenant_id  = data.azuread_client_config.current.tenant_id
+}
+`
+	assert.Equal(t, expected, code)
+}
+
+func TestGenerateAzureHCLFull(t *testing.T) {
+	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{
+		Name:    "test-integration",
+		Space:   "hungry-poet-1234",
+		Primary: "abc-123-xyz-456-1",
+		Allow:   []string{"abc-123-xyz-456-1", "abc-123-xyz-456-2", "abc-123-xyz-456-3"},
+		ScanVMs: true,
+	})
+	assert.Nil(t, err)
+	expected := `terraform {
+  required_providers {
+    mondoo = {
+      source  = "mondoohq/mondoo"
+      version = "~> 0.19"
+    }
+  }
+}
+
+provider "mondoo" {
+  space = "hungry-poet-1234"
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  subscription_id = "abc-123-xyz-456-1"
+
+  features {
+  }
+}
+
+data "azuread_client_config" "current" {
+}
+
+data "azurerm_subscriptions" "available" {
+}
+
+resource "tls_private_key" "credential" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "credential" {
+  allowed_uses          = ["key_encipherment", "digital_signature", "data_encipherment", "cert_signing"]
+  early_renewal_hours   = 3
+  private_key_pem       = tls_private_key.credential.private_key_pem
+  validity_period_hours = 4096
+
+  subject {
+    common_name = "mondoo"
+  }
+}
+
+resource "azuread_application_certificate" "mondoo" {
+  application_id = azuread_application.mondoo.id
+  type           = "AsymmetricX509Cert"
+  value          = tls_self_signed_cert.credential.cert_pem
+}
+
+resource "azuread_service_principal" "mondoo" {
+  client_id = azuread_application.mondoo.client_id
+  owners    = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_application" "mondoo" {
+  display_name  = "mondoo_security"
+  marketing_url = "https://www.mondoo.com/"
+  owners        = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_directory_role" "readers" {
+  display_name = "Directory Readers"
+}
+
+resource "azuread_directory_role_assignment" "readers" {
+  depends_on          = [time_sleep.wait_time]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  role_id             = azuread_directory_role.readers.template_id
+}
+
+resource "time_sleep" "wait_time" {
+  create_duration = "60s"
+}
+
+resource "azurerm_role_assignment" "reader-0" {
+  principal_id         = azuread_service_principal.mondoo.object_id
+  role_definition_name = "Reader"
+  scope                = "/subscriptions/abc-123-xyz-456-1"
+}
+
+resource "azurerm_role_assignment" "reader-1" {
+  principal_id         = azuread_service_principal.mondoo.object_id
+  role_definition_name = "Reader"
+  scope                = "/subscriptions/abc-123-xyz-456-2"
+}
+
+resource "azurerm_role_assignment" "reader-2" {
+  principal_id         = azuread_service_principal.mondoo.object_id
+  role_definition_name = "Reader"
+  scope                = "/subscriptions/abc-123-xyz-456-3"
+}
+
+resource "mondoo_integration_azure" "this" {
+  client_id = azuread_application.mondoo.client_id
+  credentials = {
+    pem_file = join("\n", [tls_self_signed_cert.credential.cert_pem, tls_private_key.credential.private_key_pem])
+  }
+  depends_on              = [azuread_service_principal.mondoo, azuread_application_certificate.mondoo, azuread_directory_role_assignment.readers, azurerm_role_assignment.reader-0, azurerm_role_assignment.reader-1, azurerm_role_assignment.reader-2]
+  name                    = "test-integration"
+  scan_vms                = true
+  subscription_allow_list = ["abc-123-xyz-456-1", "abc-123-xyz-456-2", "abc-123-xyz-456-3"]
+  tenant_id               = data.azuread_client_config.current.tenant_id
+}
+
+resource "azurerm_role_assignment" "mondoo_security" {
+  count              = length(data.azurerm_subscriptions.available.subscriptions)
+  principal_id       = azuread_service_principal.mondoo.object_id
+  role_definition_id = azurerm_role_definition.mondoo_security.role_definition_resource_id
+  scope              = data.azurerm_subscriptions.available.subscriptions[count.index].id
+}
+
+resource "azurerm_role_definition" "mondoo_security" {
+  assignable_scopes = data.azurerm_subscriptions.available.subscriptions[*].id
+  description       = "Allow Mondoo Security to use run commands for Virtual Machine scanning"
+  name              = "tf-mondoo-security-role"
+  scope             = "/subscriptions/abc-123-xyz-456-1"
+
+  permissions {
+    actions  = ["Microsoft.Compute/virtualMachines/runCommands/read", "Microsoft.Compute/virtualMachines/runCommands/write", "Microsoft.Compute/virtualMachines/runCommands/delete", "Microsoft.Compute/virtualMachines/runCommand/action"]
+  }
+}
+`
+	assert.Equal(t, expected, code)
+}


### PR DESCRIPTION
Improve our onboarding for azure to only add reader role to the selected subscriptions and
not all of them.

When we pass the `--allow` flag(s):
```bash
$ cnspec integrate azure --space epic-mclaren-654267 --allow 3cd8b376-ada6-4c01-afc3-84d4b7d7da9a --allow 8b7a5c6b-433b-4d12-baba-b4174f1e2fea
→ using space //captain.api.mondoo.app/spaces/epic-mclaren-654267
→ verifying role assignments for the currently logged-in user
→ user service principal ead44178-3739-4df5-bbcd-02b88de9d12a
→ role assignment Privileged Role Administrator found
→ generating automation code
→ integration name not provided, using subscription-84d4b7d7da9a
→ code stored at /Users/afiune/.config/mondoo/onboarding/azure
→ existing Terraform path /opt/homebrew/bin/terraform
→ existing Terraform version 1.8.5
→ using existing Terraform install
→ initializing automation code (terraform init)
→ creating execution plan (terraform plan)
→ getting terraform plan details

Automation code and plan output saved in /Users/afiune/.config/mondoo/onboarding/azure

The generated code can be executed at any point in the future using the following commands:
  cd /Users/afiune/.config/mondoo/onboarding/azure
  /opt/homebrew/bin/terraform plan
  /opt/homebrew/bin/terraform apply
```

We now generated code like this one:
```hcl
terraform {
  required_providers {
    mondoo = {
      source  = "mondoohq/mondoo"
      version = "~> 0.19"
    }
  }
}

provider "mondoo" {
  space = "epic-mclaren-654267"
}

provider "azuread" {
}

provider "azurerm" {
  subscription_id = "3cd8b376-ada6-4c01-afc3-84d4b7d7da9a"

  features {
  }
}

data "azuread_client_config" "current" {
}

data "azurerm_subscriptions" "available" {
}

resource "tls_private_key" "credential" {
  algorithm = "RSA"
}

resource "tls_self_signed_cert" "credential" {
  allowed_uses          = ["key_encipherment", "digital_signature", "data_encipherment", "cert_signing"]
  early_renewal_hours   = 3
  private_key_pem       = tls_private_key.credential.private_key_pem
  validity_period_hours = 4096

  subject {
    common_name = "mondoo"
  }
}

resource "azuread_application_certificate" "mondoo" {
  application_id = azuread_application.mondoo.id
  type           = "AsymmetricX509Cert"
  value          = tls_self_signed_cert.credential.cert_pem
}

resource "azuread_service_principal" "mondoo" {
  client_id = azuread_application.mondoo.client_id
  owners    = [data.azuread_client_config.current.object_id]
}

resource "azuread_application" "mondoo" {
  display_name  = "mondoo_security"
  marketing_url = "https://www.mondoo.com/"
  owners        = [data.azuread_client_config.current.object_id]
}

resource "azuread_directory_role" "readers" {
  display_name = "Directory Readers"
}

resource "azuread_directory_role_assignment" "readers" {
  depends_on          = [time_sleep.wait_time]
  principal_object_id = azuread_service_principal.mondoo.object_id
  role_id             = azuread_directory_role.readers.template_id
}

resource "time_sleep" "wait_time" {
  create_duration = "60s"
}

resource "azurerm_role_assignment" "reader-0" {
  principal_id         = azuread_service_principal.mondoo.object_id
  role_definition_name = "Reader"
  scope                = "/subscriptions/3cd8b376-ada6-4c01-afc3-84d4b7d7da9a"
}

resource "azurerm_role_assignment" "reader-1" {
  principal_id         = azuread_service_principal.mondoo.object_id
  role_definition_name = "Reader"
  scope                = "/subscriptions/8b7a5c6b-433b-4d12-baba-b4174f1e2fea"
}

resource "mondoo_integration_azure" "this" {
  client_id = azuread_application.mondoo.client_id
  credentials = {
    pem_file = join("\n", [tls_self_signed_cert.credential.cert_pem, tls_private_key.credential.private_key_pem])
  }
  depends_on              = [azuread_service_principal.mondoo, azuread_application_certificate.mondoo, azuread_directory_role_assignment.readers, azurerm_role_assignment.reader-0, azurerm_role_assignment.reader-1]
  name                    = "subscription-84d4b7d7da99"
  scan_vms                = false
  subscription_allow_list = ["3cd8b376-ada6-4c01-afc3-84d4b7d7da9a", "8b7a5c6b-433b-4d12-baba-b4174f1e2fea"]
  tenant_id               = data.azuread_client_config.current.tenant_id
}
```

Note that now we have multiple `reader-X` resources that matches with our Mondoo integration resource attribute `subscription_allow_list`.