### PR TITLE
🧹 use CloneVT instead of proto.Clone

### DIFF
--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -103,7 +103,7 @@ func (db *Db) GetRawPolicy(ctx context.Context, mrn string) (*policy.Policy, err
 	if !ok {
 		return nil, errors.New("policy '" + mrn + "' not found")
 	}
-	return proto.Clone((q.(wrapPolicy)).Policy).(*policy.Policy), nil
+	return (q.(wrapPolicy)).Policy.CloneVT(), nil
 }
 
 // GetPolicyFilters retrieves the list of asset filters for a policy (fast)
@@ -472,7 +472,7 @@ func (db *Db) GetValidatedBundle(ctx context.Context, mrn string) (*policy.Bundl
 		return nil, errors.New("failed to save bundle for '" + mrn + "' to cache")
 	}
 
-	return proto.Clone(bundle).(*policy.Bundle), nil
+	return bundle.CloneVT(), nil
 }
 
 // GetValidatedPolicy retrieves and if necessary updates the policy
@@ -491,7 +491,7 @@ func (db *Db) GetValidatedPolicy(ctx context.Context, mrn string) (*policy.Polic
 		}
 	}
 
-	return proto.Clone(p.Policy).(*policy.Policy), nil
+	return p.Policy.CloneVT(), nil
 }
 
 // entityGraphExecutionChecksum retrieves the execution checksum for a given entity.
@@ -624,7 +624,7 @@ func (db *Db) GetFramework(ctx context.Context, mrn string) (*policy.Framework, 
 		return nil, errors.New("framework '" + mrn + "' not found")
 	}
 
-	return proto.Clone(raw.(wrapFramework).Framework).(*policy.Framework), nil
+	return raw.(wrapFramework).Framework.CloneVT(), nil
 }
 
 // GetFrameworkMaps retrieves a set of framework maps for a given framework

--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -15,7 +15,6 @@ import (
 	"go.mondoo.com/cnquery/v11/utils/iox"
 	"go.mondoo.com/cnspec/v11"
 	"go.mondoo.com/cnspec/v11/policy"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -215,7 +214,7 @@ func (c *BufferedCollector) SinkScore(scores []*policy.Score) {
 	for _, s := range scores {
 		// We are making a clone of s. This safe-guards us is a
 		// consumer of s decides to mutate it
-		c.scores[s.QrId] = proto.Clone(s).(*policy.Score)
+		c.scores[s.QrId] = s.CloneVT()
 	}
 }
 

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
 	"go.mondoo.com/cnspec/v11/policy"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -447,7 +446,7 @@ func (nodeData *ReportingJobNodeData) consume(from NodeID, data *envelope) {
 			if score.Type != policy.ScoreType_Result {
 				// We map errors to failed results.
 				// Skip and unknown are mapped to passing results
-				score = proto.Clone(score).(*policy.Score)
+				score = score.CloneVT()
 				if score.Type == policy.ScoreType_Error {
 					score.Type = policy.ScoreType_Result
 					score.Value = 0
@@ -545,7 +544,7 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 					Type: policy.ScoreType_Result,
 				}
 			} else {
-				s = proto.Clone(c.score).(*policy.Score)
+				s = c.score.CloneVT()
 				s.QrId = nodeData.queryID
 				if c.impact.GetScoring() == explorer.ScoringSystem_DISABLED {
 					s.Type = policy.ScoreType_Disabled

--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/v11/explorer"
-	"google.golang.org/protobuf/proto"
 )
 
 // ScoreCalculator interface for calculating scores
@@ -58,7 +57,7 @@ func AddSpecdScore(calculator ScoreCalculator, s *Score, found bool, impact *exp
 		return
 	}
 
-	score := proto.Clone(s).(*Score)
+	score := s.CloneVT()
 	if impact != nil && impact.Value != nil {
 		floor := 100 - uint32(impact.Value.Value)
 		if floor > score.Value {


### PR DESCRIPTION
The `CloneVT` function is much more performant than the `proto.Clone`. I replaced a few calls I found around the codebase. Nothing changes functionally here