### PR TITLE
Fixes for various auditd checks in Mondoo Linux security policy

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7046,7 +7046,7 @@ queries:
       paths = ["/sbin/insmod", "/sbin/rmmod", "/sbin/modprobe"]
       paths.all(p:
         auditd.rules.files.contains( f:
-          f.path == p && f.permissions == "wa"
+          f.path == p && f.permissions == "x"
           && keyname == "modules"
         )
       )


### PR DESCRIPTION
More fixes for issues like https://github.com/mondoo-community/customer-issues/issues/46

TODO:
- [ ] Ensure events that modify date and time information are audited (-> See https://github.com/mondoohq/cnspec/issues/2125)
- [x] Ensure events that modify the system's network environment are audited
- [x] Ensure kernel module loading and unloading is audited
- [ ] Ensure unsuccessful unauthorized file access attempts are audited (-> See https://github.com/mondoohq/cnspec/issues/2125)