### PR TITLE
:bug: uniformBucketLevelAccess query for Mondoo GCP Policy

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -619,10 +619,10 @@ queries:
             ```
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
     filters: asset.platform == 'gcp-storage-bucket'
-    mql: gcp.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true
+    mql: gcp.storage.bucket.iamConfiguration.uniformBucketLevelAccess.enabled == true
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources.contains(nameLabel == 'google_storage_bucket')
     mql: |
       terraform.resources('google_storage_bucket').all(
@@ -733,7 +733,7 @@ queries:
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_sql_database_instance' && arguments.database_version.contains("MYSQL"))
     mql: |
-      # Check that settings block with ip_configuration exists and  ipv4_enabled is set to false (no public IP) on all SQL instances 
+      # Check that settings block with ip_configuration exists and  ipv4_enabled is set to false (no public IP) on all SQL instances
       terraform.resources("google_sql_database_instance").where(arguments.database_version.contains("MYSQL")).all(
        	blocks.where(type == 'settings') != empty &&
       	blocks.where(type == 'settings').all(blocks.where(type == 'ip_configuration') != empty) &&
@@ -743,7 +743,7 @@ queries:
       )
   - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-plan
     filters: |
-      asset.platform == 'terraform-plan' && 
+      asset.platform == 'terraform-plan' &&
         terraform.plan.resourceChanges.contains(type == 'google_sql_database_instance' && change.after.database_version.contains('MYSQL'))
     mql: |
       terraform.plan.resourceChanges.where(type == 'google_sql_database_instance' && change.after.database_version.contains('MYSQL')).all(
@@ -1522,7 +1522,7 @@ queries:
       gcp.project.sql.instance.settings.databaseFlags['log_disconnections'] == 'on'
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('POSTGRES')) != empty
     mql: |
       # Check if a 'log_disconnections' flag exists and is set to 'on' on all setting blocks of all MySQL instances
@@ -1680,7 +1680,7 @@ queries:
       gcp.compute.instance.networkInterfaces.all(accessConfigs == empty)
   - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-hcl
     filters: |
-      asset.platform == "terraform-hcl" && 
+      asset.platform == "terraform-hcl" &&
         terraform.resources('google_compute_instance') != empty
     mql: |
       terraform.resources('google_compute_instance').all(
@@ -1955,7 +1955,7 @@ queries:
       }
   - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_compute_instance') != empty
     mql: |
       terraform.resources('google_compute_instance').all(
@@ -2100,7 +2100,7 @@ queries:
       }
   - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_compute_instance') != empty
     mql: |
       # Check that confidential_instance_config block exists on all compute instances and enable_confidential_compute is set to true
@@ -2408,7 +2408,7 @@ queries:
       gcp.compute.instance.enableVtpm == true
   - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_compute_instance') != empty
     mql: |
       # Check that shielded_instance_config block exists on all compute instances and enable_vtpm is set to true
@@ -2568,7 +2568,7 @@ queries:
       gcp.compute.instance.enableIntegrityMonitoring == true
   - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_compute_instance') != empty
     mql: |
       # Check that shielded_instance_config block exists on all compute instances and enable_integrity_monitoring is set to true
@@ -2695,7 +2695,7 @@ queries:
       gcp.project.sql.instance.ipAddresses.all(type != "PRIMARY")
   - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('POSTGRES')) != empty
     mql: |
       # Check that settings/ip_configuration exists on all PostgreSQL instances is not set or set to false (no public IP)
@@ -2822,12 +2822,12 @@ queries:
       gcp.project.sql.instance.ipAddresses.all(type != "PRIMARY")
   - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('SQLSERVER')) != empty
     mql: |
       # Check that settings/ip_configuration exists on all SQL Server instances and ipv4_enabled set to false (no public IP)
       terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('SQLSERVER')).all(
-        blocks.where(type == 'settings') != empty && 
+        blocks.where(type == 'settings') != empty &&
         blocks.where(type == 'settings').all(blocks.where(type == 'ip_configuration') != empty) &&
         blocks.where(type == 'settings').all(
           blocks.where(type == 'ip_configuration').all(
@@ -2954,7 +2954,7 @@ queries:
       gcp.project.sql.instance.settings.ipConfiguration.sslMode == "ENCRYPTED_ONLY"
   - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('POSTGRES')) != empty
     mql: |
       # Check that ip_configuration block with ssl_mode exists and is set to ENCRYPTED_ONLY on all PostgreSQL instances
@@ -3086,7 +3086,7 @@ queries:
       gcp.project.sql.instance.settings.ipConfiguration.sslMode == "ENCRYPTED_ONLY"
   - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && 
+      asset.platform == 'terraform-hcl' &&
         terraform.resources('google_sql_database_instance').where(arguments['database_version'].contains('SQLSERVER')) != empty
     mql: |
       # Check that ip_configuration block with ssl_mode exists and ssl_mode is set to ENCRYPTED_ONLY on all SQL Server instances


### PR DESCRIPTION
Yeah basically its just a typo from what GCP SDK defines the field.
The Field is case-sensitive.

-----

But while finding this Problem i saw false positive and tried to enhance the code in cnquery
https://github.com/mondoohq/cnquery/pull/6428

Basically the key does not exist but in the UI/ actual result it looks like its false from what is provided. 
It creates actual findings while this 

To show the user that this Key does not exist and its not the resource being wrong.

The current output
```text
[failed] gcp.storage.gcloud.storage.bucket.iamConfiguration.UniformBucketLevelAccess.enabled == true
  expected: == true
  actual:   _
```