### PR TITLE
🧹 Remove all the project level GCP variants

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -65,7 +65,7 @@ queries:
     title: Ensure that instances are not configured to use the default service account
     impact: 95
     variants:
-      - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-single
+      - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-hcl
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-plan
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-state
@@ -152,7 +152,7 @@ queries:
               ```bash
               gcloud compute instances start INSTANCE_NAME
               ```
-  - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-single
+  - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
@@ -197,7 +197,7 @@ queries:
     title: Ensure instances are not configured to use the default service account with full access to all Cloud APIs
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-single
+      - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-hcl
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-plan
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-state
@@ -290,7 +290,7 @@ queries:
               ```bash
               gcloud compute instances start INSTANCE_NAME
               ```
-  - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-single
+  - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.serviceAccounts.contains( email == /^\d{12}-(compute|cloudservices)@developer\.gserviceaccount\.com$|^[a-z][a-z0-9\-]{4,28}@appspot\.gserviceaccount\.com$/ )
@@ -342,7 +342,7 @@ queries:
     title: Ensure oslogin is enabled for compute instances
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-state
@@ -437,7 +437,7 @@ queries:
             ```bash
             gcloud compute instances add-metadata INSTANCE_NAME --metadata enable-oslogin=TRUE
             ```
-  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-single
+  - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
     mql: gcp.compute.instance.metadata['enable-oslogin'] == true
   - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl
@@ -466,7 +466,7 @@ queries:
     title: Ensure that Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-single
+      - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-gcp
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-hcl
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-plan
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-state
@@ -537,7 +537,7 @@ queries:
             # Example: Remove allAuthenticatedUsers binding for objectViewer role
             gcloud storage buckets remove-iam-policy-binding gs://BUCKET_NAME --member=allAuthenticatedUsers --role=roles/storage.objectViewer
             ```
-  - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-single
+  - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-gcp
     filters: asset.platform == 'gcp-storage-bucket'
     mql: |
       gcp.storage.bucket.iamPolicy.all(members.none(_ == 'allUsers'))
@@ -576,7 +576,7 @@ queries:
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     impact: 60
     variants:
-      - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-single
+      - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-state
@@ -617,7 +617,7 @@ queries:
             # Alternatively using gsutil
             gsutil uniformbucketlevelaccess set on gs://BUCKET_NAME
             ```
-  - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-single
+  - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
     filters: asset.platform == 'gcp-storage-bucket'
     mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-hcl
@@ -646,8 +646,7 @@ queries:
     title: Ensure Cloud SQL MySQL instances are not publicly exposed
     impact: 100
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-all
-      - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-single
+      - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-state
@@ -726,17 +725,7 @@ queries:
                 gcloud sql instances describe INSTANCE_NAME
                 ```
                 Check the `ipAddresses` section in the output to confirm the absence of an entry with `type: PRIMARY`.
-  - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion.contains(/^MYSQL_/))
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion.contains(/^MYSQL_/)).all(
-        ipAddresses.all(
-          _.type != "PRIMARY"
-        )
-      )
-  - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-single
+  - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-gcp
     filters: asset.platform == "gcp-sql-mysql"
     mql: |
       gcp.sql.instance.ipAddresses.all(type != "PRIMARY")
@@ -773,8 +762,7 @@ queries:
     title: Ensure Cloud SQL MySQL connections require SSL/TLS
     impact: 100
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-all
-      - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-single
+      - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-state
@@ -860,15 +848,7 @@ queries:
             **Prevention:**
 
             Always configure new Cloud SQL MySQL instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
-  - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion.contains(/^MYSQL_/))
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion.contains(/^MYSQL_/)).all(
-        settings.ipConfiguration.sslMode == 'ENCRYPTED_ONLY'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-single
+  - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-gcp
     filters: asset.platform == "gcp-sql-mysql"
     mql: |
       gcp.sql.instance.settings.ipConfiguration.sslMode == "ENCRYPTED_ONLY"
@@ -913,8 +893,7 @@ queries:
     title: Ensure 'skip_show_database' Database Flag for Cloud SQL MySQL Instances is enabled
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-all
-      - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-single
+      - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-state
@@ -998,15 +977,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/sql/docs/mysql/flags
         title: Configure database flags
-  - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^MYSQL_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^MYSQL_/).all(
-        settings.databaseFlags['skip_show_database'] == 'on'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-single
+  - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-gcp
     filters: asset.platform == "gcp-sql-mysql"
     mql: |
       gcp.sql.instance.settings.databaseFlags["skip_show_database"] == "on"
@@ -1054,8 +1025,7 @@ queries:
     title: Ensure the 'local_infile' Database Flag for Cloud SQL MySQL Instance is disabled
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-all
-      - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-single
+      - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-state
@@ -1136,15 +1106,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^MYSQL_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^MYSQL_/).all(
-        settings.databaseFlags['local_infile'] == 'off'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-single
+  - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-gcp
     filters: asset.platform == "gcp-sql-mysql"
     mql: |
       gcp.sql.instance.settings.databaseFlags["local_infile"] == "off"
@@ -1194,8 +1156,7 @@ queries:
     title: Ensure the 'log_error_verbosity' Database Flag for Cloud SQL PostgreSQL Instance Is Set to 'DEFAULT' or 'verbose'
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-all
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-single
+      - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-state
@@ -1282,15 +1243,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^POSTGRES_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/).all(
-        settings.databaseFlags['log_error_verbosity'] == 'verbose' || settings.databaseFlags['log_error_verbosity'] == 'default'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-single
+  - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-gcp
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
@@ -1345,8 +1298,7 @@ queries:
     title: Ensure 'log_connections' Database Flag for Cloud SQL PostgreSQL Instances is enabled
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-all
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-single
+      - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-state
@@ -1427,15 +1379,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^POSTGRES_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/).all(
-        settings.databaseFlags['log_connections'] == 'on'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-single
+  - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-gcp
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
@@ -1486,8 +1430,7 @@ queries:
     title: Ensure 'log_disconnections' Database Flag for Cloud SQL PostgreSQL Instances is enabled
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-all
-      - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-single
+      - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-state
@@ -1572,15 +1515,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^POSTGRES_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/).all(
-        settings.databaseFlags['log_disconnections'] == 'on'
-      )
-  - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-single
+  - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-gcp
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
@@ -1632,7 +1567,7 @@ queries:
     title: Ensure public IP addresses are not assigned to VM instances
     impact: 75
     variants:
-      - uid: mondoo-gcp-security-compute-instances-no-public-ip-single
+      - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-state
@@ -1736,7 +1671,7 @@ queries:
             gcloud compute instances delete-access-config INSTANCE_NAME --zone=ZONE --access-config-name="ACCESS_CONFIG_NAME"
             ```
             Replace `INSTANCE_NAME`, `ZONE`, and `ACCESS_CONFIG_NAME` with the appropriate values.
-  - uid: mondoo-gcp-security-compute-instances-no-public-ip-single
+  - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
@@ -1776,7 +1711,7 @@ queries:
     title: Ensure the default service account is not used on VM instances
     impact: 80
     variants:
-      - uid: mondoo-gcp-security-compute-instances-no-default-service-account-single
+      - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-terraform-state
     docs:
@@ -1890,7 +1825,7 @@ queries:
             ```bash
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
-  - uid: mondoo-gcp-security-compute-instances-no-default-service-account-single
+  - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
@@ -1923,7 +1858,7 @@ queries:
     title: Ensure "Block Project-Wide SSH Keys" is enabled for VM instances
     impact: 80
     variants:
-      - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-single
+      - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-state
@@ -2010,7 +1945,7 @@ queries:
             gcloud compute instances add-metadata INSTANCE_NAME --zone=ZONE --metadata block-project-ssh-keys=true
             ```
             Replace `INSTANCE_NAME` and `ZONE` with the appropriate values. This command will either add the key if it doesn't exist or update its value to `true` if it does.
-  - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-single
+  - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
@@ -2044,7 +1979,7 @@ queries:
     title: Ensure Confidential VM Service is enabled for all VM instances
     impact: 75
     variants:
-      - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-state
@@ -2154,7 +2089,7 @@ queries:
             ```
 
             Replace placeholders like `INSTANCE_NAME`, `ZONE`, and `N2D_MACHINE_TYPE` with appropriate values.
-  - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-single
+  - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
@@ -2197,7 +2132,7 @@ queries:
     title: Ensure Secure Boot is enabled for all VM instances
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-state
@@ -2311,7 +2246,7 @@ queries:
             ```bash
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
-  - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-single
+  - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
     mql: |
@@ -2351,7 +2286,7 @@ queries:
     title: Ensure vTPM is enabled for all VM instances
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-state
@@ -2466,7 +2401,7 @@ queries:
             ```bash
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
-  - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-single
+  - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
     mql: |
@@ -2507,7 +2442,7 @@ queries:
     title: Ensure Integrity Monitoring is enabled for all VM instances
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-single
+      - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-hcl
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-plan
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-state
@@ -2626,7 +2561,7 @@ queries:
             ```
 
             Replace `INSTANCE_NAME` and `ZONE` with the appropriate values for your instance.
-  - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-single
+  - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
     mql: |
@@ -2667,8 +2602,7 @@ queries:
     title: Ensure Cloud SQL PostgreSQL instances are not publicly exposed
     impact: 100
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-all
-      - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-single
+      - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-state
@@ -2754,15 +2688,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^POSTGRES_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/).all(
-        ipAddresses.all(_.type != "PRIMARY")
-      )
-  - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-single
+  - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-gcp
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
@@ -2808,8 +2734,7 @@ queries:
     title: Ensure Cloud SQL for SQL Server instances are not publicly exposed
     impact: 100
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-all
-      - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-single
+      - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-gcp
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-state
@@ -2890,15 +2815,7 @@ queries:
               }
             }
             ```
-  - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^SQLSERVER_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^SQLSERVER_/).all(
-        ipAddresses.all(_.type != "PRIMARY")
-      )
-  - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-single
+  - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-gcp
     filters: |
       asset.platform == 'gcp-sql-sqlserver'
     mql: |
@@ -2944,8 +2861,7 @@ queries:
     title: Ensure Cloud SQL PostgreSQL connections require SSL/TLS
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-all
-      - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-single
+      - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-state
@@ -3031,15 +2947,7 @@ queries:
             **Prevention:**
 
             Always configure new Cloud SQL PostgreSQL instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
-  - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.sql.instances.any(databaseInstalledVersion == /^POSTGRES_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/).all(
-        settings.ipConfiguration.sslMode == "ENCRYPTED_ONLY"
-      )
-  - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-single
+  - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-gcp
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
@@ -3085,8 +2993,7 @@ queries:
     title: Ensure Cloud SQL for SQL Server connections require SSL/TLS
     impact: 90
     variants:
-      - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-all
-      - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-single
+      - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-gcp
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-hcl
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-plan
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-state
@@ -3172,15 +3079,7 @@ queries:
             **Prevention:**
 
             Always configure new Cloud SQL for SQL Server instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
-  - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-all
-    filters: |
-      asset.platform == 'gcp-project' &&
-        gcp.project.sql.instances.any(databaseInstalledVersion == /^SQLSERVER_/)
-    mql: |
-      gcp.project.sql.instances.where(databaseInstalledVersion == /^SQLSERVER_/).all(
-        settings.ipConfiguration.sslMode == "ENCRYPTED_ONLY"
-      )
-  - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-single
+  - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-gcp
     filters: |
       asset.platform == 'gcp-sql-sqlserver'
     mql: |
@@ -3226,8 +3125,7 @@ queries:
     title: Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible
     impact: 100
     variants:
-      - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-all
-      - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-single
+      - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-hcl
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-plan
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-state
@@ -3325,19 +3223,7 @@ queries:
             **Prevention:**
 
             Always review IAM policies for KMS crypto keys during code reviews. Use Terraform validation rules or policy-as-code tools to prevent public access grants. Regularly audit your Terraform configurations to ensure compliance.
-  - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.kms.keyrings.any(cryptokeys.contains(primary.state != "DESTROYED"))
-    mql: |
-      gcp.project.kms.keyrings.where(cryptokeys.where(primary.state != "DESTROYED")).all(
-        cryptokeys.all(
-          iamPolicy.all(
-            members.none(_ == "allUsers" || _ == "allAuthenticatedUsers")
-          )
-        )
-      )
-  - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-single
+  - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: |
       gcp.project.kms.keyring.cryptokeys.all(
@@ -3383,8 +3269,7 @@ queries:
     title: Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days
     impact: 30
     variants:
-      - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-all
-      - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-single
+      - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-hcl
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-plan
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-state
@@ -3460,12 +3345,39 @@ queries:
             **Prevention:**
 
             Always configure key rotation periods in your Terraform KMS configurations. Use Terraform validation rules or policy-as-code tools to ensure rotation periods are set to 90 days or less. Regularly audit your Terraform configurations to ensure compliance with key rotation requirements.
+  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
+    filters: asset.platform == "gcp-kms-keyring"
+    mql: |
+      gcp.project.kms.keyring.cryptokeys.where(primary.state == "ENABLED").all(rotationPeriod.seconds <= 7776000)
+  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' &&
+        terraform.resources('google_kms_crypto_key') != empty
+    mql: |
+      terraform.resources('google_kms_crypto_key').all(
+        arguments['rotation_period'] != null && arguments['rotation_period'] != empty
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan'
+      terraform.plan.resourceChanges.contains(type == 'google_kms_crypto_key')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_kms_crypto_key').all(
+        change.after['rotation_period'] != null && change.after['rotation_period'] != empty
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-state
+    filters: |
+      asset.platform == 'terraform-state'
+      terraform.state.resources.contains(type == 'google_kms_crypto_key')
+    mql: |
+      terraform.state.resources.where(type == 'google_kms_crypto_key').all(
+        values['rotation_period'] != null && values['rotation_period'] != empty
+      )
   - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled
     title: Ensure That DNSSEC Is Enabled for Cloud DNS
     impact: 70
     variants:
-      - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-all
-      - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-single
+      - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-hcl
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-plan
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-state
@@ -3540,14 +3452,7 @@ queries:
             **Prevention:**
 
             Always configure DNSSEC for public DNS zones in your Terraform configurations. Use Terraform validation rules or policy-as-code tools to ensure DNSSEC is enabled for all public zones. Regularly audit your Terraform configurations to ensure compliance.
-  - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.dns.managedZones.any(visibility == "public")
-    mql: |
-      publicDnsManagedZones = gcp.project.dns.managedZones.where(visibility == "public")
-      publicDnsManagedZones.all(dnssecConfig['state'] == 'on')
-  - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-single
+  - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
     filters: |
       asset.platform == "gcp-dns-managedzone"
       gcp.project.dnsService.managedzone.visibility == "public"
@@ -3582,8 +3487,7 @@ queries:
     title: Ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC
     impact: 30
     variants:
-      - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-all
-      - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-single
+      - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-hcl
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-plan
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-state
@@ -3657,15 +3561,7 @@ queries:
             **Prevention:**
 
             Always use strong cryptographic algorithms in your Terraform DNSSEC configurations. Avoid RSASHA1 and prefer RSASHA256, RSASHA512, or ECDSA algorithms. Use Terraform validation rules to prevent weak algorithms from being deployed.
-  - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.dns.managedZones.any(visibility != "private")
-    mql: |
-      privateDnsManagedZones = gcp.project.dns.managedZones.where(visibility != "private")
-      privateDnsManagedZones.all(dnssecConfig['state'] == 'on')
-      privateDnsManagedZones.all(dnssecConfig.defaultKeySpecs.where(keyType == 'keySigning').all(algorithm != 'RSASHA1'))
-  - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-single
+  - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
     filters: |
       asset.platform == "gcp-dns-managedzone"
       gcp.project.dnsService.managedzone.visibility != "private"
@@ -3705,40 +3601,4 @@ queries:
         values['dnssec_config'].where(_['state'] == "on").all(
           _['default_key_specs'].where(_['key_type'] == "keySigning").all(_['algorithm'] != "rsasha1")
         )
-      )
-  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-all
-    filters: |
-      asset.platform == 'gcp-project'
-      gcp.project.kms.keyrings.any(cryptokeys.contains(primary.state == "ENABLED"))
-    mql: |
-      gcp.project.kms.keyrings.where(cryptokeys.where(primary.state == "ENABLED")).all(
-        cryptokeys.all(rotationPeriod.seconds <= 7776000)
-      )
-  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-single
-    filters: asset.platform == "gcp-kms-keyring"
-    mql: |
-      gcp.project.kms.keyring.cryptokeys.where(primary.state == "ENABLED").all(rotationPeriod.seconds <= 7776000)
-  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-hcl
-    filters: |
-      asset.platform == 'terraform-hcl' &&
-        terraform.resources('google_kms_crypto_key') != empty
-    mql: |
-      terraform.resources('google_kms_crypto_key').all(
-        arguments['rotation_period'] != null && arguments['rotation_period'] != empty
-      )
-  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-plan
-    filters: |
-      asset.platform == 'terraform-plan'
-      terraform.plan.resourceChanges.contains(type == 'google_kms_crypto_key')
-    mql: |
-      terraform.plan.resourceChanges.where(type == 'google_kms_crypto_key').all(
-        change.after['rotation_period'] != null && change.after['rotation_period'] != empty
-      )
-  - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-state
-    filters: |
-      asset.platform == 'terraform-state'
-      terraform.state.resources.contains(type == 'google_kms_crypto_key')
-    mql: |
-      terraform.state.resources.where(type == 'google_kms_crypto_key').all(
-        values['rotation_period'] != null && values['rotation_period'] != empty
       )


### PR DESCRIPTION
Resources + TF only. Avoid duplicate results on the project and the resource. This is the final component of our migration to fine grained scanning everywhere