### PR TITLE
Update ansible remediation to use blockinfile for auditd rules

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -5292,18 +5292,18 @@ queries:
                   notify: Load audit rules
 
                 - name: Add Debian/Ubuntu-specific faillog audit rule
-                  ansible.builtin.blockinfile:
+                  ansible.builtin.lineinfile:
                     path: /etc/audit/rules.d/50-logins.rules
-                    block: "-w /var/log/faillog -p wa -k logins"
+                    line: "-w /var/log/faillog -p wa -k logins"
                     create: yes
                     insertafter: EOF
                   when: ansible_os_family == "Debian"
                   notify: Load audit rules
 
                 - name: Add RedHat/Fedora/Amazon-specific faillock audit rule
-                  ansible.builtin.blockinfile:
+                  ansible.builtin.lineinfile:
                     path: /etc/audit/rules.d/50-logins.rules
-                    block: "-w /var/run/faillock -p wa -k logins"
+                    line: "-w /var/run/faillock -p wa -k logins"
                     create: yes
                     insertafter: EOF
                   when: ansible_os_family in ["RedHat", "Amazon"]


### PR DESCRIPTION
Customer noted that some of the ansible remediation snippets for audtid rules are not idempotent