### PR TITLE
🧹 small cleanup for linting and use 'rule' as the main term

### DIFF
--- a/internal/bundle/lint_results_sarif.go
+++ b/internal/bundle/lint_results_sarif.go
@@ -32,7 +32,7 @@ func sarifLinterRules() []Rule {
 	var rules []Rule
 
 	// Add rules from registered policy checks
-	for _, check := range GetPolicyLintChecks() {
+	for _, check := range GetPolicyLintRules() {
 		rules = append(rules, Rule{
 			ID:          check.ID,
 			Name:        check.Name,
@@ -41,7 +41,7 @@ func sarifLinterRules() []Rule {
 	}
 
 	// Add rules from registered query checks
-	for _, check := range GetQueryLintChecks() {
+	for _, check := range GetQueryLintRules() {
 		rules = append(rules, Rule{
 			ID:          check.ID,
 			Name:        check.Name,

--- a/internal/bundle/lint_rules_bundle.go
+++ b/internal/bundle/lint_rules_bundle.go
@@ -7,19 +7,19 @@ const (
 	BundleGlobalPropsDeprecatedRuleID = "bundle-global-props-deprecated"
 )
 
-func GetBundleLintChecks() []LintCheck {
-	return []LintCheck{
+func GetBundleLintRules() []LintRule {
+	return []LintRule{
 		{
 			ID:          BundleGlobalPropsDeprecatedRuleID,
 			Name:        "Policy Bundle Global Properties Deprecated",
 			Description: "Checks if the policy bundle defines global properties",
 			Severity:    LevelWarning,
-			Run:         runCheckBundleGlobalPropsDeprecated,
+			Run:         runRuleBundleGlobalPropsDeprecated,
 		},
 	}
 }
 
-func runCheckBundleGlobalPropsDeprecated(ctx *LintContext, item any) []*Entry {
+func runRuleBundleGlobalPropsDeprecated(ctx *LintContext, item any) []*Entry {
 	bundle, ok := item.(*Bundle)
 	if !ok {
 		return nil

--- a/internal/bundle/lint_rules_policy.go
+++ b/internal/bundle/lint_rules_policy.go
@@ -30,9 +30,9 @@ type LintContext struct {
 	VariantMapping        map[string]string   // Maps variant child UID to parent query UID
 }
 
-// LintCheck defines the structure for a single linting rule.
+// LintRule defines the structure for a single linting rule.
 // The item any will be cast to *Policy or QueryLintInput.
-type LintCheck struct {
+type LintRule struct {
 	ID          string
 	Name        string
 	Description string
@@ -60,64 +60,64 @@ const (
 	PolicyRequiredTagsMissingRuleID  = "policy-required-tags-missing"
 )
 
-// GetPolicyLintChecks returns a list of lint checks for policies.
-func GetPolicyLintChecks() []LintCheck {
-	return []LintCheck{
+// GetPolicyLintRules returns a list of lint checks for policies.
+func GetPolicyLintRules() []LintRule {
+	return []LintRule{
 		{
 			ID:          PolicyUidRuleID,
 			Name:        "Policy UID Presence and Format",
 			Description: "Checks if a policy has a UID and if it conforms to naming standards. Also checks for uniqueness within the file.",
 			Severity:    LevelError,
-			Run:         runCheckPolicyUid,
+			Run:         runRulePolicyUid,
 		},
 		{
 			ID:          PolicyNameRuleID,
 			Name:        "Policy Name Presence",
 			Description: "Ensures every policy has a `name` field.",
 			Severity:    LevelError,
-			Run:         runCheckPolicyName,
+			Run:         runRulePolicyName,
 		},
 		{
 			ID:          PolicyRequiredTagsMissingRuleID,
 			Name:        "Policy Required Tags",
 			Description: "Ensures policies have required tags like 'mondoo.com/category' and 'mondoo.com/platform'.",
 			Severity:    LevelWarning,
-			Run:         runCheckPolicyRequiredTags,
+			Run:         runRulePolicyRequiredTags,
 		},
 		{
 			ID:          PolicyMissingVersionRuleID,
 			Name:        "Policy Version Presence",
 			Description: "Ensures every policy has a `version` field.",
 			Severity:    LevelError,
-			Run:         runCheckPolicyMissingVersion,
+			Run:         runRulePolicyMissingVersion,
 		},
 		{
 			ID:          PolicyWrongVersionRuleID,
 			Name:        "Policy Version Format",
 			Description: "Ensures policy versions follow semantic versioning (semver).",
 			Severity:    LevelError,
-			Run:         runCheckPolicyWrongVersion,
+			Run:         runRulePolicyWrongVersion,
 		},
 		{
 			ID:          PolicyMissingChecksRuleID, // Covers empty groups and empty checks/queries in groups
 			Name:        "Policy Missing Checks or Groups",
 			Description: "Ensures policies have defined groups, and groups have checks or queries.",
 			Severity:    LevelError,
-			Run:         runCheckPolicyGroupsAndChecks,
+			Run:         runRulePolicyGroupsAndChecks,
 		},
 		{
 			ID:          PolicyMissingAssetFilterRuleID,
 			Name:        "Policy Group Missing Asset Filter",
 			Description: "Warns if a policy group or its checks lack asset filters or variants.",
 			Severity:    LevelWarning, // Original was warning
-			Run:         runCheckPolicyGroupAssetFilter,
+			Run:         runRulePolicyGroupAssetFilter,
 		},
 		{
 			ID:          PolicyMissingAssignedQueryRuleID,
 			Name:        "Policy Assigned Query Existence",
 			Description: "Ensures that queries assigned in policy groups exist globally or are valid embedded queries.",
 			Severity:    LevelError,
-			Run:         runCheckPolicyAssignedQueriesExist,
+			Run:         runRulePolicyAssignedQueriesExist,
 		},
 	}
 }
@@ -132,7 +132,7 @@ func policyIdentifier(p *Policy) string {
 	return fmt.Sprintf("policy at line %d", p.FileContext.Line)
 }
 
-func runCheckPolicyUid(ctx *LintContext, item any) []*Entry {
+func runRulePolicyUid(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -181,7 +181,7 @@ func runCheckPolicyUid(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckPolicyName(ctx *LintContext, item any) []*Entry {
+func runRulePolicyName(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -201,7 +201,7 @@ func runCheckPolicyName(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckPolicyRequiredTags(ctx *LintContext, item any) []*Entry {
+func runRulePolicyRequiredTags(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -225,7 +225,7 @@ func runCheckPolicyRequiredTags(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckPolicyMissingVersion(ctx *LintContext, item any) []*Entry {
+func runRulePolicyMissingVersion(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -245,7 +245,7 @@ func runCheckPolicyMissingVersion(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckPolicyWrongVersion(ctx *LintContext, item any) []*Entry {
+func runRulePolicyWrongVersion(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -268,7 +268,7 @@ func runCheckPolicyWrongVersion(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckPolicyGroupsAndChecks(ctx *LintContext, item any) []*Entry {
+func runRulePolicyGroupsAndChecks(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -306,7 +306,7 @@ func runCheckPolicyGroupsAndChecks(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckPolicyGroupAssetFilter(ctx *LintContext, item any) []*Entry {
+func runRulePolicyGroupAssetFilter(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil
@@ -354,7 +354,7 @@ func runCheckPolicyGroupAssetFilter(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckPolicyAssignedQueriesExist(ctx *LintContext, item any) []*Entry {
+func runRulePolicyAssignedQueriesExist(ctx *LintContext, item any) []*Entry {
 	p, ok := item.(*Policy)
 	if !ok {
 		return nil

--- a/internal/bundle/lint_rules_queries.go
+++ b/internal/bundle/lint_rules_queries.go
@@ -18,45 +18,45 @@ const (
 	QueryVariantUsesNonDefaultFieldsRuleID = "query-variant-uses-non-default-fields"
 )
 
-// GetQueryLintChecks is the input type for lint checks on queries.
-func GetQueryLintChecks() []LintCheck {
-	return []LintCheck{
+// GetQueryLintRules is the input type for lint checks on queries.
+func GetQueryLintRules() []LintRule {
+	return []LintRule{
 		{
 			ID:          QueryUidRuleID, // This check now covers UID presence, format, and uniqueness for global queries
 			Name:        "Query UID Validation",
 			Description: "Ensures global queries have a UID, it's correctly formatted, and unique within the file.",
 			Severity:    LevelError,
-			Run:         runCheckQueryUid,
+			Run:         runRuleQueryUid,
 		}, {
 			ID:          QueryTitleRuleID,
 			Name:        "Query Title Presence",
 			Description: "Ensures non-variant queries have a `title` field.",
 			Severity:    LevelError,
-			Run:         runCheckQueryTitle,
+			Run:         runRuleQueryTitle,
 		}, {
 			ID:          QueryVariantUsesNonDefaultFieldsRuleID,
 			Name:        "Query Variant Field Restrictions",
 			Description: "Ensures variant queries do not define fields like impact, title, tags, or nested variants.",
 			Severity:    LevelError,
-			Run:         runCheckQueryVariantFields,
+			Run:         runRuleQueryVariantFields,
 		}, {
 			ID:          QueryMissingMQLRuleID,
 			Name:        "Query MQL Presence (for Variants and Non-Variant Parents)",
 			Description: "Ensures variant queries have MQL. Ensures parent queries without variants have MQL.",
 			Severity:    LevelError,
-			Run:         runCheckQueryMQLPresence,
+			Run:         runRuleQueryMQLPresence,
 		}, {
 			ID:          QueryUnassignedRuleID,
 			Name:        "Unassigned Query",
 			Description: "Warns if a global query is defined but not assigned to any policy.",
 			Severity:    LevelWarning,
-			Run:         runCheckQueryUnassigned,
+			Run:         runRuleQueryUnassigned,
 		}, {
 			ID:          QueryUsedAsDifferentTypesRuleID,
 			Name:        "Query Usage Consistency",
 			Description: "Ensures a query is not used as both a check and a data query within policies.",
 			Severity:    LevelError,
-			Run:         runCheckQueryUsageConsistency,
+			Run:         runRuleQueryUsageConsistency,
 		},
 	}
 }
@@ -72,7 +72,7 @@ func queryIdentifier(q *Mquery, isGlobal bool) string {
 	return fmt.Sprintf("%s at line %d", prefix, q.FileContext.Line)
 }
 
-func runCheckQueryUid(ctx *LintContext, item any) []*Entry {
+func runRuleQueryUid(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil
@@ -133,7 +133,7 @@ func runCheckQueryUid(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckQueryTitle(ctx *LintContext, item any) []*Entry {
+func runRuleQueryTitle(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil
@@ -160,7 +160,7 @@ func runCheckQueryTitle(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckQueryVariantFields(ctx *LintContext, item any) []*Entry {
+func runRuleQueryVariantFields(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil
@@ -209,7 +209,7 @@ func runCheckQueryVariantFields(ctx *LintContext, item any) []*Entry {
 	return entries
 }
 
-func runCheckQueryMQLPresence(ctx *LintContext, item any) []*Entry {
+func runRuleQueryMQLPresence(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil
@@ -243,7 +243,7 @@ func runCheckQueryMQLPresence(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckQueryUnassigned(ctx *LintContext, item any) []*Entry {
+func runRuleQueryUnassigned(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil
@@ -271,7 +271,7 @@ func runCheckQueryUnassigned(ctx *LintContext, item any) []*Entry {
 	return nil
 }
 
-func runCheckQueryUsageConsistency(ctx *LintContext, item any) []*Entry {
+func runRuleQueryUsageConsistency(ctx *LintContext, item any) []*Entry {
 	input, ok := item.(QueryLintInput)
 	if !ok {
 		return nil


### PR DESCRIPTION
No functional change, just improves readability of the linting code. We used rule and check for the same thing. This PR uses rule for all linting rules. It also renames the files that include the rules to make this more intuitive.