### PR TITLE
⭐️ cnspec report compare

### DIFF
--- a/apps/cnspec/cmd/report.go
+++ b/apps/cnspec/cmd/report.go
@@ -23,20 +23,20 @@ var reportCmd = &cobra.Command{
 }
 
 var cmpReportCmd = &cobra.Command{
-	Use:   "cmp <expected> <compare>",
+	Use:   "cmp <expected> <actual>",
 	Short: "Compare cnspec reports",
 	Run: func(cmd *cobra.Command, args []string) {
-		base := args[0]
-		compare := args[1]
+		expected := args[0]
+		actual := args[1]
 
-		expectedReport, err := reporter.FromSingleFile(base)
+		expectedReport, err := reporter.FromSingleFile(expected)
 		if err != nil {
-			log.Fatal().Err(err).Str("base", base).Msg("failed to load base report")
+			log.Fatal().Err(err).Str("expected", expected).Msg("failed to load expected report")
 		}
 
-		compareReport, err := reporter.FromSingleFile(compare)
+		compareReport, err := reporter.FromSingleFile(actual)
 		if err != nil {
-			log.Fatal().Err(err).Str("base", base).Msg("failed to load base report")
+			log.Fatal().Err(err).Str("actual", actual).Msg("failed to load actual report")
 		}
 
 		equal := reporter.CompareReports(expectedReport, compareReport)

--- a/apps/cnspec/cmd/report.go
+++ b/apps/cnspec/cmd/report.go
@@ -1,0 +1,48 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/v11/cli/reporter"
+)
+
+func init() {
+	reportCmd.AddCommand(cmpReportCmd)
+	rootCmd.AddCommand(reportCmd)
+}
+
+var reportCmd = &cobra.Command{
+	Use:    "report",
+	Short:  "Report commands (Experimental)",
+	Hidden: true,
+}
+
+var cmpReportCmd = &cobra.Command{
+	Use:   "cmp <expected> <compare>",
+	Short: "Compare cnspec reports",
+	Run: func(cmd *cobra.Command, args []string) {
+		base := args[0]
+		compare := args[1]
+
+		expectedReport, err := reporter.FromSingleFile(base)
+		if err != nil {
+			log.Fatal().Err(err).Str("base", base).Msg("failed to load base report")
+		}
+
+		compareReport, err := reporter.FromSingleFile(compare)
+		if err != nil {
+			log.Fatal().Err(err).Str("base", base).Msg("failed to load base report")
+		}
+
+		equal := reporter.CompareReports(expectedReport, compareReport)
+		// return 1 if the reports are not equal
+		if !equal {
+			os.Exit(1)
+		}
+	},
+}

--- a/cli/reporter/cnspec_report.go
+++ b/cli/reporter/cnspec_report.go
@@ -1,0 +1,55 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"errors"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+func (v *ScoreValues) GetScore(mrn string) *ScoreValue {
+	if s, ok := v.Values[mrn]; ok {
+		return s
+	}
+
+	return nil
+}
+
+// FromSingleFile loads a cnspec report bundle from a single file
+func FromSingleFile(path string) (*Report, error) {
+	reportData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return FromJSON(reportData)
+}
+
+// FromJSON creates a cnspec report from json contents
+func FromJSON(data []byte) (*Report, error) {
+	var res Report
+	err := yaml.Unmarshal(data, &res)
+	return &res, err
+}
+
+// AssetMrn returns the MRN of the asset if there is only one
+func (r Report) AssetMrn() (string, error) {
+
+	if len(r.Assets) > 1 {
+		return "", errors.New("report contains more than one asset")
+	}
+
+	if len(r.Assets) == 0 {
+		return "", errors.New("report contains no assets")
+	}
+
+	for _, asset := range r.Assets {
+		return asset.Mrn, nil
+	}
+
+	// should not happen
+	return "", errors.New("report contains no assets")
+}

--- a/cli/reporter/cnspec_report.go
+++ b/cli/reporter/cnspec_report.go
@@ -4,7 +4,6 @@
 package reporter
 
 import (
-	"errors"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -33,23 +32,4 @@ func FromJSON(data []byte) (*Report, error) {
 	var res Report
 	err := yaml.Unmarshal(data, &res)
 	return &res, err
-}
-
-// AssetMrn returns the MRN of the asset if there is only one
-func (r Report) AssetMrn() (string, error) {
-
-	if len(r.Assets) > 1 {
-		return "", errors.New("report contains more than one asset")
-	}
-
-	if len(r.Assets) == 0 {
-		return "", errors.New("report contains no assets")
-	}
-
-	for _, asset := range r.Assets {
-		return asset.Mrn, nil
-	}
-
-	// should not happen
-	return "", errors.New("report contains no assets")
 }

--- a/cli/reporter/cnspec_report_compare.go
+++ b/cli/reporter/cnspec_report_compare.go
@@ -29,7 +29,7 @@ func CompareReports(baseReport, compareReport *Report) bool {
 		similarAsset := FindSameAsset(baseAsset.Name, compareReport.Assets)
 		if similarAsset == "" {
 			log.Info().Msgf("🔴 asset %q is missing in compare report", baseAsset.Name)
-			equal = true
+			equal = false
 			continue
 		}
 
@@ -39,8 +39,8 @@ func CompareReports(baseReport, compareReport *Report) bool {
 		}
 	}
 
-	if equal {
-		log.Info().Msg("🔴 reports differ")
+	if !equal {
+		log.Info().Msg("🔴 reports are not equal")
 	} else {
 		log.Info().Msg("✅ reports are equal")
 	}

--- a/cli/reporter/cnspec_report_compare.go
+++ b/cli/reporter/cnspec_report_compare.go
@@ -1,0 +1,127 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/rs/zerolog/log"
+	cnquery_reporter "go.mondoo.com/cnquery/v11/cli/reporter"
+)
+
+func FindSameAsset(name string, assets map[string]*cnquery_reporter.Asset) string {
+	for k := range assets {
+		if assets[k].Name == name {
+			return assets[k].Mrn
+		}
+	}
+	return ""
+}
+
+func CompareReports(baseReport, compareReport *Report) bool {
+	equal := true
+	for mrn := range baseReport.Assets {
+
+		baseAsset := baseReport.Assets[mrn]
+		// best bet is to compare the asset based on the name until we have the platform id exposed
+		similarAsset := FindSameAsset(baseAsset.Name, compareReport.Assets)
+		if similarAsset == "" {
+			log.Info().Msgf("🔴 asset %q is missing in compare report", baseAsset.Name)
+			equal = true
+			continue
+		}
+
+		cmp := CompareAsset(baseReport, mrn, compareReport, similarAsset)
+		if !cmp {
+			equal = false
+		}
+	}
+
+	if equal {
+		log.Info().Msg("🔴 reports differ")
+	} else {
+		log.Info().Msg("✅ reports are equal")
+	}
+	return equal
+}
+
+// CompareAsset returns true if the reports are equal
+func CompareAsset(baseReport *Report, baseAssetMrn string, compareReport *Report, compareAssetMrn string) bool {
+	log.Info().Msgf("🔍 comparing asset %s with %s", baseReport.Assets[baseAssetMrn].Name, compareReport.Assets[compareAssetMrn].Name)
+
+	equal := true
+	// compare asset data, we ignore the mrn field
+	baseAsset := baseReport.Assets[baseAssetMrn]
+	baseAsset.Mrn = ""
+	compareAsset := compareReport.Assets[compareAssetMrn]
+	compareAsset.Mrn = ""
+	if !reflect.DeepEqual(baseAsset, compareAsset) {
+		log.Info().Msgf("🔴 assets are different:")
+		log.Info().Msgf("   expected: %s", printAsJSON(baseAsset))
+		log.Info().Msgf("   got     : %s", printAsJSON(compareAsset))
+		equal = false
+	}
+
+	// gather scores
+	baseAssetScores := baseReport.Scores[baseAssetMrn]
+	compareAssetScores := compareReport.Scores[compareAssetMrn]
+
+	// compare asset scores
+	if !compareScores(baseAssetMrn, baseAssetScores.GetScore(baseAssetMrn), compareAssetScores.GetScore(compareAssetMrn)) {
+		equal = false
+	}
+
+	// compare checks results
+	visited := make(map[string]bool)
+	for check, baseResult := range baseAssetScores.Values {
+		// ignore base asset mrn
+		if check == baseAssetMrn {
+			continue
+		}
+
+		compareResult := compareAssetScores.GetScore(check)
+		if compareResult == nil {
+			log.Info().Msgf("🔴 check %q is missing in compare report", check)
+			equal = false
+			continue
+		}
+
+		if !compareScores(check, baseResult, compareResult) {
+			equal = false
+		}
+
+		visited[check] = true
+	}
+
+	// check if there are any checks in the compare report that are not in the base report
+	for checkMrn := range compareAssetScores.Values {
+		if checkMrn == baseAssetMrn || checkMrn == compareAssetMrn {
+			continue
+		}
+		if !visited[checkMrn] {
+			log.Info().Msgf("🔴 check %q is missing in base report", checkMrn)
+			equal = false
+		}
+	}
+
+	return equal
+}
+
+func printAsJSON(v any) string {
+	data, _ := json.Marshal(v)
+	return string(data)
+}
+
+// compareScores compares the scores of two checks, if they are not equal, it will log the difference
+// and return false, otherwise it will return true
+func compareScores(check string, baseResults *ScoreValue, compareResults *ScoreValue) bool {
+	if !reflect.DeepEqual(baseResults, compareResults) {
+		log.Info().Msgf("🔴 check %q got different results", check)
+		log.Info().Msgf("   expected:      %s", printAsJSON(baseResults))
+		log.Info().Msgf("   got     : %s", printAsJSON(compareResults))
+		return false
+	}
+	return true
+}

--- a/cli/reporter/cnspec_report_compare_test.go
+++ b/cli/reporter/cnspec_report_compare_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportComparison(t *testing.T) {
+	passReport, err := FromSingleFile("testdata/cnspec_report_pass.json")
+	require.NoError(t, err)
+
+	failReport, err := FromSingleFile("testdata/cnspec_report_mixed.json")
+	require.NoError(t, err)
+
+	t.Run("pass vs pass", func(t *testing.T) {
+		equal := CompareReports(passReport, passReport)
+		assert.True(t, equal)
+
+	})
+
+	t.Run("pass vs fail", func(t *testing.T) {
+		equal := CompareReports(passReport, failReport)
+		require.False(t, equal)
+	})
+}
+
+func TestReportComparisonWithExplicitMrn(t *testing.T) {
+	passAssetMrn := "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuAAzk"
+	passReport, err := FromSingleFile("testdata/cnspec_report_pass.json")
+	require.NoError(t, err)
+
+	failAssetMrn := "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuQKwk"
+	failReport, err := FromSingleFile("testdata/cnspec_report_mixed.json")
+	require.NoError(t, err)
+
+	t.Run("pass vs pass", func(t *testing.T) {
+		equal := CompareAsset(passReport, passAssetMrn, passReport, passAssetMrn)
+		assert.True(t, equal)
+	})
+
+	t.Run("pass vs fail", func(t *testing.T) {
+		equal := CompareAsset(passReport, passAssetMrn, failReport, failAssetMrn)
+		require.False(t, equal)
+	})
+}

--- a/cli/reporter/testdata/cnspec_report_mixed.json
+++ b/cli/reporter/testdata/cnspec_report_mixed.json
@@ -1,0 +1,22 @@
+{
+  "assets": {
+    "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuQKwk": {
+      "mrn": "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuQKwk",
+      "name": "mac.fritz.box",
+      "platformName": "macos"
+    }
+  },
+  "scores": {
+    "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuQKwk": {
+      "values": {
+        "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-control-access-to-audit-records": {
+          "score": 100,
+          "status": "pass"
+        },
+        "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-reduce-the-sudo-timeout-period": {
+          "status": "fail"
+        },
+      }
+    }
+  }
+}

--- a/cli/reporter/testdata/cnspec_report_pass.json
+++ b/cli/reporter/testdata/cnspec_report_pass.json
@@ -1,0 +1,23 @@
+{
+  "assets": {
+    "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuAAzk": {
+      "mrn": "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuAAzk",
+      "name": "mac.fritz.box",
+      "platformName": "macos"
+    }
+  },
+  "scores": {
+    "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuAAzk": {
+      "values": {
+        "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-control-access-to-audit-records": {
+          "score": 100,
+          "status": "pass"
+        },
+        "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-reduce-the-sudo-timeout-period": {
+          "score": 100,
+          "status": "pass"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We introduce a new experimental sub command to compare two different cnspec reports. First you can create a report via:

```bash
cnspec scan local --output json > cnspec_report.json
```

If you want to compare this report with an older one, just run `cnspec report cmp`

```bash
cnspec report cmp cli/reporter/testdata/cnspec_report_pass.json cli/reporter/testdata/cnspec_report_mixed.json
→ 🔍 comparing asset mac.fritz.box with mac.fritz.box
→ 🔴 check "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-reduce-the-sudo-timeout-period" got different results
→    expected:      {"score":100,"status":"pass"}
→    got     : {"status":"fail"}
→ ✅ reports are equal
```