### PR TITLE
Allow HTTP listeners that redirect to HTTPS in ALB SSL check

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -5677,7 +5677,7 @@ queries:
   - uid: mondoo-aws-security-elb-ssl-listener-single
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
-      aws.elb.loadbalancer.listenerDescriptions.all(Protocol == "HTTPS")
+      aws.elb.loadbalancer.listenerDescriptions.all(Protocol == "HTTPS" || Protocol == "HTTP" && DefaultActions.any(Type == "redirect" && RedirectConfig["Protocol"] == "HTTPS"))
   - uid: mondoo-aws-security-elb-ssl-listener-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lb_listener")
     mql: |


### PR DESCRIPTION
Fixes mondoo-community/customer-issues#33

The check was failing for ALBs with HTTP:80 listeners that redirect to HTTPS, which is a valid and common security pattern. Updated the MQL query to allow HTTP listeners only if they have a redirect action to HTTPS.

Tested with ALB configuration matching customer setup:
- HTTP:80 -> redirect to HTTPS:443
- HTTPS:443 -> forward to target group