### PR TITLE
⭐ migrate --score-threshold to --risk-threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-cnquery
-cnspec
+./cnquery
+./cnspec
 data/
 .DS_Store
 gha-creds-*.json
-vendor
+./vendor
 .DS_Store
 .vscode
 # goreleaser build folder

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -75,6 +75,8 @@ func init() {
 	_ = scanCmd.Flags().String("category", "inventory", "Set the category for the assets to 'inventory|cicd'.")
 	_ = scanCmd.Flags().MarkHidden("category")
 	_ = scanCmd.Flags().Int("score-threshold", 0, "If any score falls below the threshold, exit 1.")
+	_ = scanCmd.Flags().MarkDeprecated("score-threshold", "Please use --risk-threshold instead")
+	_ = scanCmd.Flags().Int("risk-threshold", reporter.DEFAULT_RISK_THRESHOLD, "If any risk is greater or equal to this, exitstatus is 1.")
 	_ = scanCmd.Flags().String("output-target", "", "Set output target to which the asset report will be sent. Currently only supports AWS SQS topic URLs and local files")
 }
 
@@ -119,6 +121,7 @@ To manually configure a policy, use this:
 		_ = viper.BindPFlag("trace-id", cmd.Flags().Lookup("trace-id"))
 		_ = viper.BindPFlag("category", cmd.Flags().Lookup("category"))
 		_ = viper.BindPFlag("score-threshold", cmd.Flags().Lookup("score-threshold"))
+		_ = viper.BindPFlag("risk-threshold", cmd.Flags().Lookup("risk-threshold"))
 
 		// for all assets
 		_ = viper.BindPFlag("incognito", cmd.Flags().Lookup("incognito"))
@@ -163,10 +166,10 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	logger.DebugDumpJSON("report", report)
 
 	handlerConf := reporter.HandlerConfig{
-		Format:         conf.OutputFormat,
-		OutputTarget:   conf.OutputTarget,
-		Incognito:      conf.IsIncognito,
-		ScoreThreshold: conf.ScoreThreshold,
+		Format:        conf.OutputFormat,
+		OutputTarget:  conf.OutputTarget,
+		Incognito:     conf.IsIncognito,
+		RiskThreshold: conf.RiskThreshold,
 	}
 	outputHandler, err := reporter.NewOutputHandler(handlerConf)
 	if err != nil {
@@ -185,7 +188,7 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 			os.Exit(1)
 		}
 
-		if report.GetWorstScore() < uint32(conf.ScoreThreshold) {
+		if (100 - report.GetWorstScore()) >= uint32(conf.RiskThreshold) {
 			os.Exit(1)
 		}
 	}
@@ -213,8 +216,8 @@ type scanConfig struct {
 	Bundle       *policy.Bundle
 	runtime      *providers.Runtime
 
-	IsIncognito    bool
-	ScoreThreshold int
+	IsIncognito   bool
+	RiskThreshold int
 
 	DoRecord bool
 	AgentMrn string
@@ -260,17 +263,29 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}
 
+	riskThreshold := viper.GetInt("risk-threshold")
+
+	// FIXME: DEPRECATED, just remove this section in v13, it is no longer necessary
+	deprecatedThreshold := 100 - viper.GetInt("score-threshold")
+	// note: the score threshold is off by one compared to the risk threshold;
+	// ie: risk threshold 90 => risk of 90 - 100 get exit 1
+	// vs: score threshold 11 => 100-11 = risk > 89 gets exit 1
+	if deprecatedThreshold+1 < riskThreshold {
+		riskThreshold = deprecatedThreshold + 1
+	}
+	// ^^
+
 	conf := scanConfig{
-		Features:       opts.GetFeatures(),
-		IsIncognito:    viper.GetBool("incognito"),
-		Inventory:      inv,
-		PolicyPaths:    dedupe(viper.GetStringSlice("policy-bundle")),
-		PolicyNames:    viper.GetStringSlice("policies"),
-		ScoreThreshold: viper.GetInt("score-threshold"),
-		Props:          props,
-		runtime:        runtime,
-		AgentMrn:       opts.AgentMrn,
-		OutputTarget:   viper.GetString("output-target"),
+		Features:      opts.GetFeatures(),
+		IsIncognito:   viper.GetBool("incognito"),
+		Inventory:     inv,
+		PolicyPaths:   dedupe(viper.GetStringSlice("policy-bundle")),
+		PolicyNames:   viper.GetStringSlice("policies"),
+		RiskThreshold: riskThreshold,
+		Props:         props,
+		runtime:       runtime,
+		AgentMrn:      opts.AgentMrn,
+		OutputTarget:  viper.GetString("output-target"),
 	}
 
 	// FIXME: DEPRECATED, remove in v12.0 and make this the default for all

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -134,7 +134,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	}
 
 	// print the output using the specified output format
-	r := reporter.NewReporter(printConf, false, 0)
+	r := reporter.NewReporter(printConf, false)
 	logger.DebugDumpJSON("vulnReport", report)
 	if err := r.PrintVulns(vulnReport, bom.Asset.Name); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -84,22 +84,24 @@ func defaultChecksum(code mqlCode, schema resources.ResourcesSchema) (string, er
 
 // note: implements the OutputHandler interface
 type Reporter struct {
-	Conf           *PrintConfig
-	Printer        *printer.Printer
-	Colors         *colors.Theme
-	IsIncognito    bool
-	ScoreThreshold int
-	out            io.Writer
+	Conf          *PrintConfig
+	Printer       *printer.Printer
+	Colors        *colors.Theme
+	IsIncognito   bool
+	RiskThreshold int
+	out           io.Writer
 }
 
-func NewReporter(conf *PrintConfig, incognito bool, scoreThreshold int) *Reporter {
+const DEFAULT_RISK_THRESHOLD = 101
+
+func NewReporter(conf *PrintConfig, incognito bool) *Reporter {
 	return &Reporter{
-		Conf:           conf,
-		Printer:        &printer.DefaultPrinter,
-		Colors:         &colors.DefaultColorTheme,
-		IsIncognito:    incognito,
-		ScoreThreshold: scoreThreshold,
-		out:            os.Stdout,
+		Conf:          conf,
+		Printer:       &printer.DefaultPrinter,
+		Colors:        &colors.DefaultColorTheme,
+		IsIncognito:   incognito,
+		RiskThreshold: DEFAULT_RISK_THRESHOLD,
+		out:           os.Stdout,
 	}
 }
 

--- a/cli/reporter/cli_reporter_test.go
+++ b/cli/reporter/cli_reporter_test.go
@@ -61,7 +61,7 @@ func TestVulnReporter(t *testing.T) {
 
 	t.Run("format=summary", func(t *testing.T) {
 		conf := defaultPrintConfig().setFormat(FormatSummary)
-		r := NewReporter(conf, false, 0)
+		r := NewReporter(conf, false)
 		r.out = &writer
 		require.NoError(t, err)
 		err = r.PrintVulns(report, target)
@@ -70,7 +70,7 @@ func TestVulnReporter(t *testing.T) {
 
 	t.Run("format=compact", func(t *testing.T) {
 		conf := defaultPrintConfig().setFormat(FormatCompact)
-		r := NewReporter(conf, false, 0)
+		r := NewReporter(conf, false)
 		r.out = &writer
 		err = r.PrintVulns(report, target)
 		require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestVulnReporter(t *testing.T) {
 
 	t.Run("format=full", func(t *testing.T) {
 		conf := defaultPrintConfig().setFormat(FormatFull)
-		r := NewReporter(conf, false, 0)
+		r := NewReporter(conf, false)
 		r.out = &writer
 		require.NoError(t, err)
 		err = r.PrintVulns(report, target)
@@ -91,7 +91,7 @@ func TestVulnReporter(t *testing.T) {
 
 	t.Run("format=yaml", func(t *testing.T) {
 		conf := defaultPrintConfig().setFormat(FormatYAMLv1)
-		r := NewReporter(conf, false, 0)
+		r := NewReporter(conf, false)
 		r.out = &writer
 		require.NoError(t, err)
 		err = r.PrintVulns(report, target)

--- a/cli/reporter/file_handler.go
+++ b/cli/reporter/file_handler.go
@@ -26,7 +26,7 @@ func (h *localFileHandler) WriteReport(ctx context.Context, report *policy.Repor
 		return err
 	}
 	defer f.Close() //nolint: errcheck
-	reporter := NewReporter(h.conf, false, 0)
+	reporter := NewReporter(h.conf, false)
 	reporter.out = f
 	err = reporter.WriteReport(ctx, report)
 	if err != nil {

--- a/cli/reporter/output_handler.go
+++ b/cli/reporter/output_handler.go
@@ -15,10 +15,10 @@ import (
 )
 
 type HandlerConfig struct {
-	Format         string
-	OutputTarget   string
-	Incognito      bool
-	ScoreThreshold int
+	Format        string
+	OutputTarget  string
+	Incognito     bool
+	RiskThreshold int
 }
 
 type OutputTarget byte
@@ -51,7 +51,9 @@ func NewOutputHandler(config HandlerConfig) (OutputHandler, error) {
 	case CLI:
 		fallthrough
 	default:
-		return NewReporter(conf, config.Incognito, config.ScoreThreshold), nil
+		res := NewReporter(conf, config.Incognito)
+		res.RiskThreshold = config.RiskThreshold
+		return res, nil
 	}
 }
 

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -453,7 +453,7 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 
 			if score.Success {
 				sortedPassed = append(sortedPassed, id)
-			} else if score.Value >= uint32(r.ScoreThreshold) && r.ScoreThreshold != 0 {
+			} else if r.RiskThreshold != DEFAULT_RISK_THRESHOLD && (100-score.Value) < uint32(r.RiskThreshold) {
 				sortedWarnings = append(sortedWarnings, id)
 			} else {
 				if g, ok := checkToPreview[query.Mrn]; ok {
@@ -510,7 +510,7 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 				r.out(NewLineCharacter)
 			}
 			// FIXME v12: rename to risk threshold
-			r.out("Warning - above score threshold:" + NewLineCharacter)
+			r.out("Warnings (below risk threshold):" + NewLineCharacter)
 			for _, id := range sortedWarnings {
 				r.printCheck(foundChecks[id], queries[id], resolved, report, results)
 			}
@@ -563,9 +563,8 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 			if prevPrinted {
 				r.out(NewLineCharacter)
 			}
-			if r.ScoreThreshold > 0 {
-				// FIXME v12: rename to risk threshold
-				r.out("Failing - below score threshold:" + NewLineCharacter)
+			if r.RiskThreshold != DEFAULT_RISK_THRESHOLD {
+				r.out("Failures (above risk threshold):" + NewLineCharacter)
 			} else {
 				r.out("Failing:" + NewLineCharacter)
 			}
@@ -651,7 +650,7 @@ func (r *defaultReporter) printScore(title string, score simpleScore, query *exp
 			scoreIndicator = " (" + strconv.Itoa(int(score.Value)) + ")"
 		}
 		scoreSymbol := "✕"
-		if r.ScoreThreshold > 0 && score.Value > uint32(r.ScoreThreshold) {
+		if r.RiskThreshold != DEFAULT_RISK_THRESHOLD && (100-score.Value) < uint32(r.RiskThreshold) {
 			scoreSymbol = "!"
 		}
 		passfail = termenv.String(checkStatus(scoreSymbol, score.Rating.Text()+scoreIndicator)).Foreground(color).String()

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -33,7 +33,7 @@ Flags:
       --policy strings                Lists policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY.
   -f, --policy-bundle strings         Path to local policy file
       --props stringToString          Custom values for properties (default [])
-      --score-threshold int           If any score falls below the threshold, exit 1.
+      --risk-threshold int            If any risk is greater or equal to this, exitstatus is 1. (default 101)
       --trace-id string               Trace identifier
 
 Global Flags:


### PR DESCRIPTION
We are moving away from the old score system (0 = critical, 100 = info) to the risk-based scoring mechanism. For that purpose we are deprecating `--score-threshold` and moving to `--risk-threshold`. Also, the new `--risk-threshold` has a more consistent UX.

For example, let's say you want to fail a pipeline scan on critical findings. The old way: 

```
cnspec scan --score-threshold 11
```

and the new way:

```
cnspec scan --risk-threshold 90
```

The new number is inclusive i.e. risk 90-100 is critical, setting the threshold there will make it error once the number is reached.