### PR TITLE
Refactor auditd rules check for sudoers files

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -5236,9 +5236,8 @@ queries:
     mql: |
       paths = ["/etc/sudoers", "/etc/sudoers.d"]
       paths.all(p:
-        auditd.rules.syscalls.contains(
-          fields.contains(key == "path" && value == p)
-          && fields.contains(key == "perm" && value == "wa")
+        auditd.rules.files.contains( f:
+          f.path == p && f.permissions == "wa"
           && keyname == "scope"
         )
       )


### PR DESCRIPTION
Addresses the issues from https://github.com/mondoo-community/customer-issues/issues/46

Checking for the syscalls is not correct in this context