### PR TITLE
⭐ Use the new modprobe resource to simplify queries

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -1205,9 +1205,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "atm")
     mql: |
-      file("/etc/modprobe.d/atm.conf").exists &&
-      file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false") &&
-      file("/etc/modprobe.d/atm.conf").content.contains("blacklist atm")
+      modprobe.blacklists.contains(module == "atm")
+      modprobe.installs.contains(module == "atm" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the ATM (Asynchronous Transfer Mode) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/atm.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1283,9 +1282,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "can")
     mql: |
-      file("/etc/modprobe.d/can.conf").exists &&
-      file("/etc/modprobe.d/can.conf").content.contains("install can /bin/false") &&
-      file("/etc/modprobe.d/can.conf").content.contains("blacklist can")
+      modprobe.blacklists.contains(module == "can")
+      modprobe.installs.contains(module == "can" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the CAN (Controller Area Network) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/can.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1361,9 +1359,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "dccp")
     mql: |
-      file("/etc/modprobe.d/dccp.conf").exists &&
-      file("/etc/modprobe.d/dccp.conf").content.contains("install dccp /bin/false") &&
-      file("/etc/modprobe.d/dccp.conf").content.contains("blacklist dccp")
+      modprobe.blacklists.contains(module == "dccp")
+      modprobe.installs.contains(module == "dccp" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the DCCP (Datagram Congestion Control Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/dccp.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1439,9 +1436,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "rds")
     mql: |
-      file("/etc/modprobe.d/rds.conf").exists &&
-      file("/etc/modprobe.d/rds.conf").content.contains("install rds /bin/false") &&
-      file("/etc/modprobe.d/rds.conf").content.contains("blacklist rds")
+      modprobe.blacklists.contains(module == "rds")
+      modprobe.installs.contains(module == "rds" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the RDS (Reliable Datagram Sockets) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/rds.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1517,9 +1513,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "sctp")
     mql: |
-      file("/etc/modprobe.d/sctp.conf").exists &&
-      file("/etc/modprobe.d/sctp.conf").content.contains("install sctp /bin/false") &&
-      file("/etc/modprobe.d/sctp.conf").content.contains("blacklist sctp")
+      modprobe.blacklists.contains(module == "sctp")
+      modprobe.installs.contains(module == "sctp" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the SCTP (Stream Control Transmission Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/sctp.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1595,9 +1590,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "tipc")
     mql: |
-      file("/etc/modprobe.d/tipc.conf").exists &&
-      file("/etc/modprobe.d/tipc.conf").content.contains("install tipc /bin/false") &&
-      file("/etc/modprobe.d/tipc.conf").content.contains("blacklist tipc")
+      modprobe.blacklists.contains(module == "tipc")
+      modprobe.installs.contains(module == "tipc" && command == "/bin/false")
     docs:
       desc: |
         This check verifies that the TIPC (Transparent Inter-Process Communication) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/tipc.conf` that both blacklist the module and redirect its install to `/bin/false`.


### PR DESCRIPTION
These will get way more robust with this as well since they no longer rely on a specific path