### PR TITLE
⚙️  onboarding: refactor ms365 permissions

### DIFF
--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -36,12 +36,18 @@ var Ms365AppPermissions = Permissions{
 				ID:   "SecurityEvents.Read.All",
 				Type: "Role",
 			},
+			{
+				// Allows the app to read organization-wide Microsoft Forms settings on behalf of the signed-in user.
+				ID:   "OrgSettings-Forms.Read.All",
+				Type: "Role",
+			},
 		},
 	},
 	{
 		ResourceID: "Office365SharePointOnline",
 		Access: []ResourceAccess{
 			{
+				// Allows the application to have full control of all site collections on behalf of the signed-in user.
 				ID:   "Sites.FullControl.All",
 				Type: "Role",
 			},

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -27,7 +27,13 @@ var Ms365AppPermissions = Permissions{
 		ResourceID: "MicrosoftGraph",
 		Access: []ResourceAccess{
 			{
+				// Allows the app to read all organization's policies without a signed-in user.
 				ID:   "Policy.Read.All",
+				Type: "Role",
+			},
+			{
+				// Allows the app to read organization's security events without a signed-in user.
+				ID:   "SecurityEvents.Read.All",
 				Type: "Role",
 			},
 		},

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -56,6 +56,11 @@ var Ms365AppPermissions = Permissions{
 				ID:   "DeviceManagementServiceConfig.Read.All",
 				Type: "Role",
 			},
+			{
+				// Allows the app to read organization-wide apps and services settings on behalf of the signed-in user
+				ID:   "OrgSettings-AppsAndServices.Read.All",
+				Type: "Role",
+			},
 		},
 	},
 	{

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -46,6 +46,16 @@ var Ms365AppPermissions = Permissions{
 				ID:   "DeviceManagementConfiguration.Read.All",
 				Type: "Role",
 			},
+			{
+				// Allows the app to read the properties of devices managed by Microsoft Intune
+				ID:   "DeviceManagementManagedDevices.Read.All",
+				Type: "Role",
+			},
+			{
+				// Allows the app to read Microsoft Intune service properties including device enrollment and third party service connection configuration
+				ID:   "DeviceManagementServiceConfig.Read.All",
+				Type: "Role",
+			},
 		},
 	},
 	{

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -38,6 +38,15 @@ var Ms365AppPermissions = Permissions{
 			},
 		},
 	},
+	{
+		ResourceID: "Office365SharePointOnline",
+		Access: []ResourceAccess{
+			{
+				ID:   "Sites.FullControl.All",
+				Type: "Role",
+			},
+		},
+	},
 }
 
 // function wrapper to mock during testing

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -37,8 +37,13 @@ var Ms365AppPermissions = Permissions{
 				Type: "Role",
 			},
 			{
-				// Allows the app to read organization-wide Microsoft Forms settings on behalf of the signed-in user.
+				// Allows the app to read organization-wide Microsoft Forms settings without a signed-in user.
 				ID:   "OrgSettings-Forms.Read.All",
+				Type: "Role",
+			},
+			{
+				// Allows the app to read Microsoft Intune device configuration and policies without a signed-in user.
+				ID:   "DeviceManagementConfiguration.Read.All",
 				Type: "Role",
 			},
 		},

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -53,6 +53,16 @@ var Ms365AppPermissions = Permissions{
 			},
 		},
 	},
+	{
+		ResourceID: "Office365ExchangeOnline",
+		Access: []ResourceAccess{
+			{
+				// Allows the application to run Exchange Online cmdlets with the same level of access as an administrator.
+				ID:   "Exchange.ManageAsApp",
+				Type: "Role",
+			},
+		},
+	},
 }
 
 // function wrapper to mock during testing

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -83,6 +83,14 @@ resource "azuread_application" "mondoo" {
       type = "Role"
     }
   }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.Office365SharePointOnline
+    resource_access {
+      id   = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
+      type = "Role"
+    }
+  }
 }
 
 resource "azuread_directory_role" "global_reader" {
@@ -134,6 +142,17 @@ resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_service_principal" "Office365SharePointOnline" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.Office365SharePointOnline
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Sites_FullControl_All" {
+  app_role_id         = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.Office365SharePointOnline.object_id
 }
 `
 	assert.Equal(t, expected, code)
@@ -211,6 +230,14 @@ resource "azuread_application" "mondoo" {
       type = "Role"
     }
   }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.Office365SharePointOnline
+    resource_access {
+      id   = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
+      type = "Role"
+    }
+  }
 }
 
 resource "azuread_directory_role" "global_reader" {
@@ -262,6 +289,17 @@ resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_service_principal" "Office365SharePointOnline" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.Office365SharePointOnline
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Sites_FullControl_All" {
+  app_role_id         = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.Office365SharePointOnline.object_id
 }
 `
 	assert.Equal(t, expected, code)

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -98,6 +98,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -188,6 +192,12 @@ resource "azuread_app_role_assignment" "DeviceManagementManagedDevices_Read_All"
 
 resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "OrgSettings-AppsAndServices_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -304,6 +314,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -394,6 +408,12 @@ resource "azuread_app_role_assignment" "DeviceManagementManagedDevices_Read_All"
 
 resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "OrgSettings-AppsAndServices_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -78,6 +78,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
+      type = "Role"
+    }
   }
 }
 
@@ -122,6 +126,12 @@ resource "azuread_service_principal" "MicrosoftGraph" {
 
 resource "azuread_app_role_assignment" "Policy_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -196,6 +206,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
+      type = "Role"
+    }
   }
 }
 
@@ -240,6 +254,12 @@ resource "azuread_service_principal" "MicrosoftGraph" {
 
 resource "azuread_app_role_assignment" "Policy_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -95,6 +95,14 @@ resource "azuread_application" "mondoo" {
       type = "Role"
     }
   }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.Office365ExchangeOnline
+    resource_access {
+      id   = azuread_service_principal.Office365ExchangeOnline.app_role_ids["Exchange.ManageAsApp"]
+      type = "Role"
+    }
+  }
 }
 
 resource "azuread_directory_role" "global_reader" {
@@ -163,6 +171,17 @@ resource "azuread_app_role_assignment" "Sites_FullControl_All" {
   app_role_id         = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.Office365SharePointOnline.object_id
+}
+
+resource "azuread_service_principal" "Office365ExchangeOnline" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.Office365ExchangeOnline
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Exchange_ManageAsApp" {
+  app_role_id         = azuread_service_principal.Office365ExchangeOnline.app_role_ids["Exchange.ManageAsApp"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.Office365ExchangeOnline.object_id
 }
 `
 	assert.Equal(t, expected, code)
@@ -252,6 +271,14 @@ resource "azuread_application" "mondoo" {
       type = "Role"
     }
   }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.Office365ExchangeOnline
+    resource_access {
+      id   = azuread_service_principal.Office365ExchangeOnline.app_role_ids["Exchange.ManageAsApp"]
+      type = "Role"
+    }
+  }
 }
 
 resource "azuread_directory_role" "global_reader" {
@@ -320,6 +347,17 @@ resource "azuread_app_role_assignment" "Sites_FullControl_All" {
   app_role_id         = azuread_service_principal.Office365SharePointOnline.app_role_ids["Sites.FullControl.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.Office365SharePointOnline.object_id
+}
+
+resource "azuread_service_principal" "Office365ExchangeOnline" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.Office365ExchangeOnline
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Exchange_ManageAsApp" {
+  app_role_id         = azuread_service_principal.Office365ExchangeOnline.app_role_ids["Exchange.ManageAsApp"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.Office365ExchangeOnline.object_id
 }
 `
 	assert.Equal(t, expected, code)

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -90,6 +90,14 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementManagedDevices.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -168,6 +176,18 @@ resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
 
 resource "azuread_app_role_assignment" "DeviceManagementConfiguration_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementManagedDevices_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementManagedDevices.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -276,6 +296,14 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementManagedDevices.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -354,6 +382,18 @@ resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
 
 resource "azuread_app_role_assignment" "DeviceManagementConfiguration_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementManagedDevices_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementManagedDevices.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementServiceConfig.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -86,6 +86,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -158,6 +162,12 @@ resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
 
 resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementConfiguration_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -262,6 +272,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -334,6 +348,12 @@ resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
 
 resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementConfiguration_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementConfiguration.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -39,17 +39,6 @@ data "azuread_client_config" "current" {
 data "azuread_application_published_app_ids" "well_known" {
 }
 
-resource "azuread_service_principal" "msgraph" {
-  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing = true
-}
-
-resource "azuread_app_role_assignment" "graph_policy_read" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
-  principal_object_id = azuread_service_principal.mondoo.object_id
-  resource_object_id  = azuread_service_principal.msgraph.object_id
-}
-
 resource "tls_private_key" "credential" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -86,7 +75,7 @@ resource "azuread_application" "mondoo" {
   required_resource_access {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
     resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
       type = "Role"
     }
   }
@@ -125,6 +114,17 @@ resource "mondoo_integration_ms365" "this" {
   name       = "test-ms365-integration"
   tenant_id  = data.azuread_client_config.current.tenant_id
 }
+
+resource "azuread_service_principal" "MicrosoftGraph" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Policy_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
 `
 	assert.Equal(t, expected, code)
 }
@@ -155,17 +155,6 @@ data "azuread_client_config" "current" {
 }
 
 data "azuread_application_published_app_ids" "well_known" {
-}
-
-resource "azuread_service_principal" "msgraph" {
-  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing = true
-}
-
-resource "azuread_app_role_assignment" "graph_policy_read" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
-  principal_object_id = azuread_service_principal.mondoo.object_id
-  resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "tls_private_key" "credential" {
@@ -204,7 +193,7 @@ resource "azuread_application" "mondoo" {
   required_resource_access {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
     resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
       type = "Role"
     }
   }
@@ -242,6 +231,17 @@ resource "mondoo_integration_ms365" "this" {
   depends_on = [azuread_service_principal.mondoo, azuread_application_certificate.mondoo, azuread_directory_role_assignment.global_reader]
   name       = "subscription-88afcea5fb91"
   tenant_id  = data.azuread_client_config.current.tenant_id
+}
+
+resource "azuread_service_principal" "MicrosoftGraph" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
+}
+
+resource "azuread_app_role_assignment" "Policy_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
 `
 	assert.Equal(t, expected, code)

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -82,6 +82,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -140,6 +144,12 @@ resource "azuread_app_role_assignment" "Policy_Read_All" {
 
 resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -229,6 +239,10 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -287,6 +301,12 @@ resource "azuread_app_role_assignment" "Policy_Read_All" {
 
 resource "azuread_app_role_assignment" "SecurityEvents_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityEvents.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "OrgSettings-Forms_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-Forms.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }


### PR DESCRIPTION
We are still experiencing more permission issues like:
```
cnspec> ms365.sharepointonline.defaultLinkPermission
access denied, please ensure the credentials have the right permissions in Azure AD
ms365.sharepointonline.defaultLinkPermission: null
```
and
```
cnspec> microsoft.security.secureScores
error while performing request. Code: UnknownError, Message: Auth token does not contain valid permissions or user does not have valid roles.
microsoft.security.secureScores: no data available
```

This PR is refactoring how we create all the necessary resources to grant
permissions to the Mondoo App Registration we deploy to scan Microsoft
365 tenants. 

The refactor will make it easy for us visualize (human-readable) permissions
and automatically create the necessary resources in Terraform to deploy.

Look at the variable `Ms365AppPermissions` for the full list of permissions.