### PR TITLE
Prep work to support v2 policies

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -33,6 +33,7 @@ const (
 	MRN_RESOURCE_FRAMEWORKMAP = "frameworkmaps"
 	MRN_RESOURCE_CONTROL      = "controls"
 	MRN_RESOURCE_RISK         = "risks"
+	MRN_RESOURCE_PROPERTY     = "properties"
 )
 
 type BundleResolver interface {
@@ -1168,22 +1169,8 @@ func (c *bundleCache) compileProp(prop *explorer.Property) (*explorer.Property, 
 
 	if prop.Mrn == "" {
 		uid := prop.Uid
-		forUids := make([]string, len(prop.For))
-		for i := range prop.For {
-			forUids[i] = prop.For[i].Uid
-		}
-
 		if err := prop.RefreshMRN(c.ownerMrn); err != nil {
 			return nil, err
-		}
-
-		if uid != "" {
-			c.uid2mrn[uid] = prop.Mrn
-		}
-		for i := range forUids {
-			if forUids[i] != "" {
-				c.uid2mrn[forUids[i]] = prop.For[i].Mrn
-			}
 		}
 
 		// TODO: uid's can be namespaced, extract the name

--- a/policy/resolved_policy_builder.go
+++ b/policy/resolved_policy_builder.go
@@ -15,7 +15,6 @@ import (
 	"go.mondoo.com/cnquery/v11/explorer"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/mqlc"
-	"go.mondoo.com/cnquery/v11/mrn"
 )
 
 // buildResolvedPolicy builds a resolved policy from a bundle
@@ -1137,11 +1136,7 @@ func compileProps(query *explorer.Mquery, rp *ResolvedPolicy, data *rpBuilderDat
 				prop = override
 			}
 			if name == "" {
-				var err error
-				name, err = mrn.GetResource(prop.Mrn, MRN_RESOURCE_QUERY)
-				if err != nil {
-					return nil, nil, errors.New("failed to get property name")
-				}
+				return nil, nil, errors.New("resolver> property mrn is empty for query " + query.Mrn + ", cannot compile query: " + prop.Mql)
 			}
 
 			executionQuery, dataChecksum, err := mquery2executionQuery(prop, nil, map[string]string{}, rp.CollectorJob, false, data.compilerConf)


### PR DESCRIPTION
- Properties are going to start being scoped to policies and queries
- They will get their own resource name (we call them properties instead of queries)