### PR TITLE
fix(mql): Falcon EDR check for at least one running instance

### DIFF
--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -188,7 +188,7 @@ queries:
       asset.platform == 'macos'
       package('Falcon').installed
     mql: |
-      macos.systemExtensions.where(identifier == "com.crowdstrike.falcon.Agent").all(enabled == true && active == true && state == "activated_enabled")
+      macos.systemExtensions.where(identifier == "com.crowdstrike.falcon.Agent").any(enabled == true && active == true && state == "activated_enabled")
   - uid: mondoo-edr-policy-ensure-crowdstrike-agent-is-running-linux
     filters: |
       asset.family.contains('linux')


### PR DESCRIPTION
Check for at least one running Falcon instance, since during upgrades there may be multiple versions installed, but one one will be active