### PR TITLE
🧹 Replace deprecated journald.config.params with journald.config.sections

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7583,7 +7583,7 @@ queries:
     title: Ensure journald is configured to send logs to rsyslog
     impact: 50
     mql: |
-      journald.config.params.ForwardToSyslog == "yes"
+      journald.config.sections.where(name == "Journal").first.params.where(name == "ForwardToSyslog").first.value == "yes"
     docs:
       desc: |
         This check ensures that journald is configured to forward logs to rsyslog, providing a consistent and reliable means of log collection and export.
@@ -7663,7 +7663,7 @@ queries:
     title: Ensure journald is configured to compress large log files
     impact: 50
     mql: |
-      journald.config.params.Compress == "yes"
+      journald.config.sections.where(name == "Journal").first.params.where(name == "Compress").first.value == "yes"
     docs:
       desc: |
         This check ensures that journald is configured to compress large log files, helping to manage disk space and maintain system performance.
@@ -7743,7 +7743,7 @@ queries:
     title: Ensure journald is configured to write logfiles to persistent disk
     impact: 50
     mql: |
-      journald.config.params.Storage == "persistent"
+      journald.config.sections.where(name == "Journal").first.params.where(name == "Storage").first.value == "persistent"
     docs:
       desc: |
         This check ensures that journald is configured to write log files to a persistent disk, preventing log loss during system reboots and ensuring reliable log retention.


### PR DESCRIPTION
## Summary
- Replace the deprecated `journald.config.params.ParamName` field with the new `journald.config.sections` pattern in the Linux security policy

## Changes
- Updated 3 MQL queries in `content/mondoo-linux-security.mql.yaml` to use the new pattern

**Old pattern:**
```mql
journald.config.params.ForwardToSyslog == "yes"
```

**New pattern:**
```mql
journald.config.sections.where(name == "Journal").first.params.where(name == "ForwardToSyslog").first.value == "yes"
```

## Affected Queries
- `mondoo-linux-security-journald-is-configured-to-send-logs-to-rsyslog`
- `mondoo-linux-security-journald-is-configured-to-compress-large-log-files`
- `mondoo-linux-security-journald-is-configured-to-write-logfiles-to-persistent-disk`

## Related
- Similar fix for CIS policies: mondoohq/cnspec-enterprise-policies#1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)