### PR TITLE
🧹 Add note about IP forwarding and Docker

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3360,6 +3360,8 @@ queries:
       desc: |
         This check verifies that IP forwarding is disabled by confirming that the kernel parameters net.ipv4.ip_forward and net.ipv6.conf.all.forwarding are set to 0.
 
+        Note: This setting is required for Docker to perform port forwarding to containers. If you are running Docker containers on this host and require port forwarding, an exceptions should be set for this check.
+
         **Why this matters**
 
         IP forwarding allows a system to route network packets between interfaces, effectively enabling it to act as a router. While necessary for certain network infrastructure roles, IP forwarding is not appropriate for general-purpose servers, workstations, or systems that are not explicitly configured to route traffic.


### PR DESCRIPTION
This breaks Docker. Users should know that.