### PR TITLE
🧹  update `mondoo-linux-security-permissions-on-all-logfiles-are-configured`

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -6669,14 +6669,13 @@ queries:
     title: Ensure secure permissions on all log files are set
     impact: 80
     mql: |
-      files.find(from: "/var/log", type: "file").list {
-        path
-        permissions.group_writeable == false
-        permissions.group_executable == false
-        permissions.other_readable == false
-        permissions.other_writeable == false
+      files.find(from: "/var/log", type: "file").list.all(
+        permissions.group_writeable == false &&
+        permissions.group_executable == false &&
+        permissions.other_readable == false &&
+        permissions.other_writeable == false &&
         permissions.other_executable == false
-      }
+      )
     docs:
       desc: |
         This check ensures that log files stored in `/var/log/` are properly secured to protect sensitive information and maintain system integrity.


### PR DESCRIPTION
Bring logfile permission check in line with enterprise policies for better readability of the output. At the moment you get the permissions for all logfiles and have to hunt down, where the check fails 