### PR TITLE
🐛 Fix an incorrect Linux Security remediation

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -4279,40 +4279,40 @@ queries:
 
             1. Edit or create a file in the `/etc/audit/rules.d/` directory ending in `.rules`
 
-            Example: `vi /etc/audit/rules.d/50-logins.rules`
+              Example: `vi /etc/audit/rules.d/50-logins.rules`
 
             2. Add the following lines:
 
-            ```
-            -w /var/log/lastlog -p wa -k logins
-            -w /var/log/tallylog -p wa -k logins
-            ```
+              ```
+              -w /var/log/lastlog -p wa -k logins
+              -w /var/log/tallylog -p wa -k logins
+              ```
 
             3. Add the following additional line for Debian/Ubuntu based systems:
 
-            ```
-            -w /var/log/faillog -p wa -k logins
-            ```
+              ```
+              -w /var/log/faillog -p wa -k logins
+              ```
 
             4. Add the following additional line for Red Hat/Fedora/Amazon Linux based systems:
 
-            ```
-            -w /var/run/faillock -p wa -k logins
-            ```
+              ```
+              -w /var/run/faillock -p wa -k logins
+              ```
 
             5. To load the newly added rules into the running configuration:
 
-            ```bash
-            augenrules --load
-            ```
+              ```bash
+              augenrules --load
+              ```
 
-            This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
+              This command will generate a new `/etc/audit/audit.rules` file containing the newly added rules.
 
             6. Check if a reboot is required, in case the running configuration is set to be immutable:
 
-            ```bash
-            if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi
-            ```
+              ```bash
+              if [[ $(auditctl -s | grep "enabled") =~ "2" ]]; then printf "Reboot required to load rules\n"; fi
+              ```
         - id: ansible
           desc: |
             **Using Ansible**


### PR DESCRIPTION
This was a remediation for a different check. Also while I'm here cleanup some echos, don't show the full auditd config when running the bash scripts, and ensure we get code highlighting in the examples.