### PR TITLE
Update the SSH client interval query

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -8563,14 +8563,12 @@ queries:
       userBlocks = sshd.config.blocks.where(criteria.contains(props.excludedMatchBlocks) == false && criteria != "");
 
       userBlocks.all(params.ClientAliveInterval >= 1)
-      userBlocks.all(params.ClientAliveInterval <= 900)
-      userBlocks.all(params.ClientAliveCountMax > 0)
-      userBlocks.all(params.ClientAliveCountMax <= 3)
+      userBlocks.all(params.ClientAliveInterval <= 300)
+      userBlocks.all(params.ClientAliveCountMax > 0) && userBlocks.all(params.ClientAliveCountMax <= 3)
 
       defaultBlock.all(params.ClientAliveInterval >= 1)
-      defaultBlock.all(params.ClientAliveInterval <= 900)
-      defaultBlock.all(params.ClientAliveCountMax > 0)
-      defaultBlock.all(params.ClientAliveCountMax <= 3)
+      defaultBlock.all(params.ClientAliveInterval <= 300)
+      defaultBlock.all(params.ClientAliveCountMax > 0) && defaultBlock.all(params.ClientAliveCountMax <= 3)
     docs:
       desc: |
         This check ensures that the `ClientAliveInterval` and `ClientAliveCountMax` parameters in the SSH configuration are set to control the timeout of SSH sessions. These parameters help terminate idle SSH sessions after a specified period of inactivity.


### PR DESCRIPTION
Use the query we're using in CIS benchmarks