### PR TITLE
🐛 Policy list -a limit fix

### DIFF
--- a/upstream/gql.go
+++ b/upstream/gql.go
@@ -36,26 +36,26 @@ func SearchPolicy(
 	var policies []*UpstreamPolicy
 	var after *mondoogql.String = nil
 
-	for {
-		var q struct {
-			Content struct {
-				TotalCount int `json:"totalCount"`
-				Edges      []struct {
-					Cursor string `json:"cursor"`
-					Node   struct {
-						Policy struct {
-							Mrn        string
-							Name       string
-							TrustLevel mondoogql.TrustLevel
-							Action     mondoogql.PolicyAction
-							Assigned   bool
-						} `graphql:"... on Policy"`
-					} `json:"node"`
-				} `json:"edges"`
-				PageInfo PageInfo `json:"pageInfo"`
-			} `graphql:"content(input: $input)"`
-		}
+	var q struct {
+		Content struct {
+			TotalCount int `json:"totalCount"`
+			Edges      []struct {
+				Cursor string `json:"cursor"`
+				Node   struct {
+					Policy struct {
+						Mrn        string
+						Name       string
+						TrustLevel mondoogql.TrustLevel
+						Action     mondoogql.PolicyAction
+						Assigned   bool
+					} `graphql:"... on Policy"`
+				} `json:"node"`
+			} `json:"edges"`
+			PageInfo PageInfo `json:"pageInfo"`
+		} `graphql:"content(input: $input)"`
+	}
 
+	for {
 		input := mondoogql.ContentSearchInput{
 			ScopeMrn:    mondoogql.String(scopeMrn),
 			CatalogType: mondoogql.CatalogType("POLICY"),
@@ -74,7 +74,8 @@ func SearchPolicy(
 		if includePrivate != nil {
 			input.IncludePrivate = mondoogql.NewBooleanPtr(mondoogql.Boolean(*includePrivate))
 		}
-		err := c.Query(ctx, &q, map[string]interface{}{
+
+		err := c.Query(ctx, &q, map[string]any{
 			"input": input,
 		})
 		if err != nil {

--- a/upstream/gql.go
+++ b/upstream/gql.go
@@ -55,24 +55,26 @@ func SearchPolicy(
 		} `graphql:"content(input: $input)"`
 	}
 
-	for {
-		input := mondoogql.ContentSearchInput{
-			ScopeMrn:    mondoogql.String(scopeMrn),
-			CatalogType: mondoogql.CatalogType("POLICY"),
-		}
+	input := mondoogql.ContentSearchInput{
+		ScopeMrn:    mondoogql.String(scopeMrn),
+		CatalogType: mondoogql.CatalogType("POLICY"),
+	}
 
+	if assignedOnly != nil {
+		input.AssignedOnly = mondoogql.NewBooleanPtr(mondoogql.Boolean(*assignedOnly))
+	}
+	if includePublic != nil {
+		input.IncludePublic = mondoogql.NewBooleanPtr(mondoogql.Boolean(*includePublic))
+	}
+	if includePrivate != nil {
+		input.IncludePrivate = mondoogql.NewBooleanPtr(mondoogql.Boolean(*includePrivate))
+	}
+
+	for {
 		if after != nil {
 			input.After = after
-		}
-
-		if assignedOnly != nil {
-			input.AssignedOnly = mondoogql.NewBooleanPtr(mondoogql.Boolean(*assignedOnly))
-		}
-		if includePublic != nil {
-			input.IncludePublic = mondoogql.NewBooleanPtr(mondoogql.Boolean(*includePublic))
-		}
-		if includePrivate != nil {
-			input.IncludePrivate = mondoogql.NewBooleanPtr(mondoogql.Boolean(*includePrivate))
+		} else {
+			input.After = nil
 		}
 
 		err := c.Query(ctx, &q, map[string]any{


### PR DESCRIPTION
This fixes the issue where `cnspec policy list -a` only returns 200 items, it will now return all of them. 

#### Current Master
<img width="789" alt="Screenshot 2025-05-12 at 11 57 03 AM" src="https://github.com/user-attachments/assets/8f23b5f2-32ca-4194-918b-74642403084f" />

#### This PR
<img width="781" alt="Screenshot 2025-05-12 at 11 57 21 AM" src="https://github.com/user-attachments/assets/8fe72347-66f6-4170-834c-acb54e292a9a" />
