### PR TITLE
🐛 Don't change score type

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -455,17 +455,18 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 				sortedPassed = append(sortedPassed, id)
 			} else if score.Value >= uint32(r.ScoreThreshold) && r.ScoreThreshold != 0 {
 				sortedWarnings = append(sortedWarnings, id)
-			} else if score.Type == policy.ScoreType_Skip {
-				g := checkToPreview[query.Mrn]
-				var pg *previewGroup
-				if g != nil && g.Valid != nil && g.Valid.Until != nil {
-					pg = previewGroups[int(g.Valid.Until.Seconds)]
-				} else {
-					pg = previewGroups[math.MaxInt64]
-				}
-				pg.sortedFailures = append(pg.sortedFailures, id)
 			} else {
-				sortedFailed = append(sortedFailed, id)
+				if g, ok := checkToPreview[query.Mrn]; ok {
+					var pg *previewGroup
+					if g != nil && g.Valid != nil && g.Valid.Until != nil {
+						pg = previewGroups[int(g.Valid.Until.Seconds)]
+					} else {
+						pg = previewGroups[math.MaxInt64]
+					}
+					pg.sortedFailures = append(pg.sortedFailures, id)
+				} else {
+					sortedFailed = append(sortedFailed, id)
+				}
 			}
 		}
 

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -560,12 +560,6 @@ func (nodeData *ReportingJobNodeData) score() (*policy.Score, error) {
 								s.Value = floor
 							}
 						}
-
-						// since we clone it from the child, which is just the raw score,
-						// we have to set the type on this layer
-						if c.impact.Scoring == explorer.ScoringSystem_IGNORE_SCORE {
-							s.Type = policy.ScoreType_Skip
-						}
 					}
 				}
 			}


### PR DESCRIPTION
This turns out to be a breaking change. There's also no need to really do this. Its not going to be counted against any policy and it looked like this was only done for printing reasons

Broke in #1754