### PR TITLE
:star: Update AWS policy with new platforms + additional checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -108,6 +108,7 @@ enterpriseinspector
 Eperm
 eraagent
 eset
+ESKMS
 etm
 examplestorageaccount
 exim

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -162,8 +162,10 @@ policies:
       - title: AWS Elasticsearch Domain
         checks:
           - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
+          - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption
       - title: Amazon OpenSearch
         checks:
+          - uid: mondoo-aws-security-opensearch-encrypted-at-rest
           - uid: mondoo-aws-security-opensearch-enforce-https
           - uid: mondoo-aws-security-opensearch-node-to-node-encryption
           - uid: mondoo-aws-security-opensearch-tls-policy
@@ -245,7 +247,7 @@ queries:
     title: Ensure Amazon EKS clusters are configured to use AWS Key Management Service (KMS) for encryption of Kubernetes secrets
     impact: 70
     variants:
-      - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-api
+      - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -347,7 +349,7 @@ queries:
         title: Amazon EKS Security Best Practices
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
         title: AWS KMS Best Practices
-  - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-api
+  - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
       aws.eks.cluster.encryptionConfig != empty
@@ -385,7 +387,7 @@ queries:
     title: Ensure Amazon EKS clusters are configured with private endpoint access only
     impact: 90
     variants:
-      - uid: mondoo-aws-security-eks-cluster-private-controlplane-api
+      - uid: mondoo-aws-security-eks-cluster-private-controlplane-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -488,7 +490,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/eks/latest/best-practices/security.html
         title: Amazon EKS Security Best Practices
-  - uid: mondoo-aws-security-eks-cluster-private-controlplane-api
+  - uid: mondoo-aws-security-eks-cluster-private-controlplane-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
       aws.eks.cluster.resourcesVpcConfig.endpointPrivateAccess == true
@@ -519,7 +521,7 @@ queries:
     title: Ensure no root user account access key exists
     impact: 85
     variants:
-      - uid: mondoo-aws-security-iam-root-access-key-check-api
+      - uid: mondoo-aws-security-iam-root-access-key-check-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -632,7 +634,7 @@ queries:
         title: AWS Documentation - AWS account root user
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user_manage_delete-key.html
         title: AWS Documentation - Delete access keys for the root user
-  - uid: mondoo-aws-security-iam-root-access-key-check-api
+  - uid: mondoo-aws-security-iam-root-access-key-check-aws
     filters: asset.platform == "aws"
     mql: |
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(accessKey1Active == false)
@@ -840,7 +842,7 @@ queries:
         title: Denotes whether uppercase characters are required for passwords
         mql: "true"
     variants:
-      - uid: mondoo-aws-security-iam-password-policy-api
+      - uid: mondoo-aws-security-iam-password-policy-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -961,7 +963,7 @@ queries:
         title: User passwords in AWS
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
         title: Set an account password policy for IAM users
-  - uid: mondoo-aws-security-iam-password-policy-api
+  - uid: mondoo-aws-security-iam-password-policy-aws
     filters: asset.platform == "aws"
     mql: |
       // Ensure properties do exist.
@@ -1027,7 +1029,7 @@ queries:
         title: Define the maximum number of days an IAM key is allowed to exist before rotation
         mql: "90"
     variants:
-      - uid: mondoo-aws-security-access-keys-rotated-api
+      - uid: mondoo-aws-security-access-keys-rotated-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -1139,7 +1141,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
         title: AWS Documentation - Manage access keys for IAM users
-  - uid: mondoo-aws-security-access-keys-rotated-api
+  - uid: mondoo-aws-security-access-keys-rotated-aws
     filters: asset.platform == "aws"
     mql: |
       aws.iam.credentialReport.where(accessKey1Active == true && time.now - createdAt > props.mondooAWSSecurityMaxAccessKeyAge * time.day).all(time.now - accessKey1LastRotated < props.mondooAWSSecurityMaxAccessKeyAge * time.day)
@@ -1153,7 +1155,7 @@ queries:
     title: Ensure multi-factor authentication is enabled for all IAM users with console access
     impact: 90
     variants:
-      - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-api
+      - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -1286,7 +1288,7 @@ queries:
         title: Assign a virtual MFA device in the AWS Management Console
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
-  - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-api
+  - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-aws
     filters: asset.platform == "aws"
     mql: |
       aws.iam.credentialReport.where(passwordEnabled == true).all(mfaActive == true)
@@ -1322,7 +1324,7 @@ queries:
     title: Ensure IAM groups are utilized by assigning at least one user
     impact: 30
     variants:
-      - uid: mondoo-aws-security-iam-group-has-users-check-single
+      - uid: mondoo-aws-security-iam-group-has-users-check-aws
         tags:
           mondoo.com/filter-title: "AWS IAM Group"
           mondoo.com/icon: "aws"
@@ -1453,7 +1455,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage.html
         title: AWS Documentation - IAM user groups
-  - uid: mondoo-aws-security-iam-group-has-users-check-single
+  - uid: mondoo-aws-security-iam-group-has-users-check-aws
     filters: asset.platform == "aws-iam-group"
     mql: aws.iam.group.usernames != empty
   - uid: mondoo-aws-security-iam-group-has-users-check-terraform-hcl
@@ -1478,7 +1480,7 @@ queries:
     title: Ensure there is only one active access key available for any single IAM user
     impact: 70
     variants:
-      - uid: mondoo-aws-security-iam-users-only-one-access-key-single
+      - uid: mondoo-aws-security-iam-users-only-one-access-key-aws
         tags:
           mondoo.com/filter-title: "AWS IAM User"
           mondoo.com/icon: "aws"
@@ -1604,7 +1606,7 @@ queries:
         title: AWS IAM Best Practices
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
         title: AWS Documentation - Manage access keys for IAM users
-  - uid: mondoo-aws-security-iam-users-only-one-access-key-single
+  - uid: mondoo-aws-security-iam-users-only-one-access-key-aws
     filters: asset.platform == "aws-iam-user"
     mql: |
       aws.iam.user.accessKeys.flat.where(Status == "Active").length <= 1
@@ -1642,7 +1644,7 @@ queries:
     title: Ensure IAM users receive permissions only through groups
     impact: 70
     variants:
-      - uid: mondoo-aws-security-iam-user-no-inline-policies-check-single
+      - uid: mondoo-aws-security-iam-user-no-inline-policies-check-aws
         tags:
           mondoo.com/filter-title: "AWS IAM User"
           mondoo.com/icon: "aws"
@@ -1806,7 +1808,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html
         title: Managed policies and inline policies
-  - uid: mondoo-aws-security-iam-user-no-inline-policies-check-single
+  - uid: mondoo-aws-security-iam-user-no-inline-policies-check-aws
     filters: asset.platform == "aws-iam-user"
     mql: |
       aws.iam.user.policies == empty
@@ -1827,7 +1829,7 @@ queries:
     title: Ensure the default security group of every VPC restricts all traffic
     impact: 80
     variants:
-      - uid: mondoo-aws-security-vpc-default-security-group-closed-single
+      - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
         tags:
           mondoo.com/filter-title: "AWS EC2 Security Group"
           mondoo.com/icon: "aws"
@@ -1948,7 +1950,7 @@ queries:
         title: AWS Documentation - AWS CLI Reference - EC2
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
-  - uid: mondoo-aws-security-vpc-default-security-group-closed-single
+  - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
     filters: asset.platform == "aws-security-group" && aws.ec2.securitygroup.name == "default"
     mql: |
       aws.ec2.securitygroup.ipPermissions == empty
@@ -1975,7 +1977,7 @@ queries:
     title: Ensure EBS volume encryption is enabled by default
     impact: 90
     variants:
-      - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-api
+      - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -2078,7 +2080,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default
         title: AWS Documentation - Encryption by default
-  - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-api
+  - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-aws
     filters: asset.platform == "aws"
     mql: aws.ec2.ebsEncryptionByDefault.values.all(_ == true)
   - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-hcl
@@ -2466,7 +2468,7 @@ queries:
     title: Ensure no public IPs are associated with EC2 instances
     impact: 80
     variants:
-      - uid: mondoo-aws-security-ec2-instance-no-public-ip-api
+      - uid: mondoo-aws-security-ec2-instance-no-public-ip-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -2592,7 +2594,7 @@ queries:
         title: AWS Documentation - IP addressing for your VPCs and subnets
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
         title: Terraform Registry - aws_instance
-  - uid: mondoo-aws-security-ec2-instance-no-public-ip-api
+  - uid: mondoo-aws-security-ec2-instance-no-public-ip-aws
     filters: asset.platform == "aws"
     mql: aws.ec2.instances.all(publicIp == empty)
   - uid: mondoo-aws-security-ec2-instance-no-public-ip-terraform-hcl
@@ -2608,7 +2610,7 @@ queries:
     title: Ensure EC2 instances use IMDSv2 for metadata access
     impact: 90
     variants:
-      - uid: mondoo-aws-security-ec2-imdsv2-check-api
+      - uid: mondoo-aws-security-ec2-imdsv2-check-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -2718,7 +2720,7 @@ queries:
         title: Amazon EC2 Security
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
         title: Configure the Instance Metadata Service
-  - uid: mondoo-aws-security-ec2-imdsv2-check-api
+  - uid: mondoo-aws-security-ec2-imdsv2-check-aws
     filters: |
       asset.platform == "aws"
     mql: |
@@ -2747,7 +2749,7 @@ queries:
     title: Ensure VPC Block Public Access (BPA) is enabled
     impact: 90
     variants:
-      - uid: mondoo-aws-security-vpc-bpa-enabled-single
+      - uid: mondoo-aws-security-vpc-bpa-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS EC2 VPC"
           mondoo.com/icon: "aws"
@@ -2875,7 +2877,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: Amazon VPC Security Best Practices
-  - uid: mondoo-aws-security-vpc-bpa-enabled-single
+  - uid: mondoo-aws-security-vpc-bpa-enabled-aws
     filters: asset.platform == "aws-vpc"
     mql: aws.vpc.internetGatewayBlockMode != "off"
   - uid: mondoo-aws-security-vpc-bpa-enabled-terraform-hcl
@@ -2900,7 +2902,7 @@ queries:
     title: Ensure VPC flow logging is enabled in all VPCs
     impact: 70
     variants:
-      - uid: mondoo-aws-security-vpc-flow-logs-enabled-single
+      - uid: mondoo-aws-security-vpc-flow-logs-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS EC2 VPC"
           mondoo.com/icon: "aws"
@@ -3022,7 +3024,7 @@ queries:
         title: Terraform registry - Cloud Posse AWS Utils Provider
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
-  - uid: mondoo-aws-security-vpc-flow-logs-enabled-single
+  - uid: mondoo-aws-security-vpc-flow-logs-enabled-aws
     filters: asset.platform == "aws-vpc"
     mql: |
       aws.vpc.flowLogs.any(
@@ -3057,7 +3059,7 @@ queries:
     title: Ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS)
     impact: 30
     variants:
-      - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-single
+      - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-aws
         tags:
           mondoo.com/filter-title: "AWS DynamoDB Table"
           mondoo.com/icon: "aws"
@@ -3207,7 +3209,7 @@ queries:
         title: Terraform Documentation - AWS Provider
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
         title: AWS Documentation - DynamoDB encryption at rest
-  - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-single
+  - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-aws
     filters: asset.platform == "aws-dynamodb-table"
     mql: |
       aws.dynamodb.table.sseDescription.SSEType == "KMS"
@@ -3239,7 +3241,7 @@ queries:
     title: Ensure Lambda functions are configured with function-level concurrent execution limits
     impact: 60
     variants:
-      - uid: mondoo-aws-security-lambda-concurrency-check-single
+      - uid: mondoo-aws-security-lambda-concurrency-check-aws
         tags:
           mondoo.com/filter-title: "AWS Lambda Function"
           mondoo.com/icon: "aws"
@@ -3349,7 +3351,7 @@ queries:
         title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
         title: AWS Lambda Reserved Concurrency
-  - uid: mondoo-aws-security-lambda-concurrency-check-single
+  - uid: mondoo-aws-security-lambda-concurrency-check-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |
       aws.lambda.function.concurrency > 0
@@ -3379,7 +3381,7 @@ queries:
     title: Ensure the policy attached to the lambda function prohibits public access
     impact: 95
     variants:
-      - uid: mondoo-aws-lambda-function-public-access-prohibited-single
+      - uid: mondoo-aws-lambda-function-public-access-prohibited-aws
         tags:
           mondoo.com/filter-title: "AWS Lambda Function"
           mondoo.com/icon: "aws"
@@ -3509,7 +3511,7 @@ queries:
         title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html
         title: AWS Lambda Resource-Based Policies
-  - uid: mondoo-aws-lambda-function-public-access-prohibited-single
+  - uid: mondoo-aws-lambda-function-public-access-prohibited-aws
     filters: |
       asset.platform == "aws-lambda-function"
     mql: |
@@ -3647,7 +3649,7 @@ queries:
     title: Ensure all RDS instances are enabled for encryption-at-rest
     impact: 90
     variants:
-      - uid: mondoo-aws-security-rds-instance-encryption-at-rest-single
+      - uid: mondoo-aws-security-rds-instance-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: "AWS RDS DB Instance"
           mondoo.com/icon: "aws"
@@ -3801,7 +3803,7 @@ queries:
         title: Amazon RDS Security
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
         title: Amazon RDS Encryption
-  - uid: mondoo-aws-security-rds-instance-encryption-at-rest-single
+  - uid: mondoo-aws-security-rds-instance-encryption-at-rest-aws
     filters: asset.platform == "aws-rds-dbinstance"
     mql: aws.rds.dbinstance.storageEncrypted == true
   - uid: mondoo-aws-security-rds-instance-encryption-at-rest-terraform-hcl
@@ -3817,7 +3819,7 @@ queries:
     title: Ensure that encryption in transit is enabled for all RDS Clusters via cluster parameter groups
     impact: 90
     variants:
-      - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-single
+      - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-aws
         tags:
           mondoo.com/filter-title: "AWS RDS DB Cluster"
           mondoo.com/icon: "aws"
@@ -3987,7 +3989,7 @@ queries:
         title: Amazon RDS Security
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html
         title: Using SSL/TLS with Aurora
-  - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-single
+  - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-aws
     filters: asset.platform == "aws-rds-dbcluster"
     mql: |
       clusterParameterGroup = aws.rds.dbcluster.parameterGroupName
@@ -4173,7 +4175,7 @@ queries:
     title: Ensure all RDS clusters are set to be encrypted-at-rest
     impact: 90
     variants:
-      - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-single
+      - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: "AWS RDS DB Cluster"
           mondoo.com/icon: "aws"
@@ -4363,7 +4365,7 @@ queries:
         title: Amazon RDS Security
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.Encryption.html
         title: Amazon Aurora Encryption
-  - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-single
+  - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-aws
     filters: |
       asset.platform == "aws-rds-dbcluster"
     mql: |
@@ -4555,7 +4557,7 @@ queries:
     title: Ensure all RDS instances are not publicly accessible
     impact: 100
     variants:
-      - uid: mondoo-aws-security-rds-instance-public-access-check-single
+      - uid: mondoo-aws-security-rds-instance-public-access-check-aws
         tags:
           mondoo.com/filter-title: "AWS RDS DB Instance"
           mondoo.com/icon: "aws"
@@ -4684,7 +4686,7 @@ queries:
         title: Terraform Registry - aws_db_instance
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
-  - uid: mondoo-aws-security-rds-instance-public-access-check-single
+  - uid: mondoo-aws-security-rds-instance-public-access-check-aws
     filters: |
       asset.platform == "aws-rds-dbinstance"
     mql: |
@@ -4707,7 +4709,7 @@ queries:
     title: Ensure Redshift clusters are not publicly accessible
     impact: 95
     variants:
-      - uid: mondoo-aws-security-redshift-cluster-public-access-check-single
+      - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
         tags:
           mondoo.com/filter-title: "AWS Redshift Cluster"
           mondoo.com/icon: "aws"
@@ -4833,7 +4835,7 @@ queries:
         title: AWS Documentation - AWS CLI Command Reference - Redshift
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
-  - uid: mondoo-aws-security-redshift-cluster-public-access-check-single
+  - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: aws.redshift.cluster.publiclyAccessible == false
   - uid: mondoo-aws-security-redshift-cluster-public-access-check-terraform-hcl
@@ -4853,7 +4855,7 @@ queries:
         title: Defines whether instances should be configured to delete volumes on termination
         mql: "true"
     variants:
-      - uid: mondoo-aws-security-ec2-volume-inuse-check-single
+      - uid: mondoo-aws-security-ec2-volume-inuse-check-aws
         tags:
           mondoo.com/filter-title: "AWS EBS Volume"
           mondoo.com/icon: "aws"
@@ -4959,7 +4961,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-deleting-volume.html
         title: AWS Documentation - Delete an Amazon EBS volume
-  - uid: mondoo-aws-security-ec2-volume-inuse-check-single
+  - uid: mondoo-aws-security-ec2-volume-inuse-check-aws
     filters: asset.platform == "aws-ebs-volume" && aws.ec2.volume.attachments != empty
     mql: |
       aws.ec2.volume.attachments.any(DeleteOnTermination == true)
@@ -4988,7 +4990,7 @@ queries:
     title: Ensure EBS snapshots are not publicly restorable
     impact: 80
     variants:
-      - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-single
+      - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-aws
         tags:
           mondoo.com/filter-title: "AWS EBS Snapshot"
           mondoo.com/icon: "aws"
@@ -5077,7 +5079,7 @@ queries:
         title: Amazon EC2 Security
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html
         title: Share an Amazon EBS Snapshot
-  - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-single
+  - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-aws
     filters: asset.platform == "aws-ebs-snapshot"
     mql: |
       aws.ec2.snapshot.createVolumePermission.none(Group == "all")
@@ -5103,7 +5105,7 @@ queries:
     title: Ensure EBS Snapshots are configured to be encrypted at-rest
     impact: 70
     variants:
-      - uid: mondoo-aws-security-ebs-snapshot-encrypted-single
+      - uid: mondoo-aws-security-ebs-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS EBS Snapshot"
           mondoo.com/icon: "aws"
@@ -5265,7 +5267,7 @@ queries:
         title: Amazon EC2 Security
       - url: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html
         title: Amazon EBS Encryption
-  - uid: mondoo-aws-security-ebs-snapshot-encrypted-single
+  - uid: mondoo-aws-security-ebs-snapshot-encrypted-aws
     filters: asset.platform == "aws-ebs-snapshot"
     mql: |
       aws.ec2.snapshot.encrypted == true
@@ -5291,7 +5293,7 @@ queries:
     title: Ensure attached EBS volumes are configured to be encrypted at-rest
     impact: 70
     variants:
-      - uid: mondoo-aws-security-ec2-encrypted-volumes-single
+      - uid: mondoo-aws-security-ec2-encrypted-volumes-aws
         tags:
           mondoo.com/filter-title: "AWS EBS Volume"
           mondoo.com/icon: "aws"
@@ -5500,7 +5502,7 @@ queries:
         title: Amazon EC2 Security
       - url: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html
         title: Amazon EBS Encryption
-  - uid: mondoo-aws-security-ec2-encrypted-volumes-single
+  - uid: mondoo-aws-security-ec2-encrypted-volumes-aws
     filters: |
       asset.platform == "aws-ebs-volume" &&
       aws.ec2.volume.state != /deleting|deleted|error/
@@ -5527,7 +5529,7 @@ queries:
     title: Ensure EFS is configured to encrypt file data using KMS
     impact: 75
     variants:
-      - uid: mondoo-aws-security-efs-encrypted-check-single
+      - uid: mondoo-aws-security-efs-encrypted-check-aws
         tags:
           mondoo.com/filter-title: "AWS EFS File System"
           mondoo.com/icon: "aws"
@@ -5632,7 +5634,7 @@ queries:
         title: Terraform Registry - aws_efs_file_system resource
       - url: https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html#creating-using-fs-part1-cli
         title: AWS Documentation - Creating a file system using the AWS CLI
-  - uid: mondoo-aws-security-efs-encrypted-check-single
+  - uid: mondoo-aws-security-efs-encrypted-check-aws
     filters: asset.platform == "aws-efs-filesystem"
     mql: |
       aws.efs.filesystem.encrypted == true
@@ -5664,7 +5666,7 @@ queries:
     title: Ensure CloudWatch Logs are encrypted at rest using KMS CMKs
     impact: 70
     variants:
-      - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-api
+      - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS CloudWatch Log Group"
           mondoo.com/icon: "aws"
@@ -5769,7 +5771,7 @@ queries:
         title: Amazon CloudWatch Security
       - url: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
         title: Encrypt Log Data in CloudWatch Logs Using AWS KMS
-  - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-api
+  - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-aws
     filters: asset.platform == "aws-cloudwatch-loggroup"
     mql: |
       aws.cloudwatch.loggroup.kmsKey != empty
@@ -5805,7 +5807,7 @@ queries:
             "ELBSecurityPolicy-FS-1-2-Res-2020-10"
           ]
     variants:
-      - uid: mondoo-aws-security-elb-security-policy-enabled-single
+      - uid: mondoo-aws-security-elb-security-policy-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Application Load Balancer"
           mondoo.com/icon: "aws"
@@ -5947,7 +5949,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html
         title: Elastic Load Balancing Security
-  - uid: mondoo-aws-security-elb-security-policy-enabled-single
+  - uid: mondoo-aws-security-elb-security-policy-enabled-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
       aws.elb.loadbalancer.listenerDescriptions.all(
@@ -5975,7 +5977,7 @@ queries:
     title: Ensure Application Load Balancers are configured with HTTPS listeners
     impact: 70
     variants:
-      - uid: mondoo-aws-security-elb-ssl-listener-single
+      - uid: mondoo-aws-security-elb-ssl-listener-aws
         tags:
           mondoo.com/filter-title: "AWS Application Load Balancer"
           mondoo.com/icon: "aws"
@@ -6153,7 +6155,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html
         title: Elastic Load Balancing Security
-  - uid: mondoo-aws-security-elb-ssl-listener-single
+  - uid: mondoo-aws-security-elb-ssl-listener-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
       aws.elb.loadbalancer.listenerDescriptions.all(Protocol == "HTTPS" || Protocol == "HTTP" && DefaultActions.any(Type == "redirect" && RedirectConfig["Protocol"] == "HTTPS"))
@@ -6179,7 +6181,7 @@ queries:
     title: Ensure Application Load Balancers have logging enabled
     impact: 70
     variants:
-      - uid: mondoo-aws-security-elb-logging-enabled-single
+      - uid: mondoo-aws-security-elb-logging-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Application Load Balancer"
           mondoo.com/icon: "aws"
@@ -6366,7 +6368,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html
         title: Elastic Load Balancing Security
-  - uid: mondoo-aws-security-elb-logging-enabled-single
+  - uid: mondoo-aws-security-elb-logging-enabled-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
       aws.elb.loadbalancer.attributes.any(Key == "access_logs.s3.enabled")
@@ -6396,7 +6398,7 @@ queries:
     title: Ensure Application Load Balancers are configured with deletion protection enabled
     impact: 70
     variants:
-      - uid: mondoo-aws-security-elb-deletion-protection-enabled-single
+      - uid: mondoo-aws-security-elb-deletion-protection-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Application Load Balancer"
           mondoo.com/icon: "aws"
@@ -6505,7 +6507,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html
         title: Elastic Load Balancing Security
-  - uid: mondoo-aws-security-elb-deletion-protection-enabled-single
+  - uid: mondoo-aws-security-elb-deletion-protection-enabled-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
       aws.elb.loadbalancer.attributes.any(Key == "deletion_protection.enabled")
@@ -6529,12 +6531,12 @@ queries:
         values.enable_deletion_protection == true
       )
   - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
-    title: Ensure Amazon OpenSearch Service domains are configured with encryption-at-rest
+    title: Ensure Amazon Elasticsearch Service domains are configured with encryption-at-rest
     impact: 70
     variants:
-      - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-api
+      - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-aws
         tags:
-          mondoo.com/filter-title: "AWS Amazon OpenSearch Service"
+          mondoo.com/filter-title: "AWS ES Domain"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-hcl
         tags:
@@ -6550,17 +6552,17 @@ queries:
           mondoo.com/icon: "terraform"
     docs:
       desc: |
-        This check ensures that Amazon OpenSearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
+        This check ensures that Amazon Elasticsearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
 
         **Why this matters**
 
-        By default, OpenSearch Service does not encrypt data at rest unless explicitly enabled. Without encryption:
+        By default, Elasticsearch Service does not encrypt data at rest unless explicitly enabled. Without encryption:
 
         - Sensitive data remains in plaintext, making it vulnerable to unauthorized access.
         - Security and compliance risks increase under regulations such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
-        - Data exposure risks exist if an OpenSearch domain is compromised.
+        - Data exposure risks exist if an Elasticsearch domain is compromised.
 
-        To mitigate these risks, OpenSearch domains should be encrypted using AWS KMS, which provides centralized key management, access control, and audit logging.
+        To mitigate these risks, Elasticsearch domains should be encrypted using AWS KMS, which provides centralized key management, access control, and audit logging.
 
         **Risk mitigation:**
 
@@ -6572,11 +6574,11 @@ queries:
           desc: |
             **Using AWS Console**
 
-            1.  Navigate to the AWS OpenSearch Service Console.
+            1.  Navigate to the Amazon Elasticsearch Service Console.
             2.  Select Domains in the left panel.
-            3.  Select an OpenSearch domain and go to the Security tab.
+            3.  Select an Elasticsearch domain and go to the Security tab.
             4.  Under Encryption at rest, check if encryption is enabled.
-            5.  If encryption is not enabled, create a new OpenSearch domain with encryption:
+            5.  If encryption is not enabled, create a new Elasticsearch domain with encryption:
               - Select Create domain.
               - Under Encryption at rest, enable encrypt data at rest.
               - Choose a customer-managed KMS key (CMK) if required.
@@ -6586,36 +6588,38 @@ queries:
           desc: |
             **Using AWS CLI**
 
-            Check if an OpenSearch domain is encrypted:
+            Check if an Elasticsearch domain is encrypted:
 
             ```bash
-            aws opensearch describe-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
+            aws es describe-elasticsearch-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
             ```
 
-            If encryption is not enabled, create a new encrypted OpenSearch domain:
+            If encryption is not enabled, create a new encrypted Elasticsearch domain:
 
             ```bash
-            aws opensearch create-domain \
-            --domain-name "secure-opensearch-domain" \
+            aws es create-elasticsearch-domain \
+            --domain-name "secure-es-domain" \
             --encryption-at-rest-options Enabled=true,KmsKeyId="arn:aws:kms:region:account-id:key/key-id"
             ```
         - id: terraform
           desc: |
             **Using Terraform**
 
-            Ensure OpenSearch Service encryption is enabled using AWS KMS:
+            Ensure Elasticsearch Service encryption is enabled using AWS KMS:
 
             ```hcl
-            resource "aws_kms_key" "opensearch_kms_key" {
-              description         = "KMS key for OpenSearch encryption"
+            resource "aws_kms_key" "es_kms_key" {
+              description         = "KMS key for Elasticsearch encryption"
               enable_key_rotation = true
             }
 
-            resource "aws_opensearch_domain" "secure_opensearch" {
-              domain_name = "secure-opensearch-domain"
+            resource "aws_elasticsearch_domain" "secure_es" {
+              domain_name           = "secure-es-domain"
+              elasticsearch_version = "7.10"
 
               encrypt_at_rest {
                 enabled    = true
+                kms_key_id = aws_kms_key.es_kms_key.arn
               }
             }
             ```
@@ -6623,58 +6627,180 @@ queries:
           desc: |
             **Using CloudFormation**
 
-            Enable encryption at rest for OpenSearch domains:
+            Enable encryption at rest for Elasticsearch domains:
 
             ```yaml
             Resources:
-              SecureOpenSearchDomain:
-                Type: "AWS::OpenSearchService::Domain"
+              SecureESDomain:
+                Type: "AWS::Elasticsearch::Domain"
                 Properties:
-                  DomainName: "secure-opensearch-domain"
+                  DomainName: "secure-es-domain"
+                  ElasticsearchVersion: "7.10"
                   EncryptionAtRestOptions:
                     Enabled: true
-                    KmsKeyId: !Ref OpenSearchKMSKey
+                    KmsKeyId: !Ref ESKMSKey
 
-              OpenSearchKMSKey:
+              ESKMSKey:
                 Type: "AWS::KMS::Key"
                 Properties:
-                  Description: "KMS key for OpenSearch encryption"
+                  Description: "KMS key for Elasticsearch encryption"
                   EnableKeyRotation: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/encryption-at-rest.html
-        title: Encryption of Data at Rest for Amazon OpenSearch Service
+      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/encryption-at-rest.html
+        title: Encryption of Data at Rest for Amazon Elasticsearch Service
       - url: https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html
         title: AWS Well-Architected Security Pillar
-  - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-api
-    filters: asset.platform == "aws"
-    mql: aws.es.domains.all(encryptionAtRestEnabled == true)
+  - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-aws
+    filters: asset.platform == "aws-es-domain"
+    mql: aws.es.domain.encryptionAtRestEnabled == true
   - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticsearch_domain")
     mql: |
-      terraform.resources.where(nameLabel == "aws_opensearch_domain").all(
+      terraform.resources.where(nameLabel == "aws_elasticsearch_domain").all(
         blocks.where(type == "encrypt_at_rest") != empty &&
         blocks.where(type == "encrypt_at_rest").all(arguments.enabled == true)
       )
   - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_opensearch_domain")
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elasticsearch_domain")
     mql: |
-      terraform.plan.resourceChanges.where(type == "aws_opensearch_domain").all(
+      terraform.plan.resourceChanges.where(type == "aws_elasticsearch_domain").all(
         change.after.encrypt_at_rest != empty &&
         change.after.encrypt_at_rest.all(enabled == true)
       )
   - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_opensearch_domain")
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_elasticsearch_domain")
     mql: |
-      terraform.state.resources.where(type == "aws_opensearch_domain").all(
+      terraform.state.resources.where(type == "aws_elasticsearch_domain").all(
         values.encrypt_at_rest != empty &&
         values.encrypt_at_rest.all(enabled == true)
+      )
+  - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption
+    title: Ensure Amazon Elasticsearch Service domains use node-to-node encryption
+    impact: 80
+    variants:
+      - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-aws
+        tags:
+          mondoo.com/filter-title: "AWS ES Domain"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that Amazon Elasticsearch Service domains have node-to-node encryption enabled. Node-to-node encryption provides an additional layer of security by encrypting data as it is transferred between nodes within the Elasticsearch cluster, protecting against potential internal network eavesdropping.
+
+        **Why this matters**
+
+        - Without node-to-node encryption, data moving between cluster nodes is transmitted in plaintext within the VPC.
+        - Attackers with network access within the VPC could potentially intercept inter-node traffic containing indexed data, search results, and cluster metadata.
+        - This is especially critical for domains processing sensitive or regulated data.
+
+        **Risk mitigation:**
+
+        - **Internal traffic protection:** Encrypts all communication between nodes within the Elasticsearch cluster.
+        - **Defense in depth:** Adds an encryption layer beyond VPC-level network isolation.
+        - **Compliance:** Meets regulatory requirements for comprehensive encryption.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon Elasticsearch Service Console.
+            2. Select the domain you want to update.
+            3. Select Edit security configuration.
+            4. Enable Node-to-node encryption.
+            5. Select Save changes.
+
+            Note: Enabling node-to-node encryption on an existing domain requires a blue/green deployment. Plan for potential downtime.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Check if node-to-node encryption is enabled:
+
+            ```bash
+            aws es describe-elasticsearch-domain --domain-name <domain-name> \
+              --query "DomainStatus.NodeToNodeEncryptionOptions.Enabled"
+            ```
+
+            Enable node-to-node encryption:
+
+            ```bash
+            aws es update-elasticsearch-domain-config --domain-name <domain-name> \
+              --node-to-node-encryption-options Enabled=true
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "aws_elasticsearch_domain" "example" {
+              domain_name           = "example-domain"
+              elasticsearch_version = "7.10"
+
+              node_to_node_encryption {
+                enabled = true
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              ElasticsearchDomain:
+                Type: "AWS::Elasticsearch::Domain"
+                Properties:
+                  DomainName: "example-domain"
+                  ElasticsearchVersion: "7.10"
+                  NodeToNodeEncryptionOptions:
+                    Enabled: true
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/ntn.html
+        title: AWS Documentation - Node-to-node encryption for Amazon Elasticsearch Service
+      - url: https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html
+        title: AWS Well-Architected Security Pillar
+  - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-aws
+    filters: asset.platform == "aws-es-domain"
+    mql: aws.es.domain.nodeToNodeEncryptionEnabled == true
+  - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticsearch_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_elasticsearch_domain").all(
+        blocks.where(type == "node_to_node_encryption") != empty &&
+        blocks.where(type == "node_to_node_encryption").all(arguments.enabled == true)
+      )
+  - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elasticsearch_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_elasticsearch_domain").all(
+        change.after.node_to_node_encryption != empty &&
+        change.after.node_to_node_encryption.all(enabled == true)
+      )
+  - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_elasticsearch_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_elasticsearch_domain").all(
+        values.node_to_node_encryption != empty &&
+        values.node_to_node_encryption.all(enabled == true)
       )
   - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
     title: Ensure rotation for customer-managed keys (CMKs) is enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-single
+      - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS KMS Key"
           mondoo.com/icon: "aws"
@@ -6769,7 +6895,7 @@ queries:
         title: AWS KMS Best Practices
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html
         title: Rotating AWS KMS Keys
-  - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-single
+  - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyState == "Enabled" && aws.kms.key.metadata.KeySpec == "SYMMETRIC_DEFAULT" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: |
       aws.kms.key.keyRotationEnabled == true
@@ -6795,7 +6921,7 @@ queries:
     title: Ensure SageMaker notebook instances are configured to use KMS
     impact: 50
     variants:
-      - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-single
+      - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-aws
         tags:
           mondoo.com/filter-title: "AWS SageMaker Notebook Instance"
           mondoo.com/icon: "aws"
@@ -6905,7 +7031,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/security.html
         title: Amazon SageMaker Security
-  - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-single
+  - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-aws
     filters: asset.platform == "aws-sagemaker-notebookinstance"
     mql: |
       aws.sagemaker.notebookinstance.details.kmsKey != empty
@@ -6932,7 +7058,7 @@ queries:
     title: Ensure CloudTrail log file validation is enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-single
+      - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS CloudTrail Trail"
           mondoo.com/icon: "aws"
@@ -7110,7 +7236,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/best-practices-security.html
         title: AWS CloudTrail Security Best Practices
-  - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-single
+  - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-aws
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: aws.cloudtrail.trail.logFileValidationEnabled == true
   - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-terraform-hcl
@@ -7126,7 +7252,7 @@ queries:
     title: Ensure CloudTrail trails are configured to use the server-side encryption KMS
     impact: 70
     variants:
-      - uid: mondoo-aws-security-cloud-trail-encryption-enabled-single
+      - uid: mondoo-aws-security-cloud-trail-encryption-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS CloudTrail Trail"
           mondoo.com/icon: "aws"
@@ -7236,7 +7362,7 @@ queries:
         title: AWS CloudTrail Security Best Practices
       - url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html
         title: Encrypting CloudTrail Log Files with AWS KMS
-  - uid: mondoo-aws-security-cloud-trail-encryption-enabled-single
+  - uid: mondoo-aws-security-cloud-trail-encryption-enabled-aws
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
       aws.cloudtrail.trail.kmsKey != empty
@@ -7263,7 +7389,7 @@ queries:
     title: Ensure security groups restrict incoming SSH traffic
     impact: 90
     variants:
-      - uid: mondoo-aws-security-secgroup-restricted-ssh-single
+      - uid: mondoo-aws-security-secgroup-restricted-ssh-aws
         tags:
           mondoo.com/filter-title: "AWS Security Group"
           mondoo.com/icon: "aws"
@@ -7396,7 +7522,7 @@ queries:
         title: Amazon VPC Security Best Practices
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
         title: Security Group Rules Reference
-  - uid: mondoo-aws-security-secgroup-restricted-ssh-single
+  - uid: mondoo-aws-security-secgroup-restricted-ssh-aws
     filters: asset.platform == "aws-security-group"
     mql: |
       aws.ec2.securitygroup.ipPermissions.where(
@@ -7416,7 +7542,7 @@ queries:
     title: Ensure security groups restrict incoming VNC traffic
     impact: 90
     variants:
-      - uid: mondoo-aws-security-secgroup-restricted-vnc-single
+      - uid: mondoo-aws-security-secgroup-restricted-vnc-aws
         tags:
           mondoo.com/filter-title: "AWS Security Group"
           mondoo.com/icon: "aws"
@@ -7537,7 +7663,7 @@ queries:
         title: Amazon VPC Security Best Practices
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
         title: Security Group Rules Reference
-  - uid: mondoo-aws-security-secgroup-restricted-vnc-single
+  - uid: mondoo-aws-security-secgroup-restricted-vnc-aws
     filters: asset.platform == "aws-security-group"
     mql: |
       aws.ec2.securitygroup.ipPermissions.where(
@@ -7579,7 +7705,7 @@ queries:
     title: Ensure security groups restrict incoming RDP traffic
     impact: 90
     variants:
-      - uid: mondoo-aws-security-secgroup-restricted-rdp-single
+      - uid: mondoo-aws-security-secgroup-restricted-rdp-aws
         tags:
           mondoo.com/filter-title: "AWS Security Group"
           mondoo.com/icon: "aws"
@@ -7714,7 +7840,7 @@ queries:
         title: Amazon VPC Security Best Practices
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
         title: Security Group Rules Reference
-  - uid: mondoo-aws-security-secgroup-restricted-rdp-single
+  - uid: mondoo-aws-security-secgroup-restricted-rdp-aws
     filters: asset.platform == "aws-security-group"
     mql: |
       aws.ec2.securitygroup.ipPermissions.where(
@@ -7734,7 +7860,7 @@ queries:
     title: Ensure security groups restrict access to specific IPs and ports
     impact: 90
     variants:
-      - uid: mondoo-aws-security-secgroup-restrict-traffic-single
+      - uid: mondoo-aws-security-secgroup-restrict-traffic-aws
         tags:
           mondoo.com/filter-title: "AWS Security Group"
           mondoo.com/icon: "aws"
@@ -7881,7 +8007,7 @@ queries:
         title: Amazon VPC Security Best Practices
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
         title: Security Group Rules Reference
-  - uid: mondoo-aws-security-secgroup-restrict-traffic-single
+  - uid: mondoo-aws-security-secgroup-restrict-traffic-aws
     filters: asset.platform == "aws-security-group"
     mql: |
       aws.ec2.securitygroup.ipPermissions.where(
@@ -8000,9 +8126,9 @@ queries:
     title: Ensure API Gateway cache is enabled and encrypted
     impact: 70
     variants:
-      - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-api
+      - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Gateway REST API"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-terraform-hcl
         tags:
@@ -8079,13 +8205,11 @@ queries:
         title: AWS Documentation - Enable API caching
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_method_settings
         title: Terraform Documentation - api_gateway_method_settings Resource
-  - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-api
-    filters: asset.platform == "aws"
+  - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-aws
+    filters: asset.platform == "aws-gateway-restapi"
     mql: |
-      aws.apigateway.restApis.all(
-        stages.all(
-          methodSettings['*/*']['CacheDataEncrypted'] == true || methodSettings == empty
-        )
+      aws.apigateway.restapi.stages.all(
+        methodSettings['*/*']['CacheDataEncrypted'] == true || methodSettings == empty
       )
   - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_api_gateway_method_settings")
@@ -8109,9 +8233,9 @@ queries:
     title: Ensure API Gateway stages have execution logging enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-api-gw-execution-logging-enabled-api
+      - uid: mondoo-aws-security-api-gw-execution-logging-enabled-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Gateway REST API"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-api-gw-execution-logging-enabled-terraform-hcl
         tags:
@@ -8200,15 +8324,13 @@ queries:
         title: AWS Config Managed Rules
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage
         title: Terraform Documentation - api_gateway_stage Resource
-  - uid: mondoo-aws-security-api-gw-execution-logging-enabled-api
-    filters: asset.platform == "aws"
+  - uid: mondoo-aws-security-api-gw-execution-logging-enabled-aws
+    filters: asset.platform == "aws-gateway-restapi"
     mql: |
-      aws.apigateway.restApis.all(
-        stages.all(
-          methodSettings['*/*'] != empty &&
-          methodSettings['*/*']['LoggingLevel'] != "" &&
-          methodSettings['*/*']['LoggingLevel'] != "OFF"
-        )
+      aws.apigateway.restapi.stages.all(
+        methodSettings['*/*'] != empty &&
+        methodSettings['*/*']['LoggingLevel'] != "" &&
+        methodSettings['*/*']['LoggingLevel'] != "OFF"
       )
   - uid: mondoo-aws-security-api-gw-execution-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_api_gateway_stage" || nameLabel == "aws_apigatewayv2_stage")
@@ -8348,9 +8470,9 @@ queries:
     title: Ensure API Gateway uses TLS 1.2 or higher
     impact: 80
     variants:
-      - uid: mondoo-aws-security-api-gw-tls-api
+      - uid: mondoo-aws-security-api-gw-tls-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Gateway REST API"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-api-gw-tls-terraform-hcl
         tags:
@@ -8426,12 +8548,10 @@ queries:
         title: AWS Config Managed Rules
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_domain_name
         title: Terraform Documentation - api_gateway_domain_name Resource
-  - uid: mondoo-aws-security-api-gw-tls-api
-    filters: asset.platform == "aws"
+  - uid: mondoo-aws-security-api-gw-tls-aws
+    filters: asset.platform == "aws-gateway-restapi"
     mql: |
-      aws.apigateway.restApis.all(
-        securityPolicy == "TLS_1_2"
-      )
+      aws.apigateway.restapi.securityPolicy == "TLS_1_2"
   - uid: mondoo-aws-security-api-gw-tls-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_api_gateway_domain_name")
     mql: |
@@ -8454,9 +8574,9 @@ queries:
     title: Ensure API Gateway X-Ray tracing is enabled
     impact: 50
     variants:
-      - uid: mondoo-aws-security-api-gw-xray-enabled-api
+      - uid: mondoo-aws-security-api-gw-xray-enabled-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Gateway REST API"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-api-gw-xray-enabled-terraform-hcl
         tags:
@@ -8528,12 +8648,10 @@ queries:
         title: AWS Config Managed Rules
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage
         title: Terraform Documentation - api_gateway_stage Resource
-  - uid: mondoo-aws-security-api-gw-xray-enabled-api
-    filters: asset.platform == "aws"
+  - uid: mondoo-aws-security-api-gw-xray-enabled-aws
+    filters: asset.platform == "aws-gateway-restapi"
     mql: |
-      aws.apigateway.restApis.all(
-        stages.all(tracingEnabled == true)
-      )
+      aws.apigateway.restapi.stages.all(tracingEnabled == true)
   - uid: mondoo-aws-security-api-gw-xray-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_api_gateway_stage")
     mql: |
@@ -8672,7 +8790,7 @@ queries:
     title: Ensure IAM policies do not use wildcards and apply least privilege
     impact: 80
     variants:
-      - uid: mondoo-aws-security-iam-no-wildcards-policies-api
+      - uid: mondoo-aws-security-iam-no-wildcards-policies-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -8765,7 +8883,7 @@ queries:
         title: AWS Documentation - Security best practices in IAM
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy
         title: Terraform Documentation - iam_policy Resource
-  - uid: mondoo-aws-security-iam-no-wildcards-policies-api
+  - uid: mondoo-aws-security-iam-no-wildcards-policies-aws
     filters: asset.platform == "aws"
     mql: |
       aws.iam.policies.where(isAttachable == true) {
@@ -8826,7 +8944,7 @@ queries:
     title: Ensure S3 bucket versioning is enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-s3-bucket-versioning-enabled-api
+      - uid: mondoo-aws-security-s3-bucket-versioning-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS S3 Bucket"
           mondoo.com/icon: "aws"
@@ -8903,7 +9021,7 @@ queries:
         title: AWS Config Managed Rules
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning
         title: Terraform Documentation - s3_bucket_versioning Resource
-  - uid: mondoo-aws-security-s3-bucket-versioning-enabled-api
+  - uid: mondoo-aws-security-s3-bucket-versioning-enabled-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.versioning['Status'] == "Enabled"
@@ -8932,7 +9050,7 @@ queries:
     title: Ensure S3 bucket logging is enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-s3-bucket-logging-enabled-api
+      - uid: mondoo-aws-security-s3-bucket-logging-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS S3 Bucket"
           mondoo.com/icon: "aws"
@@ -9016,7 +9134,7 @@ queries:
         title: AWS Documentation - Logging requests using server access logging
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging
         title: Terraform Documentation - s3_bucket_logging Resource
-  - uid: mondoo-aws-security-s3-bucket-logging-enabled-api
+  - uid: mondoo-aws-security-s3-bucket-logging-enabled-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.logging['TargetBucket'] != empty
@@ -9042,7 +9160,7 @@ queries:
     title: Ensure S3 bucket server-side encryption is enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-api
+      - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS S3 Bucket"
           mondoo.com/icon: "aws"
@@ -9134,7 +9252,7 @@ queries:
         title: AWS Config Managed Rules
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration
         title: Terraform Documentation - s3_bucket_server_side_encryption_configuration Resource
-  - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-api
+  - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.encryption['Rules'] != empty
@@ -9163,7 +9281,7 @@ queries:
     title: Ensure S3 buckets do not allow public read access via ACLs
     impact: 95
     variants:
-      - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-api
+      - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-aws
         tags:
           mondoo.com/filter-title: "AWS S3 Bucket"
           mondoo.com/icon: "aws"
@@ -9254,7 +9372,7 @@ queries:
         title: AWS Config Managed Rules - public write
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl
         title: Terraform Documentation - s3_bucket_acl Resource
-  - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-api
+  - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.acl.none(
@@ -9285,7 +9403,7 @@ queries:
     title: Ensure S3 bucket static website hosting is disabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-api
+      - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-aws
         tags:
           mondoo.com/filter-title: "AWS S3 Bucket"
           mondoo.com/icon: "aws"
@@ -9355,7 +9473,7 @@ queries:
         title: Hosting a static website using Amazon S3
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration
         title: Terraform Documentation - s3_bucket_website_configuration Resource
-  - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-api
+  - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.staticWebsiteHosting == empty
@@ -9375,7 +9493,7 @@ queries:
     title: Ensure CloudTrail is enabled in all regions with a multi-region trail
     impact: 90
     variants:
-      - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-single
+      - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS CloudTrail Trail"
           mondoo.com/icon: "aws"
@@ -9482,7 +9600,7 @@ queries:
         title: AWS Documentation - Creating and updating a trail
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html
         title: AWS Documentation - CloudTrail controls
-  - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-single
+  - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-aws
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
       aws.cloudtrail.trail.isMultiRegionTrail == true
@@ -9500,7 +9618,7 @@ queries:
     title: Ensure CloudFront distributions require HTTPS for viewer connections
     impact: 80
     variants:
-      - uid: mondoo-aws-security-cloudfront-viewer-policy-https-api
+      - uid: mondoo-aws-security-cloudfront-viewer-policy-https-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -9637,7 +9755,7 @@ queries:
         title: AWS Documentation - Requiring HTTPS for communication between viewers and CloudFront
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/cloudfront-controls.html
         title: AWS Documentation - CloudFront controls
-  - uid: mondoo-aws-security-cloudfront-viewer-policy-https-api
+  - uid: mondoo-aws-security-cloudfront-viewer-policy-https-aws
     filters: asset.platform == "aws"
     mql: |
       aws.cloudfront.distributions.all(
@@ -9667,7 +9785,7 @@ queries:
     title: Ensure Amazon EKS control plane logging is enabled
     impact: 70
     variants:
-      - uid: mondoo-aws-security-eks-cluster-logging-enabled-api
+      - uid: mondoo-aws-security-eks-cluster-logging-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -9780,7 +9898,7 @@ queries:
         title: AWS Documentation - Amazon EKS control plane logging
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/eks-controls.html
         title: AWS Documentation - EKS controls
-  - uid: mondoo-aws-security-eks-cluster-logging-enabled-api
+  - uid: mondoo-aws-security-eks-cluster-logging-enabled-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
       aws.eks.cluster.logging['clusterLogging'] != null
@@ -9803,17 +9921,158 @@ queries:
       terraform.state.resources.where(type == "aws_eks_cluster").all(
         values.enabled_cluster_log_types != empty
       )
+  - uid: mondoo-aws-security-opensearch-encrypted-at-rest
+    title: Ensure Amazon OpenSearch Service domains are configured with encryption-at-rest
+    impact: 70
+    variants:
+      - uid: mondoo-aws-security-opensearch-encrypted-at-rest-aws
+        tags:
+          mondoo.com/filter-title: "AWS OpenSearch Domain"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that Amazon OpenSearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
+
+        **Why this matters**
+
+        By default, OpenSearch Service does not encrypt data at rest unless explicitly enabled. Without encryption:
+
+        - Sensitive data remains in plaintext, making it vulnerable to unauthorized access.
+        - Security and compliance risks increase under regulations such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
+        - Data exposure risks exist if an OpenSearch domain is compromised.
+
+        To mitigate these risks, OpenSearch domains should be encrypted using AWS KMS, which provides centralized key management, access control, and audit logging.
+
+        **Risk mitigation:**
+
+        - Prevents unauthorized access by ensuring all stored data is encrypted.
+        - Enhances compliance with industry security frameworks requiring encryption at rest.
+        - Improves security posture by integrating AWS KMS for key management.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1.  Navigate to the Amazon OpenSearch Service Console.
+            2.  Select Domains in the left panel.
+            3.  Select an OpenSearch domain and go to the Security tab.
+            4.  Under Encryption at rest, check if encryption is enabled.
+            5.  If encryption is not enabled, create a new OpenSearch domain with encryption:
+              - Select Create domain.
+              - Under Encryption at rest, enable encrypt data at rest.
+              - Choose a customer-managed KMS key (CMK) if required.
+              - Complete the domain creation process.
+            6.  Migrate data from the unencrypted domain to the new encrypted domain, then delete the unencrypted domain.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Check if an OpenSearch domain is encrypted:
+
+            ```bash
+            aws opensearch describe-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
+            ```
+
+            If encryption is not enabled, create a new encrypted OpenSearch domain:
+
+            ```bash
+            aws opensearch create-domain \
+            --domain-name "secure-opensearch-domain" \
+            --encryption-at-rest-options Enabled=true,KmsKeyId="arn:aws:kms:region:account-id:key/key-id"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Ensure OpenSearch Service encryption is enabled using AWS KMS:
+
+            ```hcl
+            resource "aws_kms_key" "opensearch_kms_key" {
+              description         = "KMS key for OpenSearch encryption"
+              enable_key_rotation = true
+            }
+
+            resource "aws_opensearch_domain" "secure_opensearch" {
+              domain_name    = "secure-opensearch-domain"
+              engine_version = "OpenSearch_2.11"
+
+              encrypt_at_rest {
+                enabled    = true
+                kms_key_id = aws_kms_key.opensearch_kms_key.arn
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            Enable encryption at rest for OpenSearch domains:
+
+            ```yaml
+            Resources:
+              SecureOpenSearchDomain:
+                Type: "AWS::OpenSearchService::Domain"
+                Properties:
+                  DomainName: "secure-opensearch-domain"
+                  EngineVersion: "OpenSearch_2.11"
+                  EncryptionAtRestOptions:
+                    Enabled: true
+                    KmsKeyId: !Ref OpenSearchKMSKey
+
+              OpenSearchKMSKey:
+                Type: "AWS::KMS::Key"
+                Properties:
+                  Description: "KMS key for OpenSearch encryption"
+                  EnableKeyRotation: true
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/encryption-at-rest.html
+        title: Encryption of Data at Rest for Amazon OpenSearch Service
+      - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
+        title: AWS Documentation - OpenSearch controls
+  - uid: mondoo-aws-security-opensearch-encrypted-at-rest-aws
+    filters: asset.platform == "aws-opensearch-domain"
+    mql: aws.opensearch.domain.encryptionAtRestEnabled == true
+  - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_opensearch_domain").all(
+        blocks.where(type == "encrypt_at_rest") != empty &&
+        blocks.where(type == "encrypt_at_rest").all(arguments.enabled == true)
+      )
+  - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_opensearch_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_opensearch_domain").all(
+        change.after.encrypt_at_rest != empty &&
+        change.after.encrypt_at_rest.all(enabled == true)
+      )
+  - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_opensearch_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_opensearch_domain").all(
+        values.encrypt_at_rest != empty &&
+        values.encrypt_at_rest.all(enabled == true)
+      )
   - uid: mondoo-aws-security-opensearch-enforce-https
     title: Ensure Amazon OpenSearch Service domains enforce HTTPS
     impact: 90
     variants:
-      - uid: mondoo-aws-security-opensearch-enforce-https-single
+      - uid: mondoo-aws-security-opensearch-enforce-https-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-enforce-https-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-enforce-https-terraform-hcl
         tags:
@@ -9905,12 +10164,9 @@ queries:
         title: AWS Documentation - Encryption in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-enforce-https-single
+  - uid: mondoo-aws-security-opensearch-enforce-https-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.enforceHTTPS == true
-  - uid: mondoo-aws-security-opensearch-enforce-https-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(enforceHTTPS == true)
   - uid: mondoo-aws-security-opensearch-enforce-https-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -9936,13 +10192,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains use node-to-node encryption
     impact: 80
     variants:
-      - uid: mondoo-aws-security-opensearch-node-to-node-encryption-single
+      - uid: mondoo-aws-security-opensearch-node-to-node-encryption-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-node-to-node-encryption-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-terraform-hcl
         tags:
@@ -10034,12 +10286,9 @@ queries:
         title: AWS Documentation - Node-to-node encryption for Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-node-to-node-encryption-single
+  - uid: mondoo-aws-security-opensearch-node-to-node-encryption-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.nodeToNodeEncryptionEnabled == true
-  - uid: mondoo-aws-security-opensearch-node-to-node-encryption-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(nodeToNodeEncryptionEnabled == true)
   - uid: mondoo-aws-security-opensearch-node-to-node-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10065,13 +10314,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains use TLS 1.2 or higher
     impact: 70
     variants:
-      - uid: mondoo-aws-security-opensearch-tls-policy-single
+      - uid: mondoo-aws-security-opensearch-tls-policy-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-tls-policy-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-tls-policy-terraform-hcl
         tags:
@@ -10163,12 +10408,9 @@ queries:
         title: AWS Documentation - Encryption in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-tls-policy-single
+  - uid: mondoo-aws-security-opensearch-tls-policy-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.tlsSecurityPolicy == /Policy-Min-TLS-1-2/
-  - uid: mondoo-aws-security-opensearch-tls-policy-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(tlsSecurityPolicy == /Policy-Min-TLS-1-2/)
   - uid: mondoo-aws-security-opensearch-tls-policy-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10196,13 +10438,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains have fine-grained access control enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-opensearch-fine-grained-access-control-single
+      - uid: mondoo-aws-security-opensearch-fine-grained-access-control-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-fine-grained-access-control-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-terraform-hcl
         tags:
@@ -10319,12 +10557,9 @@ queries:
         title: AWS Documentation - Fine-grained access control in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-fine-grained-access-control-single
+  - uid: mondoo-aws-security-opensearch-fine-grained-access-control-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.advancedSecurityEnabled == true
-  - uid: mondoo-aws-security-opensearch-fine-grained-access-control-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(advancedSecurityEnabled == true)
   - uid: mondoo-aws-security-opensearch-fine-grained-access-control-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10350,13 +10585,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains have audit logging enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-opensearch-audit-logging-single
+      - uid: mondoo-aws-security-opensearch-audit-logging-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-audit-logging-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-audit-logging-terraform-hcl
         tags:
@@ -10463,12 +10694,9 @@ queries:
         title: AWS Documentation - Monitoring audit logs in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-audit-logging-single
+  - uid: mondoo-aws-security-opensearch-audit-logging-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.auditLogEnabled == true
-  - uid: mondoo-aws-security-opensearch-audit-logging-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(auditLogEnabled == true)
   - uid: mondoo-aws-security-opensearch-audit-logging-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10494,13 +10722,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains are deployed within a VPC
     impact: 80
     variants:
-      - uid: mondoo-aws-security-opensearch-in-vpc-single
+      - uid: mondoo-aws-security-opensearch-in-vpc-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-in-vpc-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-in-vpc-terraform-hcl
         tags:
@@ -10610,12 +10834,9 @@ queries:
         title: AWS Documentation - Launching your Amazon OpenSearch Service domains within a VPC
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-in-vpc-single
+  - uid: mondoo-aws-security-opensearch-in-vpc-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.vpcId != ""
-  - uid: mondoo-aws-security-opensearch-in-vpc-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(vpcId != "")
   - uid: mondoo-aws-security-opensearch-in-vpc-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10638,13 +10859,9 @@ queries:
     title: Ensure Amazon OpenSearch Service domains do not allow anonymous authentication
     impact: 90
     variants:
-      - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-single
+      - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-aws
         tags:
           mondoo.com/filter-title: "AWS OpenSearch Domain"
-          mondoo.com/icon: "aws"
-      - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-api
-        tags:
-          mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-terraform-hcl
         tags:
@@ -10745,12 +10962,9 @@ queries:
         title: AWS Documentation - Fine-grained access control in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html
         title: AWS Documentation - OpenSearch controls
-  - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-single
+  - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-aws
     filters: asset.platform == "aws-opensearch-domain"
     mql: aws.opensearch.domain.anonymousAuthEnabled != true
-  - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-api
-    filters: asset.platform == "aws"
-    mql: aws.opensearch.domains.all(anonymousAuthEnabled != true)
   - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -10773,7 +10987,7 @@ queries:
     title: Ensure ECR repositories have image scanning on push enabled
     impact: 70
     variants:
-      - uid: mondoo-aws-security-ecr-image-scan-on-push-api
+      - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -10864,7 +11078,7 @@ queries:
         title: AWS Documentation - Amazon ECR image scanning
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
-  - uid: mondoo-aws-security-ecr-image-scan-on-push-api
+  - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
     filters: asset.platform == "aws"
     mql: aws.ecr.privateRepositories.all(imageScanOnPush == true)
   - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl
@@ -10892,7 +11106,7 @@ queries:
     title: Ensure ECR repositories have image tag immutability enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-ecr-tag-immutability-api
+      - uid: mondoo-aws-security-ecr-tag-immutability-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -10979,7 +11193,7 @@ queries:
         title: AWS Documentation - Image tag mutability
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
-  - uid: mondoo-aws-security-ecr-tag-immutability-api
+  - uid: mondoo-aws-security-ecr-tag-immutability-aws
     filters: asset.platform == "aws"
     mql: aws.ecr.privateRepositories.all(imageTagMutability == "IMMUTABLE")
   - uid: mondoo-aws-security-ecr-tag-immutability-terraform-hcl
@@ -11004,7 +11218,7 @@ queries:
     title: Ensure ECS task definitions do not allow privileged containers
     impact: 90
     variants:
-      - uid: mondoo-aws-security-ecs-no-privileged-containers-api
+      - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -11108,7 +11322,7 @@ queries:
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
-  - uid: mondoo-aws-security-ecs-no-privileged-containers-api
+  - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ecs.taskDefinitions.all(
@@ -11136,7 +11350,7 @@ queries:
     title: Ensure ECS task definitions configure read-only root filesystems for containers
     impact: 70
     variants:
-      - uid: mondoo-aws-security-ecs-readonly-root-filesystem-api
+      - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -11251,7 +11465,7 @@ queries:
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
-  - uid: mondoo-aws-security-ecs-readonly-root-filesystem-api
+  - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ecs.taskDefinitions.all(
@@ -11279,7 +11493,7 @@ queries:
     title: Ensure ECS task definitions have logging configured for all containers
     impact: 60
     variants:
-      - uid: mondoo-aws-security-ecs-logging-enabled-api
+      - uid: mondoo-aws-security-ecs-logging-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -11408,7 +11622,7 @@ queries:
         title: AWS Documentation - Using the awslogs log driver
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
-  - uid: mondoo-aws-security-ecs-logging-enabled-api
+  - uid: mondoo-aws-security-ecs-logging-enabled-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ecs.taskDefinitions.all(
@@ -11436,7 +11650,7 @@ queries:
     title: Ensure EFS file systems have automatic backups enabled
     impact: 60
     variants:
-      - uid: mondoo-aws-security-efs-backup-enabled-single
+      - uid: mondoo-aws-security-efs-backup-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS EFS File System"
           mondoo.com/icon: "aws"
@@ -11529,7 +11743,7 @@ queries:
         title: AWS Documentation - Using AWS Backup to back up and restore Amazon EFS file systems
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html
         title: AWS Documentation - EFS controls
-  - uid: mondoo-aws-security-efs-backup-enabled-single
+  - uid: mondoo-aws-security-efs-backup-enabled-aws
     filters: asset.platform == "aws-efs-filesystem"
     mql: aws.efs.filesystem.backupPolicy["Status"] == "ENABLED"
   - uid: mondoo-aws-security-efs-backup-enabled-terraform-hcl
@@ -11555,7 +11769,7 @@ queries:
     title: Ensure Application Load Balancers are configured to drop invalid HTTP headers
     impact: 60
     variants:
-      - uid: mondoo-aws-security-elb-drop-invalid-headers-single
+      - uid: mondoo-aws-security-elb-drop-invalid-headers-aws
         tags:
           mondoo.com/filter-title: "AWS Application Load Balancer"
           mondoo.com/icon: "aws"
@@ -11660,7 +11874,7 @@ queries:
         title: AWS Documentation - Application Load Balancers
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/elb-controls.html
         title: AWS Documentation - ELB controls
-  - uid: mondoo-aws-security-elb-drop-invalid-headers-single
+  - uid: mondoo-aws-security-elb-drop-invalid-headers-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
       aws.elb.loadbalancer.attributes.where(Key == "routing.http.drop_invalid_header_fields.enabled").all(Value == true)
@@ -11686,7 +11900,7 @@ queries:
     title: Ensure SageMaker notebook instances do not have direct internet access
     impact: 80
     variants:
-      - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-single
+      - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-aws
         tags:
           mondoo.com/filter-title: "AWS SageMaker Notebook Instance"
           mondoo.com/icon: "aws"
@@ -11793,7 +12007,7 @@ queries:
         title: AWS Documentation - Notebook Instance Internet Access
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/sagemaker-controls.html
         title: AWS Documentation - SageMaker controls
-  - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-single
+  - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-aws
     filters: asset.platform == "aws-sagemaker-notebookinstance"
     mql: aws.sagemaker.notebookinstance.details.directInternetAccess == "Disabled"
   - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-terraform-hcl
@@ -11818,7 +12032,7 @@ queries:
     title: Ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0
     impact: 80
     variants:
-      - uid: mondoo-aws-security-eks-cluster-restrict-public-access-api
+      - uid: mondoo-aws-security-eks-cluster-restrict-public-access-aws
         tags:
           mondoo.com/filter-title: "AWS EKS Cluster"
           mondoo.com/icon: "aws"
@@ -11919,7 +12133,7 @@ queries:
         title: AWS Documentation - Amazon EKS cluster endpoint access control
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/eks-controls.html
         title: AWS Documentation - EKS controls
-  - uid: mondoo-aws-security-eks-cluster-restrict-public-access-api
+  - uid: mondoo-aws-security-eks-cluster-restrict-public-access-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: aws.eks.cluster.publicAccessCidrs.none(_ == "0.0.0.0/0")
   - uid: mondoo-aws-security-eks-cluster-restrict-public-access-terraform-hcl
@@ -11956,7 +12170,7 @@ queries:
     title: Ensure Amazon EKS clusters have deletion protection enabled
     impact: 50
     variants:
-      - uid: mondoo-aws-security-eks-cluster-deletion-protection-api
+      - uid: mondoo-aws-security-eks-cluster-deletion-protection-aws
         tags:
           mondoo.com/filter-title: "AWS EKS Cluster"
           mondoo.com/icon: "aws"
@@ -12056,7 +12270,7 @@ queries:
         title: AWS Documentation - Deleting an Amazon EKS cluster
       - url: https://docs.aws.amazon.com/eks/latest/best-practices/security.html
         title: Amazon EKS Security Best Practices
-  - uid: mondoo-aws-security-eks-cluster-deletion-protection-api
+  - uid: mondoo-aws-security-eks-cluster-deletion-protection-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: aws.eks.cluster.deletionProtection == true
   - uid: mondoo-aws-security-eks-cluster-deletion-protection-terraform-hcl
@@ -12081,7 +12295,7 @@ queries:
     title: Ensure CodeBuild projects do not run in privileged mode
     impact: 80
     variants:
-      - uid: mondoo-aws-security-codebuild-no-privileged-mode-api
+      - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12196,7 +12410,7 @@ queries:
         title: AWS Documentation - Build environment reference for CodeBuild
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/security.html
         title: AWS Documentation - Security in AWS CodeBuild
-  - uid: mondoo-aws-security-codebuild-no-privileged-mode-api
+  - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
     filters: asset.platform == "aws"
     mql: aws.codebuild.projects.all(environment["privilegedMode"] != true)
   - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl
@@ -12221,7 +12435,7 @@ queries:
     title: Ensure CodeBuild projects do not store plaintext credentials in environment variables
     impact: 90
     variants:
-      - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-api
+      - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12366,7 +12580,7 @@ queries:
         title: AWS Documentation - Change a build project's settings in CodeBuild
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
         title: AWS Documentation - What is AWS Secrets Manager
-  - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-api
+  - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
     filters: asset.platform == "aws"
     mql: |
       aws.codebuild.projects.all(
@@ -12430,7 +12644,7 @@ queries:
     title: Ensure Neptune DB clusters are encrypted at rest
     impact: 80
     variants:
-      - uid: mondoo-aws-security-neptune-cluster-encrypted-api
+      - uid: mondoo-aws-security-neptune-cluster-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12544,7 +12758,7 @@ queries:
         title: AWS Documentation - Encrypting Neptune resources
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/security.html
         title: AWS Documentation - Security in Amazon Neptune
-  - uid: mondoo-aws-security-neptune-cluster-encrypted-api
+  - uid: mondoo-aws-security-neptune-cluster-encrypted-aws
     filters: asset.platform == "aws"
     mql: aws.neptune.clusters.all(storageEncrypted == true)
   - uid: mondoo-aws-security-neptune-cluster-encrypted-terraform-hcl
@@ -12569,7 +12783,7 @@ queries:
     title: Ensure Amazon GuardDuty is enabled
     impact: 90
     variants:
-      - uid: mondoo-aws-security-guardduty-enabled-api
+      - uid: mondoo-aws-security-guardduty-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12653,7 +12867,7 @@ queries:
         title: AWS Documentation - What is Amazon GuardDuty?
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html
         title: AWS Documentation - GuardDuty controls
-  - uid: mondoo-aws-security-guardduty-enabled-api
+  - uid: mondoo-aws-security-guardduty-enabled-aws
     filters: asset.platform == "aws"
     mql: |
       aws.guardduty.detectors.length > 0
@@ -12680,7 +12894,7 @@ queries:
     title: Ensure GuardDuty findings are published at least every 15 minutes
     impact: 60
     variants:
-      - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-api
+      - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12753,7 +12967,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_exportfindings.html
         title: AWS Documentation - Exporting GuardDuty findings
-  - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-api
+  - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-aws
     filters: asset.platform == "aws"
     mql: |
       aws.guardduty.detectors.length > 0
@@ -12780,7 +12994,7 @@ queries:
     title: Ensure AWS Security Hub is enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-securityhub-enabled-api
+      - uid: mondoo-aws-security-securityhub-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12847,7 +13061,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html
         title: AWS Documentation - What is AWS Security Hub?
-  - uid: mondoo-aws-security-securityhub-enabled-api
+  - uid: mondoo-aws-security-securityhub-enabled-aws
     filters: asset.platform == "aws"
     mql: aws.securityhub.hubs.length > 0
   - uid: mondoo-aws-security-securityhub-enabled-terraform-hcl
@@ -12863,7 +13077,7 @@ queries:
     title: Ensure AWS Config recorder is enabled and recording
     impact: 80
     variants:
-      - uid: mondoo-aws-security-config-recorder-enabled-api
+      - uid: mondoo-aws-security-config-recorder-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -12939,7 +13153,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/config/latest/developerguide/gs-console.html
         title: AWS Documentation - Setting up AWS Config
-  - uid: mondoo-aws-security-config-recorder-enabled-api
+  - uid: mondoo-aws-security-config-recorder-enabled-aws
     filters: asset.platform == "aws"
     mql: |
       aws.config.recorders.length > 0
@@ -12966,7 +13180,7 @@ queries:
     title: Ensure AWS Config records all supported resource types
     impact: 70
     variants:
-      - uid: mondoo-aws-security-config-recorder-all-resources-api
+      - uid: mondoo-aws-security-config-recorder-all-resources-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13048,7 +13262,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html
         title: AWS Documentation - Selecting which resources AWS Config records
-  - uid: mondoo-aws-security-config-recorder-all-resources-api
+  - uid: mondoo-aws-security-config-recorder-all-resources-aws
     filters: asset.platform == "aws"
     mql: |
       aws.config.recorders.length > 0
@@ -13081,7 +13295,7 @@ queries:
     title: Ensure Secrets Manager secrets have automatic rotation enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-secretsmanager-rotation-enabled-api
+      - uid: mondoo-aws-security-secretsmanager-rotation-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Secretsmanager Secret"
           mondoo.com/icon: "aws"
@@ -13165,7 +13379,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html
         title: AWS Documentation - Rotate Secrets Manager secrets
-  - uid: mondoo-aws-security-secretsmanager-rotation-enabled-api
+  - uid: mondoo-aws-security-secretsmanager-rotation-enabled-aws
     filters: asset.platform == "aws-secretsmanager-secret"
     mql: aws.secretsmanager.secret.rotationEnabled == true
   - uid: mondoo-aws-security-secretsmanager-rotation-enabled-terraform-hcl
@@ -13181,7 +13395,7 @@ queries:
     title: Ensure Secrets Manager secrets are encrypted with a customer-managed KMS key
     impact: 70
     variants:
-      - uid: mondoo-aws-security-secretsmanager-cmk-encryption-api
+      - uid: mondoo-aws-security-secretsmanager-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: "AWS Secretsmanager Secret"
           mondoo.com/icon: "aws"
@@ -13258,7 +13472,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/security-encryption.html
         title: AWS Documentation - Secret encryption in Secrets Manager
-  - uid: mondoo-aws-security-secretsmanager-cmk-encryption-api
+  - uid: mondoo-aws-security-secretsmanager-cmk-encryption-aws
     filters: asset.platform == "aws-secretsmanager-secret"
     mql: aws.secretsmanager.secret.kmsKey != empty
   - uid: mondoo-aws-security-secretsmanager-cmk-encryption-terraform-hcl
@@ -13283,7 +13497,7 @@ queries:
     title: Ensure IAM Access Analyzer is enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-iam-access-analyzer-enabled-api
+      - uid: mondoo-aws-security-iam-access-analyzer-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13358,7 +13572,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html
         title: AWS Documentation - What is IAM Access Analyzer?
-  - uid: mondoo-aws-security-iam-access-analyzer-enabled-api
+  - uid: mondoo-aws-security-iam-access-analyzer-enabled-aws
     filters: asset.platform == "aws"
     mql: aws.iam.accessAnalyzer.analyzers.where(status == "ACTIVE").length > 0
   - uid: mondoo-aws-security-iam-access-analyzer-enabled-terraform-hcl
@@ -13374,7 +13588,7 @@ queries:
     title: Ensure SNS topics are encrypted with KMS
     impact: 70
     variants:
-      - uid: mondoo-aws-security-sns-topic-encrypted-api
+      - uid: mondoo-aws-security-sns-topic-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13451,7 +13665,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SNS
-  - uid: mondoo-aws-security-sns-topic-encrypted-api
+  - uid: mondoo-aws-security-sns-topic-encrypted-aws
     filters: asset.platform == "aws"
     mql: |
       aws.sns.topics.all(
@@ -13479,7 +13693,7 @@ queries:
     title: Ensure SNS topics use signature version 2 for message verification
     impact: 60
     variants:
-      - uid: mondoo-aws-security-sns-topic-signature-version-api
+      - uid: mondoo-aws-security-sns-topic-signature-version-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13554,7 +13768,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
         title: AWS Documentation - Verifying the signatures of Amazon SNS messages
-  - uid: mondoo-aws-security-sns-topic-signature-version-api
+  - uid: mondoo-aws-security-sns-topic-signature-version-aws
     filters: asset.platform == "aws"
     mql: aws.sns.topics.all(signatureVersion == "2")
   - uid: mondoo-aws-security-sns-topic-signature-version-terraform-hcl
@@ -13579,7 +13793,7 @@ queries:
     title: Ensure SQS queues are encrypted
     impact: 70
     variants:
-      - uid: mondoo-aws-security-sqs-queue-encrypted-api
+      - uid: mondoo-aws-security-sqs-queue-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13656,7 +13870,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SQS
-  - uid: mondoo-aws-security-sqs-queue-encrypted-api
+  - uid: mondoo-aws-security-sqs-queue-encrypted-aws
     filters: asset.platform == "aws"
     mql: aws.sqs.queues.all(sqsManagedSseEnabled == true || kmsKey != empty)
   - uid: mondoo-aws-security-sqs-queue-encrypted-terraform-hcl
@@ -13681,7 +13895,7 @@ queries:
     title: Ensure SQS queues have a dead letter queue configured
     impact: 60
     variants:
-      - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-api
+      - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13770,7 +13984,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
         title: AWS Documentation - Amazon SQS dead-letter queues
-  - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-api
+  - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-aws
     filters: asset.platform == "aws"
     mql: aws.sqs.queues.all(deadLetterQueue != empty)
   - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-hcl
@@ -13795,7 +14009,7 @@ queries:
     title: Ensure ElastiCache clusters have encryption at rest enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-elasticache-encryption-at-rest-api
+      - uid: mondoo-aws-security-elasticache-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13882,7 +14096,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
         title: AWS Documentation - ElastiCache at-rest encryption
-  - uid: mondoo-aws-security-elasticache-encryption-at-rest-api
+  - uid: mondoo-aws-security-elasticache-encryption-at-rest-aws
     filters: asset.platform == "aws"
     mql: aws.elasticache.cacheClusters.where(engine == "redis").all(atRestEncryptionEnabled == true)
   - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-hcl
@@ -13907,7 +14121,7 @@ queries:
     title: Ensure ElastiCache clusters have encryption in transit enabled
     impact: 80
     variants:
-      - uid: mondoo-aws-security-elasticache-encryption-in-transit-api
+      - uid: mondoo-aws-security-elasticache-encryption-in-transit-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -13990,7 +14204,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html
         title: AWS Documentation - ElastiCache in-transit encryption
-  - uid: mondoo-aws-security-elasticache-encryption-in-transit-api
+  - uid: mondoo-aws-security-elasticache-encryption-in-transit-aws
     filters: asset.platform == "aws"
     mql: aws.elasticache.cacheClusters.where(engine == "redis").all(transitEncryptionEnabled == true)
   - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-hcl
@@ -14015,7 +14229,7 @@ queries:
     title: Ensure ElastiCache Redis clusters require authentication
     impact: 70
     variants:
-      - uid: mondoo-aws-security-elasticache-redis-auth-enabled-api
+      - uid: mondoo-aws-security-elasticache-redis-auth-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -14101,7 +14315,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html
         title: AWS Documentation - Authenticating with the Redis AUTH command
-  - uid: mondoo-aws-security-elasticache-redis-auth-enabled-api
+  - uid: mondoo-aws-security-elasticache-redis-auth-enabled-aws
     filters: asset.platform == "aws"
     mql: aws.elasticache.cacheClusters.where(engine == "redis").all(authTokenEnabled == true)
   - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-hcl
@@ -14126,7 +14340,7 @@ queries:
     title: Ensure AWS Backup vaults are encrypted
     impact: 70
     variants:
-      - uid: mondoo-aws-security-backup-vault-encrypted-api
+      - uid: mondoo-aws-security-backup-vault-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -14199,7 +14413,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/aws-backup/latest/devguide/encryption.html
         title: AWS Documentation - Encryption for backups in AWS Backup
-  - uid: mondoo-aws-security-backup-vault-encrypted-api
+  - uid: mondoo-aws-security-backup-vault-encrypted-aws
     filters: asset.platform == "aws"
     mql: aws.backup.vaults.all(encryptionKeyArn != empty)
   - uid: mondoo-aws-security-backup-vault-encrypted-terraform-hcl
@@ -14224,7 +14438,7 @@ queries:
     title: Ensure FSx file systems are encrypted at rest
     impact: 70
     variants:
-      - uid: mondoo-aws-security-fsx-filesystem-encrypted-api
+      - uid: mondoo-aws-security-fsx-filesystem-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -14304,7 +14518,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/fsx/latest/LustreGuide/encryption-at-rest.html
         title: AWS Documentation - Encrypting data at rest for Amazon FSx
-  - uid: mondoo-aws-security-fsx-filesystem-encrypted-api
+  - uid: mondoo-aws-security-fsx-filesystem-encrypted-aws
     filters: asset.platform == "aws"
     mql: aws.fsx.fileSystems.all(encrypted == true)
   - uid: mondoo-aws-security-fsx-filesystem-encrypted-terraform-hcl
@@ -14329,7 +14543,7 @@ queries:
     title: Ensure Redshift clusters are encrypted at rest
     impact: 80
     variants:
-      - uid: mondoo-aws-security-redshift-cluster-encrypted-api
+      - uid: mondoo-aws-security-redshift-cluster-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS Redshift Cluster"
           mondoo.com/icon: "aws"
@@ -14409,7 +14623,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html
         title: AWS Documentation - Amazon Redshift database encryption
-  - uid: mondoo-aws-security-redshift-cluster-encrypted-api
+  - uid: mondoo-aws-security-redshift-cluster-encrypted-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: aws.redshift.cluster.encrypted == true
   - uid: mondoo-aws-security-redshift-cluster-encrypted-terraform-hcl
@@ -14434,7 +14648,7 @@ queries:
     title: Ensure Redshift clusters have audit logging enabled
     impact: 70
     variants:
-      - uid: mondoo-aws-security-redshift-cluster-audit-logging-api
+      - uid: mondoo-aws-security-redshift-cluster-audit-logging-aws
         tags:
           mondoo.com/filter-title: "AWS Redshift Cluster"
           mondoo.com/icon: "aws"
@@ -14519,7 +14733,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html
         title: AWS Documentation - Database audit logging for Amazon Redshift
-  - uid: mondoo-aws-security-redshift-cluster-audit-logging-api
+  - uid: mondoo-aws-security-redshift-cluster-audit-logging-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: aws.redshift.cluster.logging["LoggingEnabled"] == true
   - uid: mondoo-aws-security-redshift-cluster-audit-logging-terraform-hcl
@@ -14547,7 +14761,7 @@ queries:
     title: Ensure Redshift clusters use enhanced VPC routing
     impact: 70
     variants:
-      - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-api
+      - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-aws
         tags:
           mondoo.com/filter-title: "AWS Redshift Cluster"
           mondoo.com/icon: "aws"
@@ -14623,7 +14837,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html
         title: AWS Documentation - Amazon Redshift enhanced VPC routing
-  - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-api
+  - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: aws.redshift.cluster.enhancedVpcRouting == true
   - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-terraform-hcl
@@ -14648,7 +14862,7 @@ queries:
     title: Ensure CloudFront distributions use TLS 1.2 or higher
     impact: 80
     variants:
-      - uid: mondoo-aws-security-cloudfront-minimum-tls-version-api
+      - uid: mondoo-aws-security-cloudfront-minimum-tls-version-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -14728,7 +14942,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
         title: AWS Documentation - Supported protocols and ciphers between viewers and CloudFront
-  - uid: mondoo-aws-security-cloudfront-minimum-tls-version-api
+  - uid: mondoo-aws-security-cloudfront-minimum-tls-version-aws
     filters: asset.platform == "aws"
     mql: aws.cloudfront.distributions.all(minimumProtocolVersion == /TLSv1.2/)
   - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-hcl
@@ -14757,7 +14971,7 @@ queries:
     title: Ensure CloudFront distributions have WAF web ACL associated
     impact: 70
     variants:
-      - uid: mondoo-aws-security-cloudfront-waf-enabled-api
+      - uid: mondoo-aws-security-cloudfront-waf-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -14832,7 +15046,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-awswaf.html
         title: AWS Documentation - Using AWS WAF to control access to your content
-  - uid: mondoo-aws-security-cloudfront-waf-enabled-api
+  - uid: mondoo-aws-security-cloudfront-waf-enabled-aws
     filters: asset.platform == "aws"
     mql: aws.cloudfront.distributions.all(webAclId != empty)
   - uid: mondoo-aws-security-cloudfront-waf-enabled-terraform-hcl
@@ -14857,7 +15071,7 @@ queries:
     title: Ensure RDS snapshots are encrypted at rest
     impact: 70
     variants:
-      - uid: mondoo-aws-security-rds-snapshot-encrypted-single
+      - uid: mondoo-aws-security-rds-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: "AWS RDS Snapshot"
           mondoo.com/icon: "aws"
@@ -14955,7 +15169,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
         title: AWS Documentation - Encrypting Amazon RDS resources
-  - uid: mondoo-aws-security-rds-snapshot-encrypted-single
+  - uid: mondoo-aws-security-rds-snapshot-encrypted-aws
     filters: asset.platform == "aws-rds-snapshot"
     mql: |
       aws.rds.snapshot.encrypted == true
@@ -14981,7 +15195,7 @@ queries:
     title: Ensure AMIs owned by the account are not publicly shared
     impact: 90
     variants:
-      - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-api
+      - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -15084,7 +15298,7 @@ queries:
         title: AWS Documentation - Share an AMI with specific organizations or accounts
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-public-access-to-amis.html
         title: AWS Documentation - Block public access to your AMIs
-  - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-api
+  - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ec2.images.all(
@@ -15112,7 +15326,7 @@ queries:
     title: Ensure ECS task definitions specify a non-root user for containers
     impact: 80
     variants:
-      - uid: mondoo-aws-security-ecs-container-non-root-user-api
+      - uid: mondoo-aws-security-ecs-container-non-root-user-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -15216,7 +15430,7 @@ queries:
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
-  - uid: mondoo-aws-security-ecs-container-non-root-user-api
+  - uid: mondoo-aws-security-ecs-container-non-root-user-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ecs.taskDefinitions.all(
@@ -15250,7 +15464,7 @@ queries:
     title: Ensure ECS task definitions enforce transit encryption for EFS volumes
     impact: 70
     variants:
-      - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-api
+      - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
           mondoo.com/icon: "aws"
@@ -15370,7 +15584,7 @@ queries:
         title: AWS Documentation - Amazon EFS volumes
       - url: https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
         title: AWS Documentation - Encrypting data in transit
-  - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-api
+  - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-aws
     filters: asset.platform == "aws"
     mql: |
       aws.ecs.taskDefinitions.all(
@@ -15408,7 +15622,7 @@ queries:
     title: Ensure CloudWatch log groups have a retention period configured
     impact: 60
     variants:
-      - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-api
+      - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-aws
         tags:
           mondoo.com/filter-title: "AWS CloudWatch Log Group"
           mondoo.com/icon: "aws"
@@ -15496,7 +15710,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
         title: AWS Documentation - Working with log groups and log streams
-  - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-api
+  - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-aws
     filters: asset.platform == "aws-cloudwatch-loggroup"
     mql: |
       aws.cloudwatch.loggroup.retentionInDays > 0
@@ -15522,7 +15736,7 @@ queries:
     title: Ensure Redshift clusters require SSL for connections
     impact: 80
     variants:
-      - uid: mondoo-aws-security-redshift-cluster-require-ssl-api
+      - uid: mondoo-aws-security-redshift-cluster-require-ssl-aws
         tags:
           mondoo.com/filter-title: "AWS Redshift Cluster"
           mondoo.com/icon: "aws"
@@ -15643,7 +15857,7 @@ queries:
         title: AWS Documentation - Configure security options for connections
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html
         title: AWS Documentation - Amazon Redshift parameter groups
-  - uid: mondoo-aws-security-redshift-cluster-require-ssl-api
+  - uid: mondoo-aws-security-redshift-cluster-require-ssl-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: |
       aws.redshift.cluster.parameters.where(_['ParameterName'] == "require_ssl").all(


### PR DESCRIPTION
## Summary

- Rename all `-api` and `-single` variant suffixes to `-aws` for consistency across the policy file
- Add resource-specific platform variants for Elasticsearch (`aws-es-domain`) and API Gateway (`aws-gateway-restapi`) checks, replacing broad `asset.platform == "aws"` filters with
targeted filters that use singular MQL resource access
- Split the Elasticsearch encrypted-at-rest check to be Elasticsearch-specific (descriptions, CLI commands, Terraform resources, CloudFormation types) instead of referencing OpenSearch
- Add a new OpenSearch encrypted-at-rest check (`mondoo-aws-security-opensearch-encrypted-at-rest`) mirroring the Elasticsearch version for OpenSearch Service domains
- Add a new Elasticsearch node-to-node encryption check (`mondoo-aws-security-elasticsearch-node-to-node-encryption`) with AWS, Terraform HCL/plan/state variants
- Remove redundant account-level `asset.platform == "aws"` variants from checks that now have resource-specific platform variants

## Checks with new resource-specific variants

| Check | Platform filter |
|---|---|
| `elasticsearch-encrypted-at-rest` | `aws-es-domain` |
| `api-gw-cache-enabled-and-encrypted` | `aws-gateway-restapi` |
| `api-gw-execution-logging-enabled` | `aws-gateway-restapi` |
| `api-gw-tls` | `aws-gateway-restapi` |
| `api-gw-xray-enabled` | `aws-gateway-restapi` |

## New checks

| Check | Platform filter | MQL |
|---|---|---|
| `opensearch-encrypted-at-rest` | `aws-opensearch-domain` | `aws.opensearch.domain.encryptionAtRestEnabled == true` |
| `elasticsearch-node-to-node-encryption` | `aws-es-domain` | `aws.es.domain.nodeToNodeEncryptionEnabled == true` |
