### PR TITLE
Enable runtime auto-update configuration for LocalScanner

### DIFF
--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -70,7 +70,13 @@ var serveApiCmd = &cobra.Command{
 			Creds:       serviceAccount,
 		}
 
+		enabledAutoUpdate := true
+		if viper.IsSet("auto_update") {
+			enabledAutoUpdate = viper.GetBool("auto_update")
+		}
+
 		scanner := scan.NewLocalScanner(
+			scan.WithAutoUpdate(enabledAutoUpdate),
 			scan.WithUpstream(&upstreamConfig),
 			scan.DisableProgressBar(),
 			scan.WithRecording(recording.Null{}),

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -525,3 +525,64 @@ func (s *LocalScannerSuite) TestRunIncognito_Frameworks_Exceptions_OutOfScope() 
 func TestLocalScannerSuite(t *testing.T) {
 	suite.Run(t, new(LocalScannerSuite))
 }
+
+func TestNewLocalScannerWithOptions(t *testing.T) {
+	t.Run("default values", func(t *testing.T) {
+		scanner := NewLocalScanner()
+		require.NotNil(t, scanner)
+
+		assert.Nil(t, scanner.autoUpdate)
+		assert.Zero(t, scanner.refreshInterval)
+
+		rt, ok := scanner.runtime.(*providers.Runtime)
+		require.True(t, ok)
+		assert.True(t, rt.AutoUpdate.Enabled)
+		assert.Equal(t, defaultRefreshInterval, rt.AutoUpdate.RefreshInterval)
+	})
+
+	t.Run("with auto update disabled", func(t *testing.T) {
+		scanner := NewLocalScanner(WithAutoUpdate(false))
+		require.NotNil(t, scanner)
+
+		require.NotNil(t, scanner.autoUpdate)
+		assert.False(t, *scanner.autoUpdate)
+		assert.Zero(t, scanner.refreshInterval)
+
+		rt, ok := scanner.runtime.(*providers.Runtime)
+		require.True(t, ok)
+		assert.False(t, rt.AutoUpdate.Enabled)
+		assert.Equal(t, defaultRefreshInterval, rt.AutoUpdate.RefreshInterval)
+	})
+
+	t.Run("with custom refresh interval", func(t *testing.T) {
+		scanner := NewLocalScanner(WithRefreshInterval(1234))
+		require.NotNil(t, scanner)
+
+		assert.Nil(t, scanner.autoUpdate)
+		assert.Equal(t, 1234, scanner.refreshInterval)
+
+		rt, ok := scanner.runtime.(*providers.Runtime)
+		require.True(t, ok)
+		assert.True(t, rt.AutoUpdate.Enabled)
+		assert.Equal(t, 1234, rt.AutoUpdate.RefreshInterval)
+	})
+
+	t.Run("with custom runtime ignores auto-update option", func(t *testing.T) {
+		// Create a new runtime instance for this test to ensure isolation.
+		customRuntime := &providers.Runtime{
+			AutoUpdate: providers.UpdateProvidersConfig{
+				RefreshInterval: 9999,
+				Enabled:         false,
+			},
+		}
+		scanner := NewLocalScanner(WithRuntime(customRuntime), WithAutoUpdate(true), WithRefreshInterval(123))
+		require.NotNil(t, scanner)
+
+		assert.Same(t, customRuntime, scanner.runtime)
+
+		rt, ok := scanner.runtime.(*providers.Runtime)
+		require.True(t, ok)
+		assert.Equal(t, 9999, rt.AutoUpdate.RefreshInterval)
+		assert.False(t, rt.AutoUpdate.Enabled, "should not be modified if a custom runtime is provided")
+	})
+}

--- a/test/providers/scan_flags_test.go
+++ b/test/providers/scan_flags_test.go
@@ -4,6 +4,7 @@
 package providers
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,5 +73,18 @@ func TestScanFlags(t *testing.T) {
 		assert.Contains(t, string(r.Stderr()),
 			"could not read private key", // expected! it means we loaded the flags
 		)
+	})
+
+	t.Run("output contains no log messages", func(t *testing.T) {
+		r := test.NewCliTestRunner("./cnspec", "scan")
+		err := r.Run()
+		require.NoError(t, err)
+		assert.NotNil(t, r.Stdout())
+		assert.NotNil(t, r.Stderr())
+
+		// Verify that structured log entries (e.g., {"level": "debug", ...})
+		// are not leaked into the Stderr output
+		assert.NotContains(t, string(r.Stderr()), `"level":`,
+			fmt.Sprintf("output contains no log messages: %q\n", string(r.Stderr())))
 	})
 }


### PR DESCRIPTION
This PR introduces a new ScannerOption, scan.WithRuntimeAutoUpdate, that allows consumers to pass a providers.UpdateProvidersConfig struct. This configuration is then applied to the LocalScanner's runtime instance after its default initialization.