### PR TITLE
Pin self-hosted jobs to group instead of label

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -17,7 +17,8 @@ jobs:
       # Add "id-token" for google-github-actions/auth
       id-token: 'write'
 
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,7 +38,8 @@ jobs:
       # Add "id-token" for google-github-actions/auth
       id-token: "write"
 
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     environment: prod
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
use 
```    
runs-on:
  group: Default
```
instead of the default label for all self-hosted runners:
``` 
runs-on: self-hosted
```