### PR TITLE
🧹 Remove the check for the legacy google workspace asset platform

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -65,7 +65,7 @@ policies:
 
         If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
-      - filters: asset.platform == "google-workspace" || asset.platform == "googleworkspace"
+      - filters: asset.platform == "google-workspace"
         checks:
           - uid: mondoo-googleworkspace-security-less-secure-app-access-should-not-be-allowed
           - uid: mondoo-googleworkspace-security-limit-super-admins


### PR DESCRIPTION
This has been google-workspace for a while