### PR TITLE
🧹 ensure provider for cnspec scan

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -393,6 +393,17 @@ func (c *scanConfig) loadPolicies(ctx context.Context) error {
 			return err
 		}
 
+		// ensure all required providers are installed before we try to compile the bundle
+		if bundle.HasRequirements() {
+			autoUpdate := true
+			if viper.IsSet("auto-update") {
+				autoUpdate = viper.GetBool("auto-update")
+			}
+			if err := bundle.EnsureRequirements(false, autoUpdate); err != nil {
+				return errors.Wrap(err, "failed to ensure policy requirements")
+			}
+		}
+
 		// prepare the bundle for compilation
 		bundle.Prepare()
 		conf := mqlc.NewConfig(c.runtime.Schema(), cnquery.DefaultFeatures)

--- a/policy/bundle_require.go
+++ b/policy/bundle_require.go
@@ -9,6 +9,16 @@ import (
 	"go.mondoo.com/cnquery/v12/utils/multierr"
 )
 
+// HasRequirements returns true if any policy in the bundle has provider requirements defined.
+func (p *Bundle) HasRequirements() bool {
+	for _, policy := range p.Policies {
+		if len(policy.Require) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // EnsureRequirements makes sure that all required providers for the policies
 // in the bundle are installed. If `installIfNoRequire` is true, it will install
 // default providers for policies that do not specify any requirements.


### PR DESCRIPTION
We introduced https://github.com/mondoohq/cnspec/pull/1803 for policies to improve the linting. Now we also want to use the same require definition to ensure all depended providers are installed when we want to run the policy. This helps with cases where policies use resource providers like virustotal or yara.