### PR TITLE
🧹 Cleanup some compiler warnings.

### DIFF
--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -113,16 +113,16 @@ func runWindowsUpdate(hc *http.Client) error {
 }
 
 func runUpdate(hc *http.Client) error {
-	if runtime.GOOS == "windows" {
+	switch runtime.GOOS {
+	case "windows":
 		return runWindowsUpdate(hc)
-	} else if runtime.GOOS == "darwin" {
+	case "darwin":
 		return runUnixUpdate(hc)
-	} else if runtime.GOOS == "linux" {
+	case "linux":
 		return runUnixUpdate(hc)
-	} else {
+	default:
 		return fmt.Errorf("platform %s is not supported for automatic update", runtime.GOOS)
 	}
-	return nil
 }
 
 func runCmd(cmd *exec.Cmd) error {

--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -245,6 +245,4 @@ func (ge *GraphExecutor) Debug() {
 		log.Error().Err(err).Msg("failed to write debug graph")
 		return
 	}
-
-	return
 }

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -382,7 +382,6 @@ func (s *LocalServices) GetFramework(ctx context.Context, req *Mrn) (*Framework,
 
 func (s *LocalServices) DeleteFramework(ctx context.Context, req *Mrn) (*Empty, error) {
 	panic("NOT YET IMPLEMENTED")
-	return globalEmpty, nil
 }
 
 func (s *LocalServices) ListFrameworks(ctx context.Context, req *ListReq) (*Frameworks, error) {


### PR DESCRIPTION
Some unreachable code and unnecessary return statements that the lang server was bugging me about.