### PR TITLE
🧹 Unpin goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -82,8 +82,8 @@ jobs:
         env:
           GPG_KEY: "${{ secrets.GPG_KEY}}"
 
-# jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
-# These packages have been installed on the self-hosted runner using ansible from the private repo
+      # jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
+      # These packages have been installed on the self-hosted runner using ansible from the private repo
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -132,7 +132,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.5.1
+          version: latest
           args: >
             release
             --config .goreleaser.yml
@@ -157,7 +157,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.5.1
+          version: latest
           args: >
             release
             ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}


### PR DESCRIPTION
I'd like to update to get the retries:
https://goreleaser.com/customization/docker/\#customization

These were introduced with v2.12. That should help with: https://github.com/mondoohq/cnspec/actions/runs/19455653988/job/55668916189

We pinned goreleaser becasuse of rpm signiture issues: https://github.com/mondoohq/cnspec/pull/1556

But goreleaser now includes a nfpm version which should no longer have this problem: https://github.com/goreleaser/goreleaser/blob/main/go.mod\#L33C2-L33C28

https://github.com/goreleaser/nfpm/releases/tag/v2.41.3