### PR TITLE
🐛 Prevent errors checking for kernel modules

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -1203,8 +1203,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/atm.conf").exists
-      file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false")
+      file("/etc/modprobe.d/atm.conf").exists &&
+      file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false") &&
       file("/etc/modprobe.d/atm.conf").content.contains("blacklist atm")
     docs:
       desc: |
@@ -1280,7 +1280,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/can.conf").content.contains("install can /bin/false")
+      file("/etc.modprobe.d/can.conf").exists &&
+      file("/etc/modprobe.d/can.conf").content.contains("install can /bin/false") &&
       file("/etc/modprobe.d/can.conf").content.contains("blacklist can")
     docs:
       desc: |
@@ -1356,7 +1357,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/dccp.conf").content.contains("install dccp /bin/false")
+      file("/etc/modprobe.d/dccp.conf").exists &&
+      file("/etc/modprobe.d/dccp.conf").content.contains("install dccp /bin/false") &&
       file("/etc/modprobe.d/dccp.conf").content.contains("blacklist dccp")
     docs:
       desc: |
@@ -1432,7 +1434,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/rds.conf").content.contains("install rds /bin/false")
+      file("/etc/modprobe.d/rds.conf").exists &&
+      file("/etc/modprobe.d/rds.conf").content.contains("install rds /bin/false") &&
       file("/etc/modprobe.d/rds.conf").content.contains("blacklist rds")
     docs:
       desc: |
@@ -1508,7 +1511,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/sctp.conf").content.contains("install sctp /bin/false")
+      file("/etc/modprobe.d/sctp.conf").exists &&
+      file("/etc/modprobe.d/sctp.conf").content.contains("install sctp /bin/false") &&
       file("/etc/modprobe.d/sctp.conf").content.contains("blacklist sctp")
     docs:
       desc: |
@@ -1584,7 +1588,8 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      file("/etc/modprobe.d/tipc.conf").content.contains("install tipc /bin/false")
+      file("/etc.modprobe.d/tipc.conf").exists &&
+      file("/etc/modprobe.d/tipc.conf").content.contains("install tipc /bin/false") &&
       file("/etc/modprobe.d/tipc.conf").content.contains("blacklist tipc")
     docs:
       desc: |


### PR DESCRIPTION
Update all queries to check if the file exists and use && so fails early vs. erroring when the file can't be opened to check the content