### PR TITLE
🧹 Use the --region flag in aws provider docs example

### DIFF
--- a/docs/supplychain/terraform.mdx
+++ b/docs/supplychain/terraform.mdx
@@ -373,7 +373,7 @@ resource "aws_instance" "web" {
 # run scan of aws account
 resource "null_resource" "example1" {
   provisioner "local-exec" {
-    command = "cnspec scan aws --option 'region=${var.aws_region}' --risk-threshold 90"
+    command = "cnspec scan aws --region ${var.aws_region} --risk-threshold 90"
   }
 
   depends_on = [


### PR DESCRIPTION
We've had this flag for a while now