### PR TITLE
🐛 Use explicit and for filter query

### DIFF
--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -31,8 +31,7 @@ policies:
     groups:
       - title: Secure TLS/SSL connection
         filters: |
-          asset.platform == 'host'
-          tls.params != empty
+          asset.platform == 'host' && tls.params != empty
         checks:
           - uid: mondoo-tls-security-ciphers-include-aead-ciphers
           - uid: mondoo-tls-security-ciphers-include-pfs
@@ -48,8 +47,7 @@ policies:
           - uid: mondoo-tls-security-no-weak-tls-versions
       - title: Valid TLS/SSL certificate
         filters: |
-          asset.platform == 'host'
-          tls.params != empty
+          asset.platform == 'host' && tls.params != empty
         checks:
           - uid: mondoo-tls-security-cert-domain-name-match
           - uid: mondoo-tls-security-cert-is-valid


### PR DESCRIPTION
We don't want to try to run `tls.params` if the platform is not as expected. Without the and, we will definetly do that as both results will be computed in the block. The block will be true if all items inside are truthy