### PR TITLE
only check CMK´s not aws managed keys

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -6235,7 +6235,7 @@ queries:
                   EnableKeyRotation: true
             ```
   - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-single
-    filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyState == "Enabled" && aws.kms.key.metadata.KeySpec == "SYMMETRIC_DEFAULT"
+    filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyState == "Enabled" && aws.kms.key.metadata.KeySpec == "SYMMETRIC_DEFAULT" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: |
       aws.kms.key.keyRotationEnabled == true
   - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-terraform-hcl


### PR DESCRIPTION
acme is one of the view aws managed keys where we dont have 'kms:GetKeyRotationStatus' per policy.
As everything is AWS managed nevertheless we can do two things.
1. open support request towards AWS in order to change acme key policy (key was created august 2024)
2. filter every AWS managed key and trust aws that they will handle there keys properly.