### PR TITLE
Fix errors in openssh remediation on minimal systems

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -8515,6 +8515,11 @@ queries:
             #!/bin/bash
             set -e
 
+            if ! command -v bc >/dev/null 2>&1; then
+              echo "Warning: 'bc' is required but not installed. Please install 'bc' and re-run this script."
+              exit 1
+            fi
+
             echo "Configuring SSH with strong KexAlgorithms"
             openssh_version=$(sshd -v 2>&1 | grep -oP 'OpenSSH_\K\d+\.\d+')
 


### PR DESCRIPTION
Check for BC and error if it can't be found. Turns out my raspi did not have that.