### PR TITLE
🧹 respect auto-update disabled for cnpsec scan 

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -163,7 +163,7 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Fatal().Err(err).Msg("failed to resolve policies")
 	}
 
-	report, err := RunScan(conf, scan.WithReportType(conf.ReportType))
+	report, err := RunScan(conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}

--- a/policy/bundle_require.go
+++ b/policy/bundle_require.go
@@ -43,7 +43,12 @@ func (p *Bundle) EnsureRequirements(installIfNoRequire bool, autoUpdate bool) er
 				continue
 			}
 			if _, err := providers.EnsureProvider(providers.ProviderLookup{ID: require.Id, ProviderName: require.Provider}, autoUpdate, existing); err != nil {
-				return multierr.Wrap(err, "failed to validate policy '"+policy.Name+"'")
+				if !autoUpdate {
+					// only warn if auto update is disabled, as the user might want to manually install providers
+					log.Warn().Str("provider", require.Provider).Msgf("failed to ensure policy requirements for policy %q", policy.Name)
+				} else {
+					return multierr.Wrap(err, "failed to validate policy '"+policy.Name+"'")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is required to make sure that k8s scan who disable auto-update are not accidentally try to install providers for policies that are not applicable although they are in the list of potentially applicable policies to be executed.