### PR TITLE
use v12 cnspec in cnspec_policy.proto

### DIFF
--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -4,7 +4,7 @@
 syntax = "proto3";
 
 package cnspec.policy.v1;
-option go_package = "go.mondoo.com/cnspec/v11/policy";
+option go_package = "go.mondoo.com/cnspec/v12/policy";
 
 import "llx/llx.proto";
 import "explorer/cnquery_explorer.proto";


### PR DESCRIPTION

`go generate ./policy` fails without this. 

```
go generate ./queryhub
go generate ./policy
entc/load: ../queryhub/mondoo_queryhub.pb.go:11:2: no required module provides package go.mondoo.com/cnspec/v11/policy; to add it:
	go get go.mondoo.com/cnspec/v11/policy
exit status 1
policy/mondoo_policy.go:14: running "go": exit status 1
```