### PR TITLE
🧹 Error linter if global props are defined

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -134,6 +134,7 @@ func LintPolicyBundle(schema resources.ResourcesSchema, filename string, data []
 func lintParsedBundle(schema resources.ResourcesSchema, filename string, policyBundle *Bundle) []*Entry {
 	aggregatedEntries := []*Entry{}
 
+	bundleChecks := GetBundleLintChecks()
 	policyChecks := GetPolicyLintChecks()
 	queryChecks := GetQueryLintChecks()
 
@@ -207,6 +208,12 @@ func lintParsedBundle(schema resources.ResourcesSchema, filename string, policyB
 				}
 			}
 		}
+	}
+
+	// Run Bundle checks
+	for _, check := range bundleChecks {
+		entries := check.Run(lintCtx, policyBundle)
+		aggregatedEntries = append(aggregatedEntries, entries...)
 	}
 
 	// Run Policy Checks

--- a/internal/bundle/lint_bundle.go
+++ b/internal/bundle/lint_bundle.go
@@ -1,0 +1,42 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+const (
+	BundleGlobalPropsDeprecatedRuleID = "bundle-global-props-deprecated"
+)
+
+func GetBundleLintChecks() []LintCheck {
+	return []LintCheck{
+		{
+			ID:          BundleGlobalPropsDeprecatedRuleID,
+			Name:        "Policy Bundle Global Properties Deprecated",
+			Description: "Checks if the policy bundle defines global properties",
+			Severity:    LevelWarning,
+			Run:         runCheckBundleGlobalPropsDeprecated,
+		},
+	}
+}
+
+func runCheckBundleGlobalPropsDeprecated(ctx *LintContext, item any) []*Entry {
+	bundle, ok := item.(*Bundle)
+	if !ok {
+		return nil
+	}
+
+	if len(bundle.Props) == 0 {
+		return nil
+	}
+
+	return []*Entry{{
+		RuleID:  BundleGlobalPropsDeprecatedRuleID,
+		Message: "Defining global properties in a policy bundle is deprecated. Define properties within individual policies and queries instead.",
+		Level:   LevelError,
+		Location: []Location{{
+			File:   ctx.FilePath,
+			Line:   bundle.Props[0].FileContext.Line,
+			Column: bundle.Props[0].FileContext.Column,
+		}},
+	}}
+}

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -51,6 +51,16 @@ func TestLinter_Fail(t *testing.T) {
 		return nil
 	}
 
+	t.Run("fail-global-props", func(t *testing.T) {
+		file := "./testdata/fail-bundle-global-props.mql.yaml"
+		results, err := Lint(schema, file)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(results.Entries))
+		assert.Equal(t, "bundle-global-props-deprecated", results.Entries[0].RuleID)
+		assert.Equal(t, "error", results.Entries[0].Level)
+		assert.Equal(t, "Defining global properties in a policy bundle is deprecated. Define properties within individual policies and queries instead.", results.Entries[0].Message)
+	})
+
 	t.Run("fail-policy-uid", func(t *testing.T) {
 		file := "./testdata/fail-policy-uid.mql.yaml"
 		results, err := Lint(schema, file)

--- a/internal/bundle/testdata/fail-bundle-global-props.mql.yaml
+++ b/internal/bundle/testdata/fail-bundle-global-props.mql.yaml
@@ -1,0 +1,4 @@
+props:
+  - uid: global-prop
+    title: Global Prop
+    mql: "true"


### PR DESCRIPTION
We now expect all props are defined on the query and policy levels. Added a linter to fail if props are defined on the bundle level

See https://github.com/mondoohq/cnspec/pull/1734