### PR TITLE
fix query: enhance core dump restrictions by checking limits configuration files

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -491,11 +491,23 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/security/limits.conf").content.lines.where( _ == /^[^#]/ ).where( _.contains("core") ) {
-        _ == /\*\s+hard\s+core\s+0/
-      }
+      limitsConfFile = ["/etc/security/limits.conf"].where(file(_).exists).all(
+        file(_).content.lines.where( _ == /^[^#]/ ).one(
+          _ == /\*\s+hard\s+core\s+0/
+        )
+      )
+
+      limitsRulesDirectory = files.find(from: "/etc/security/limits.d/", type: "file").list.where(basename == /\.conf/).one(
+        _.content.lines.where( _ == /^[^#]/ ).one(
+          _ == /\*\s+hard\s+core\s+0/
+        )
+      )
+
+      limitsConfFile || limitsRulesDirectory
+
       kernel.parameters['fs.suid_dumpable'] == 0
-      if(service("coredump").enabled || service("coredump").running) {
+
+      if (service("coredump").enabled || service("coredump").running) {
         parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['ProcessSizeMax'] == 0
         parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['Storage'] == 'none'
       }


### PR DESCRIPTION
Fixing the query 'mondoo-linux-security-core-dumps-are-restricted' to check the rules directory for the `/etc/securitylimits**`