### PR TITLE
Notify when a policy checksum must be recalculated

### DIFF
--- a/internal/datalakes/inmemory/assets.go
+++ b/internal/datalakes/inmemory/assets.go
@@ -69,7 +69,7 @@ func (db *Db) ensureAsset(ctx context.Context, mrn string) (wrapAsset, wrapPolic
 
 func (db *Db) ensureAssetPolicy(ctx context.Context, mrn string) (wrapPolicy, error) {
 	policyObj := db.services.CreatePolicyObject(mrn, "")
-	policyObj, filters, err := db.services.PreparePolicy(ctx, policyObj, nil)
+	policyObj, filters, _, err := db.services.PreparePolicy(ctx, policyObj, nil)
 	if err != nil {
 		return wrapPolicy{}, err
 	}

--- a/internal/datalakes/inmemory/policyresolver.go
+++ b/internal/datalakes/inmemory/policyresolver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
@@ -185,7 +186,8 @@ func (db *Db) mutatePolicy(ctx context.Context, mrn string, actions map[string]e
 	}
 
 	policyw.Policy.InvalidateExecutionChecksums()
-	err = policyw.Policy.UpdateChecksums(ctx,
+	_, err = policyw.Policy.UpdateChecksums(ctx,
+		time.Now(),
 		func(ctx context.Context, mrn string) (*policy.Policy, error) { return db.GetValidatedPolicy(ctx, mrn) },
 		func(ctx context.Context, mrn string) (*explorer.Mquery, error) { return db.GetQuery(ctx, mrn) },
 		nil,
@@ -369,7 +371,8 @@ func (db *Db) refreshDependentAssetFilters(ctx context.Context, startPolicy wrap
 			}
 
 			policyw.Policy.InvalidateGraphChecksums()
-			err = policyw.Policy.UpdateChecksums(ctx,
+			_, err = policyw.Policy.UpdateChecksums(ctx,
+				time.Now(),
 				func(ctx context.Context, mrn string) (*policy.Policy, error) { return db.GetValidatedPolicy(ctx, mrn) },
 				func(ctx context.Context, mrn string) (*explorer.Mquery, error) { return db.GetQuery(ctx, mrn) },
 				nil,
@@ -993,7 +996,8 @@ func (db *Db) SetProps(ctx context.Context, req *explorer.PropsReq) error {
 	}
 
 	policyw.Policy.InvalidateExecutionChecksums()
-	err = policyw.Policy.UpdateChecksums(ctx,
+	_, err = policyw.Policy.UpdateChecksums(ctx,
+		time.Now(),
 		func(ctx context.Context, mrn string) (*policy.Policy, error) { return db.GetValidatedPolicy(ctx, mrn) },
 		func(ctx context.Context, mrn string) (*explorer.Mquery, error) { return db.GetQuery(ctx, mrn) },
 		nil,

--- a/policy/datalake.go
+++ b/policy/datalake.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"context"
+	"time"
 
 	"go.mondoo.com/cnquery/v11/explorer"
 	"go.mondoo.com/cnquery/v11/explorer/resources"
@@ -59,7 +60,7 @@ type DataLake interface {
 	// GetRawPolicy retrieves the policy without fixing any invalidations (fast)
 	GetRawPolicy(ctx context.Context, mrn string) (*Policy, error)
 	// SetPolicy stores a given policy in the data lake
-	SetPolicy(ctx context.Context, policy *Policy, filters []*explorer.Mquery) error
+	SetPolicy(ctx context.Context, policy *Policy, recalculateAt *time.Time, filters []*explorer.Mquery) error
 	// SetRiskFactor creates and stores a risk factor
 	SetRiskFactor(ctx context.Context, ownerMrn string, riskFactor *RiskFactor) error
 

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -451,7 +451,7 @@ func (s *LocalServices) resolve(ctx context.Context, policyMrn string, assetFilt
 }
 
 func (s *LocalServices) tryResolve(ctx context.Context, bundleMrn string, assetFilters []*explorer.Mquery) (*ResolvedPolicy, error) {
-	now := time.Now()
+	now := s.NowProvider()
 	conf := s.NewCompilerConfig()
 
 	// phase 1: resolve asset filters and see if we can find a cached policy

--- a/policy/services.go
+++ b/policy/services.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"go.mondoo.com/cnquery/v11"
 	"go.mondoo.com/cnquery/v11/explorer/transport"
@@ -41,19 +42,21 @@ type Services struct {
 // yield results for a request, and the upstream handler is defined, it will
 // be used instead.
 type LocalServices struct {
-	DataLake  DataLake
-	Upstream  *Services
-	Incognito bool
-	Runtime   llx.Runtime
+	DataLake    DataLake
+	Upstream    *Services
+	Incognito   bool
+	Runtime     llx.Runtime
+	NowProvider func() time.Time
 }
 
 // NewLocalServices initializes a reasonably configured local services struct
 func NewLocalServices(datalake DataLake, uuid string, runtime llx.Runtime) *LocalServices {
 	return &LocalServices{
-		DataLake:  datalake,
-		Upstream:  nil,
-		Incognito: false,
-		Runtime:   runtime,
+		DataLake:    datalake,
+		Upstream:    nil,
+		Incognito:   false,
+		Runtime:     runtime,
+		NowProvider: time.Now,
 	}
 }
 


### PR DESCRIPTION
The execution checksum needs to change as time passes a groups start and end. This change returns to the caller when the checksum should be recomputed