### PR TITLE
🧹 update policy linting to focus on errors

### DIFF
--- a/.github/workflows/policies_lint.yaml
+++ b/.github/workflows/policies_lint.yaml
@@ -36,7 +36,7 @@ jobs:
         id: check_sarif
         run: |
           echo "Checking SARIF file content..."
-          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | length == 0')
+          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | map(select(.level != "warning" and .level != "note")) | length == 0')
           if [ "$RESULTS_EMPTY" = "true" ]; then
             echo "SARIF file content is as expected. No results found."
           else


### PR DESCRIPTION
As seen in https://github.com/mondoohq/cnspec/pull/1803, we fail the PR because the policy linter returns a warning. That warning is ok and we should not stop the pipeline for warnings. Therefore, this PR is restricting the sarif results on errors.