### PR TITLE
🧹 avoid reporting panics from dev environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,13 @@ ifndef MANIFEST_VERSION
 MANIFEST_VERSION=$(shell git describe --abbrev=0 --tags)
 endif
 
-# The build in the Makefile is hardcoded to be "dev" for development
-# purposes like avoid sending alerts from our development environemnts.
-#
-# The real build tag is being set by our release pipelines.
-BUILD=dev
-
 ifndef VERSION
 # echo "read VERSION from git"
 VERSION=${LATEST_VERSION_TAG}+$(shell git rev-list --count HEAD)
 endif
 
-LDFLAGS=-ldflags "-s -w -X go.mondoo.com/cnspec/v11.Version=${VERSION} -X go.mondoo.com/cnspec/v11.Build=${BUILD}" # -linkmode external -extldflags=-static
-LDFLAGSDIST=-tags production -ldflags "-s -w -X go.mondoo.com/cnquery/v11.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnquery/v11.Build=${BUILD} -X go.mondoo.com/cnspec/v11.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnspec/v11.Build=${BUILD} -s -w"
+LDFLAGS=-ldflags "-s -w -X go.mondoo.com/cnspec/v11.Version=${VERSION}" # -linkmode external -extldflags=-static
+LDFLAGSDIST=-tags production -ldflags "-s -w -X go.mondoo.com/cnquery/v11.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnspec/v11.Version=${LATEST_VERSION_TAG} -s -w"
 
 .PHONY: info/ldflags
 info/ldflags:
@@ -160,7 +154,7 @@ license/headers/apply:
 metrics/start: metrics/grafana/start metrics/prometheus/start
 
 metrics/prometheus/start:
-	APP_NAME=cnspec VERSION=${VERSION} BUILD=${BUILD} prometheus --config.file=prometheus.yml
+	APP_NAME=cnspec VERSION=${VERSION} prometheus --config.file=prometheus.yml
 
 metrics/grafana/start:
 	docker run -d --name=grafana \


### PR DESCRIPTION
Depends on https://github.com/mondoohq/cnquery/pull/5604

When we are doing development, we may cause a panic on purpose, or by mistake.
On those cases, we don't want to report back to the platform.

Only production releases will.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOXA5NDF5ZGNqZTVvbDBzbTVhbXdzeTRwd2tldW4zdXp3MHUwNnlyeSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ES9cAJlcxblRESzOH1/giphy.gif"/>