### PR TITLE
🧹 provide collector context externally

### DIFF
--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"context"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -20,7 +21,7 @@ type GraphExecutor interface {
 	Execute()
 }
 
-func ExecuteResolvedPolicy(runtime llx.Runtime, collectorSvc policy.PolicyResolver, assetMrn string,
+func ExecuteResolvedPolicy(ctx context.Context, runtime llx.Runtime, collectorSvc policy.PolicyResolver, assetMrn string,
 	resolvedPolicy *policy.ResolvedPolicy, features cnquery.Features, progressReporter progress.Progress,
 ) error {
 	var opts []internal.BufferedCollectorOpt
@@ -33,6 +34,7 @@ func ExecuteResolvedPolicy(runtime llx.Runtime, collectorSvc policy.PolicyResolv
 	}
 
 	collector := internal.NewBufferedCollector(
+		ctx,
 		internal.NewPolicyServiceCollector(assetMrn, collectorSvc),
 		opts...,
 	)

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1014,7 +1014,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	logger.DebugDumpJSON("resolvedPolicy", resolvedPolicy)
 
 	features := cnquery.GetFeatures(s.job.Ctx)
-	err = executor.ExecuteResolvedPolicy(s.Runtime, resolver, s.job.Asset.Mrn, resolvedPolicy, features, s.ProgressReporter)
+	err = executor.ExecuteResolvedPolicy(s.job.Ctx, s.Runtime, resolver, s.job.Asset.Mrn, resolvedPolicy, features, s.ProgressReporter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No functional changes here, just making sure we provide the context to the `BufferedCollector` externally instead of creating a background context for every request