### PR TITLE
🐛 Don't run the ptrace check when ptrace isn't available

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -1111,6 +1111,7 @@ queries:
     filters: |
       asset.kind != "container-image"
       asset.runtime != "docker-container"
+      file("/proc/sys/kernel/yama/ptrace_scope").exists
     mql: |
       kernel.parameters["kernel.yama.ptrace_scope"] >= 2
     docs:


### PR DESCRIPTION
There's no need to lock it down if the kernel doesn't include ptrace support. Currently when the check runs and the support isn't there we error.