### PR TITLE
:broom: Fix SARIF file missing rules error -> Fixes: failing pipeline

### DIFF
--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -14,54 +14,13 @@ Usage:
   cnspec scan [command]
 
 Available Commands:
-  ansible          Scan an Ansible playbook
-  arista           Scan an Arista EOS device
-  atlassian        Scan an Atlassian Cloud Jira, Confluence or Bitbucket instance
-  aws              Scan an AWS account
-  azure            Scan an Azure subscription
-  ciscocatalyst    Scan Cisco Catalyst Connection
-  cloudflare       Scan Cloudflare provider
-  cloudformation   Scan an AWS CloudFormation template or AWS SAM template
-  container        Scan a running container or container image
-  device           Scan a block device target
-  docker           Scan a running Docker container, Docker image, or Dockerfile
-  equinix          Scan an Equinix Metal organization
-  filesystem       Scan a mounted file system target
-  gcp              Scan a Google Cloud project or folder
-  github           Scan a GitHub organization or repository
-  gitlab           Scan a GitLab group or project
-  google-workspace Scan a Google Workspace account
-  host             Scan a remote HTTP or HTTPS host
-  ipmi             Scan an IPMI interface
-  k8s              Scan a Kubernetes cluster or local manifest file(s)
-  local            Scan your local system
-  mcp              Scan Model Context Protocol Provider
-  mock             Scan a recording file without an active connection
-  mondoo           Scan Mondoo Platform
-  ms365            Scan a Microsoft 365 tenant
-  nd-ssh           Scan a remote network device via SSH
-  networkdiscovery Scan Discover subdomains for a given domain.
-  nmap             Scan a Nmap network scanner
-  oci              Scan an Oracle Cloud Infrastructure tenancy
-  okta             Scan an Okta organization
-  opcua            Scan an OPC UA device
-  sbom             Scan read SBOM file on disk
-  shodan           Scan a Shodan account
-  slack            Scan a Slack team
-  snowflake        Scan a Snowflake account
-  ssh              Scan a remote system via SSH
-  tailscale        Scan a Tailscale network
-  terraform        Scan a Terraform HCL file or directory
-  vagrant          Scan a Vagrant host
-  vcd              Scan a VMware Cloud Director installation
-  vsphere          Scan a VMware vSphere installation
-  winrm            Scan a remote system via WinRM
+  mock        Scan a recording file without an active connection
+  sbom        Scan read SBOM file on disk
 
 Flags:
       --annotation stringToString     Add an annotation to the asset in this format: key=value. (default [])
       --asset-name string             User-override for the asset name
       --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd'. (default true)
-      --discover strings              Enable the discovery of nested assets. Supports: all, auto, container, container-images
   -h, --help                          help for scan
       --incognito                     Run in incognito mode. Do not report scan results to Mondoo Platform.
       --inventory-file string         Set the path to the inventory file.
@@ -74,11 +33,8 @@ Flags:
       --policy strings                Lists policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY.
   -f, --policy-bundle strings         Path to local policy file
       --props stringToString          Custom values for properties (default [])
-      --record string                 Record all resource calls and use resources in the recording
       --risk-threshold int            If any risk is greater or equal to this, exitstatus is 1. (default 101)
-      --sudo                          Elevate privileges with sudo
       --trace-id string               Trace identifier
-      --use-recording string          Use a recording to inject resource data (read-only)
 
 Global Flags:
       --api-proxy string   Set proxy for communications with Mondoo API

--- a/test/cli/testdata/cnspec_vuln.ct
+++ b/test/cli/testdata/cnspec_vuln.ct
@@ -2,31 +2,18 @@ $ cnspec vuln --help
 Scans a target for vulnerabilities
 
 Usage:
-  cnspec vuln [flags]
   cnspec vuln [command]
 
 Available Commands:
-  container   Check for vulnerabilities a running container or container image
-  docker      Check for vulnerabilities a running Docker container, Docker image, or Dockerfile
-  filesystem  Check for vulnerabilities a mounted file system target
-  local       Check for vulnerabilities your local system
   sbom        Check for vulnerabilities read SBOM file on disk
-  ssh         Check for vulnerabilities a remote system via SSH
-  vagrant     Check for vulnerabilities a Vagrant host
-  vsphere     Check for vulnerabilities a VMware vSphere installation
-  winrm       Check for vulnerabilities a remote system via WinRM
 
 Flags:
-      --discover strings        Enable the discovery of nested assets. Supports: all, auto, container, container-images
   -h, --help                    help for vuln
       --inventory-ansible       Set the inventory format to Ansible.
       --inventory-domainlist    Set the inventory format to domain list.
       --inventory-file string   Set the path to the inventory file.
   -o, --output string           Set output format: compact, csv, full, json, json-v1, json-v2, junit, report, summary, yaml, yaml-v1, yaml-v2 (default "full")
       --platform-id string      Select a specific target asset by providing its platform ID.
-      --record string           Record all resource calls and use resources in the recording
-      --sudo                    Elevate privileges with sudo
-      --use-recording string    Use a recording to inject resource data (read-only)
 
 Global Flags:
       --api-proxy string   Set proxy for communications with Mondoo API


### PR DESCRIPTION
Currently the policy release pipeline (`Lint Policies`) fails because it generates SARIF files with problematic rule indices:
```
"ruleIndex":18446744073709551615,"level":"error","message": ...
```

This:
- adds the missing rules

<s>We might need to temporarily build cnspec in the pipeline to pass this check (instead of using the cnspec/action)</s> -> Turns out we don't. But we'll need to do another release and update the `cnspec/lint` action, again to make subsequent Policy PRs pass.