### PR TITLE
Improve logic in sysctl remediations + improve auditd remediation

### DIFF
--- a/content/chef-infra-server.mql.yaml
+++ b/content/chef-infra-server.mql.yaml
@@ -468,8 +468,8 @@ queries:
             Run these commands to set proper permissions on your /var/opt/opscode/local-mode-cache/backup directory:
 
             ```bash
-            sudo chown root:root /var/opt/opscode/local-mode-cache/backup
-            sudo chmod 700 /var/opt/opscode/local-mode-cache/backup
+            chown root:root /var/opt/opscode/local-mode-cache/backup
+            chmod 700 /var/opt/opscode/local-mode-cache/backup
             ```
 
             Note: Chef Infra Server 15.7 and later automatically set the configuration backup path to `600` permissions on each `chef-server-ctl` execution.

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -80,7 +80,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -96,8 +96,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -149,7 +149,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -165,8 +165,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -216,7 +216,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -232,8 +232,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -282,7 +282,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -299,8 +299,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -348,7 +348,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -364,8 +364,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -413,7 +413,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -429,8 +429,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -478,7 +478,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -494,8 +494,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |
@@ -543,7 +543,7 @@ queries:
             3. Save the file and reload NGINX:
 
                 ```bash
-                sudo nginx -s reload
+                nginx -s reload
                 ```
         - id: apache
           desc: |
@@ -559,8 +559,8 @@ queries:
             3. Make sure the headers module is enabled:
 
                 ```bash
-                sudo a2enmod headers
-                sudo systemctl restart apache2
+                a2enmod headers
+                systemctl restart apache2
                 ```
         - id: iis
           desc: |

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -4041,6 +4041,47 @@ queries:
                     msg: "Reboot required to load audit rules because auditd is in immutable mode"
                   when: immutable_check.rc == 0
             ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to configure the auditd parameters for handling full audit logs.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            if grep -q '^space_left_action' /etc/audit/auditd.conf; then
+              echo "Updating space_left_action to email in /etc/audit/auditd.conf"
+              sed -i 's/^space_left_action.*/space_left_action = email/' /etc/audit/auditd.conf
+            else
+              echo "Adding space_left_action = email to /etc/audit/auditd.conf"
+              echo "space_left_action = email" >> /etc/audit/auditd.conf
+            fi
+
+            if grep -q '^action_mail_acct' /etc/audit/auditd.conf; then
+              echo "Updating action_mail_acct to root in /etc/audit/auditd.conf"
+              sed -i 's/^action_mail_acct.*/action_mail_acct = root/' /etc/audit/auditd.conf
+            else
+              echo "Adding action_mail_acct = root to /etc/audit/auditd.conf"
+              echo "action_mail_acct = root" >> /etc/audit/auditd.conf
+            fi
+
+            if grep -q '^admin_space_left_action' /etc/audit/auditd.conf; then
+              echo "Updating admin_space_left_action to halt in /etc/audit/auditd.conf"
+              sed -i 's/^admin_space_left_action.*/admin_space_left_action = halt/' /etc/audit/auditd.conf
+            else
+              echo "Adding admin_space_left_action = halt to /etc/audit/auditd.conf"
+              echo "admin_space_left_action = halt" >> /etc/audit/auditd.conf
+            fi
+
+            echo "Restarting auditd service to apply changes"
+            systemctl restart auditd
+
+            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
+              echo "Reboot required to load rules because auditd is in immutable mode"
+            fi
+            ```
   - uid: mondoo-linux-security-changes-to-system-administration-scope-sudoers-is-collected
     title: Ensure changes to system administration scope (sudoers) is collected
     impact: 50
@@ -4124,6 +4165,38 @@ queries:
                   ansible.builtin.systemd:
                     name: auditd
                     state: reloaded
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to ensure changes to the sudoers file and directory are collected.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            RULES_FILE="/etc/audit/rules.d/50-scope.rules"
+
+            if [ ! -f "$RULES_FILE" ]; then
+              echo "Creating audit rules file: $RULES_FILE"
+              touch "$RULES_FILE"
+            fi
+
+            echo "Ensuring audit rules for sudoers are configured"
+            if ! grep -q '^-w /etc/sudoers -p wa -k scope' "$RULES_FILE"; then
+              echo "-w /etc/sudoers -p wa -k scope" >> "$RULES_FILE"
+            fi
+            if ! grep -q '^-w /etc/sudoers.d -p wa -k scope' "$RULES_FILE"; then
+              echo "-w /etc/sudoers.d -p wa -k scope" >> "$RULES_FILE"
+            fi
+
+            echo "Loading audit rules"
+            augenrules --load
+
+            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
+              echo "Reboot required to load rules because auditd is in immutable mode"
+            fi
             ```
   - uid: mondoo-linux-security-login-and-logout-events-are-collected
     title: Ensure login and logout events are collected
@@ -4246,6 +4319,42 @@ queries:
                 - name: Load audit rules
                   command: augenrules --load
               ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to ensure login and logout events are collected, overwriting any existing content in the rules file.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            RULES_FILE="/etc/audit/rules.d/50-logins.rules"
+
+            echo "Ensuring audit rules for lastlog and tallylog are configured in $RULES_FILE"
+            cat > "$RULES_FILE" <<EOF
+            -w /var/log/lastlog -p wa -k logins
+            -w /var/log/tallylog -p wa -k logins
+            EOF
+
+            if [[ -d /var/log/faillog ]]; then
+              echo "Adding auditing for faillog in $RULES_FILE"
+              echo "-w /var/log/faillog -p wa -k logins" >> "$RULES_FILE"
+            fi
+
+            if [[ -d /var/run/faillock ]]; then
+              echo "Adding auditing for faillock in $RULES_FILE"
+              echo "-w /var/run/faillock -p wa -k logins" >> "$RULES_FILE"
+            fi
+
+            echo "Audit rules for login and logout events have been set in $RULES_FILE"
+            augenrules --load
+
+            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
+              echo "Reboot required to load rules because auditd is in immutable mode"
+            fi
+            ```
+
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
     filters: asset.family.contains("debian")
     mql: |
@@ -4370,6 +4479,32 @@ queries:
               handlers:
                 - name: Load audit rules
                   command: augenrules --load
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to ensure session initiation information is collected, overwriting any existing content in the rules file.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            RULES_FILE="/etc/audit/rules.d/50-session.rules"
+
+            echo "Ensuring audit rules for session initiation are configured in $RULES_FILE"
+            cat > "$RULES_FILE" <<EOF
+            -w /var/run/utmp -p wa -k session
+            -w /var/log/wtmp -p wa -k logins
+            -w /var/log/btmp -p wa -k logins
+            EOF
+
+            echo "Reloading audit rules"
+            augenrules --load
+
+            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
+              echo "Reboot required to load rules because auditd is in immutable mode"
+            fi
             ```
   - uid: mondoo-linux-security-events-that-modify-date-and-time-information-are-collected
     title: Ensure events that modify date and time information are collected

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3761,10 +3761,10 @@ queries:
             max_log_file = <MB>
             ```
 
-            2. Reload the auditd service to apply the new configuration:
+            2. Restart the auditd service to apply the new configuration:
 
             ```bash
-            systemctl reload auditd
+            systemctl restart auditd
             ```
 
             3. Check if a reboot is required, in case the running configuration is set to be immutable:
@@ -3828,7 +3828,7 @@ queries:
 
             echo "Configuring audit log storage size..."
             echo "max_log_file = $MB_SIZE" >> /etc/audit/auditd.conf
-            systemctl reload auditd
+            systemctl restart auditd
 
             if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
               echo "Reboot required to load rules because auditd is in immutable mode"
@@ -3865,10 +3865,10 @@ queries:
             max_log_file_action = keep_logs
             ```
 
-            2. Reload the service to load the new configuration values:
+            2. Restart the service to load the new configuration values:
 
             ```bash
-            service auditd reload
+            systemctl restart auditd
             ```
 
             3. Check if a reboot is required, in case the running configuration is set to be immutable:
@@ -3905,10 +3905,10 @@ queries:
                     state: present
                     register: auditd_logfile_action_changed
 
-                - name: Reload auditd service to apply changes if not immutable
+                - name: Restart auditd service to apply changes if not immutable
                   ansible.builtin.systemd:
                     name: auditd
-                    state: reloaded
+                    state: restarted
                     when:
                     - immutable_check.rc != 0
                     - auditd_logfile_action_changed.changed
@@ -3955,10 +3955,10 @@ queries:
             admin_space_left_action = halt
             ```
 
-            2. Reload the service to load the new configuration values:
+            2. Restart the service to load the new configuration values:
 
             ```bash
-            service auditd reload
+            systemctl restart auditd
             ```
 
             3. Check if a reboot is required, in case the running configuration is set to be immutable:
@@ -3997,10 +3997,10 @@ queries:
                   failed_when: false
                   changed_when: false
 
-                - name: Reload auditd service to apply changes if not immutable and config changed
+                - name: Restart auditd service to apply changes if not immutable and config changed
                   ansible.builtin.systemd:
                     name: auditd
-                    state: reloaded
+                    state: restarted
                   when:
                     - immutable_check.rc != 0
                     - auditd_params_changed.changed
@@ -7281,7 +7281,7 @@ queries:
             After editing the file, restart the SSH service:
 
             ```bash
-            sudo systemctl restart sshd
+            systemctl restart sshd
             ```
         - id: ansible
           desc: |

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -2441,8 +2441,23 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.ip_forward = 0" >> /etc/sysctl.d/99-disable-ip-forwarding.conf
-            echo "net.ipv6.conf.all.forwarding = 0" >> /etc/sysctl.d/99-disable-ip-forwarding.conf
+            # Set net.ipv4.ip_forward
+            if grep -q '^net.ipv4.ip_forward' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.ip_forward to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.ip_forward.*/net.ipv4.ip_forward = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.ip_forward to 0 in /etc/sysctl.d/99-disable-ip-forwarding.conf"
+              echo "net.ipv4.ip_forward = 0" >> /etc/sysctl.d/99-disable-ip-forwarding.conf
+            fi
+
+            # Set net.ipv6.conf.all.forwarding
+            if grep -q '^net.ipv6.conf.all.forwarding' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.all.forwarding to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.all.forwarding.*/net.ipv6.conf.all.forwarding = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.all.forwarding to 0 in /etc/sysctl.d/99-disable-ip-forwarding.conf"
+              echo "net.ipv6.conf.all.forwarding = 0" >> /etc/sysctl.d/99-disable-ip-forwarding.conf
+            fi
 
             sysctl -w net.ipv4.ip_forward=0
             sysctl -w net.ipv4.route.flush=1
@@ -2530,8 +2545,23 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.send_redirects = 0" >> /etc/sysctl.d/99-disable-packet-redirect.conf
-            echo "net.ipv4.conf.default.send_redirects = 0" >> /etc/sysctl.d/99-disable-packet-redirect.conf
+            # Set net.ipv4.conf.all.send_redirects
+            if grep -q '^net.ipv4.conf.all.send_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.send_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.send_redirects.*/net.ipv4.conf.all.send_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.send_redirects to 0 in /etc/sysctl.d/99-disable-packet-redirect.conf"
+              echo "net.ipv4.conf.all.send_redirects = 0" >> /etc/sysctl.d/99-disable-packet-redirect.conf
+            fi
+
+            # Set net.ipv4.conf.default.send_redirects
+            if grep -q '^net.ipv4.conf.default.send_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.send_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.send_redirects.*/net.ipv4.conf.default.send_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.send_redirects to 0 in /etc/sysctl.d/99-disable-packet-redirect.conf"
+              echo "net.ipv4.conf.default.send_redirects = 0" >> /etc/sysctl.d/99-disable-packet-redirect.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.send_redirects=0
             sysctl -w net.ipv4.conf.default.send_redirects=0
@@ -2630,10 +2660,41 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
-            echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
-            echo "net.ipv6.conf.all.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
-            echo "net.ipv6.conf.default.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
+            # Set net.ipv4.conf.all.accept_source_route
+            if grep -q '^net.ipv4.conf.all.accept_source_route' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.accept_source_route to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.accept_source_route.*/net.ipv4.conf.all.accept_source_route = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.accept_source_route to 0 in /etc/sysctl.d/99-disable-source-routing.conf"
+              echo "net.ipv4.conf.all.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
+            fi
+
+            # Set net.ipv4.conf.default.accept_source_route
+            if grep -q '^net.ipv4.conf.default.accept_source_route' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.accept_source_route to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.accept_source_route.*/net.ipv4.conf.default.accept_source_route = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.accept_source_route to 0 in /etc/sysctl.d/99-disable-source-routing.conf"
+              echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
+            fi
+
+            # Set net.ipv6.conf.all.accept_source_route
+            if grep -q '^net.ipv6.conf.all.accept_source_route' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.all.accept_source_route to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.all.accept_source_route.*/net.ipv6.conf.all.accept_source_route = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.all.accept_source_route to 0 in /etc/sysctl.d/99-disable-source-routing.conf"
+              echo "net.ipv6.conf.all.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
+            fi
+
+            # Set net.ipv6.conf.default.accept_source_route
+            if grep -q '^net.ipv6.conf.default.accept_source_route' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.default.accept_source_route to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.default.accept_source_route.*/net.ipv6.conf.default.accept_source_route = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.default.accept_source_route to 0 in /etc/sysctl.d/99-disable-source-routing.conf"
+              echo "net.ipv6.conf.default.accept_source_route = 0" >> /etc/sysctl.d/99-disable-source-routing.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.accept_source_route=0
             sysctl -w net.ipv4.conf.default.accept_source_route=0
@@ -2736,10 +2797,41 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
-            echo "net.ipv4.conf.default.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
-            echo "net.ipv6.conf.all.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
-            echo "net.ipv6.conf.default.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
+            # Set net.ipv4.conf.all.accept_redirects
+            if grep -q '^net.ipv4.conf.all.accept_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.accept_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.accept_redirects.*/net.ipv4.conf.all.accept_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.accept_redirects to 0 in /etc/sysctl.d/99-disable-icmp-redirects.conf"
+              echo "net.ipv4.conf.all.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
+            fi
+
+            # Set net.ipv4.conf.default.accept_redirects
+            if grep -q '^net.ipv4.conf.default.accept_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.accept_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.accept_redirects.*/net.ipv4.conf.default.accept_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.accept_redirects to 0 in /etc/sysctl.d/99-disable-icmp-redirects.conf"
+              echo "net.ipv4.conf.default.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
+            fi
+
+            # Set net.ipv6.conf.all.accept_redirects
+            if grep -q '^net.ipv6.conf.all.accept_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.all.accept_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.all.accept_redirects.*/net.ipv6.conf.all.accept_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.all.accept_redirects to 0 in /etc/sysctl.d/99-disable-icmp-redirects.conf"
+              echo "net.ipv6.conf.all.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
+            fi
+
+            # Set net.ipv6.conf.default.accept_redirects
+            if grep -q '^net.ipv6.conf.default.accept_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.default.accept_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.default.accept_redirects.*/net.ipv6.conf.default.accept_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.default.accept_redirects to 0 in /etc/sysctl.d/99-disable-icmp-redirects.conf"
+              echo "net.ipv6.conf.default.accept_redirects = 0" >> /etc/sysctl.d/99-disable-icmp-redirects.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.accept_redirects=0
             sysctl -w net.ipv4.conf.default.accept_redirects=0
@@ -2828,8 +2920,23 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.secure_redirects = 0" >> /etc/sysctl.d/99-disable-secure-icmp-redirects.conf
-            echo "net.ipv4.conf.default.secure_redirects = 0" >> /etc/sysctl.d/99-disable-secure-icmp-redirects.conf
+            # Set net.ipv4.conf.all.secure_redirects
+            if grep -q '^net.ipv4.conf.all.secure_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.secure_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.secure_redirects.*/net.ipv4.conf.all.secure_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.secure_redirects to 0 in /etc/sysctl.d/99-disable-secure-icmp-redirects.conf"
+              echo "net.ipv4.conf.all.secure_redirects = 0" >> /etc/sysctl.d/99-disable-secure-icmp-redirects.conf
+            fi
+
+            # Set net.ipv4.conf.default.secure_redirects
+            if grep -q '^net.ipv4.conf.default.secure_redirects' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.secure_redirects to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.secure_redirects.*/net.ipv4.conf.default.secure_redirects = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.secure_redirects to 0 in /etc/sysctl.d/99-disable-secure-icmp-redirects.conf"
+              echo "net.ipv4.conf.default.secure_redirects = 0" >> /etc/sysctl.d/99-disable-secure-icmp-redirects.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.secure_redirects=0
             sysctl -w net.ipv4.conf.default.secure_redirects=0
@@ -2917,8 +3024,21 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.log_martians = 1" >> /etc/sysctl.d/99-log-martians.conf
-            echo "net.ipv4.conf.default.log_martians = 1" >> /etc/sysctl.d/99-log-martians.conf
+            if grep -q '^net.ipv4.conf.all.log_martians' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.log_martians to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.log_martians.*/net.ipv4.conf.all.log_martians = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.log_martians to 1 in /etc/sysctl.d/99-log-martians.conf"
+              echo "net.ipv4.conf.all.log_martians = 1" >> /etc/sysctl.d/99-log-martians.conf
+            fi
+
+            if grep -q '^net.ipv4.conf.default.log_martians' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.log_martians to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.log_martians.*/net.ipv4.conf.default.log_martians = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.log_martians to 1 in /etc/sysctl.d/99-log-martians.conf"
+              echo "net.ipv4.conf.default.log_martians = 1" >> /etc/sysctl.d/99-log-martians.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.log_martians=1
             sysctl -w net.ipv4.conf.default.log_martians=1
@@ -2998,7 +3118,13 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.icmp_echo_ignore_broadcasts = 1" >> /etc/sysctl.d/99-disable-icmp-echo-broadcasts.conf
+            if grep -q '^net.ipv4.icmp_echo_ignore_broadcasts' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.icmp_echo_ignore_broadcasts.*/net.ipv4.icmp_echo_ignore_broadcasts = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 in /etc/sysctl.d/99-disable-icmp-echo-broadcasts.conf"
+              echo "net.ipv4.icmp_echo_ignore_broadcasts = 1" >> /etc/sysctl.d/99-disable-icmp-echo-broadcasts.conf
+            fi
 
             sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
             sysctl -w net.ipv4.route.flush=1
@@ -3077,7 +3203,13 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.icmp_ignore_bogus_error_responses = 1" >> /etc/sysctl.d/99-disable-bogus-icmp-responses.conf
+            if grep -q '^net.ipv4.icmp_ignore_bogus_error_responses' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.icmp_ignore_bogus_error_responses to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.icmp_ignore_bogus_error_responses.*/net.ipv4.icmp_ignore_bogus_error_responses = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.icmp_ignore_bogus_error_responses to 1 in /etc/sysctl.d/99-disable-bogus-icmp-responses.conf"
+              echo "net.ipv4.icmp_ignore_bogus_error_responses = 1" >> /etc/sysctl.d/99-disable-bogus-icmp-responses.conf
+            fi
 
             sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
             sysctl -w net.ipv4.route.flush=1
@@ -3160,8 +3292,21 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.conf.all.rp_filter = 1" >> /etc/sysctl.d/99-enable-reverse-path-filtering.conf
-            echo "net.ipv4.conf.default.rp_filter = 1" >> /etc/sysctl.d/99-enable-reverse-path-filtering.conf
+            if grep -q '^net.ipv4.conf.all.rp_filter' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.all.rp_filter to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.all.rp_filter.*/net.ipv4.conf.all.rp_filter = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.all.rp_filter to 1 in /etc/sysctl.d/99-enable-reverse-path-filtering.conf"
+              echo "net.ipv4.conf.all.rp_filter = 1" >> /etc/sysctl.d/99-enable-reverse-path-filtering.conf
+            fi
+
+            if grep -q '^net.ipv4.conf.default.rp_filter' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.conf.default.rp_filter to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.conf.default.rp_filter.*/net.ipv4.conf.default.rp_filter = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.conf.default.rp_filter to 1 in /etc/sysctl.d/99-enable-reverse-path-filtering.conf"
+              echo "net.ipv4.conf.default.rp_filter = 1" >> /etc/sysctl.d/99-enable-reverse-path-filtering.conf
+            fi
 
             sysctl -w net.ipv4.conf.all.rp_filter=1
             sysctl -w net.ipv4.conf.default.rp_filter=1
@@ -3241,8 +3386,23 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv4.tcp_syncookies = 1" >> /etc/sysctl.d/99-enable-tcp-syncookies.conf
-            echo "net.ipv4.route.flush = 1" >> /etc/sysctl.d/99-enable-tcp-syncookies.conf
+            # Set net.ipv4.tcp_syncookies
+            if grep -q '^net.ipv4.tcp_syncookies' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.tcp_syncookies to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.tcp_syncookies.*/net.ipv4.tcp_syncookies = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.tcp_syncookies to 1 in /etc/sysctl.d/99-enable-tcp-syncookies.conf"
+              echo "net.ipv4.tcp_syncookies = 1" >> /etc/sysctl.d/99-enable-tcp-syncookies.conf
+            fi
+
+            # Set net.ipv4.route.flush
+            if grep -q '^net.ipv4.route.flush' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv4.route.flush to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv4.route.flush.*/net.ipv4.route.flush = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv4.route.flush to 1 in /etc/sysctl.d/99-enable-tcp-syncookies.conf"
+              echo "net.ipv4.route.flush = 1" >> /etc/sysctl.d/99-enable-tcp-syncookies.conf
+            fi
 
             sysctl -w net.ipv4.tcp_syncookies=1
             sysctl -w net.ipv4.route.flush=1
@@ -3327,9 +3487,32 @@ queries:
             #!/bin/bash
             set -e
 
-            echo "net.ipv6.conf.all.accept_ra = 0" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
-            echo "net.ipv6.conf.default.accept_ra = 0" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
-            echo "net.ipv6.route.flush = 1" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
+            # Set net.ipv6.conf.all.accept_ra
+            if grep -q '^net.ipv6.conf.all.accept_ra' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.all.accept_ra to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.all.accept_ra.*/net.ipv6.conf.all.accept_ra = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.all.accept_ra to 0 in /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf"
+              echo "net.ipv6.conf.all.accept_ra = 0" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
+            fi
+
+            # Set net.ipv6.conf.default.accept_ra
+            if grep -q '^net.ipv6.conf.default.accept_ra' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.conf.default.accept_ra to 0 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.conf.default.accept_ra.*/net.ipv6.conf.default.accept_ra = 0/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.conf.default.accept_ra to 0 in /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf"
+              echo "net.ipv6.conf.default.accept_ra = 0" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
+            fi
+
+            # Set net.ipv6.route.flush
+            if grep -q '^net.ipv6.route.flush' /etc/sysctl.conf 2>/dev/null; then
+              echo "Setting net.ipv6.route.flush to 1 in /etc/sysctl.conf"
+              sed -i 's/^net.ipv6.route.flush.*/net.ipv6.route.flush = 1/' /etc/sysctl.conf
+            else
+              echo "Setting net.ipv6.route.flush to 1 in /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf"
+              echo "net.ipv6.route.flush = 1" >> /etc/sysctl.d/99-disable-ipv6-router-advertisements.conf
+            fi
 
             sysctl -w net.ipv6.conf.all.accept_ra=0
             sysctl -w net.ipv6.conf.default.accept_ra=0
@@ -3458,7 +3641,6 @@ queries:
 
             echo "Enabling and starting auditd service..."
             systemctl --now enable auditd
-            systemctl start auditd
             ```
   - uid: mondoo-linux-security-auditing-for-processes-that-start-prior-to-auditd-is-enabled
     title: Ensure auditing for processes that start prior to auditd is enabled

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -268,17 +268,17 @@ queries:
 
             if command -v yum >/dev/null 2>&1; then
               echo "Detected yum-based system. Installing aide..."
-              sudo yum install -y aide
+              yum install -y aide
             elif command -v dnf >/dev/null 2>&1; then
               echo "Detected dnf-based system. Installing aide..."
-              sudo dnf install -y aide
+              dnf install -y aide
             elif command -v apt-get >/dev/null 2>&1; then
               echo "Detected apt-based system. Installing aide..."
-              sudo apt-get update
-              sudo apt-get install -y aide
+              apt-get update
+              apt-get install -y aide
             elif command -v zypper >/dev/null 2>&1; then
               echo "Detected zypper-based system. Installing aide..."
-              sudo zypper install -y aide
+              zypper install -y aide
             else
               echo "No supported package manager found. Please install AIDE manually."
               exit 1
@@ -453,17 +453,17 @@ queries:
             if ! command -v aide >/dev/null 2>&1; then
               if command -v yum >/dev/null 2>&1; then
                 echo "Detected yum-based system. Installing aide..."
-                sudo yum install -y aide
+                yum install -y aide
               elif command -v dnf >/dev/null 2>&1; then
                 echo "Detected dnf-based system. Installing aide..."
-                sudo dnf install -y aide
+                dnf install -y aide
               elif command -v apt-get >/dev/null 2>&1; then
                 echo "Detected apt-based system. Installing aide..."
-                sudo apt-get update
-                sudo apt-get install -y aide
+                apt-get update
+                apt-get install -y aide
               elif command -v zypper >/dev/null 2>&1; then
                 echo "Detected zypper-based system. Installing aide..."
-                sudo zypper install -y aide
+                zypper install -y aide
               else
                 echo "No supported package manager found. Please install AIDE manually."
                 exit 1
@@ -473,14 +473,14 @@ queries:
             # Initialize AIDE database if not already initialized
             if [ ! -f /var/lib/aide/aide.db.gz ] && [ ! -f /var/lib/aide/aide.db ]; then
               echo "Initializing AIDE database..."
-              sudo aide --init
-              sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz 2>/dev/null || true
-              sudo cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db 2>/dev/null || true
+              aide --init
+              cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz 2>/dev/null || true
+              cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db 2>/dev/null || true
             fi
 
             # Add cron job for daily check at 5AM if not already present
             CRON_LINE="0 5 * * * /usr/sbin/aide --check"
-            (sudo crontab -l 2>/dev/null | grep -v -F "$CRON_LINE" ; echo "$CRON_LINE") | sudo crontab -
+            (crontab -l 2>/dev/null | grep -v -F "$CRON_LINE" ; echo "$CRON_LINE") | crontab -
 
             echo "AIDE daily check scheduled at 5AM via cron."
             ```
@@ -613,23 +613,23 @@ queries:
             # Set hard core dump limit to 0
             if ! grep -qE '^\*\s+hard\s+core\s+0' /etc/security/limits.conf; then
               echo "Adding hard core limit to /etc/security/limits.conf"
-              echo '* hard core 0' | sudo tee -a /etc/security/limits.conf
+              echo '* hard core 0' | tee -a /etc/security/limits.conf
             fi
 
             # Set fs.suid_dumpable to 0 in sysctl
             if ! grep -q '^fs.suid_dumpable' /etc/sysctl.conf 2>/dev/null && ! grep -q '^fs.suid_dumpable' /etc/sysctl.d/* 2>/dev/null; then
               echo "Setting fs.suid_dumpable to 0 in /etc/sysctl.d/99-disable-coredump.conf"
-              echo 'fs.suid_dumpable = 0' | sudo tee /etc/sysctl.d/99-disable-coredump.conf
+              echo 'fs.suid_dumpable = 0' | tee /etc/sysctl.d/99-disable-coredump.conf
             fi
-            sudo sysctl -w fs.suid_dumpable=0
+            sysctl -w fs.suid_dumpable=0
 
             # Configure systemd-coredump if present
             if [ -f /etc/systemd/coredump.conf ]; then
               echo "Setting systemd-coredump configuration"
-              sudo sed -i '/^ProcessSizeMax/d' /etc/systemd/coredump.conf
-              sudo sed -i '/^Storage/d' /etc/systemd/coredump.conf
-              echo -e '[Coredump]\nProcessSizeMax=0\nStorage=none' | sudo tee -a /etc/systemd/coredump.conf
-              sudo systemctl daemon-reexec
+              sed -i '/^ProcessSizeMax/d' /etc/systemd/coredump.conf
+              sed -i '/^Storage/d' /etc/systemd/coredump.conf
+              echo -e '[Coredump]\nProcessSizeMax=0\nStorage=none' | tee -a /etc/systemd/coredump.conf
+              systemctl daemon-reexec
             fi
 
             echo "Core dump restrictions applied."
@@ -709,10 +709,10 @@ queries:
             # Set ASLR to 2
             if ! grep -q '^kernel.randomize_va_space' /etc/sysctl.conf 2>/dev/null && ! grep -q '^kernel.randomize_va_space' /etc/sysctl.d/* 2>/dev/null; then
               echo "Setting kernel.randomize_va_space to 2 in /etc/sysctl.d/99-aslr.conf"
-              echo 'kernel.randomize_va_space = 2' | sudo tee /etc/sysctl.d/99-aslr.conf
+              echo 'kernel.randomize_va_space = 2' | tee /etc/sysctl.d/99-aslr.conf
             fi
 
-            sudo sysctl -w kernel.randomize_va_space=2
+            sysctl -w kernel.randomize_va_space=2
             ```
   - uid: mondoo-linux-security-prelink-is-disabled
     title: Ensure prelink is disabled
@@ -786,13 +786,13 @@ queries:
 
             if command -v yum >/dev/null 2>&1; then
               echo "Detected yum-based system. Removing prelink..."
-              sudo yum remove -y prelink
+              yum remove -y prelink
             elif command -v dnf >/dev/null 2>&1; then
               echo "Detected dnf-based system. Removing prelink..."
-              sudo dnf remove -y prelink
+              dnf remove -y prelink
             elif command -v apt-get >/dev/null 2>&1; then
               echo "Detected apt-based system. Removing prelink..."
-              sudo apt-get purge -y prelink
+              apt-get purge -y prelink
             else
               echo "No supported package manager found. Please remove prelink manually."
               exit 1
@@ -885,16 +885,16 @@ queries:
 
             if command -v yum >/dev/null 2>&1; then
               echo "Detected yum-based system. Removing X Window System packages..."
-              sudo yum remove -y xorg-x11*
+              yum remove -y xorg-x11*
             elif command -v dnf >/dev/null 2>&1; then
               echo "Detected dnf-based system. Removing X Window System packages..."
-              sudo dnf remove -y xorg-x11*
+              dnf remove -y xorg-x11*
             elif command -v apt-get >/dev/null 2>&1; then
               echo "Detected apt-based system. Removing X Window System packages..."
-              sudo apt-get purge -y xserver-xorg
+              apt-get purge -y xserver-xorg
             elif command -v zypper >/dev/null 2>&1; then
               echo "Detected zypper-based system. Removing X Window System packages..."
-              sudo zypper remove -y xorg-x11-server
+              zypper remove -y xorg-x11-server
             else
               echo "No supported package manager found. Please remove X Window System packages manually."
               exit 1
@@ -1856,13 +1856,13 @@ queries:
             3. Restart Postfix:
 
             ```bash
-            sudo systemctl restart postfix
+            systemctl restart postfix
             ```
 
             4. For Exim4, edit the Exim4 configuration file:
 
             ```bash
-            sudo nano /etc/exim4/update-exim4.conf.conf
+            nano /etc/exim4/update-exim4.conf.conf
             ```
 
             5. Find the line that sets `dc_local_interfaces` and modify it to:
@@ -1874,8 +1874,8 @@ queries:
             6. Regenerate the Exim4 runtime configuration and restart the service:
 
             ```bash
-            sudo update-exim4.conf
-            sudo systemctl restart exim4
+            update-exim4.conf
+            systemctl restart exim4
             ```
         - id: ansible
           desc: |

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -612,17 +612,20 @@ queries:
 
             # Set hard core dump limit to 0
             if ! grep -qE '^\*\s+hard\s+core\s+0' /etc/security/limits.conf; then
+              echo "Adding hard core limit to /etc/security/limits.conf"
               echo '* hard core 0' | sudo tee -a /etc/security/limits.conf
             fi
 
             # Set fs.suid_dumpable to 0 in sysctl
             if ! grep -q '^fs.suid_dumpable' /etc/sysctl.conf 2>/dev/null && ! grep -q '^fs.suid_dumpable' /etc/sysctl.d/* 2>/dev/null; then
+              echo "Setting fs.suid_dumpable to 0 in /etc/sysctl.d/99-disable-coredump.conf"
               echo 'fs.suid_dumpable = 0' | sudo tee /etc/sysctl.d/99-disable-coredump.conf
             fi
             sudo sysctl -w fs.suid_dumpable=0
 
             # Configure systemd-coredump if present
             if [ -f /etc/systemd/coredump.conf ]; then
+              echo "Setting systemd-coredump configuration"
               sudo sed -i '/^ProcessSizeMax/d' /etc/systemd/coredump.conf
               sudo sed -i '/^Storage/d' /etc/systemd/coredump.conf
               echo -e '[Coredump]\nProcessSizeMax=0\nStorage=none' | sudo tee -a /etc/systemd/coredump.conf
@@ -705,12 +708,11 @@ queries:
 
             # Set ASLR to 2
             if ! grep -q '^kernel.randomize_va_space' /etc/sysctl.conf 2>/dev/null && ! grep -q '^kernel.randomize_va_space' /etc/sysctl.d/* 2>/dev/null; then
+              echo "Setting kernel.randomize_va_space to 2 in /etc/sysctl.d/99-aslr.conf"
               echo 'kernel.randomize_va_space = 2' | sudo tee /etc/sysctl.d/99-aslr.conf
             fi
 
             sudo sysctl -w kernel.randomize_va_space=2
-
-            echo "ASLR set to 2."
             ```
   - uid: mondoo-linux-security-prelink-is-disabled
     title: Ensure prelink is disabled
@@ -897,6 +899,7 @@ queries:
               echo "No supported package manager found. Please remove X Window System packages manually."
               exit 1
             fi
+            ```
   - uid: mondoo-linux-security-avahi-server-is-not-enabled
     title: Ensure Avahi server is stopped and not enabled
     impact: 100

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3925,6 +3925,30 @@ queries:
                     msg: "Reboot required to load audit rules because auditd is in immutable mode"
                     when: immutable_check.rc == 0
             ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+            Use this Bash script to configure the maximum log file action for audit logs.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            if grep -q '^max_log_file_action' /etc/audit/auditd.conf; then
+              echo "Updating max_log_file_action to keep_logs in /etc/audit/auditd.conf"
+              sed -i 's/^max_log_file_action.*/max_log_file_action = keep_logs/' /etc/audit/auditd.conf
+            else
+              echo "Adding max_log_file_action = keep_logs to /etc/audit/auditd.conf"
+              echo "max_log_file_action = keep_logs" >> /etc/audit/auditd.conf
+            fi
+
+            echo "Restarting auditd service to apply changes"
+            systemctl restart auditd
+
+            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then
+              echo "Reboot required to load rules because auditd is in immutable mode"
+            fi
+            ```
   - uid: mondoo-linux-security-system-is-disabled-when-audit-logs-are-full
     title: Ensure system is disabled when audit logs are full
     impact: 40

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3824,10 +3824,17 @@ queries:
             #!/bin/bash
             set -e
 
-            MB_SIZE="<MB>"  # Replace <MB> with the desired size in megabytes
+            MB_SIZE="500"  # Replace 500 with the desired size in megabytes
 
-            echo "Configuring audit log storage size..."
-            echo "max_log_file = $MB_SIZE" >> /etc/audit/auditd.conf
+            if grep -q '^max_log_file' /etc/audit/auditd.conf; then
+              echo "Updating max_log_file to $MB_SIZE in /etc/audit/auditd.conf"
+              sed -i "s/^max_log_file.*/max_log_file = $MB_SIZE/" /etc/audit/auditd.conf
+            else
+              echo "Adding max_log_file = $MB_SIZE to /etc/audit/auditd.conf"
+              echo "max_log_file = $MB_SIZE" >> /etc/audit/auditd.conf
+            fi
+
+            echo "Restarting auditd service to apply changes"
             systemctl restart auditd
 
             if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -4357,7 +4357,6 @@ queries:
               echo "Reboot required to load rules because auditd is in immutable mode"
             fi
             ```
-
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
     filters: asset.family.contains("debian")
     mql: |
@@ -4573,6 +4572,7 @@ queries:
             ```bash
             augenrules --load
             ```
+
             This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
             4. Check if a reboot is required, in case the running configuration is set to be immutable:
@@ -4861,7 +4861,6 @@ queries:
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
-
         Check if a reboot is required, in case the running configuration is set to be immutable:
 
         ```bash
@@ -4916,19 +4915,7 @@ queries:
 
         By auditing these system calls, administrators can detect and respond to unauthorized changes, ensuring the integrity of file permissions and attributes.
       remediation: |-
-        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
-
-        Example: `vi /etc/audit/rules.d/50-perm_mod.rules`
-
-        Add the following lines:
-
-        ```
-        -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        ```
-
-        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
+        1. Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-perm_mod.rules`
 
@@ -4943,7 +4930,7 @@ queries:
         -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
         ```
 
-        To load the newly added rules into the running configuration:
+        2. Reload the running configuration to load the newly added rules:
 
         ```bash
         augenrules --load
@@ -4952,7 +4939,7 @@ queries:
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
 
-        Check if a reboot is required, in case the running configuration is set to be immutable:
+        3. Check if a reboot is required, in case the running configuration is set to be immutable:
 
         ```bash
         if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi
@@ -5002,18 +4989,7 @@ queries:
 
         By auditing these system calls, administrators can identify and respond to unauthorized access attempts, ensuring the integrity and security of the system.
       remediation: |-
-        For 32-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
-
-        Example: `vi /etc/audit/rules.d/50-access.rules`
-
-        Add the following lines:
-
-        ```
-        -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
-        -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
-        ```
-
-        For 64-bit systems edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
+        1. Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
         Example: `vi /etc/audit/rules.d/50-access.rules`
 
@@ -5026,7 +5002,7 @@ queries:
         -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
         ```
 
-        To load the newly added rules into the running configuration:
+        2. Load the newly added rules into the running configuration:
 
         ```bash
         augenrules --load
@@ -5034,7 +5010,7 @@ queries:
 
         This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
-        Check if a reboot is required, in case the running configuration is set to be immutable:
+        3. Check if a reboot is required, in case the running configuration is set to be immutable:
 
         ```bash
         if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi
@@ -5255,7 +5231,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
+            1. Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
             Example: `vi /etc/audit/rules.d/50-deletion.rules`
 
@@ -5266,7 +5242,7 @@ queries:
             -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
             ```
 
-            To load the newly added rules into the running configuration:
+            2. Load the newly added rules into the running configuration:
 
             ```bash
             augenrules --load
@@ -5274,7 +5250,7 @@ queries:
 
             This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
-            Check if a reboot is required, in case the running configuration is set to be immutable:
+            3. Check if a reboot is required, in case the running configuration is set to be immutable:
 
             ```bash
             if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi


### PR DESCRIPTION
I noticed a lot of our steps didn't work for my Debian system because the config was already set in the /etc/sysctl.conf file. If it's there let's make sure to edit it. If not then we can create the .d file

I also confirmed that a reload of auditd does not load the main config file so if you change that you need to do a full restart.

Finally I nuked some sudo usage in our remediations so things are consistent