### PR TITLE
Fix a missing code block start in a bash remediation

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7032,13 +7032,15 @@ queries:
 
             To ensure that SSH LoginGraceTime is set to one minute or less, you can run the following bash script:
 
+            ```bash
             #!/bin/bash
             set -e
 
-            echo "Setting SSH LoginGraceTime"
             if grep -q '^LoginGraceTime' /etc/ssh/sshd_config; then
+              echo "Updating existing LoginGraceTime configuration value"
               sed -i 's/^LoginGraceTime.*/LoginGraceTime 60/' /etc/ssh/sshd_config
             else
+              echo "Adding LoginGraceTime configuration value to SSH config"
               echo 'LoginGraceTime 60' >> /etc/ssh/sshd_config
             fi
             systemctl restart sshd


### PR DESCRIPTION
Make sure this displays correctly

Fixes:

<img width="1286" height="618" alt="image" src="https://github.com/user-attachments/assets/da81f413-d7ed-48a3-b7f4-de523aa0e717" />
