### PR TITLE
⭐ Add new Linux Security policy checks for extra kernel modules

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -41,6 +41,7 @@ CUSTOMERID
 CYAAAAAAAKEY
 cyserver
 DBKMS
+dccp
 deactivateduser
 decomp
 dhe
@@ -155,6 +156,7 @@ saas
 sacl
 SCENo
 screensharing
+sctp
 secboot
 secureboot
 securepassword
@@ -181,6 +183,7 @@ syncookies
 tallylog
 testdata
 tinyssh
+tipc
 tmpfiles
 uefi
 umac

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -31,7 +31,7 @@
 \b[Ww]hite listed\b
 
 # s.b. Block list
-\b[Bb]lacklist\b
+# \b[Bb]lacklist\b # kernel modules still use this term
 \b[Bb]lacklisting\b
 \b[Bb]lacklisted\b
 \b[Bb]lack list\b

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -85,6 +85,16 @@ policies:
           - uid: mondoo-linux-security-restrict-dmesg-access
           - uid: mondoo-linux-security-prevent-nonprivileged-ebpf-access
           - uid: mondoo-linux-security-prevent-nonprivileged-ptrace-access
+      - title: Kernel modules
+        filters: |
+          asset.family.contains('linux')
+        checks:
+          - uid: mondoo-linux-security-disable-loading-of-atm-module
+          - uid: mondoo-linux-security-disable-loading-of-can-module
+          - uid: mondoo-linux-security-disable-loading-of-dccp-module
+          - uid: mondoo-linux-security-disable-loading-of-rds-module
+          - uid: mondoo-linux-security-disable-loading-of-sctp-module
+          - uid: mondoo-linux-security-disable-loading-of-tipc-module
       - title: Network Stack
         filters: |
           asset.family.contains('linux')
@@ -1186,6 +1196,463 @@ queries:
     refs:
       - url: https://www.kernel.org/doc/Documentation/security/Yama.txt
         title: 'Linux Kernel Documentation: Yama'
+  - uid: mondoo-linux-security-disable-loading-of-atm-module
+    title: Ensure loading of the ATM module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/atm.conf").exists
+      file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false")
+      file("/etc/modprobe.d/atm.conf").content.contains("blacklist atm")
+    docs:
+      desc: |
+        This check verifies that the ATM (Asynchronous Transfer Mode) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/atm.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The ATM module provides support for Asynchronous Transfer Mode networking, a technology that was once used for high-speed data transfer. However, ATM has largely fallen out of favor and is rarely used in modern systems. Keeping the ATM module enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like ATM helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the ATM module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/atm.conf` and add the following lines to disable loading and installation of the ATM module:
+
+            ```
+            blacklist atm
+            install atm /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the ATM module:
+
+            ```yaml
+            ---
+            - name: Disable ATM module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable ATM module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/atm.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content: |
+                      blacklist atm
+                      install atm /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to disable the ATM module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Unload ATM module if currently loaded..."
+            modprobe -r atm || true
+            echo "ATM module disabled."
+
+            echo "Disabling ATM module..."
+            cat <<EOF > /etc/modprobe.d/atm.conf
+            blacklist atm
+            install atm /bin/false
+            EOF
+  - uid: mondoo-linux-security-disable-loading-of-can-module
+    title: Ensure loading of the CAN module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/can.conf").content.contains("install can /bin/false")
+      file("/etc/modprobe.d/can.conf").content.contains("blacklist can")
+    docs:
+      desc: |
+        This check verifies that the CAN (Controller Area Network) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/can.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The CAN module provides support for Controller Area Network communication, which is primarily used in automotive and industrial applications. However, if the CAN module is not required for the system's operation, keeping it enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like CAN helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the CAN module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/can.conf` and add the following lines to disable loading and installation of the CAN module:
+
+            ```
+            blacklist can
+            install can /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the CAN module:
+
+            ```yaml
+            ---
+            - name: Disable CAN module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable CAN module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/can.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content: |
+                      blacklist can
+                      install can /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to disable the CAN module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Unload CAN module if currently loaded..."
+            modprobe -r can || true
+            
+            echo "Disabling CAN module..."
+            cat <<EOF > /etc/modprobe.d/can.conf
+            blacklist can
+            install can /bin/false
+            EOF
+            ```
+  - uid: mondoo-linux-security-disable-loading-of-dccp-module
+    title: Ensure loading of the DCCP module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/dccp.conf").content.contains("install dccp /bin/false")
+      file("/etc/modprobe.d/dccp.conf").content.contains("blacklist dccp")
+    docs:
+      desc: |
+        This check verifies that the DCCP (Datagram Congestion Control Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/dccp.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The DCCP module provides support for the Datagram Congestion Control Protocol, which is used for streaming media and real-time applications. However, if the DCCP module is not required for the system's operation, keeping it enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like DCCP helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the DCCP module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/dccp.conf` and add the following lines to disable loading and installation of the DCCP module:
+
+            ```
+            blacklist dccp
+            install dccp /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the DCCP module:
+
+            ```yaml
+            ---
+            - name: Disable DCCP module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable DCCP module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/dccp.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content:
+                      blacklist dccp
+                      install dccp /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+            
+            Use this Bash script to disable the DCCP module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Unload DCCP module if currently loaded..."
+            modprobe -r dccp || true
+            
+            echo "Disabling DCCP module..."
+            cat <<EOF > /etc/modprobe.d/dccp.conf
+            blacklist dccp
+            install dccp /bin/false
+            EOF
+            ```
+  - uid: mondoo-linux-security-disable-loading-of-rds-module
+    title: Ensure loading of the RDS module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/rds.conf").content.contains("install rds /bin/false")
+      file("/etc/modprobe.d/rds.conf").content.contains("blacklist rds")
+    docs:
+      desc: |
+        This check verifies that the RDS (Reliable Datagram Sockets) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/rds.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The RDS module provides support for Reliable Datagram Sockets, which is used for high-performance computing and clustering applications. However, if the RDS module is not required for the system's operation, keeping it enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like RDS helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the RDS module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/rds.conf` and add the following lines to disable loading and installation of the RDS module:
+
+            ```
+            blacklist rds
+            install rds /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the RDS module:
+
+            ```yaml
+            ---
+            - name: Disable RDS module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable RDS module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/rds.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content: |
+                      blacklist rds
+                      install rds /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to disable the RDS module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Unload RDS module if currently loaded..."
+            modprobe -r rds || true
+            
+            echo "Disabling RDS module..."
+            cat <<EOF > /etc/modprobe.d/rds.conf
+            blacklist rds
+            install rds /bin/false
+            EOF
+            ```
+  - uid: mondoo-linux-security-disable-loading-of-sctp-module
+    title: Ensure loading of the SCTP module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/sctp.conf").content.contains("install sctp /bin/false")
+      file("/etc/modprobe.d/sctp.conf").content.contains("blacklist sctp")
+    docs:
+      desc: |
+        This check verifies that the SCTP (Stream Control Transmission Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/sctp.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The SCTP module provides support for the Stream Control Transmission Protocol, which is used for telecommunication and signaling applications. However, if the SCTP module is not required for the system's operation, keeping it enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like SCTP helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the SCTP module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/sctp.conf` and add the following lines to disable loading and installation of the SCTP module:
+
+            ```
+            blacklist sctp
+            install sctp /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the SCTP module:
+
+            ```yaml
+            ---
+            - name: Disable SCTP module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable SCTP module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/sctp.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content: |
+                      blacklist sctp
+                      install sctp /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to disable the SCTP module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Unload SCTP module if currently loaded..."
+            modprobe -r sctp || true
+            
+            echo "Disabling SCTP module..."
+            cat <<EOF > /etc/modprobe.d/sctp.conf
+            blacklist sctp
+            install sctp /bin/false
+            EOF
+            ```
+  - uid: mondoo-linux-security-disable-loading-of-tipc-module
+    title: Ensure loading of the TIPC module is disabled
+    impact: 50
+    filters: |
+      asset.kind != "container-image"
+      asset.runtime != "docker-container"
+    mql: |
+      file("/etc/modprobe.d/tipc.conf").content.contains("install tipc /bin/false")
+      file("/etc/modprobe.d/tipc.conf").content.contains("blacklist tipc")
+    docs:
+      desc: |
+        This check verifies that the TIPC (Transparent Inter-Process Communication) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/tipc.conf` that both blacklist the module and redirect its install to `/bin/false`.
+
+        **Why this matters**
+
+        The TIPC module provides support for Transparent Inter-Process Communication, which is used for communication between nodes in a cluster. However, if the TIPC module is not required for the system's operation, keeping it enabled can introduce unnecessary security risks, as it may contain vulnerabilities that could be exploited by attackers.
+
+        Disabling unused kernel modules like TIPC helps to:
+          - Reduce the system's attack surface by eliminating unnecessary code that could be exploited.
+          - Prevent potential conflicts or issues with other networking components.
+          - Enhance overall system security by adhering to the principle of least functionality.
+
+        By ensuring that the TIPC module is disabled, organizations can mitigate potential risks associated with unused or legacy components in their Linux systems.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Create or edit the file `/etc/modprobe.d/tipc.conf` and add the following lines to disable loading and installation of the TIPC module:
+
+            ```
+            blacklist tipc
+            install tipc /bin/false
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to disable the TIPC module:
+
+            ```yaml
+            ---
+            - name: Disable TIPC module on Linux systems
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Create modprobe config to disable TIPC module
+                  ansible.builtin.copy:
+                    dest: /etc/modprobe.d/tipc.conf
+                    owner: root
+                    group: root
+                    mode: '0644'
+                    content: |
+                      blacklist tipc
+                      install tipc /bin/false
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to disable the TIPC module by creating the appropriate modprobe configuration file:
+
+            ```bash
+            #!/bin/bash
+            set -e 
+
+            echo "Unload TIPC module if currently loaded..."
+            modprobe -r tipc || true
+
+            echo "Disabling TIPC module..."
+            cat <<EOF > /etc/modprobe.d/tipc.conf
+            blacklist tipc
+            install tipc /bin/false
+            EOF
+            ```
   - uid: mondoo-linux-security-prelink-is-disabled
     title: Ensure prelink is disabled
     impact: 70


### PR DESCRIPTION
This has users disable extra networking transports that are generally unused and have historically been the source of CVEs.