### PR TITLE
⭐ add support for server-side features

### DIFF
--- a/policy/cnspec_policy.pb.go
+++ b/policy/cnspec_policy.pb.go
@@ -258,6 +258,58 @@ func (ReviewStatus) EnumDescriptor() ([]byte, []int) {
 	return file_cnspec_policy_proto_rawDescGZIP(), []int{3}
 }
 
+// ServerFeature which tells us if the upstream endpoint can handle certain
+// requests and data. Usually proto handles missing fields etc really well,
+// but we are also trying to avoid work on the client or sending large
+// amounts of data to the server that aren't necessary.
+type ServerFeature int32
+
+const (
+	// Default value, should not be used
+	ServerFeature_SERVER_FEATURE_UNSPECIFIED ServerFeature = 0
+	// StoreResourcesData as structure recording data
+	ServerFeature_STORE_RESOURCES_DATA ServerFeature = 1
+)
+
+// Enum value maps for ServerFeature.
+var (
+	ServerFeature_name = map[int32]string{
+		0: "SERVER_FEATURE_UNSPECIFIED",
+		1: "STORE_RESOURCES_DATA",
+	}
+	ServerFeature_value = map[string]int32{
+		"SERVER_FEATURE_UNSPECIFIED": 0,
+		"STORE_RESOURCES_DATA":       1,
+	}
+)
+
+func (x ServerFeature) Enum() *ServerFeature {
+	p := new(ServerFeature)
+	*p = x
+	return p
+}
+
+func (x ServerFeature) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ServerFeature) Descriptor() protoreflect.EnumDescriptor {
+	return file_cnspec_policy_proto_enumTypes[4].Descriptor()
+}
+
+func (ServerFeature) Type() protoreflect.EnumType {
+	return &file_cnspec_policy_proto_enumTypes[4]
+}
+
+func (x ServerFeature) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ServerFeature.Descriptor instead.
+func (ServerFeature) EnumDescriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{4}
+}
+
 type ScoreRating int32
 
 const (
@@ -330,11 +382,11 @@ func (x ScoreRating) String() string {
 }
 
 func (ScoreRating) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[4].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[5].Descriptor()
 }
 
 func (ScoreRating) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[4]
+	return &file_cnspec_policy_proto_enumTypes[5]
 }
 
 func (x ScoreRating) Number() protoreflect.EnumNumber {
@@ -343,7 +395,7 @@ func (x ScoreRating) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ScoreRating.Descriptor instead.
 func (ScoreRating) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{4}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{5}
 }
 
 type Comparison int32
@@ -376,11 +428,11 @@ func (x Comparison) String() string {
 }
 
 func (Comparison) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[5].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[6].Descriptor()
 }
 
 func (Comparison) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[5]
+	return &file_cnspec_policy_proto_enumTypes[6]
 }
 
 func (x Comparison) Number() protoreflect.EnumNumber {
@@ -389,7 +441,7 @@ func (x Comparison) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Comparison.Descriptor instead.
 func (Comparison) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{5}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{6}
 }
 
 type DateFilterField int32
@@ -422,11 +474,11 @@ func (x DateFilterField) String() string {
 }
 
 func (DateFilterField) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[6].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[7].Descriptor()
 }
 
 func (DateFilterField) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[6]
+	return &file_cnspec_policy_proto_enumTypes[7]
 }
 
 func (x DateFilterField) Number() protoreflect.EnumNumber {
@@ -435,7 +487,7 @@ func (x DateFilterField) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DateFilterField.Descriptor instead.
 func (DateFilterField) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{6}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{7}
 }
 
 type Migration_Action int32
@@ -474,11 +526,11 @@ func (x Migration_Action) String() string {
 }
 
 func (Migration_Action) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[7].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[8].Descriptor()
 }
 
 func (Migration_Action) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[7]
+	return &file_cnspec_policy_proto_enumTypes[8]
 }
 
 func (x Migration_Action) Number() protoreflect.EnumNumber {
@@ -541,11 +593,11 @@ func (x ReportingJob_Type) String() string {
 }
 
 func (ReportingJob_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[8].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[9].Descriptor()
 }
 
 func (ReportingJob_Type) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[8]
+	return &file_cnspec_policy_proto_enumTypes[9]
 }
 
 func (x ReportingJob_Type) Number() protoreflect.EnumNumber {
@@ -587,11 +639,11 @@ func (x PolicyDelta_PolicyAssignmentActionType) String() string {
 }
 
 func (PolicyDelta_PolicyAssignmentActionType) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[9].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[10].Descriptor()
 }
 
 func (PolicyDelta_PolicyAssignmentActionType) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[9]
+	return &file_cnspec_policy_proto_enumTypes[10]
 }
 
 func (x PolicyDelta_PolicyAssignmentActionType) Number() protoreflect.EnumNumber {
@@ -642,11 +694,11 @@ func (x Source_Vendor) String() string {
 }
 
 func (Source_Vendor) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[10].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[11].Descriptor()
 }
 
 func (Source_Vendor) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[10]
+	return &file_cnspec_policy_proto_enumTypes[11]
 }
 
 func (x Source_Vendor) Number() protoreflect.EnumNumber {
@@ -3228,6 +3280,7 @@ type ResolvedPolicy struct {
 	GraphExecutionChecksum string                 `protobuf:"bytes,7,opt,name=graph_execution_checksum,json=graphExecutionChecksum,proto3" json:"graph_execution_checksum,omitempty"`
 	FiltersChecksum        string                 `protobuf:"bytes,20,opt,name=filters_checksum,json=filtersChecksum,proto3" json:"filters_checksum,omitempty"`
 	ReportingJobUuid       string                 `protobuf:"bytes,21,opt,name=reporting_job_uuid,json=reportingJobUuid,proto3" json:"reporting_job_uuid,omitempty"`
+	Features               []ServerFeature        `protobuf:"varint,8,rep,packed,name=features,proto3,enum=cnspec.policy.v1.ServerFeature" json:"features,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -3302,6 +3355,13 @@ func (x *ResolvedPolicy) GetReportingJobUuid() string {
 		return x.ReportingJobUuid
 	}
 	return ""
+}
+
+func (x *ResolvedPolicy) GetFeatures() []ServerFeature {
+	if x != nil {
+		return x.Features
+	}
+	return nil
 }
 
 // The list of queries that an asset needs to execute
@@ -6867,14 +6927,15 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x03mrn\x18\x01 \x01(\tR\x03mrn\x12\x12\n" +
 	"\x04name\x18\x12 \x01(\tR\x04name\x12\x10\n" +
 	"\x03url\x18\x13 \x01(\tR\x03url\x12:\n" +
-	"\bplatform\x18\x15 \x01(\v2\x1e.cnquery.providers.v1.PlatformR\bplatformJ\x04\b\x14\x10\x15\"\xe1\x02\n" +
+	"\bplatform\x18\x15 \x01(\v2\x1e.cnquery.providers.v1.PlatformR\bplatformJ\x04\b\x14\x10\x15\"\x9e\x03\n" +
 	"\x0eResolvedPolicy\x12C\n" +
 	"\rexecution_job\x18\x02 \x01(\v2\x1e.cnspec.policy.v1.ExecutionJobR\fexecutionJob\x12C\n" +
 	"\rcollector_job\x18\x03 \x01(\v2\x1e.cnspec.policy.v1.CollectorJobR\fcollectorJob\x122\n" +
 	"\afilters\x18\x01 \x03(\v2\x18.cnquery.explorer.MqueryR\afilters\x128\n" +
 	"\x18graph_execution_checksum\x18\a \x01(\tR\x16graphExecutionChecksum\x12)\n" +
 	"\x10filters_checksum\x18\x14 \x01(\tR\x0ffiltersChecksum\x12,\n" +
-	"\x12reporting_job_uuid\x18\x15 \x01(\tR\x10reportingJobUuid\"\xcf\x01\n" +
+	"\x12reporting_job_uuid\x18\x15 \x01(\tR\x10reportingJobUuid\x12;\n" +
+	"\bfeatures\x18\b \x03(\x0e2\x1f.cnspec.policy.v1.ServerFeatureR\bfeatures\"\xcf\x01\n" +
 	"\fExecutionJob\x12\x1a\n" +
 	"\bchecksum\x18\x01 \x01(\tR\bchecksum\x12E\n" +
 	"\aqueries\x18\x02 \x03(\v2+.cnspec.policy.v1.ExecutionJob.QueriesEntryR\aqueries\x1a\\\n" +
@@ -7304,7 +7365,10 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\fReviewStatus\x12\x10\n" +
 	"\fNOT_REVIEWED\x10\x00\x12\f\n" +
 	"\bAPPROVED\x10\x01\x12\f\n" +
-	"\bREJECTED\x10\x02*\xb3\x01\n" +
+	"\bREJECTED\x10\x02*I\n" +
+	"\rServerFeature\x12\x1e\n" +
+	"\x1aSERVER_FEATURE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14STORE_RESOURCES_DATA\x10\x01*\xb3\x01\n" +
 	"\vScoreRating\x12\v\n" +
 	"\aunrated\x10\x00\x12\t\n" +
 	"\x05aPlus\x10\x01\x12\x05\n" +
@@ -7375,367 +7439,369 @@ func file_cnspec_policy_proto_rawDescGZIP() []byte {
 	return file_cnspec_policy_proto_rawDescData
 }
 
-var file_cnspec_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
+var file_cnspec_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 12)
 var file_cnspec_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 102)
 var file_cnspec_policy_proto_goTypes = []any{
 	(GroupType)(0),         // 0: cnspec.policy.v1.GroupType
 	(QueryAction)(0),       // 1: cnspec.policy.v1.QueryAction
 	(ScopeType)(0),         // 2: cnspec.policy.v1.ScopeType
 	(ReviewStatus)(0),      // 3: cnspec.policy.v1.ReviewStatus
-	(ScoreRating)(0),       // 4: cnspec.policy.v1.ScoreRating
-	(Comparison)(0),        // 5: cnspec.policy.v1.Comparison
-	(DateFilterField)(0),   // 6: cnspec.policy.v1.DateFilterField
-	(Migration_Action)(0),  // 7: cnspec.policy.v1.Migration.Action
-	(ReportingJob_Type)(0), // 8: cnspec.policy.v1.ReportingJob.Type
-	(PolicyDelta_PolicyAssignmentActionType)(0), // 9: cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
-	(Source_Vendor)(0),                          // 10: cnspec.policy.v1.Source.Vendor
-	(*PolicyGroup)(nil),                         // 11: cnspec.policy.v1.PolicyGroup
-	(*Validity)(nil),                            // 12: cnspec.policy.v1.Validity
-	(*PolicyRef)(nil),                           // 13: cnspec.policy.v1.PolicyRef
-	(*Policy)(nil),                              // 14: cnspec.policy.v1.Policy
-	(*Policies)(nil),                            // 15: cnspec.policy.v1.Policies
-	(*QueryCounts)(nil),                         // 16: cnspec.policy.v1.QueryCounts
-	(*Bundle)(nil),                              // 17: cnspec.policy.v1.Bundle
-	(*MigrationGroup)(nil),                      // 18: cnspec.policy.v1.MigrationGroup
-	(*Migration)(nil),                           // 19: cnspec.policy.v1.Migration
-	(*MigrationMatch)(nil),                      // 20: cnspec.policy.v1.MigrationMatch
-	(*MigrationDelta)(nil),                      // 21: cnspec.policy.v1.MigrationDelta
-	(*SoftwareSelector)(nil),                    // 22: cnspec.policy.v1.SoftwareSelector
-	(*ResourceSelector)(nil),                    // 23: cnspec.policy.v1.ResourceSelector
-	(*RiskMagnitude)(nil),                       // 24: cnspec.policy.v1.RiskMagnitude
-	(*RiskFactor)(nil),                          // 25: cnspec.policy.v1.RiskFactor
-	(*RiskFactorDocs)(nil),                      // 26: cnspec.policy.v1.RiskFactorDocs
-	(*PolicyGroupDocs)(nil),                     // 27: cnspec.policy.v1.PolicyGroupDocs
-	(*PolicyDocs)(nil),                          // 28: cnspec.policy.v1.PolicyDocs
-	(*Framework)(nil),                           // 29: cnspec.policy.v1.Framework
-	(*Frameworks)(nil),                          // 30: cnspec.policy.v1.Frameworks
-	(*FrameworkGroup)(nil),                      // 31: cnspec.policy.v1.FrameworkGroup
-	(*FrameworkRef)(nil),                        // 32: cnspec.policy.v1.FrameworkRef
-	(*Evidence)(nil),                            // 33: cnspec.policy.v1.Evidence
-	(*Control)(nil),                             // 34: cnspec.policy.v1.Control
-	(*FrameworkMap)(nil),                        // 35: cnspec.policy.v1.FrameworkMap
-	(*ControlMap)(nil),                          // 36: cnspec.policy.v1.ControlMap
-	(*ControlDocs)(nil),                         // 37: cnspec.policy.v1.ControlDocs
-	(*ControlRef)(nil),                          // 38: cnspec.policy.v1.ControlRef
-	(*Asset)(nil),                               // 39: cnspec.policy.v1.Asset
-	(*ResolvedPolicy)(nil),                      // 40: cnspec.policy.v1.ResolvedPolicy
-	(*ExecutionJob)(nil),                        // 41: cnspec.policy.v1.ExecutionJob
-	(*ExecutionQuery)(nil),                      // 42: cnspec.policy.v1.ExecutionQuery
-	(*CollectorJob)(nil),                        // 43: cnspec.policy.v1.CollectorJob
-	(*StringArray)(nil),                         // 44: cnspec.policy.v1.StringArray
-	(*DataQueryInfo)(nil),                       // 45: cnspec.policy.v1.DataQueryInfo
-	(*ReportingJob)(nil),                        // 46: cnspec.policy.v1.ReportingJob
-	(*Report)(nil),                              // 47: cnspec.policy.v1.Report
-	(*Reports)(nil),                             // 48: cnspec.policy.v1.Reports
-	(*ReportCollection)(nil),                    // 49: cnspec.policy.v1.ReportCollection
-	(*FrameworkReport)(nil),                     // 50: cnspec.policy.v1.FrameworkReport
-	(*ControlScore)(nil),                        // 51: cnspec.policy.v1.ControlScore
-	(*Cvss)(nil),                                // 52: cnspec.policy.v1.Cvss
-	(*CvssStats)(nil),                           // 53: cnspec.policy.v1.CvssStats
-	(*Score)(nil),                               // 54: cnspec.policy.v1.Score
-	(*ScoreDelta)(nil),                          // 55: cnspec.policy.v1.ScoreDelta
-	(*ScoredRiskFactor)(nil),                    // 56: cnspec.policy.v1.ScoredRiskFactor
-	(*ScoredRiskFactors)(nil),                   // 57: cnspec.policy.v1.ScoredRiskFactors
-	(*RiskFactorStats)(nil),                     // 58: cnspec.policy.v1.RiskFactorStats
-	(*RiskFactorsStats)(nil),                    // 59: cnspec.policy.v1.RiskFactorsStats
-	(*Stats)(nil),                               // 60: cnspec.policy.v1.Stats
-	(*ScoreDistribution)(nil),                   // 61: cnspec.policy.v1.ScoreDistribution
-	(*ScoreStats)(nil),                          // 62: cnspec.policy.v1.ScoreStats
-	(*AssetFindingsStats)(nil),                  // 63: cnspec.policy.v1.AssetFindingsStats
-	(*Empty)(nil),                               // 64: cnspec.policy.v1.Empty
-	(*Mrn)(nil),                                 // 65: cnspec.policy.v1.Mrn
-	(*Mqueries)(nil),                            // 66: cnspec.policy.v1.Mqueries
-	(*ListReq)(nil),                             // 67: cnspec.policy.v1.ListReq
-	(*DefaultPoliciesReq)(nil),                  // 68: cnspec.policy.v1.DefaultPoliciesReq
-	(*URLs)(nil),                                // 69: cnspec.policy.v1.URLs
-	(*PolicyAssignment)(nil),                    // 70: cnspec.policy.v1.PolicyAssignment
-	(*PolicyMutationDelta)(nil),                 // 71: cnspec.policy.v1.PolicyMutationDelta
-	(*PolicyDelta)(nil),                         // 72: cnspec.policy.v1.PolicyDelta
-	(*ResolveReq)(nil),                          // 73: cnspec.policy.v1.ResolveReq
-	(*UpdateAssetJobsReq)(nil),                  // 74: cnspec.policy.v1.UpdateAssetJobsReq
-	(*StoreResultsReq)(nil),                     // 75: cnspec.policy.v1.StoreResultsReq
-	(*EntityScoreReq)(nil),                      // 76: cnspec.policy.v1.EntityScoreReq
-	(*SynchronizeAssetsReq)(nil),                // 77: cnspec.policy.v1.SynchronizeAssetsReq
-	(*SynchronizeAssetsRespAssetDetail)(nil),    // 78: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
-	(*SynchronizeAssetsResp)(nil),               // 79: cnspec.policy.v1.SynchronizeAssetsResp
-	(*PurgeAssetsRequest)(nil),                  // 80: cnspec.policy.v1.PurgeAssetsRequest
-	(*DateFilter)(nil),                          // 81: cnspec.policy.v1.DateFilter
-	(*PurgeAssetsConfirmation)(nil),             // 82: cnspec.policy.v1.PurgeAssetsConfirmation
-	(*Sources)(nil),                             // 83: cnspec.policy.v1.Sources
-	(*Source)(nil),                              // 84: cnspec.policy.v1.Source
-	nil,                                         // 85: cnspec.policy.v1.Policy.TagsEntry
-	nil,                                         // 86: cnspec.policy.v1.RiskFactor.TagsEntry
-	nil,                                         // 87: cnspec.policy.v1.Framework.TagsEntry
-	nil,                                         // 88: cnspec.policy.v1.Control.TagsEntry
-	nil,                                         // 89: cnspec.policy.v1.ExecutionJob.QueriesEntry
-	nil,                                         // 90: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	nil,                                         // 91: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	nil,                                         // 92: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	nil,                                         // 93: cnspec.policy.v1.CollectorJob.DatapointsEntry
-	nil,                                         // 94: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	nil,                                         // 95: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	nil,                                         // 96: cnspec.policy.v1.ReportingJob.DatapointsEntry
-	nil,                                         // 97: cnspec.policy.v1.ReportingJob.ChildJobsEntry
-	nil,                                         // 98: cnspec.policy.v1.Report.ScoresEntry
-	nil,                                         // 99: cnspec.policy.v1.Report.DataEntry
-	nil,                                         // 100: cnspec.policy.v1.Report.CvssScoresEntry
-	nil,                                         // 101: cnspec.policy.v1.ReportCollection.AssetsEntry
-	nil,                                         // 102: cnspec.policy.v1.ReportCollection.ReportsEntry
-	nil,                                         // 103: cnspec.policy.v1.ReportCollection.ErrorsEntry
-	nil,                                         // 104: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	nil,                                         // 105: cnspec.policy.v1.ReportCollection.VulnReportsEntry
-	nil,                                         // 106: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
-	nil,                                         // 107: cnspec.policy.v1.StoreResultsReq.DataEntry
-	nil,                                         // 108: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
-	nil,                                         // 109: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	nil,                                         // 110: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	nil,                                         // 111: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
-	nil,                                         // 112: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	(*explorer.Mquery)(nil),                     // 113: cnquery.explorer.Mquery
-	(*explorer.Filters)(nil),                    // 114: cnquery.explorer.Filters
-	(*explorer.Author)(nil),                     // 115: cnquery.explorer.Author
-	(*explorer.HumanTime)(nil),                  // 116: cnquery.explorer.HumanTime
-	(explorer.Action)(0),                        // 117: cnquery.explorer.Action
-	(*explorer.Impact)(nil),                     // 118: cnquery.explorer.Impact
-	(explorer.ScoringSystem)(0),                 // 119: cnquery.explorer.ScoringSystem
-	(*explorer.Property)(nil),                   // 120: cnquery.explorer.Property
-	(*explorer.QueryPack)(nil),                  // 121: cnquery.explorer.QueryPack
-	(*explorer.ObjectRef)(nil),                  // 122: cnquery.explorer.ObjectRef
-	(*explorer.MqueryRef)(nil),                  // 123: cnquery.explorer.MqueryRef
-	(*inventory.Platform)(nil),                  // 124: cnquery.providers.v1.Platform
-	(*llx.CodeBundle)(nil),                      // 125: cnquery.llx.CodeBundle
-	(*inventory.Asset)(nil),                     // 126: cnquery.providers.v1.Asset
-	(*llx.Result)(nil),                          // 127: cnquery.llx.Result
-	(*mvd.VulnReport)(nil),                      // 128: mondoo.mvd.v1.VulnReport
-	(*llx.ResourceRecording)(nil),               // 129: cnquery.llx.ResourceRecording
-	(*explorer.PropsReq)(nil),                   // 130: cnquery.explorer.PropsReq
-	(*resources.EntityResourcesReq)(nil),        // 131: cnquery.explorer.resources.EntityResourcesReq
-	(*explorer.Empty)(nil),                      // 132: cnquery.explorer.Empty
-	(*resources.EntityResourcesRes)(nil),        // 133: cnquery.explorer.resources.EntityResourcesRes
+	(ServerFeature)(0),     // 4: cnspec.policy.v1.ServerFeature
+	(ScoreRating)(0),       // 5: cnspec.policy.v1.ScoreRating
+	(Comparison)(0),        // 6: cnspec.policy.v1.Comparison
+	(DateFilterField)(0),   // 7: cnspec.policy.v1.DateFilterField
+	(Migration_Action)(0),  // 8: cnspec.policy.v1.Migration.Action
+	(ReportingJob_Type)(0), // 9: cnspec.policy.v1.ReportingJob.Type
+	(PolicyDelta_PolicyAssignmentActionType)(0), // 10: cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
+	(Source_Vendor)(0),                          // 11: cnspec.policy.v1.Source.Vendor
+	(*PolicyGroup)(nil),                         // 12: cnspec.policy.v1.PolicyGroup
+	(*Validity)(nil),                            // 13: cnspec.policy.v1.Validity
+	(*PolicyRef)(nil),                           // 14: cnspec.policy.v1.PolicyRef
+	(*Policy)(nil),                              // 15: cnspec.policy.v1.Policy
+	(*Policies)(nil),                            // 16: cnspec.policy.v1.Policies
+	(*QueryCounts)(nil),                         // 17: cnspec.policy.v1.QueryCounts
+	(*Bundle)(nil),                              // 18: cnspec.policy.v1.Bundle
+	(*MigrationGroup)(nil),                      // 19: cnspec.policy.v1.MigrationGroup
+	(*Migration)(nil),                           // 20: cnspec.policy.v1.Migration
+	(*MigrationMatch)(nil),                      // 21: cnspec.policy.v1.MigrationMatch
+	(*MigrationDelta)(nil),                      // 22: cnspec.policy.v1.MigrationDelta
+	(*SoftwareSelector)(nil),                    // 23: cnspec.policy.v1.SoftwareSelector
+	(*ResourceSelector)(nil),                    // 24: cnspec.policy.v1.ResourceSelector
+	(*RiskMagnitude)(nil),                       // 25: cnspec.policy.v1.RiskMagnitude
+	(*RiskFactor)(nil),                          // 26: cnspec.policy.v1.RiskFactor
+	(*RiskFactorDocs)(nil),                      // 27: cnspec.policy.v1.RiskFactorDocs
+	(*PolicyGroupDocs)(nil),                     // 28: cnspec.policy.v1.PolicyGroupDocs
+	(*PolicyDocs)(nil),                          // 29: cnspec.policy.v1.PolicyDocs
+	(*Framework)(nil),                           // 30: cnspec.policy.v1.Framework
+	(*Frameworks)(nil),                          // 31: cnspec.policy.v1.Frameworks
+	(*FrameworkGroup)(nil),                      // 32: cnspec.policy.v1.FrameworkGroup
+	(*FrameworkRef)(nil),                        // 33: cnspec.policy.v1.FrameworkRef
+	(*Evidence)(nil),                            // 34: cnspec.policy.v1.Evidence
+	(*Control)(nil),                             // 35: cnspec.policy.v1.Control
+	(*FrameworkMap)(nil),                        // 36: cnspec.policy.v1.FrameworkMap
+	(*ControlMap)(nil),                          // 37: cnspec.policy.v1.ControlMap
+	(*ControlDocs)(nil),                         // 38: cnspec.policy.v1.ControlDocs
+	(*ControlRef)(nil),                          // 39: cnspec.policy.v1.ControlRef
+	(*Asset)(nil),                               // 40: cnspec.policy.v1.Asset
+	(*ResolvedPolicy)(nil),                      // 41: cnspec.policy.v1.ResolvedPolicy
+	(*ExecutionJob)(nil),                        // 42: cnspec.policy.v1.ExecutionJob
+	(*ExecutionQuery)(nil),                      // 43: cnspec.policy.v1.ExecutionQuery
+	(*CollectorJob)(nil),                        // 44: cnspec.policy.v1.CollectorJob
+	(*StringArray)(nil),                         // 45: cnspec.policy.v1.StringArray
+	(*DataQueryInfo)(nil),                       // 46: cnspec.policy.v1.DataQueryInfo
+	(*ReportingJob)(nil),                        // 47: cnspec.policy.v1.ReportingJob
+	(*Report)(nil),                              // 48: cnspec.policy.v1.Report
+	(*Reports)(nil),                             // 49: cnspec.policy.v1.Reports
+	(*ReportCollection)(nil),                    // 50: cnspec.policy.v1.ReportCollection
+	(*FrameworkReport)(nil),                     // 51: cnspec.policy.v1.FrameworkReport
+	(*ControlScore)(nil),                        // 52: cnspec.policy.v1.ControlScore
+	(*Cvss)(nil),                                // 53: cnspec.policy.v1.Cvss
+	(*CvssStats)(nil),                           // 54: cnspec.policy.v1.CvssStats
+	(*Score)(nil),                               // 55: cnspec.policy.v1.Score
+	(*ScoreDelta)(nil),                          // 56: cnspec.policy.v1.ScoreDelta
+	(*ScoredRiskFactor)(nil),                    // 57: cnspec.policy.v1.ScoredRiskFactor
+	(*ScoredRiskFactors)(nil),                   // 58: cnspec.policy.v1.ScoredRiskFactors
+	(*RiskFactorStats)(nil),                     // 59: cnspec.policy.v1.RiskFactorStats
+	(*RiskFactorsStats)(nil),                    // 60: cnspec.policy.v1.RiskFactorsStats
+	(*Stats)(nil),                               // 61: cnspec.policy.v1.Stats
+	(*ScoreDistribution)(nil),                   // 62: cnspec.policy.v1.ScoreDistribution
+	(*ScoreStats)(nil),                          // 63: cnspec.policy.v1.ScoreStats
+	(*AssetFindingsStats)(nil),                  // 64: cnspec.policy.v1.AssetFindingsStats
+	(*Empty)(nil),                               // 65: cnspec.policy.v1.Empty
+	(*Mrn)(nil),                                 // 66: cnspec.policy.v1.Mrn
+	(*Mqueries)(nil),                            // 67: cnspec.policy.v1.Mqueries
+	(*ListReq)(nil),                             // 68: cnspec.policy.v1.ListReq
+	(*DefaultPoliciesReq)(nil),                  // 69: cnspec.policy.v1.DefaultPoliciesReq
+	(*URLs)(nil),                                // 70: cnspec.policy.v1.URLs
+	(*PolicyAssignment)(nil),                    // 71: cnspec.policy.v1.PolicyAssignment
+	(*PolicyMutationDelta)(nil),                 // 72: cnspec.policy.v1.PolicyMutationDelta
+	(*PolicyDelta)(nil),                         // 73: cnspec.policy.v1.PolicyDelta
+	(*ResolveReq)(nil),                          // 74: cnspec.policy.v1.ResolveReq
+	(*UpdateAssetJobsReq)(nil),                  // 75: cnspec.policy.v1.UpdateAssetJobsReq
+	(*StoreResultsReq)(nil),                     // 76: cnspec.policy.v1.StoreResultsReq
+	(*EntityScoreReq)(nil),                      // 77: cnspec.policy.v1.EntityScoreReq
+	(*SynchronizeAssetsReq)(nil),                // 78: cnspec.policy.v1.SynchronizeAssetsReq
+	(*SynchronizeAssetsRespAssetDetail)(nil),    // 79: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
+	(*SynchronizeAssetsResp)(nil),               // 80: cnspec.policy.v1.SynchronizeAssetsResp
+	(*PurgeAssetsRequest)(nil),                  // 81: cnspec.policy.v1.PurgeAssetsRequest
+	(*DateFilter)(nil),                          // 82: cnspec.policy.v1.DateFilter
+	(*PurgeAssetsConfirmation)(nil),             // 83: cnspec.policy.v1.PurgeAssetsConfirmation
+	(*Sources)(nil),                             // 84: cnspec.policy.v1.Sources
+	(*Source)(nil),                              // 85: cnspec.policy.v1.Source
+	nil,                                         // 86: cnspec.policy.v1.Policy.TagsEntry
+	nil,                                         // 87: cnspec.policy.v1.RiskFactor.TagsEntry
+	nil,                                         // 88: cnspec.policy.v1.Framework.TagsEntry
+	nil,                                         // 89: cnspec.policy.v1.Control.TagsEntry
+	nil,                                         // 90: cnspec.policy.v1.ExecutionJob.QueriesEntry
+	nil,                                         // 91: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	nil,                                         // 92: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	nil,                                         // 93: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	nil,                                         // 94: cnspec.policy.v1.CollectorJob.DatapointsEntry
+	nil,                                         // 95: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	nil,                                         // 96: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	nil,                                         // 97: cnspec.policy.v1.ReportingJob.DatapointsEntry
+	nil,                                         // 98: cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	nil,                                         // 99: cnspec.policy.v1.Report.ScoresEntry
+	nil,                                         // 100: cnspec.policy.v1.Report.DataEntry
+	nil,                                         // 101: cnspec.policy.v1.Report.CvssScoresEntry
+	nil,                                         // 102: cnspec.policy.v1.ReportCollection.AssetsEntry
+	nil,                                         // 103: cnspec.policy.v1.ReportCollection.ReportsEntry
+	nil,                                         // 104: cnspec.policy.v1.ReportCollection.ErrorsEntry
+	nil,                                         // 105: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	nil,                                         // 106: cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	nil,                                         // 107: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	nil,                                         // 108: cnspec.policy.v1.StoreResultsReq.DataEntry
+	nil,                                         // 109: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	nil,                                         // 110: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	nil,                                         // 111: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	nil,                                         // 112: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	nil,                                         // 113: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	(*explorer.Mquery)(nil),                     // 114: cnquery.explorer.Mquery
+	(*explorer.Filters)(nil),                    // 115: cnquery.explorer.Filters
+	(*explorer.Author)(nil),                     // 116: cnquery.explorer.Author
+	(*explorer.HumanTime)(nil),                  // 117: cnquery.explorer.HumanTime
+	(explorer.Action)(0),                        // 118: cnquery.explorer.Action
+	(*explorer.Impact)(nil),                     // 119: cnquery.explorer.Impact
+	(explorer.ScoringSystem)(0),                 // 120: cnquery.explorer.ScoringSystem
+	(*explorer.Property)(nil),                   // 121: cnquery.explorer.Property
+	(*explorer.QueryPack)(nil),                  // 122: cnquery.explorer.QueryPack
+	(*explorer.ObjectRef)(nil),                  // 123: cnquery.explorer.ObjectRef
+	(*explorer.MqueryRef)(nil),                  // 124: cnquery.explorer.MqueryRef
+	(*inventory.Platform)(nil),                  // 125: cnquery.providers.v1.Platform
+	(*llx.CodeBundle)(nil),                      // 126: cnquery.llx.CodeBundle
+	(*inventory.Asset)(nil),                     // 127: cnquery.providers.v1.Asset
+	(*llx.Result)(nil),                          // 128: cnquery.llx.Result
+	(*mvd.VulnReport)(nil),                      // 129: mondoo.mvd.v1.VulnReport
+	(*llx.ResourceRecording)(nil),               // 130: cnquery.llx.ResourceRecording
+	(*explorer.PropsReq)(nil),                   // 131: cnquery.explorer.PropsReq
+	(*resources.EntityResourcesReq)(nil),        // 132: cnquery.explorer.resources.EntityResourcesReq
+	(*explorer.Empty)(nil),                      // 133: cnquery.explorer.Empty
+	(*resources.EntityResourcesRes)(nil),        // 134: cnquery.explorer.resources.EntityResourcesRes
 }
 var file_cnspec_policy_proto_depIdxs = []int32{
-	13,  // 0: cnspec.policy.v1.PolicyGroup.policies:type_name -> cnspec.policy.v1.PolicyRef
-	113, // 1: cnspec.policy.v1.PolicyGroup.checks:type_name -> cnquery.explorer.Mquery
-	113, // 2: cnspec.policy.v1.PolicyGroup.queries:type_name -> cnquery.explorer.Mquery
+	14,  // 0: cnspec.policy.v1.PolicyGroup.policies:type_name -> cnspec.policy.v1.PolicyRef
+	114, // 1: cnspec.policy.v1.PolicyGroup.checks:type_name -> cnquery.explorer.Mquery
+	114, // 2: cnspec.policy.v1.PolicyGroup.queries:type_name -> cnquery.explorer.Mquery
 	0,   // 3: cnspec.policy.v1.PolicyGroup.type:type_name -> cnspec.policy.v1.GroupType
-	114, // 4: cnspec.policy.v1.PolicyGroup.filters:type_name -> cnquery.explorer.Filters
-	12,  // 5: cnspec.policy.v1.PolicyGroup.valid:type_name -> cnspec.policy.v1.Validity
-	27,  // 6: cnspec.policy.v1.PolicyGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
-	115, // 7: cnspec.policy.v1.PolicyGroup.authors:type_name -> cnquery.explorer.Author
-	115, // 8: cnspec.policy.v1.PolicyGroup.reviewers:type_name -> cnquery.explorer.Author
+	115, // 4: cnspec.policy.v1.PolicyGroup.filters:type_name -> cnquery.explorer.Filters
+	13,  // 5: cnspec.policy.v1.PolicyGroup.valid:type_name -> cnspec.policy.v1.Validity
+	28,  // 6: cnspec.policy.v1.PolicyGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
+	116, // 7: cnspec.policy.v1.PolicyGroup.authors:type_name -> cnquery.explorer.Author
+	116, // 8: cnspec.policy.v1.PolicyGroup.reviewers:type_name -> cnquery.explorer.Author
 	3,   // 9: cnspec.policy.v1.PolicyGroup.review_status:type_name -> cnspec.policy.v1.ReviewStatus
-	116, // 10: cnspec.policy.v1.Validity.from:type_name -> cnquery.explorer.HumanTime
-	116, // 11: cnspec.policy.v1.Validity.until:type_name -> cnquery.explorer.HumanTime
-	117, // 12: cnspec.policy.v1.PolicyRef.action:type_name -> cnquery.explorer.Action
-	118, // 13: cnspec.policy.v1.PolicyRef.impact:type_name -> cnquery.explorer.Impact
-	119, // 14: cnspec.policy.v1.PolicyRef.scoring_system:type_name -> cnquery.explorer.ScoringSystem
-	11,  // 15: cnspec.policy.v1.Policy.groups:type_name -> cnspec.policy.v1.PolicyGroup
-	28,  // 16: cnspec.policy.v1.Policy.docs:type_name -> cnspec.policy.v1.PolicyDocs
-	119, // 17: cnspec.policy.v1.Policy.scoring_system:type_name -> cnquery.explorer.ScoringSystem
-	115, // 18: cnspec.policy.v1.Policy.authors:type_name -> cnquery.explorer.Author
-	85,  // 19: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
-	120, // 20: cnspec.policy.v1.Policy.props:type_name -> cnquery.explorer.Property
-	25,  // 21: cnspec.policy.v1.Policy.risk_factors:type_name -> cnspec.policy.v1.RiskFactor
-	114, // 22: cnspec.policy.v1.Policy.computed_filters:type_name -> cnquery.explorer.Filters
-	16,  // 23: cnspec.policy.v1.Policy.query_counts:type_name -> cnspec.policy.v1.QueryCounts
-	14,  // 24: cnspec.policy.v1.Policies.items:type_name -> cnspec.policy.v1.Policy
-	14,  // 25: cnspec.policy.v1.Bundle.policies:type_name -> cnspec.policy.v1.Policy
-	121, // 26: cnspec.policy.v1.Bundle.packs:type_name -> cnquery.explorer.QueryPack
-	120, // 27: cnspec.policy.v1.Bundle.props:type_name -> cnquery.explorer.Property
-	113, // 28: cnspec.policy.v1.Bundle.queries:type_name -> cnquery.explorer.Mquery
-	29,  // 29: cnspec.policy.v1.Bundle.frameworks:type_name -> cnspec.policy.v1.Framework
-	35,  // 30: cnspec.policy.v1.Bundle.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
-	28,  // 31: cnspec.policy.v1.Bundle.docs:type_name -> cnspec.policy.v1.PolicyDocs
-	18,  // 32: cnspec.policy.v1.Bundle.migration_groups:type_name -> cnspec.policy.v1.MigrationGroup
-	14,  // 33: cnspec.policy.v1.MigrationGroup.policy:type_name -> cnspec.policy.v1.Policy
-	19,  // 34: cnspec.policy.v1.MigrationGroup.migrations:type_name -> cnspec.policy.v1.Migration
-	20,  // 35: cnspec.policy.v1.Migration.match:type_name -> cnspec.policy.v1.MigrationMatch
-	21,  // 36: cnspec.policy.v1.Migration.target:type_name -> cnspec.policy.v1.MigrationDelta
-	7,   // 37: cnspec.policy.v1.Migration.action:type_name -> cnspec.policy.v1.Migration.Action
-	26,  // 38: cnspec.policy.v1.RiskFactor.docs:type_name -> cnspec.policy.v1.RiskFactorDocs
-	114, // 39: cnspec.policy.v1.RiskFactor.filters:type_name -> cnquery.explorer.Filters
-	113, // 40: cnspec.policy.v1.RiskFactor.checks:type_name -> cnquery.explorer.Mquery
+	117, // 10: cnspec.policy.v1.Validity.from:type_name -> cnquery.explorer.HumanTime
+	117, // 11: cnspec.policy.v1.Validity.until:type_name -> cnquery.explorer.HumanTime
+	118, // 12: cnspec.policy.v1.PolicyRef.action:type_name -> cnquery.explorer.Action
+	119, // 13: cnspec.policy.v1.PolicyRef.impact:type_name -> cnquery.explorer.Impact
+	120, // 14: cnspec.policy.v1.PolicyRef.scoring_system:type_name -> cnquery.explorer.ScoringSystem
+	12,  // 15: cnspec.policy.v1.Policy.groups:type_name -> cnspec.policy.v1.PolicyGroup
+	29,  // 16: cnspec.policy.v1.Policy.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	120, // 17: cnspec.policy.v1.Policy.scoring_system:type_name -> cnquery.explorer.ScoringSystem
+	116, // 18: cnspec.policy.v1.Policy.authors:type_name -> cnquery.explorer.Author
+	86,  // 19: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
+	121, // 20: cnspec.policy.v1.Policy.props:type_name -> cnquery.explorer.Property
+	26,  // 21: cnspec.policy.v1.Policy.risk_factors:type_name -> cnspec.policy.v1.RiskFactor
+	115, // 22: cnspec.policy.v1.Policy.computed_filters:type_name -> cnquery.explorer.Filters
+	17,  // 23: cnspec.policy.v1.Policy.query_counts:type_name -> cnspec.policy.v1.QueryCounts
+	15,  // 24: cnspec.policy.v1.Policies.items:type_name -> cnspec.policy.v1.Policy
+	15,  // 25: cnspec.policy.v1.Bundle.policies:type_name -> cnspec.policy.v1.Policy
+	122, // 26: cnspec.policy.v1.Bundle.packs:type_name -> cnquery.explorer.QueryPack
+	121, // 27: cnspec.policy.v1.Bundle.props:type_name -> cnquery.explorer.Property
+	114, // 28: cnspec.policy.v1.Bundle.queries:type_name -> cnquery.explorer.Mquery
+	30,  // 29: cnspec.policy.v1.Bundle.frameworks:type_name -> cnspec.policy.v1.Framework
+	36,  // 30: cnspec.policy.v1.Bundle.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
+	29,  // 31: cnspec.policy.v1.Bundle.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	19,  // 32: cnspec.policy.v1.Bundle.migration_groups:type_name -> cnspec.policy.v1.MigrationGroup
+	15,  // 33: cnspec.policy.v1.MigrationGroup.policy:type_name -> cnspec.policy.v1.Policy
+	20,  // 34: cnspec.policy.v1.MigrationGroup.migrations:type_name -> cnspec.policy.v1.Migration
+	21,  // 35: cnspec.policy.v1.Migration.match:type_name -> cnspec.policy.v1.MigrationMatch
+	22,  // 36: cnspec.policy.v1.Migration.target:type_name -> cnspec.policy.v1.MigrationDelta
+	8,   // 37: cnspec.policy.v1.Migration.action:type_name -> cnspec.policy.v1.Migration.Action
+	27,  // 38: cnspec.policy.v1.RiskFactor.docs:type_name -> cnspec.policy.v1.RiskFactorDocs
+	115, // 39: cnspec.policy.v1.RiskFactor.filters:type_name -> cnquery.explorer.Filters
+	114, // 40: cnspec.policy.v1.RiskFactor.checks:type_name -> cnquery.explorer.Mquery
 	2,   // 41: cnspec.policy.v1.RiskFactor.scope:type_name -> cnspec.policy.v1.ScopeType
-	24,  // 42: cnspec.policy.v1.RiskFactor.magnitude:type_name -> cnspec.policy.v1.RiskMagnitude
-	22,  // 43: cnspec.policy.v1.RiskFactor.software:type_name -> cnspec.policy.v1.SoftwareSelector
-	23,  // 44: cnspec.policy.v1.RiskFactor.resources:type_name -> cnspec.policy.v1.ResourceSelector
-	117, // 45: cnspec.policy.v1.RiskFactor.action:type_name -> cnquery.explorer.Action
-	86,  // 46: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
-	31,  // 47: cnspec.policy.v1.Framework.groups:type_name -> cnspec.policy.v1.FrameworkGroup
-	28,  // 48: cnspec.policy.v1.Framework.docs:type_name -> cnspec.policy.v1.PolicyDocs
-	115, // 49: cnspec.policy.v1.Framework.authors:type_name -> cnquery.explorer.Author
-	87,  // 50: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
-	32,  // 51: cnspec.policy.v1.Framework.dependencies:type_name -> cnspec.policy.v1.FrameworkRef
-	35,  // 52: cnspec.policy.v1.Framework.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
-	29,  // 53: cnspec.policy.v1.Frameworks.items:type_name -> cnspec.policy.v1.Framework
-	34,  // 54: cnspec.policy.v1.FrameworkGroup.controls:type_name -> cnspec.policy.v1.Control
+	25,  // 42: cnspec.policy.v1.RiskFactor.magnitude:type_name -> cnspec.policy.v1.RiskMagnitude
+	23,  // 43: cnspec.policy.v1.RiskFactor.software:type_name -> cnspec.policy.v1.SoftwareSelector
+	24,  // 44: cnspec.policy.v1.RiskFactor.resources:type_name -> cnspec.policy.v1.ResourceSelector
+	118, // 45: cnspec.policy.v1.RiskFactor.action:type_name -> cnquery.explorer.Action
+	87,  // 46: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
+	32,  // 47: cnspec.policy.v1.Framework.groups:type_name -> cnspec.policy.v1.FrameworkGroup
+	29,  // 48: cnspec.policy.v1.Framework.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	116, // 49: cnspec.policy.v1.Framework.authors:type_name -> cnquery.explorer.Author
+	88,  // 50: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
+	33,  // 51: cnspec.policy.v1.Framework.dependencies:type_name -> cnspec.policy.v1.FrameworkRef
+	36,  // 52: cnspec.policy.v1.Framework.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
+	30,  // 53: cnspec.policy.v1.Frameworks.items:type_name -> cnspec.policy.v1.Framework
+	35,  // 54: cnspec.policy.v1.FrameworkGroup.controls:type_name -> cnspec.policy.v1.Control
 	0,   // 55: cnspec.policy.v1.FrameworkGroup.type:type_name -> cnspec.policy.v1.GroupType
-	27,  // 56: cnspec.policy.v1.FrameworkGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
-	115, // 57: cnspec.policy.v1.FrameworkGroup.authors:type_name -> cnquery.explorer.Author
-	115, // 58: cnspec.policy.v1.FrameworkGroup.reviewers:type_name -> cnquery.explorer.Author
+	28,  // 56: cnspec.policy.v1.FrameworkGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
+	116, // 57: cnspec.policy.v1.FrameworkGroup.authors:type_name -> cnquery.explorer.Author
+	116, // 58: cnspec.policy.v1.FrameworkGroup.reviewers:type_name -> cnquery.explorer.Author
 	3,   // 59: cnspec.policy.v1.FrameworkGroup.review_status:type_name -> cnspec.policy.v1.ReviewStatus
-	117, // 60: cnspec.policy.v1.FrameworkRef.action:type_name -> cnquery.explorer.Action
-	113, // 61: cnspec.policy.v1.Evidence.checks:type_name -> cnquery.explorer.Mquery
-	113, // 62: cnspec.policy.v1.Evidence.queries:type_name -> cnquery.explorer.Mquery
-	38,  // 63: cnspec.policy.v1.Evidence.controls:type_name -> cnspec.policy.v1.ControlRef
-	37,  // 64: cnspec.policy.v1.Control.docs:type_name -> cnspec.policy.v1.ControlDocs
-	88,  // 65: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
-	117, // 66: cnspec.policy.v1.Control.action:type_name -> cnquery.explorer.Action
-	33,  // 67: cnspec.policy.v1.Control.evidence:type_name -> cnspec.policy.v1.Evidence
-	122, // 68: cnspec.policy.v1.FrameworkMap.framework_dependencies:type_name -> cnquery.explorer.ObjectRef
-	122, // 69: cnspec.policy.v1.FrameworkMap.policy_dependencies:type_name -> cnquery.explorer.ObjectRef
-	122, // 70: cnspec.policy.v1.FrameworkMap.query_pack_dependencies:type_name -> cnquery.explorer.ObjectRef
-	36,  // 71: cnspec.policy.v1.FrameworkMap.controls:type_name -> cnspec.policy.v1.ControlMap
-	122, // 72: cnspec.policy.v1.FrameworkMap.framework_owner:type_name -> cnquery.explorer.ObjectRef
-	38,  // 73: cnspec.policy.v1.ControlMap.checks:type_name -> cnspec.policy.v1.ControlRef
-	38,  // 74: cnspec.policy.v1.ControlMap.policies:type_name -> cnspec.policy.v1.ControlRef
-	38,  // 75: cnspec.policy.v1.ControlMap.controls:type_name -> cnspec.policy.v1.ControlRef
-	38,  // 76: cnspec.policy.v1.ControlMap.queries:type_name -> cnspec.policy.v1.ControlRef
-	123, // 77: cnspec.policy.v1.ControlDocs.refs:type_name -> cnquery.explorer.MqueryRef
-	117, // 78: cnspec.policy.v1.ControlRef.action:type_name -> cnquery.explorer.Action
-	124, // 79: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
-	41,  // 80: cnspec.policy.v1.ResolvedPolicy.execution_job:type_name -> cnspec.policy.v1.ExecutionJob
-	43,  // 81: cnspec.policy.v1.ResolvedPolicy.collector_job:type_name -> cnspec.policy.v1.CollectorJob
-	113, // 82: cnspec.policy.v1.ResolvedPolicy.filters:type_name -> cnquery.explorer.Mquery
-	89,  // 83: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
-	90,  // 84: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	125, // 85: cnspec.policy.v1.ExecutionQuery.code:type_name -> cnquery.llx.CodeBundle
-	91,  // 86: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	92,  // 87: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	93,  // 88: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
-	94,  // 89: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	95,  // 90: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	119, // 91: cnspec.policy.v1.ReportingJob.scoring_system:type_name -> cnquery.explorer.ScoringSystem
-	96,  // 92: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
-	97,  // 93: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
-	8,   // 94: cnspec.policy.v1.ReportingJob.type:type_name -> cnspec.policy.v1.ReportingJob.Type
-	54,  // 95: cnspec.policy.v1.Report.score:type_name -> cnspec.policy.v1.Score
-	98,  // 96: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
-	99,  // 97: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
-	60,  // 98: cnspec.policy.v1.Report.stats:type_name -> cnspec.policy.v1.Stats
-	57,  // 99: cnspec.policy.v1.Report.risks:type_name -> cnspec.policy.v1.ScoredRiskFactors
-	60,  // 100: cnspec.policy.v1.Report.ignored_stats:type_name -> cnspec.policy.v1.Stats
-	52,  // 101: cnspec.policy.v1.Report.cvss_score:type_name -> cnspec.policy.v1.Cvss
-	100, // 102: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
-	53,  // 103: cnspec.policy.v1.Report.cvss_stats:type_name -> cnspec.policy.v1.CvssStats
-	47,  // 104: cnspec.policy.v1.Reports.reports:type_name -> cnspec.policy.v1.Report
-	101, // 105: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
-	17,  // 106: cnspec.policy.v1.ReportCollection.bundle:type_name -> cnspec.policy.v1.Bundle
-	102, // 107: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
-	103, // 108: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
-	104, // 109: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	105, // 110: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
-	51,  // 111: cnspec.policy.v1.FrameworkReport.score:type_name -> cnspec.policy.v1.ControlScore
-	51,  // 112: cnspec.policy.v1.FrameworkReport.controls:type_name -> cnspec.policy.v1.ControlScore
-	51,  // 113: cnspec.policy.v1.ControlScore.assets:type_name -> cnspec.policy.v1.ControlScore
-	61,  // 114: cnspec.policy.v1.ControlScore.scores:type_name -> cnspec.policy.v1.ScoreDistribution
-	57,  // 115: cnspec.policy.v1.Score.risk_factors:type_name -> cnspec.policy.v1.ScoredRiskFactors
-	84,  // 116: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
-	83,  // 117: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
-	56,  // 118: cnspec.policy.v1.ScoredRiskFactors.items:type_name -> cnspec.policy.v1.ScoredRiskFactor
-	58,  // 119: cnspec.policy.v1.RiskFactorsStats.items:type_name -> cnspec.policy.v1.RiskFactorStats
-	61,  // 120: cnspec.policy.v1.Stats.failed:type_name -> cnspec.policy.v1.ScoreDistribution
-	61,  // 121: cnspec.policy.v1.Stats.passed:type_name -> cnspec.policy.v1.ScoreDistribution
-	61,  // 122: cnspec.policy.v1.Stats.errors:type_name -> cnspec.policy.v1.ScoreDistribution
-	62,  // 123: cnspec.policy.v1.AssetFindingsStats.score_stats:type_name -> cnspec.policy.v1.ScoreStats
-	59,  // 124: cnspec.policy.v1.AssetFindingsStats.risk_factors:type_name -> cnspec.policy.v1.RiskFactorsStats
-	113, // 125: cnspec.policy.v1.Mqueries.items:type_name -> cnquery.explorer.Mquery
-	117, // 126: cnspec.policy.v1.PolicyAssignment.action:type_name -> cnquery.explorer.Action
-	119, // 127: cnspec.policy.v1.PolicyAssignment.scoring_system:type_name -> cnquery.explorer.ScoringSystem
-	106, // 128: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
-	117, // 129: cnspec.policy.v1.PolicyMutationDelta.action:type_name -> cnquery.explorer.Action
-	9,   // 130: cnspec.policy.v1.PolicyDelta.action:type_name -> cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
-	119, // 131: cnspec.policy.v1.PolicyDelta.scoring_system:type_name -> cnquery.explorer.ScoringSystem
-	113, // 132: cnspec.policy.v1.ResolveReq.asset_filters:type_name -> cnquery.explorer.Mquery
-	113, // 133: cnspec.policy.v1.UpdateAssetJobsReq.asset_filters:type_name -> cnquery.explorer.Mquery
-	54,  // 134: cnspec.policy.v1.StoreResultsReq.scores:type_name -> cnspec.policy.v1.Score
-	107, // 135: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
-	108, // 136: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
-	56,  // 137: cnspec.policy.v1.StoreResultsReq.risks:type_name -> cnspec.policy.v1.ScoredRiskFactor
-	52,  // 138: cnspec.policy.v1.StoreResultsReq.cvssScores:type_name -> cnspec.policy.v1.Cvss
-	126, // 139: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
-	109, // 140: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	110, // 141: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	81,  // 142: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
-	111, // 143: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
-	5,   // 144: cnspec.policy.v1.DateFilter.comparison:type_name -> cnspec.policy.v1.Comparison
-	6,   // 145: cnspec.policy.v1.DateFilter.field:type_name -> cnspec.policy.v1.DateFilterField
-	112, // 146: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	84,  // 147: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
-	10,  // 148: cnspec.policy.v1.Source.vendor:type_name -> cnspec.policy.v1.Source.Vendor
-	42,  // 149: cnspec.policy.v1.ExecutionJob.QueriesEntry.value:type_name -> cnspec.policy.v1.ExecutionQuery
-	46,  // 150: cnspec.policy.v1.CollectorJob.ReportingJobsEntry.value:type_name -> cnspec.policy.v1.ReportingJob
-	44,  // 151: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry.value:type_name -> cnspec.policy.v1.StringArray
-	45,  // 152: cnspec.policy.v1.CollectorJob.DatapointsEntry.value:type_name -> cnspec.policy.v1.DataQueryInfo
-	44,  // 153: cnspec.policy.v1.CollectorJob.RiskMrnsEntry.value:type_name -> cnspec.policy.v1.StringArray
-	25,  // 154: cnspec.policy.v1.CollectorJob.RiskFactorsEntry.value:type_name -> cnspec.policy.v1.RiskFactor
-	118, // 155: cnspec.policy.v1.ReportingJob.ChildJobsEntry.value:type_name -> cnquery.explorer.Impact
-	54,  // 156: cnspec.policy.v1.Report.ScoresEntry.value:type_name -> cnspec.policy.v1.Score
-	127, // 157: cnspec.policy.v1.Report.DataEntry.value:type_name -> cnquery.llx.Result
-	52,  // 158: cnspec.policy.v1.Report.CvssScoresEntry.value:type_name -> cnspec.policy.v1.Cvss
-	126, // 159: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
-	47,  // 160: cnspec.policy.v1.ReportCollection.ReportsEntry.value:type_name -> cnspec.policy.v1.Report
-	40,  // 161: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry.value:type_name -> cnspec.policy.v1.ResolvedPolicy
-	128, // 162: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
-	72,  // 163: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry.value:type_name -> cnspec.policy.v1.PolicyDelta
-	127, // 164: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> cnquery.llx.Result
-	129, // 165: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> cnquery.llx.ResourceRecording
-	78,  // 166: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry.value:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
-	17,  // 167: cnspec.policy.v1.PolicyHub.SetBundle:input_type -> cnspec.policy.v1.Bundle
-	17,  // 168: cnspec.policy.v1.PolicyHub.ValidateBundle:input_type -> cnspec.policy.v1.Bundle
-	65,  // 169: cnspec.policy.v1.PolicyHub.GetBundle:input_type -> cnspec.policy.v1.Mrn
-	65,  // 170: cnspec.policy.v1.PolicyHub.GetPolicy:input_type -> cnspec.policy.v1.Mrn
-	65,  // 171: cnspec.policy.v1.PolicyHub.DeletePolicy:input_type -> cnspec.policy.v1.Mrn
-	65,  // 172: cnspec.policy.v1.PolicyHub.GetPolicyFilters:input_type -> cnspec.policy.v1.Mrn
-	67,  // 173: cnspec.policy.v1.PolicyHub.List:input_type -> cnspec.policy.v1.ListReq
-	68,  // 174: cnspec.policy.v1.PolicyHub.DefaultPolicies:input_type -> cnspec.policy.v1.DefaultPoliciesReq
-	65,  // 175: cnspec.policy.v1.PolicyHub.GetFramework:input_type -> cnspec.policy.v1.Mrn
-	65,  // 176: cnspec.policy.v1.PolicyHub.DeleteFramework:input_type -> cnspec.policy.v1.Mrn
-	67,  // 177: cnspec.policy.v1.PolicyHub.ListFrameworks:input_type -> cnspec.policy.v1.ListReq
-	70,  // 178: cnspec.policy.v1.PolicyResolver.Assign:input_type -> cnspec.policy.v1.PolicyAssignment
-	70,  // 179: cnspec.policy.v1.PolicyResolver.Unassign:input_type -> cnspec.policy.v1.PolicyAssignment
-	130, // 180: cnspec.policy.v1.PolicyResolver.SetProps:input_type -> cnquery.explorer.PropsReq
-	73,  // 181: cnspec.policy.v1.PolicyResolver.Resolve:input_type -> cnspec.policy.v1.ResolveReq
-	74,  // 182: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
-	74,  // 183: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
-	65,  // 184: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:input_type -> cnspec.policy.v1.Mrn
-	75,  // 185: cnspec.policy.v1.PolicyResolver.StoreResults:input_type -> cnspec.policy.v1.StoreResultsReq
-	76,  // 186: cnspec.policy.v1.PolicyResolver.GetReport:input_type -> cnspec.policy.v1.EntityScoreReq
-	76,  // 187: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:input_type -> cnspec.policy.v1.EntityScoreReq
-	76,  // 188: cnspec.policy.v1.PolicyResolver.GetScore:input_type -> cnspec.policy.v1.EntityScoreReq
-	131, // 189: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> cnquery.explorer.resources.EntityResourcesReq
-	77,  // 190: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:input_type -> cnspec.policy.v1.SynchronizeAssetsReq
-	80,  // 191: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
-	64,  // 192: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
-	64,  // 193: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
-	17,  // 194: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
-	14,  // 195: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
-	64,  // 196: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
-	66,  // 197: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
-	15,  // 198: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
-	69,  // 199: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
-	29,  // 200: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
-	64,  // 201: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
-	30,  // 202: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
-	64,  // 203: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
-	64,  // 204: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
-	132, // 205: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnquery.explorer.Empty
-	40,  // 206: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
-	64,  // 207: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
-	40,  // 208: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
-	40,  // 209: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
-	64,  // 210: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
-	47,  // 211: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
-	50,  // 212: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
-	47,  // 213: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
-	133, // 214: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> cnquery.explorer.resources.EntityResourcesRes
-	79,  // 215: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
-	82,  // 216: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
-	192, // [192:217] is the sub-list for method output_type
-	167, // [167:192] is the sub-list for method input_type
-	167, // [167:167] is the sub-list for extension type_name
-	167, // [167:167] is the sub-list for extension extendee
-	0,   // [0:167] is the sub-list for field type_name
+	118, // 60: cnspec.policy.v1.FrameworkRef.action:type_name -> cnquery.explorer.Action
+	114, // 61: cnspec.policy.v1.Evidence.checks:type_name -> cnquery.explorer.Mquery
+	114, // 62: cnspec.policy.v1.Evidence.queries:type_name -> cnquery.explorer.Mquery
+	39,  // 63: cnspec.policy.v1.Evidence.controls:type_name -> cnspec.policy.v1.ControlRef
+	38,  // 64: cnspec.policy.v1.Control.docs:type_name -> cnspec.policy.v1.ControlDocs
+	89,  // 65: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
+	118, // 66: cnspec.policy.v1.Control.action:type_name -> cnquery.explorer.Action
+	34,  // 67: cnspec.policy.v1.Control.evidence:type_name -> cnspec.policy.v1.Evidence
+	123, // 68: cnspec.policy.v1.FrameworkMap.framework_dependencies:type_name -> cnquery.explorer.ObjectRef
+	123, // 69: cnspec.policy.v1.FrameworkMap.policy_dependencies:type_name -> cnquery.explorer.ObjectRef
+	123, // 70: cnspec.policy.v1.FrameworkMap.query_pack_dependencies:type_name -> cnquery.explorer.ObjectRef
+	37,  // 71: cnspec.policy.v1.FrameworkMap.controls:type_name -> cnspec.policy.v1.ControlMap
+	123, // 72: cnspec.policy.v1.FrameworkMap.framework_owner:type_name -> cnquery.explorer.ObjectRef
+	39,  // 73: cnspec.policy.v1.ControlMap.checks:type_name -> cnspec.policy.v1.ControlRef
+	39,  // 74: cnspec.policy.v1.ControlMap.policies:type_name -> cnspec.policy.v1.ControlRef
+	39,  // 75: cnspec.policy.v1.ControlMap.controls:type_name -> cnspec.policy.v1.ControlRef
+	39,  // 76: cnspec.policy.v1.ControlMap.queries:type_name -> cnspec.policy.v1.ControlRef
+	124, // 77: cnspec.policy.v1.ControlDocs.refs:type_name -> cnquery.explorer.MqueryRef
+	118, // 78: cnspec.policy.v1.ControlRef.action:type_name -> cnquery.explorer.Action
+	125, // 79: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
+	42,  // 80: cnspec.policy.v1.ResolvedPolicy.execution_job:type_name -> cnspec.policy.v1.ExecutionJob
+	44,  // 81: cnspec.policy.v1.ResolvedPolicy.collector_job:type_name -> cnspec.policy.v1.CollectorJob
+	114, // 82: cnspec.policy.v1.ResolvedPolicy.filters:type_name -> cnquery.explorer.Mquery
+	4,   // 83: cnspec.policy.v1.ResolvedPolicy.features:type_name -> cnspec.policy.v1.ServerFeature
+	90,  // 84: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
+	91,  // 85: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	126, // 86: cnspec.policy.v1.ExecutionQuery.code:type_name -> cnquery.llx.CodeBundle
+	92,  // 87: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	93,  // 88: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	94,  // 89: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
+	95,  // 90: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	96,  // 91: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	120, // 92: cnspec.policy.v1.ReportingJob.scoring_system:type_name -> cnquery.explorer.ScoringSystem
+	97,  // 93: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
+	98,  // 94: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	9,   // 95: cnspec.policy.v1.ReportingJob.type:type_name -> cnspec.policy.v1.ReportingJob.Type
+	55,  // 96: cnspec.policy.v1.Report.score:type_name -> cnspec.policy.v1.Score
+	99,  // 97: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
+	100, // 98: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
+	61,  // 99: cnspec.policy.v1.Report.stats:type_name -> cnspec.policy.v1.Stats
+	58,  // 100: cnspec.policy.v1.Report.risks:type_name -> cnspec.policy.v1.ScoredRiskFactors
+	61,  // 101: cnspec.policy.v1.Report.ignored_stats:type_name -> cnspec.policy.v1.Stats
+	53,  // 102: cnspec.policy.v1.Report.cvss_score:type_name -> cnspec.policy.v1.Cvss
+	101, // 103: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
+	54,  // 104: cnspec.policy.v1.Report.cvss_stats:type_name -> cnspec.policy.v1.CvssStats
+	48,  // 105: cnspec.policy.v1.Reports.reports:type_name -> cnspec.policy.v1.Report
+	102, // 106: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
+	18,  // 107: cnspec.policy.v1.ReportCollection.bundle:type_name -> cnspec.policy.v1.Bundle
+	103, // 108: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
+	104, // 109: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
+	105, // 110: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	106, // 111: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	52,  // 112: cnspec.policy.v1.FrameworkReport.score:type_name -> cnspec.policy.v1.ControlScore
+	52,  // 113: cnspec.policy.v1.FrameworkReport.controls:type_name -> cnspec.policy.v1.ControlScore
+	52,  // 114: cnspec.policy.v1.ControlScore.assets:type_name -> cnspec.policy.v1.ControlScore
+	62,  // 115: cnspec.policy.v1.ControlScore.scores:type_name -> cnspec.policy.v1.ScoreDistribution
+	58,  // 116: cnspec.policy.v1.Score.risk_factors:type_name -> cnspec.policy.v1.ScoredRiskFactors
+	85,  // 117: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
+	84,  // 118: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
+	57,  // 119: cnspec.policy.v1.ScoredRiskFactors.items:type_name -> cnspec.policy.v1.ScoredRiskFactor
+	59,  // 120: cnspec.policy.v1.RiskFactorsStats.items:type_name -> cnspec.policy.v1.RiskFactorStats
+	62,  // 121: cnspec.policy.v1.Stats.failed:type_name -> cnspec.policy.v1.ScoreDistribution
+	62,  // 122: cnspec.policy.v1.Stats.passed:type_name -> cnspec.policy.v1.ScoreDistribution
+	62,  // 123: cnspec.policy.v1.Stats.errors:type_name -> cnspec.policy.v1.ScoreDistribution
+	63,  // 124: cnspec.policy.v1.AssetFindingsStats.score_stats:type_name -> cnspec.policy.v1.ScoreStats
+	60,  // 125: cnspec.policy.v1.AssetFindingsStats.risk_factors:type_name -> cnspec.policy.v1.RiskFactorsStats
+	114, // 126: cnspec.policy.v1.Mqueries.items:type_name -> cnquery.explorer.Mquery
+	118, // 127: cnspec.policy.v1.PolicyAssignment.action:type_name -> cnquery.explorer.Action
+	120, // 128: cnspec.policy.v1.PolicyAssignment.scoring_system:type_name -> cnquery.explorer.ScoringSystem
+	107, // 129: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	118, // 130: cnspec.policy.v1.PolicyMutationDelta.action:type_name -> cnquery.explorer.Action
+	10,  // 131: cnspec.policy.v1.PolicyDelta.action:type_name -> cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
+	120, // 132: cnspec.policy.v1.PolicyDelta.scoring_system:type_name -> cnquery.explorer.ScoringSystem
+	114, // 133: cnspec.policy.v1.ResolveReq.asset_filters:type_name -> cnquery.explorer.Mquery
+	114, // 134: cnspec.policy.v1.UpdateAssetJobsReq.asset_filters:type_name -> cnquery.explorer.Mquery
+	55,  // 135: cnspec.policy.v1.StoreResultsReq.scores:type_name -> cnspec.policy.v1.Score
+	108, // 136: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
+	109, // 137: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	57,  // 138: cnspec.policy.v1.StoreResultsReq.risks:type_name -> cnspec.policy.v1.ScoredRiskFactor
+	53,  // 139: cnspec.policy.v1.StoreResultsReq.cvssScores:type_name -> cnspec.policy.v1.Cvss
+	127, // 140: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
+	110, // 141: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	111, // 142: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	82,  // 143: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
+	112, // 144: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	6,   // 145: cnspec.policy.v1.DateFilter.comparison:type_name -> cnspec.policy.v1.Comparison
+	7,   // 146: cnspec.policy.v1.DateFilter.field:type_name -> cnspec.policy.v1.DateFilterField
+	113, // 147: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	85,  // 148: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
+	11,  // 149: cnspec.policy.v1.Source.vendor:type_name -> cnspec.policy.v1.Source.Vendor
+	43,  // 150: cnspec.policy.v1.ExecutionJob.QueriesEntry.value:type_name -> cnspec.policy.v1.ExecutionQuery
+	47,  // 151: cnspec.policy.v1.CollectorJob.ReportingJobsEntry.value:type_name -> cnspec.policy.v1.ReportingJob
+	45,  // 152: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry.value:type_name -> cnspec.policy.v1.StringArray
+	46,  // 153: cnspec.policy.v1.CollectorJob.DatapointsEntry.value:type_name -> cnspec.policy.v1.DataQueryInfo
+	45,  // 154: cnspec.policy.v1.CollectorJob.RiskMrnsEntry.value:type_name -> cnspec.policy.v1.StringArray
+	26,  // 155: cnspec.policy.v1.CollectorJob.RiskFactorsEntry.value:type_name -> cnspec.policy.v1.RiskFactor
+	119, // 156: cnspec.policy.v1.ReportingJob.ChildJobsEntry.value:type_name -> cnquery.explorer.Impact
+	55,  // 157: cnspec.policy.v1.Report.ScoresEntry.value:type_name -> cnspec.policy.v1.Score
+	128, // 158: cnspec.policy.v1.Report.DataEntry.value:type_name -> cnquery.llx.Result
+	53,  // 159: cnspec.policy.v1.Report.CvssScoresEntry.value:type_name -> cnspec.policy.v1.Cvss
+	127, // 160: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
+	48,  // 161: cnspec.policy.v1.ReportCollection.ReportsEntry.value:type_name -> cnspec.policy.v1.Report
+	41,  // 162: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry.value:type_name -> cnspec.policy.v1.ResolvedPolicy
+	129, // 163: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
+	73,  // 164: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry.value:type_name -> cnspec.policy.v1.PolicyDelta
+	128, // 165: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> cnquery.llx.Result
+	130, // 166: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> cnquery.llx.ResourceRecording
+	79,  // 167: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry.value:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
+	18,  // 168: cnspec.policy.v1.PolicyHub.SetBundle:input_type -> cnspec.policy.v1.Bundle
+	18,  // 169: cnspec.policy.v1.PolicyHub.ValidateBundle:input_type -> cnspec.policy.v1.Bundle
+	66,  // 170: cnspec.policy.v1.PolicyHub.GetBundle:input_type -> cnspec.policy.v1.Mrn
+	66,  // 171: cnspec.policy.v1.PolicyHub.GetPolicy:input_type -> cnspec.policy.v1.Mrn
+	66,  // 172: cnspec.policy.v1.PolicyHub.DeletePolicy:input_type -> cnspec.policy.v1.Mrn
+	66,  // 173: cnspec.policy.v1.PolicyHub.GetPolicyFilters:input_type -> cnspec.policy.v1.Mrn
+	68,  // 174: cnspec.policy.v1.PolicyHub.List:input_type -> cnspec.policy.v1.ListReq
+	69,  // 175: cnspec.policy.v1.PolicyHub.DefaultPolicies:input_type -> cnspec.policy.v1.DefaultPoliciesReq
+	66,  // 176: cnspec.policy.v1.PolicyHub.GetFramework:input_type -> cnspec.policy.v1.Mrn
+	66,  // 177: cnspec.policy.v1.PolicyHub.DeleteFramework:input_type -> cnspec.policy.v1.Mrn
+	68,  // 178: cnspec.policy.v1.PolicyHub.ListFrameworks:input_type -> cnspec.policy.v1.ListReq
+	71,  // 179: cnspec.policy.v1.PolicyResolver.Assign:input_type -> cnspec.policy.v1.PolicyAssignment
+	71,  // 180: cnspec.policy.v1.PolicyResolver.Unassign:input_type -> cnspec.policy.v1.PolicyAssignment
+	131, // 181: cnspec.policy.v1.PolicyResolver.SetProps:input_type -> cnquery.explorer.PropsReq
+	74,  // 182: cnspec.policy.v1.PolicyResolver.Resolve:input_type -> cnspec.policy.v1.ResolveReq
+	75,  // 183: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
+	75,  // 184: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
+	66,  // 185: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:input_type -> cnspec.policy.v1.Mrn
+	76,  // 186: cnspec.policy.v1.PolicyResolver.StoreResults:input_type -> cnspec.policy.v1.StoreResultsReq
+	77,  // 187: cnspec.policy.v1.PolicyResolver.GetReport:input_type -> cnspec.policy.v1.EntityScoreReq
+	77,  // 188: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:input_type -> cnspec.policy.v1.EntityScoreReq
+	77,  // 189: cnspec.policy.v1.PolicyResolver.GetScore:input_type -> cnspec.policy.v1.EntityScoreReq
+	132, // 190: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> cnquery.explorer.resources.EntityResourcesReq
+	78,  // 191: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:input_type -> cnspec.policy.v1.SynchronizeAssetsReq
+	81,  // 192: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
+	65,  // 193: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
+	65,  // 194: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
+	18,  // 195: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
+	15,  // 196: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
+	65,  // 197: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
+	67,  // 198: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
+	16,  // 199: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
+	70,  // 200: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
+	30,  // 201: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
+	65,  // 202: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
+	31,  // 203: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
+	65,  // 204: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
+	65,  // 205: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
+	133, // 206: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnquery.explorer.Empty
+	41,  // 207: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
+	65,  // 208: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
+	41,  // 209: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
+	41,  // 210: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
+	65,  // 211: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
+	48,  // 212: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
+	51,  // 213: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
+	48,  // 214: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
+	134, // 215: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> cnquery.explorer.resources.EntityResourcesRes
+	80,  // 216: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
+	83,  // 217: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
+	193, // [193:218] is the sub-list for method output_type
+	168, // [168:193] is the sub-list for method input_type
+	168, // [168:168] is the sub-list for extension type_name
+	168, // [168:168] is the sub-list for extension extendee
+	0,   // [0:168] is the sub-list for field type_name
 }
 
 func init() { file_cnspec_policy_proto_init() }
@@ -7748,7 +7814,7 @@ func file_cnspec_policy_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cnspec_policy_proto_rawDesc), len(file_cnspec_policy_proto_rawDesc)),
-			NumEnums:      11,
+			NumEnums:      12,
 			NumMessages:   102,
 			NumExtensions: 0,
 			NumServices:   2,

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -488,6 +488,17 @@ message Asset {
   cnquery.providers.v1.Platform platform = 21;
 }
 
+// ServerFeature which tells us if the upstream endpoint can handle certain
+// requests and data. Usually proto handles missing fields etc really well,
+// but we are also trying to avoid work on the client or sending large
+// amounts of data to the server that aren't necessary.
+enum ServerFeature {
+  // Default value, should not be used
+  SERVER_FEATURE_UNSPECIFIED = 0;
+  // StoreResourcesData as structure recording data
+  STORE_RESOURCES_DATA = 1;
+}
+
 /*
   Once a policy has been                     , it can easily be retrieved.
   We will store the different ways in which policies are resolved in the DB
@@ -500,6 +511,7 @@ message ResolvedPolicy {
   string graph_execution_checksum = 7;
   string filters_checksum = 20;
   string reporting_job_uuid = 21;
+  repeated ServerFeature features = 8;
 }
 
 /*

--- a/policy/cnspec_policy_vtproto.pb.go
+++ b/policy/cnspec_policy_vtproto.pb.go
@@ -1083,6 +1083,11 @@ func (m *ResolvedPolicy) CloneVT() *ResolvedPolicy {
 		}
 		r.Filters = tmpContainer
 	}
+	if rhs := m.Features; rhs != nil {
+		tmpContainer := make([]ServerFeature, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Features = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5305,6 +5310,27 @@ func (m *ResolvedPolicy) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i--
 		dAtA[i] = 0xa2
+	}
+	if len(m.Features) > 0 {
+		var pksize2 int
+		for _, num := range m.Features {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.Features {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x42
 	}
 	if len(m.GraphExecutionChecksum) > 0 {
 		i -= len(m.GraphExecutionChecksum)
@@ -10028,6 +10054,13 @@ func (m *ResolvedPolicy) SizeVT() (n int) {
 	l = len(m.GraphExecutionChecksum)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Features) > 0 {
+		l = 0
+		for _, e := range m.Features {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
 	}
 	l = len(m.FiltersChecksum)
 	if l > 0 {
@@ -19008,6 +19041,75 @@ func (m *ResolvedPolicy) UnmarshalVT(dAtA []byte) error {
 			}
 			m.GraphExecutionChecksum = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 8:
+			if wireType == 0 {
+				var v ServerFeature
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= ServerFeature(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.Features = append(m.Features, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.Features) == 0 {
+					m.Features = make([]ServerFeature, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v ServerFeature
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= ServerFeature(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.Features = append(m.Features, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field Features", wireType)
+			}
 		case 20:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FiltersChecksum", wireType)

--- a/policy/resolved_policy.go
+++ b/policy/resolved_policy.go
@@ -119,3 +119,14 @@ func (x *ResolvedPolicy) EnumerateQueryResources() map[string][]string {
 
 	return res
 }
+
+// HasFeature checks if the resolved policy indicates if certain features
+// should be supported on the execution and collection of it
+func (r *ResolvedPolicy) HasFeature(feature ServerFeature) bool {
+	for _, f := range r.Features {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -861,7 +861,7 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 		ResolvedPolicy: resolvedPolicy,
 	}
 
-	report, err := s.getReport()
+	report, err := s.getReport(resolvedPolicy)
 	if err != nil {
 		return ar, err
 	}
@@ -1091,7 +1091,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	return resolvedPolicy, nil
 }
 
-func (s *localAssetScanner) getReport() (*policy.Report, error) {
+func (s *localAssetScanner) getReport(resolvedPolicy *policy.ResolvedPolicy) (*policy.Report, error) {
 	var resolver policy.PolicyResolver = s.services
 
 	// TODO: we do not needs this anymore since we receive updates already
@@ -1105,7 +1105,7 @@ func (s *localAssetScanner) getReport() (*policy.Report, error) {
 		}, err
 	}
 
-	if cnquery.GetFeatures(s.job.Ctx).IsActive(cnquery.StoreResourcesData) {
+	if cnquery.GetFeatures(s.job.Ctx).IsActive(cnquery.StoreResourcesData) && resolvedPolicy.HasFeature(policy.ServerFeature_STORE_RESOURCES_DATA) {
 		log.Info().Str("mrn", s.job.Asset.Mrn).Msg("store resources for asset")
 		recording := s.Runtime.Recording()
 		data, ok := recording.GetAssetData(s.job.Asset.Mrn)


### PR DESCRIPTION
This allows the server to set or unset certain features that it supports. This means e.g. that if the server can store resources data in the new format, we can send it this way.