### PR TITLE
🧹 Stop exposing resolved policy cache

### DIFF
--- a/internal/datalakes/inmemory/inmemory.go
+++ b/internal/datalakes/inmemory/inmemory.go
@@ -22,12 +22,10 @@ type Db struct {
 }
 
 // NewServices creates a new set of policy services
-func NewServices(runtime llx.Runtime, resolvedPolicyCache *ResolvedPolicyCache) (*Db, *policy.LocalServices, error) {
+func NewServices(runtime llx.Runtime) (*Db, *policy.LocalServices, error) {
 	var cache kvStore = newKissDb()
 
-	if resolvedPolicyCache == nil {
-		resolvedPolicyCache = NewResolvedPolicyCache(0)
-	}
+	resolvedPolicyCache := NewResolvedPolicyCache(0)
 
 	db := &Db{
 		cache:               cache,
@@ -43,8 +41,8 @@ func NewServices(runtime llx.Runtime, resolvedPolicyCache *ResolvedPolicyCache) 
 }
 
 // WithDb creates a new set of policy services and closes everything out once the function is done
-func WithDb(runtime llx.Runtime, resolvedPolicyCache *ResolvedPolicyCache, f func(*Db, *policy.LocalServices) error) error {
-	db, ls, err := NewServices(runtime, resolvedPolicyCache)
+func WithDb(runtime llx.Runtime, f func(*Db, *policy.LocalServices) error) error {
+	db, ls, err := NewServices(runtime)
 	if err != nil {
 		return err
 	}

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -578,7 +578,7 @@ framework_maps:
 
 	checksumToTestCases := map[string][]string{}
 
-	_, srv, err := inmemory.NewServices(providers.DefaultRuntime(), nil)
+	_, srv, err := inmemory.NewServices(providers.DefaultRuntime())
 	require.NoError(t, err)
 
 	t.Run("no duplicate checksums", func(t *testing.T) {

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -28,7 +28,7 @@ func parseBundle(t *testing.T, data string) *policy.Bundle {
 
 func initResolver(t *testing.T, assets []*testAsset, bundles []*policy.Bundle) *policy.LocalServices {
 	runtime := testutils.LinuxMock()
-	_, srv, err := inmemory.NewServices(runtime, nil)
+	_, srv, err := inmemory.NewServices(runtime)
 	require.NoError(t, err)
 
 	for i := range bundles {

--- a/policy/resolver_v2_test.go
+++ b/policy/resolver_v2_test.go
@@ -727,7 +727,7 @@ policies:
       action: 4
 `)
 
-	_, srv, err := inmemory.NewServices(providers.DefaultRuntime(), nil)
+	_, srv, err := inmemory.NewServices(providers.DefaultRuntime())
 	require.NoError(t, err)
 
 	_, err = srv.SetBundle(ctx, b)
@@ -1737,7 +1737,7 @@ framework_maps:
         - uid: sshd-ciphers-02
 `
 
-	_, srv, err := inmemory.NewServices(providers.DefaultRuntime(), nil)
+	_, srv, err := inmemory.NewServices(providers.DefaultRuntime())
 	require.NoError(t, err)
 
 	t.Run("resolve with ignored control", func(t *testing.T) {

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -50,14 +50,13 @@ const (
 )
 
 type LocalScanner struct {
-	resolvedPolicyCache *inmemory.ResolvedPolicyCache
-	queue               *diskQueueClient
-	ctx                 context.Context
-	fetcher             *fetcher
-	upstream            *upstream.UpstreamConfig
-	_upstreamClient     *upstream.UpstreamClient
-	recording           llx.Recording
-	runtime             llx.Runtime
+	queue           *diskQueueClient
+	ctx             context.Context
+	fetcher         *fetcher
+	upstream        *upstream.UpstreamConfig
+	_upstreamClient *upstream.UpstreamClient
+	recording       llx.Recording
+	runtime         llx.Runtime
 
 	// allows setting the upstream credentials from a job
 	allowJobCredentials bool
@@ -119,9 +118,8 @@ func WithRuntime(r *providers.Runtime) ScannerOption {
 
 func NewLocalScanner(opts ...ScannerOption) *LocalScanner {
 	ls := &LocalScanner{
-		resolvedPolicyCache: inmemory.NewResolvedPolicyCache(ResolvedPolicyCacheSize),
-		fetcher:             newFetcher(),
-		ctx:                 context.Background(),
+		fetcher: newFetcher(),
+		ctx:     context.Background(),
 		// By default, auto-update is enabled. It can be explicitly disabled
 		// by passing WithAutoUpdate(false)
 		autoUpdate: true,
@@ -679,7 +677,7 @@ func (s *LocalScanner) runMotorizedAsset(job *AssetJob) (*AssetReport, error) {
 	var res *AssetReport
 	var policyErr error
 
-	runtimeErr := inmemory.WithDb(s.runtime, s.resolvedPolicyCache, func(db *inmemory.Db, services *policy.LocalServices) error {
+	runtimeErr := inmemory.WithDb(s.runtime, func(db *inmemory.Db, services *policy.LocalServices) error {
 		if job.UpstreamConfig.ApiEndpoint != "" && !job.UpstreamConfig.Incognito {
 			log.Debug().Msg("using API endpoint " + job.UpstreamConfig.ApiEndpoint)
 			client, err := s.upstreamClient(job.Ctx, job.UpstreamConfig)

--- a/policy/scan/scan.go
+++ b/policy/scan/scan.go
@@ -20,9 +20,6 @@ import (
 
 //go:generate protoc --proto_path=../../:../../cnquery:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. scan.proto
 
-// 50MB default size
-const ResolvedPolicyCacheSize = 52428800
-
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }


### PR DESCRIPTION
- It looks unused. Each scan will get a single resolved policy. Caching doesn't make sense in this context