### PR TITLE
Fix text / remediations for SSHd ClientAliveCountMax config

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -9227,7 +9227,7 @@ queries:
       defaultBlock.all(params.ClientAliveCountMax > 0) && defaultBlock.all(params.ClientAliveCountMax <= 3)
     docs:
       desc: |
-        This check ensures that the `ClientAliveInterval` and `ClientAliveCountMax` parameters in the SSH configuration are set to control the timeout of SSH sessions. Recommended values: set `ClientAliveInterval` to a value between 1 and 300 seconds and `ClientAliveCountMax` to a value between 1 and 3. These parameters together determine how long an idle SSH session is allowed to remain before the server terminates it.
+        This check ensures that the `ClientAliveInterval` and `ClientAliveCountMax` parameters in the SSH configuration are set to control the timeout of SSH sessions. Recommended values: Set `ClientAliveInterval` to a value between 1 and 300 seconds and `ClientAliveCountMax` to a value between 1 and 3. These parameters together determine how long an idle SSH session is allowed to remain before the server terminates it.
 
         **Why this matters**
 


### PR DESCRIPTION
The recommended values were way too aggressive and caused the check to actually fail