### PR TITLE
exitstatus -> exitstatus in help

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -80,7 +80,7 @@ func init() {
 	_ = scanCmd.Flags().MarkHidden("report-type")
 	_ = scanCmd.Flags().Int("score-threshold", 0, "If any score falls below the threshold, exit 1.")
 	_ = scanCmd.Flags().MarkDeprecated("score-threshold", "Please use --risk-threshold instead")
-	_ = scanCmd.Flags().Int("risk-threshold", reporter.DEFAULT_RISK_THRESHOLD, "If any risk is greater or equal to this, exitstatus is 1.")
+	_ = scanCmd.Flags().Int("risk-threshold", reporter.DEFAULT_RISK_THRESHOLD, "If any risk is greater or equal to this, exit status is 1.")
 	_ = scanCmd.Flags().String("output-target", "", "Set output target to which the asset report will be sent. Currently only supports AWS SQS topic URLs and local files")
 }
 

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -33,7 +33,7 @@ Flags:
       --policy strings                Lists policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY.
   -f, --policy-bundle strings         Path to local policy file
       --props stringToString          Custom values for properties (default [])
-      --risk-threshold int            If any risk is greater or equal to this, exitstatus is 1. (default 101)
+      --risk-threshold int            If any risk is greater or equal to this, exit status is 1. (default 101)
       --trace-id string               Trace identifier
 
 Global Flags:


### PR DESCRIPTION
This is usually written as two words outside the actual code