### PR TITLE
fix(ci): Skip installer dispatch hook on pre-release versions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -221,6 +221,10 @@ jobs:
             mondoohq/installer
             mondoohq/cnspec
 
+      - name: Check if pre-release
+        id: is_prerelease
+        run: echo "is_pre=${{ contains(github.ref_name, '-pre') }}" >> $GITHUB_OUTPUT
+
       - name: Trigger installer release
         uses: peter-evans/repository-dispatch@v3
         with:
@@ -228,7 +232,8 @@ jobs:
           repository: "mondoohq/installer"
           event-type: trigger-release
           client-payload: '{
-            "version": "${{ github.ref_name }}"
+            "version": "${{ github.ref_name }}",
+            "skip-publish": "${{ steps.is_prerelease.outputs.is_pre }}"
             }'
 
   mondoo-operator-cnspec:


### PR DESCRIPTION
Trigger the final release job only if we are not on a pre-release ref (`-pre`)