### PR TITLE
🧹 Update descriptions in the AWS policy to match branding

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -20,6 +20,7 @@ policies:
 
         This policy provides security checks across key AWS services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 
+        - API Gateway
         - CloudTrail
         - CloudWatch
         - DynamoDB
@@ -43,7 +44,7 @@ policies:
       - title: AWS General
         checks:
           - uid: mondoo-aws-security-no-static-credentials-in-providers
-      - title: AWS API Gateway
+      - title: Amazon API Gateway
         checks:
           - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted
           - uid: mondoo-aws-security-api-gw-execution-logging-enabled
@@ -65,7 +66,7 @@ policies:
         checks:
           - uid: mondoo-aws-security-lambda-concurrency-check
           - uid: mondoo-aws-security-lambda-function-public-access-prohibited
-      - title: AWS S3 Bucket
+      - title: Amazon S3 Bucket
         checks:
           - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited
           - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access
@@ -84,24 +85,24 @@ policies:
           - uid: mondoo-aws-security-vpc-default-security-group-closed
           - uid: mondoo-aws-security-vpc-flow-logs-enabled
           - uid: mondoo-aws-security-vpc-bpa-enabled
-      - title: AWS DynamoDB Table
+      - title: Amazon DynamoDB Table
         checks:
           - uid: mondoo-aws-security-dynamodb-table-encrypted-kms
-      - title: AWS RDS DB Instance
+      - title: Amazon RDS DB Instance
         checks:
           - uid: mondoo-aws-security-rds-instance-public-access-check
           - uid: mondoo-aws-security-rds-instance-encryption-at-rest
           - uid: mondoo-aws-security-rds-instance-no-pending-os-upgrades
-      - title: AWS RDS DB Cluster
+      - title: Amazon RDS DB Cluster
         checks:
           - uid: mondoo-aws-security-rds-cluster-public-access-check
           - uid: mondoo-aws-security-rds-cluster-encryption-at-rest
           - uid: mondoo-aws-security-rds-cluster-no-pending-os-upgrades
           - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl
-      - title: AWS Redshift Cluster
+      - title: Amazon Redshift Cluster
         checks:
           - uid: mondoo-aws-security-redshift-cluster-public-access-check
-      - title: AWS EC2
+      - title: Amazon EC2
         checks:
           - uid: mondoo-aws-security-ec2-ebs-encryption-by-default
           - uid: mondoo-aws-security-ec2-imdsv2-check
@@ -111,7 +112,7 @@ policies:
           - uid: mondoo-aws-security-ebs-snapshot-encrypted
           - uid: mondoo-aws-security-ec2-encrypted-volumes
           - uid: mondoo-aws-security-ec2-user-data-no-secrets
-      - title: AWS EFS Filesystem
+      - title: Amazon EFS Filesystem
         checks:
           - uid: mondoo-aws-security-efs-encrypted-check
       - title: AWS CloudWatch
@@ -129,14 +130,14 @@ policies:
       - title: AWS KMS Key
         checks:
           - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
-      - title: AWS SageMaker Notebook Instance
+      - title: Amazon SageMaker Notebook Instance
         checks:
           - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured
       - title: AWS CloudTrail Trail
         checks:
           - uid: mondoo-aws-security-cloud-trail-encryption-enabled
           - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled
-      - title: AWS EKS Cluster
+      - title: Amazon EKS Cluster
         checks:
           - uid: mondoo-aws-security-eks-cluster-cmks-in-kms
           - uid: mondoo-aws-security-eks-cluster-private-controlplane


### PR DESCRIPTION
Amazon uses a jumbled mess of AWS and Amazon for their product names. Update our chapters to match their branding. It's all terrible.