### PR TITLE
⭐ Add 68 new security checks for AWS and Azure and use resource-specific Azure platforms

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -26,6 +26,7 @@ ashburn
 asl
 aslr
 atlassian
+authnotrequired
 autoconfiguration
 autoremove
 awslogs
@@ -79,6 +80,7 @@ ctl
 CUSTOMERID
 CYAAAAAAAKEY
 cyserver
+databricks
 datalakes
 dccp
 ddos
@@ -116,6 +118,7 @@ examplestorageaccount
 exim
 faillock
 faillog
+fargate
 FCr
 FEMI
 fileless
@@ -130,6 +133,7 @@ ftruncate
 fullchain
 fumadocs
 functionapp
+Gbps
 getenv
 getstealthmode
 globalstate
@@ -143,10 +147,12 @@ Hostbased
 hostpath
 hotlink
 hvm
+Iaa
 iap
 idps
 idpuser
 iis
+IKEv
 inplace
 insertafter
 ipfw
@@ -164,7 +170,10 @@ kickstart
 KKBUGHG
 kptr
 ksk
+kubeconfigs
+kubenet
 lastlog
+liveanalytics
 localtime
 logfile
 loggingservice
@@ -175,6 +184,7 @@ Lsass
 lsetxattr
 lsp
 lsws
+lts
 managedzone
 Mbeze
 mcp
@@ -195,6 +205,7 @@ networkdiscovery
 newkey
 nft
 nmap
+nodepool
 nonarm
 nopasswd
 norestart
@@ -205,6 +216,7 @@ ntalk
 NTE
 odata
 oidc
+omsagent
 onestop
 ONTAP
 opasswd
@@ -217,6 +229,7 @@ opensuse
 opscode
 Ossec
 otp
+Paa
 pagerduty
 paloaltonetworks
 panos
@@ -230,6 +243,8 @@ postgre
 prebuilt
 privs
 PROJECTID
+psc
+psql
 querypack
 RClient
 rdp
@@ -301,6 +316,7 @@ tacacs
 tailnets
 tailscale
 tallylog
+timestream
 tinyssh
 tipc
 tmpfiles

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -107,7 +107,7 @@
 \be-mail\b
 
 # s.b. APIs
-\bapis\b
+# \bapis\b # false positives on mql
 
 # s.b. Base64
 \bBase 64\b

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 6.0.0
+    version: 6.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -52,6 +52,12 @@ policies:
         - Simple Notification Service (SNS)
         - Simple Queue Service (SQS)
         - Simple Storage Service (S3)
+        - AWS Certificate Manager (ACM)
+        - AWS Database Migration Service (DMS)
+        - AWS Elastic Disaster Recovery (DRS)
+        - Amazon Inspector
+        - Amazon Timestream
+        - AWS Systems Manager (SSM)
         - Virtual Private Cloud (VPCs)
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
@@ -101,6 +107,9 @@ policies:
           - uid: mondoo-aws-security-vpc-default-security-group-closed
           - uid: mondoo-aws-security-vpc-flow-logs-enabled
           - uid: mondoo-aws-security-vpc-bpa-enabled
+          - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip
+          - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp
+          - uid: mondoo-aws-security-default-nacl-restrictive
       - title: Amazon DynamoDB Table
         checks:
           - uid: mondoo-aws-security-dynamodb-table-encrypted-kms
@@ -110,6 +119,7 @@ policies:
           - uid: mondoo-aws-security-rds-instance-encryption-at-rest
           - uid: mondoo-aws-security-rds-instance-no-pending-os-upgrades
           - uid: mondoo-aws-security-rds-snapshot-encrypted
+          - uid: mondoo-aws-security-rds-instance-iam-auth
       - title: Amazon RDS DB Cluster
         checks:
           - uid: mondoo-aws-security-rds-cluster-public-access-check
@@ -127,6 +137,7 @@ policies:
         checks:
           - uid: mondoo-aws-security-ec2-ebs-encryption-by-default
           - uid: mondoo-aws-security-ec2-imdsv2-check
+          - uid: mondoo-aws-security-ec2-imds-hop-limit
           - uid: mondoo-aws-security-ec2-instance-no-public-ip
           - uid: mondoo-aws-security-ec2-volume-inuse-check
           - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check
@@ -134,6 +145,7 @@ policies:
           - uid: mondoo-aws-security-ec2-encrypted-volumes
           - uid: mondoo-aws-security-ec2-user-data-no-secrets
           - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited
+          - uid: mondoo-aws-security-ec2-keypair-type
       - title: Amazon ECR
         checks:
           - uid: mondoo-aws-security-ecr-image-scan-on-push
@@ -145,6 +157,8 @@ policies:
           - uid: mondoo-aws-security-ecs-logging-enabled
           - uid: mondoo-aws-security-ecs-container-non-root-user
           - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption
+          - uid: mondoo-aws-security-ecs-cluster-container-insights
+          - uid: mondoo-aws-security-ecs-cluster-fargate-encryption
       - title: Amazon EFS Filesystem
         checks:
           - uid: mondoo-aws-security-efs-encrypted-check
@@ -177,6 +191,7 @@ policies:
       - title: AWS KMS Key
         checks:
           - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
+          - uid: mondoo-aws-security-kms-grants-no-create-grant
       - title: Amazon SageMaker Notebook Instance
         checks:
           - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured
@@ -198,10 +213,14 @@ policies:
           - uid: mondoo-aws-security-eks-cluster-logging-enabled
           - uid: mondoo-aws-security-eks-cluster-restrict-public-access
           - uid: mondoo-aws-security-eks-cluster-deletion-protection
+          - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes
+          - uid: mondoo-aws-security-eks-cluster-iam-auth-mode
+          - uid: mondoo-aws-security-eks-addon-healthy
       - title: Amazon GuardDuty
         checks:
           - uid: mondoo-aws-security-guardduty-enabled
           - uid: mondoo-aws-security-guardduty-findings-publishing-frequency
+          - uid: mondoo-aws-security-guardduty-all-features-enabled
       - title: AWS Security Hub
         checks:
           - uid: mondoo-aws-security-securityhub-enabled
@@ -229,6 +248,7 @@ policies:
           - uid: mondoo-aws-security-elasticache-encryption-at-rest
           - uid: mondoo-aws-security-elasticache-encryption-in-transit
           - uid: mondoo-aws-security-elasticache-redis-auth-enabled
+          - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption
       - title: AWS Backup
         checks:
           - uid: mondoo-aws-security-backup-vault-encrypted
@@ -239,9 +259,32 @@ policies:
         checks:
           - uid: mondoo-aws-security-codebuild-no-privileged-mode
           - uid: mondoo-aws-security-codebuild-no-plaintext-credentials
+          - uid: mondoo-aws-security-codebuild-source-ssl-verification
       - title: Amazon Neptune
         checks:
           - uid: mondoo-aws-security-neptune-cluster-encrypted
+          - uid: mondoo-aws-security-neptune-cluster-iam-authentication
+      - title: Amazon Inspector
+        checks:
+          - uid: mondoo-aws-security-inspector-ec2-scanning-enabled
+          - uid: mondoo-aws-security-inspector-ecr-scanning-enabled
+          - uid: mondoo-aws-security-inspector-lambda-scanning-enabled
+      - title: AWS Systems Manager (SSM)
+        checks:
+          - uid: mondoo-aws-security-ssm-parameter-encryption
+      - title: AWS Database Migration Service (DMS)
+        checks:
+          - uid: mondoo-aws-security-dms-replication-not-public
+          - uid: mondoo-aws-security-dms-replication-encrypted
+      - title: AWS Elastic Disaster Recovery (DRS)
+        checks:
+          - uid: mondoo-aws-security-drs-replication-ebs-encrypted
+      - title: Amazon Timestream
+        checks:
+          - uid: mondoo-aws-security-timestream-database-encrypted
+      - title: Amazon ACM
+        checks:
+          - uid: mondoo-aws-security-acm-certificate-key-algorithm
     scoring_system: highest impact
 queries:
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms
@@ -16796,4 +16839,1783 @@ queries:
     mql: |
       terraform.state.resources.where(type == "aws_redshift_parameter_group").all(
         values.parameter.where(name == "require_ssl").map(value).first == "true"
+      )
+  - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip
+    title: Ensure VPC subnets do not automatically assign public IP addresses
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    variants:
+      - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-aws
+        tags:
+          mondoo.com/filter-title: "AWS EC2 VPC"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that VPC subnets are not configured to automatically assign public IP addresses to instances launched within them. When a subnet has auto-assign public IP enabled, every instance launched in that subnet receives a public IP address by default, potentially exposing it to the internet.
+
+        **Why this matters**
+
+        - Instances launched in subnets with auto-assign public IP enabled are immediately reachable from the internet if security group rules permit, increasing the attack surface.
+        - Developers or automation tools may inadvertently launch instances in public subnets without realizing they will be publicly accessible.
+        - Private workloads such as databases, internal APIs, and backend services should never be assigned public IP addresses.
+        - Compliance frameworks including CIS AWS Foundations Benchmark, PCI DSS, and SOC 2 recommend minimizing public network exposure.
+
+        **Risk mitigation:**
+
+        - **Reduced attack surface:** Prevents accidental public exposure of instances that should remain private.
+        - **Defense in depth:** Works alongside security groups and NACLs to enforce network isolation.
+        - **Intentional access:** Forces teams to explicitly assign public IPs or use NAT gateways/load balancers for internet access.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the AWS VPC Console.
+            2. Select Subnets from the left panel.
+            3. Select the subnet to modify.
+            4. Select Actions > Edit subnet settings.
+            5. Uncheck Enable auto-assign public IPv4 address.
+            6. Select Save.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Disable auto-assign public IP for a subnet:
+
+            ```bash
+            aws ec2 modify-subnet-attribute \
+              --subnet-id <subnet-id> \
+              --no-map-public-ip-on-launch
+            ```
+
+            Verify the setting:
+
+            ```bash
+            aws ec2 describe-subnets --subnet-ids <subnet-id> \
+              --query "Subnets[*].{SubnetId:SubnetId,MapPublicIpOnLaunch:MapPublicIpOnLaunch}"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Ensure `map_public_ip_on_launch` is set to `false` (or omitted, as `false` is the default):
+
+            ```hcl
+            resource "aws_subnet" "private" {
+              vpc_id                  = aws_vpc.main.id
+              cidr_block              = "10.0.1.0/24"
+              map_public_ip_on_launch = false
+
+              tags = {
+                Name = "private-subnet"
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              PrivateSubnet:
+                Type: "AWS::EC2::Subnet"
+                Properties:
+                  VpcId: !Ref MainVPC
+                  CidrBlock: "10.0.1.0/24"
+                  MapPublicIpOnLaunch: false
+                  Tags:
+                    - Key: "Name"
+                      Value: "private-subnet"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html
+        title: AWS Documentation - Configure subnets
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
+        title: AWS Documentation - VPC security best practices
+  - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-aws
+    filters: asset.platform == "aws-vpc"
+    mql: aws.vpc.subnets.all(mapPublicIpOnLaunch == false)
+  - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_subnet")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_subnet").all(
+        arguments.map_public_ip_on_launch != true
+      )
+  - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_subnet")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_subnet").all(
+        change.after.map_public_ip_on_launch != true
+      )
+  - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_subnet")
+    mql: |
+      terraform.state.resources.where(type == "aws_subnet").all(
+        values.map_public_ip_on_launch != true
+      )
+  - uid: mondoo-aws-security-ec2-imds-hop-limit
+    title: Ensure EC2 instances have IMDS hop limit set to 1
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
+    variants:
+      - uid: mondoo-aws-security-ec2-imds-hop-limit-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that EC2 instances have the Instance Metadata Service (IMDS) HTTP PUT response hop limit set to 1. The hop limit controls how many network hops the metadata token can travel, and a value greater than 1 allows containers or reverse proxies running on the instance to reach the metadata service, increasing the risk of credential theft through SSRF attacks.
+
+        **Why this matters**
+
+        - When the hop limit is greater than 1, containers running on the instance can access the instance metadata service and retrieve IAM role credentials, even when IMDSv2 is enforced.
+        - SSRF vulnerabilities in applications can be exploited to retrieve metadata tokens if the hop limit allows the request to reach the metadata endpoint through additional network layers.
+        - AWS sets the default hop limit to 1 for standard instances, but some configurations (particularly container-optimized AMIs or ECS) may increase it to 2, which should be reviewed.
+        - CIS AWS Foundations Benchmark and AWS security best practices recommend setting the hop limit to 1 unless there is a specific operational need for a higher value.
+
+        **Risk mitigation:**
+
+        - **SSRF protection:** Limits the ability of containerized workloads to reach the instance metadata service through network hops.
+        - **Credential isolation:** Prevents containers from inheriting the EC2 instance IAM role credentials via the metadata service.
+        - **Defense in depth:** Complements IMDSv2 enforcement by reducing the attack surface even when token-based authentication is required.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the AWS EC2 Console.
+            2. Select Instances in the left panel.
+            3. Select the instance to modify.
+            4. Select Actions > Instance settings > Modify instance metadata options.
+            5. Set the Metadata response hop limit to 1.
+            6. Select Save.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Set the IMDS hop limit to 1:
+
+            ```bash
+            aws ec2 modify-instance-metadata-options \
+              --instance-id <instance-id> \
+              --http-put-response-hop-limit 1
+            ```
+
+            Verify the setting:
+
+            ```bash
+            aws ec2 describe-instances --instance-ids <instance-id> \
+              --query "Reservations[*].Instances[*].MetadataOptions.{HttpPutResponseHopLimit:HttpPutResponseHopLimit}"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Set `http_put_response_hop_limit` to 1 in the `metadata_options` block:
+
+            ```hcl
+            resource "aws_instance" "secure_instance" {
+              ami           = "ami-12345678"
+              instance_type = "t3.micro"
+
+              metadata_options {
+                http_tokens                 = "required"
+                http_put_response_hop_limit = 1
+                http_endpoint               = "enabled"
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              SecureInstance:
+                Type: "AWS::EC2::Instance"
+                Properties:
+                  ImageId: "ami-12345678"
+                  InstanceType: "t3.micro"
+                  MetadataOptions:
+                    HttpTokens: "required"
+                    HttpPutResponseHopLimit: 1
+                    HttpEndpoint: "enabled"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+        title: AWS Documentation - Configure the Instance Metadata Service
+      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+        title: AWS Documentation - Retrieve instance metadata
+  - uid: mondoo-aws-security-ec2-imds-hop-limit-aws
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.ec2.instances.where(
+        state != /terminated|shutting-down/
+          && httpEndpoint == "enabled"
+        ).all(
+          httpPutResponseHopLimit == 1
+        )
+  - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_instance")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_instance").all(
+        blocks.where(type == "metadata_options") != empty &&
+        blocks.where(type == "metadata_options").all(
+          arguments.http_put_response_hop_limit == 1
+        )
+      )
+  - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_instance").all(
+        change.after.metadata_options[0].http_put_response_hop_limit == 1
+      )
+  - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_instance").all(
+        values.metadata_options[0].http_put_response_hop_limit == 1
+      )
+  - uid: mondoo-aws-security-guardduty-all-features-enabled
+    title: Ensure GuardDuty protection features are enabled
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    variants:
+      - uid: mondoo-aws-security-guardduty-all-features-enabled-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that Amazon GuardDuty has all available protection features enabled, including S3 Protection, EKS Audit Log Monitoring, Malware Protection, RDS Login Activity Monitoring, and Lambda Network Activity Monitoring. Each feature provides threat detection coverage for a specific AWS service, and leaving any feature disabled creates blind spots in your security monitoring.
+
+        **Why this matters**
+
+        - GuardDuty's core functionality only monitors CloudTrail management events, VPC Flow Logs, and DNS logs. Additional protection features must be explicitly enabled to cover other AWS services.
+        - Without S3 Protection, GuardDuty cannot detect suspicious access patterns to S3 buckets such as data exfiltration or unauthorized access from unusual locations.
+        - Without EKS Audit Log Monitoring, Kubernetes-specific threats such as unauthorized pod deployments or privilege escalation within clusters go undetected.
+        - Without Malware Protection, GuardDuty cannot scan EBS volumes for malware when suspicious activity is detected on EC2 instances.
+        - Without RDS Login Activity Monitoring, anomalous login behavior to RDS databases is not monitored.
+        - Without Lambda Network Activity Monitoring, suspicious network connections from Lambda functions are not detected.
+
+        **Risk mitigation:**
+
+        - **Comprehensive threat coverage:** Ensures all AWS services are monitored for threats, eliminating blind spots.
+        - **Early detection:** Enables detection of service-specific attack patterns that core GuardDuty monitoring cannot identify.
+        - **Compliance:** Meets security monitoring requirements across all AWS services in use.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon GuardDuty Console.
+            2. Select Settings in the left panel.
+            3. Under Protection plans, review each feature:
+              - S3 Protection
+              - EKS Protection (EKS Audit Log Monitoring)
+              - Malware Protection
+              - RDS Protection
+              - Lambda Protection
+            4. Enable any features that are currently disabled.
+            5. Select Save.
+            6. Repeat in each AWS Region where GuardDuty is active.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Enable all GuardDuty protection features:
+
+            ```bash
+            aws guardduty update-detector \
+              --detector-id <detector-id> \
+              --features '[
+                {"Name": "S3_DATA_EVENTS", "Status": "ENABLED"},
+                {"Name": "EKS_AUDIT_LOGS", "Status": "ENABLED"},
+                {"Name": "EBS_MALWARE_PROTECTION", "Status": "ENABLED"},
+                {"Name": "RDS_LOGIN_EVENTS", "Status": "ENABLED"},
+                {"Name": "LAMBDA_NETWORK_LOGS", "Status": "ENABLED"},
+                {"Name": "RUNTIME_MONITORING", "Status": "ENABLED"}
+              ]'
+            ```
+
+            Verify the features:
+
+            ```bash
+            aws guardduty get-detector --detector-id <detector-id> \
+              --query "Features[*].{Name:Name,Status:Status}"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Enable all GuardDuty features using `aws_guardduty_detector_feature` resources:
+
+            ```hcl
+            resource "aws_guardduty_detector" "main" {
+              enable                       = true
+              finding_publishing_frequency = "FIFTEEN_MINUTES"
+            }
+
+            resource "aws_guardduty_detector_feature" "s3" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "S3_DATA_EVENTS"
+              status      = "ENABLED"
+            }
+
+            resource "aws_guardduty_detector_feature" "eks" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "EKS_AUDIT_LOGS"
+              status      = "ENABLED"
+            }
+
+            resource "aws_guardduty_detector_feature" "malware" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "EBS_MALWARE_PROTECTION"
+              status      = "ENABLED"
+            }
+
+            resource "aws_guardduty_detector_feature" "rds" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "RDS_LOGIN_EVENTS"
+              status      = "ENABLED"
+            }
+
+            resource "aws_guardduty_detector_feature" "lambda" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "LAMBDA_NETWORK_LOGS"
+              status      = "ENABLED"
+            }
+
+            resource "aws_guardduty_detector_feature" "runtime" {
+              detector_id = aws_guardduty_detector.main.id
+              name        = "RUNTIME_MONITORING"
+              status      = "ENABLED"
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              GuardDutyDetector:
+                Type: AWS::GuardDuty::Detector
+                Properties:
+                  Enable: true
+                  FindingPublishingFrequency: FIFTEEN_MINUTES
+                  Features:
+                    - Name: S3_DATA_EVENTS
+                      Status: ENABLED
+                    - Name: EKS_AUDIT_LOGS
+                      Status: ENABLED
+                    - Name: EBS_MALWARE_PROTECTION
+                      Status: ENABLED
+                    - Name: RDS_LOGIN_EVENTS
+                      Status: ENABLED
+                    - Name: LAMBDA_NETWORK_LOGS
+                      Status: ENABLED
+                    - Name: RUNTIME_MONITORING
+                      Status: ENABLED
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-features-activation-model.html
+        title: AWS Documentation - GuardDuty feature activation
+      - url: https://docs.aws.amazon.com/guardduty/latest/ug/what-is-guardduty.html
+        title: AWS Documentation - What is Amazon GuardDuty?
+  - uid: mondoo-aws-security-guardduty-all-features-enabled-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.guardduty.detectors.all(
+        features.where(
+          _['Name'] == /S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING/
+        ).length == 6
+      )
+      aws.guardduty.detectors.all(
+        features.where(
+          _['Name'] == /S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING/
+        ).all(_['Status'] == "ENABLED")
+      )
+  - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_guardduty_detector_feature")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_guardduty_detector_feature").length >= 6
+      terraform.resources.where(nameLabel == "aws_guardduty_detector_feature").all(
+        arguments.status == "ENABLED"
+      )
+  - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_guardduty_detector_feature")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_guardduty_detector_feature").length >= 6
+      terraform.plan.resourceChanges.where(type == "aws_guardduty_detector_feature").all(
+        change.after.status == "ENABLED"
+      )
+  - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_guardduty_detector_feature")
+    mql: |
+      terraform.state.resources.where(type == "aws_guardduty_detector_feature").length >= 6
+      terraform.state.resources.where(type == "aws_guardduty_detector_feature").all(
+        values.status == "ENABLED"
+      )
+  - uid: mondoo-aws-security-neptune-cluster-iam-authentication
+    title: Ensure Neptune DB clusters have IAM database authentication enabled
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+    variants:
+      - uid: mondoo-aws-security-neptune-cluster-iam-authentication-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that Amazon Neptune DB clusters have IAM database authentication enabled. IAM authentication allows managing database access using AWS IAM policies instead of relying solely on database-level passwords.
+
+        **Why this matters**
+
+        - Password-based authentication requires managing and rotating credentials separately from AWS IAM, increasing operational complexity and the risk of credential leakage.
+        - IAM authentication integrates with AWS CloudTrail for audit logging of database access.
+        - IAM policies provide fine-grained, centralized access control consistent with other AWS services.
+        - Without IAM authentication, database credentials may be hardcoded in application configurations or stored insecurely.
+
+        **Risk mitigation:**
+
+        - **Centralized access control:** Manages database access through IAM policies alongside other AWS resource permissions.
+        - **Auditability:** All authentication attempts are logged in CloudTrail.
+        - **No static credentials:** Eliminates the need to store or rotate database passwords.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon Neptune Console.
+            2. Select Databases in the left panel.
+            3. Select the Neptune DB cluster.
+            4. Select Modify.
+            5. Enable IAM DB authentication.
+            6. Select Continue and apply the changes.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Enable IAM authentication on an existing cluster:
+
+            ```bash
+            aws neptune modify-db-cluster \
+              --db-cluster-identifier <cluster-id> \
+              --enable-iam-database-authentication
+            ```
+
+            Verify the setting:
+
+            ```bash
+            aws neptune describe-db-clusters --db-cluster-identifier <cluster-id> \
+              --query "DBClusters[*].{ClusterId:DBClusterIdentifier,IAMAuth:IAMDatabaseAuthenticationEnabled}"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "aws_neptune_cluster" "example" {
+              cluster_identifier                  = "neptune-cluster"
+              engine                              = "neptune"
+              iam_database_authentication_enabled = true
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              NeptuneCluster:
+                Type: "AWS::Neptune::DBCluster"
+                Properties:
+                  DBClusterIdentifier: "neptune-cluster"
+                  IamAuthEnabled: true
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth.html
+        title: AWS Documentation - IAM database authentication in Neptune
+      - url: https://docs.aws.amazon.com/neptune/latest/userguide/security.html
+        title: AWS Documentation - Security in Amazon Neptune
+  - uid: mondoo-aws-security-neptune-cluster-iam-authentication-aws
+    filters: asset.platform == "aws"
+    mql: aws.neptune.clusters.all(iamDatabaseAuthenticationEnabled == true)
+  - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_neptune_cluster").all(
+        arguments.iam_database_authentication_enabled == true
+      )
+  - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_neptune_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_neptune_cluster").all(
+        change.after.iam_database_authentication_enabled == true
+      )
+  - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_neptune_cluster")
+    mql: |
+      terraform.state.resources.where(type == "aws_neptune_cluster").all(
+        values.iam_database_authentication_enabled == true
+      )
+  - uid: mondoo-aws-security-kms-grants-no-create-grant
+    title: Ensure KMS key grants do not include the CreateGrant permission
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+    variants:
+      - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
+        tags:
+          mondoo.com/filter-title: "AWS KMS Key"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS KMS key grants do not include the `CreateGrant` operation. When a grant includes `CreateGrant`, the grantee can create additional grants on the same key, effectively delegating their own permissions to other principals without requiring changes to the key policy.
+
+        **Why this matters**
+
+        - The `CreateGrant` operation enables privilege escalation: a grantee with `CreateGrant` can create new grants that give other AWS principals (users, roles, or services) access to the KMS key.
+        - This delegation chain can be difficult to audit and track, creating hidden access paths to encrypted data.
+        - An attacker who compromises a principal with a `CreateGrant` grant can silently expand their access by granting `Decrypt` permissions to additional principals under their control.
+        - Grants with `CreateGrant` effectively bypass the centralized access control provided by the key policy, undermining the principle of least privilege.
+
+        **Risk mitigation:**
+
+        - **Prevent privilege escalation:** Removes the ability for grantees to delegate KMS key access to other principals.
+        - **Auditable access:** Ensures all access to KMS keys is controlled through key policies and explicitly created grants.
+        - **Least privilege:** Limits grant permissions to only the operations needed (Encrypt, Decrypt, GenerateDataKey, etc.) without delegation capability.
+
+        **Important caveats:**
+
+        - Some AWS services (such as AWS EBS, RDS, and S3) create grants with `CreateGrant` as part of their normal operation when using customer-managed CMKs. Review flagged grants to determine if they are service-linked before removing them.
+        - Removing `CreateGrant` from service-linked grants may break encryption workflows for those services.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the AWS KMS Console.
+            2. Select Customer managed keys.
+            3. Select a key and go to the Key policy tab.
+            4. Review the Grants section for any grants that include `CreateGrant`.
+            5. For each flagged grant, determine if it is service-linked or user-created.
+            6. For user-created grants, retire or revoke the grant and recreate it without the `CreateGrant` operation.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            List all grants for a KMS key and check for `CreateGrant`:
+
+            ```bash
+            aws kms list-grants --key-id <key-id> \
+              --query "Grants[?contains(Operations, 'CreateGrant')].{GrantId:GrantId,Grantee:GranteePrincipal,Operations:Operations}"
+            ```
+
+            Revoke a grant that includes `CreateGrant`:
+
+            ```bash
+            aws kms revoke-grant --key-id <key-id> --grant-id <grant-id>
+            ```
+
+            Create a replacement grant without `CreateGrant`:
+
+            ```bash
+            aws kms create-grant \
+              --key-id <key-id> \
+              --grantee-principal <principal-arn> \
+              --operations "Decrypt" "Encrypt" "GenerateDataKey"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
+        title: AWS Documentation - Grants in AWS KMS
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html
+        title: AWS Documentation - Managing grants
+  - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
+    filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
+    mql: aws.kms.key.grants.none(operations.contains("CreateGrant"))
+  - uid: mondoo-aws-security-codebuild-source-ssl-verification
+    title: Ensure CodeBuild projects have SSL verification enabled for source fetches
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    variants:
+      - uid: mondoo-aws-security-codebuild-source-ssl-verification-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that AWS CodeBuild projects have SSL verification enabled when fetching source code. When `insecureSsl` is set to `true`, CodeBuild skips TLS certificate verification when connecting to the source repository, making the build vulnerable to man-in-the-middle (MITM) attacks.
+
+        **Why this matters**
+
+        - Disabling SSL verification allows an attacker to intercept and modify source code during transit between the repository and CodeBuild, injecting malicious code into builds.
+        - Supply chain attacks that compromise the build pipeline can affect all downstream artifacts, containers, and deployments.
+        - An attacker performing a MITM attack could inject backdoors, credential-stealing code, or other malware that gets built into production artifacts.
+        - SSL verification is enabled by default; disabling it is typically done as a workaround for self-signed certificates rather than a deliberate security decision.
+
+        **Risk mitigation:**
+
+        - **Supply chain protection:** Ensures source code integrity by verifying the repository's TLS certificate during fetches.
+        - **MITM prevention:** Prevents attackers from injecting malicious code during source retrieval.
+        - **Build integrity:** Guarantees that the code being built matches what is stored in the source repository.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the AWS CodeBuild Console.
+            2. Select the build project to modify.
+            3. Select Edit > Source.
+            4. Ensure Insecure SSL is not checked.
+            5. If using a self-signed certificate, upload the certificate to an S3 bucket and configure CodeBuild to use it via the `certificate` setting instead of disabling SSL verification.
+            6. Select Update source to apply the changes.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Check the current setting:
+
+            ```bash
+            aws codebuild batch-get-projects --names <project-name> \
+              --query "projects[*].{Name:name,InsecureSsl:source.insecureSsl}"
+            ```
+
+            Update the project to enable SSL verification:
+
+            ```bash
+            aws codebuild update-project \
+              --name <project-name> \
+              --source "type=CODECOMMIT,location=<repo-url>,insecureSsl=false"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Ensure `insecure_ssl` is set to `false` (or omitted, as `false` is the default):
+
+            ```hcl
+            resource "aws_codebuild_project" "example" {
+              name = "example-project"
+
+              source {
+                type         = "CODECOMMIT"
+                location     = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example"
+                insecure_ssl = false
+              }
+
+              # For self-signed certificates, use certificate instead:
+              # source {
+              #   type         = "GITHUB_ENTERPRISE"
+              #   location     = "https://github.example.com/repo"
+              #   insecure_ssl = false
+              # }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              CodeBuildProject:
+                Type: AWS::CodeBuild::Project
+                Properties:
+                  Name: example-project
+                  Source:
+                    Type: CODECOMMIT
+                    Location: "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example"
+                    InsecureSsl: false
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
+        title: AWS Documentation - Build specification reference
+      - url: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-source-version.html
+        title: AWS Documentation - Source version sample
+  - uid: mondoo-aws-security-codebuild-source-ssl-verification-aws
+    filters: asset.platform == "aws"
+    mql: aws.codebuild.projects.all(source["insecureSsl"] != true)
+  - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_codebuild_project").all(
+        blocks.where(type == "source").all(
+          arguments.insecure_ssl != true
+        )
+      )
+  - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_codebuild_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_codebuild_project").all(
+        change.after.source[0].insecure_ssl != true
+      )
+  - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_codebuild_project")
+    mql: |
+      terraform.state.resources.where(type == "aws_codebuild_project").all(
+        values.source[0].insecure_ssl != true
+      )
+  - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption
+    title: Ensure ElastiCache serverless caches use CMK encryption
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+      - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: "Terraform HCL"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: "Terraform Plan"
+          mondoo.com/icon: "terraform"
+      - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: "Terraform State"
+          mondoo.com/icon: "terraform"
+    docs:
+      desc: |
+        This check ensures that Amazon ElastiCache serverless caches are encrypted using a customer-managed AWS KMS key (CMK). While ElastiCache serverless caches are encrypted by default with AWS-managed keys, using a CMK provides additional control over key management, access policies, and rotation schedules.
+
+        **Why this matters**
+
+        - AWS-managed encryption keys do not allow customers to control key policies, audit key usage, or enforce custom rotation schedules.
+        - Customer-managed KMS keys enable fine-grained access control, allowing organizations to restrict which principals can encrypt and decrypt cache data.
+        - CMKs integrate with AWS CloudTrail for key usage auditing, providing visibility into who accessed encrypted data and when.
+        - Compliance frameworks including PCI DSS, HIPAA, and SOC 2 often require customer-controlled encryption keys for sensitive data stores.
+
+        **Risk mitigation:**
+
+        - **Key control:** Organizations maintain full control over the encryption key lifecycle, including creation, rotation, and deletion.
+        - **Access auditing:** All key usage is logged in CloudTrail, enabling security monitoring and compliance reporting.
+        - **Compliance:** Meets regulatory requirements for customer-managed encryption of data at rest.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon ElastiCache Console.
+            2. Select Serverless caches from the left panel.
+            3. When creating a new serverless cache, under Encryption, select Customer managed CMK.
+            4. Select or create a KMS key.
+            5. Complete the cache creation.
+
+            Note: Encryption settings cannot be changed after creation. To switch to CMK encryption, create a new serverless cache with the desired KMS key and migrate data.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Create a serverless cache with CMK encryption:
+
+            ```bash
+            aws elasticache create-serverless-cache \
+              --serverless-cache-name my-cache \
+              --engine redis \
+              --kms-key-id arn:aws:kms:region:account-id:key/key-id
+            ```
+
+            Check existing serverless caches:
+
+            ```bash
+            aws elasticache describe-serverless-caches \
+              --query "ServerlessCaches[*].{Name:ServerlessCacheName,KmsKeyId:KmsKeyId}"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "aws_kms_key" "elasticache" {
+              description         = "KMS key for ElastiCache serverless"
+              enable_key_rotation = true
+            }
+
+            resource "aws_elasticache_serverless_cache" "example" {
+              engine = "redis"
+              name   = "example-cache"
+
+              kms_key_id = aws_kms_key.elasticache.arn
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            **Using CloudFormation**
+
+            ```yaml
+            Resources:
+              ElastiCacheKMSKey:
+                Type: "AWS::KMS::Key"
+                Properties:
+                  Description: "KMS key for ElastiCache serverless"
+                  EnableKeyRotation: true
+
+              ServerlessCache:
+                Type: "AWS::ElastiCache::ServerlessCache"
+                Properties:
+                  ServerlessCacheName: "example-cache"
+                  Engine: redis
+                  KmsKeyId: !Ref ElastiCacheKMSKey
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/serverless-overview.html
+        title: AWS Documentation - ElastiCache Serverless
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
+        title: AWS Documentation - ElastiCache encryption at rest
+  - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-aws
+    filters: asset.platform == "aws"
+    mql: aws.elasticache.serverlessCaches.all(kmsKeyId != empty)
+  - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticache_serverless_cache")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_elasticache_serverless_cache").all(
+        arguments.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elasticache_serverless_cache")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_elasticache_serverless_cache").all(
+        change.after.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_elasticache_serverless_cache")
+    mql: |
+      terraform.state.resources.where(type == "aws_elasticache_serverless_cache").all(
+        values.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-inspector-ec2-scanning-enabled
+    title: Ensure Amazon Inspector is enabled for EC2 instance scanning
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    variants:
+      - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon Inspector is enabled and actively scanning EC2 instances for vulnerabilities. Inspector automatically discovers and scans EC2 instances for software vulnerabilities and unintended network exposure.
+
+        **Why this matters**
+
+        - **Vulnerability detection**: Inspector continuously monitors EC2 instances for known software vulnerabilities (CVEs) and provides prioritized findings.
+        - **Automated discovery**: Automatically detects new EC2 instances and begins scanning without manual configuration.
+        - **Risk prioritization**: Uses context-aware risk scoring to help teams focus on the most critical vulnerabilities first.
+        - **Compliance alignment**: Meets requirements for continuous vulnerability assessment mandated by frameworks such as PCI DSS and NIST.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon Inspector console.
+            2. Choose **Get Started** or go to **Account management**.
+            3. Enable scanning for **Amazon EC2** instances.
+            4. Inspector will automatically begin discovering and scanning EC2 instances.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws inspector2 enable --resource-types EC2
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html
+        title: Getting started with Amazon Inspector
+  - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.inspector.coverages.where(resourceType == "AWS_EC2_INSTANCE" && statusCode == "ACTIVE").length > 0
+  - uid: mondoo-aws-security-inspector-ecr-scanning-enabled
+    title: Ensure Amazon Inspector is enabled for ECR container image scanning
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    variants:
+      - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon Inspector is enabled and actively scanning ECR container images for vulnerabilities. Inspector automatically scans container images pushed to ECR for software vulnerabilities.
+
+        **Why this matters**
+
+        - **Container security**: Automatically scans container images for known vulnerabilities before they are deployed to production.
+        - **Shift-left security**: Identifies vulnerabilities in container images early in the development lifecycle.
+        - **Continuous monitoring**: Re-scans images when new CVEs are published, ensuring ongoing protection.
+        - **Supply chain security**: Helps detect vulnerabilities in base images and third-party dependencies.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon Inspector console.
+            2. Choose **Account management**.
+            3. Enable scanning for **Amazon ECR** container images.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws inspector2 enable --resource-types ECR
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html
+        title: Scanning Amazon ECR container images with Amazon Inspector
+  - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.inspector.coverages.where(resourceType == "AWS_ECR_CONTAINER_IMAGE" && statusCode == "ACTIVE").length > 0
+  - uid: mondoo-aws-security-inspector-lambda-scanning-enabled
+    title: Ensure Amazon Inspector is enabled for Lambda function scanning
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    variants:
+      - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon Inspector is enabled and actively scanning Lambda functions for vulnerabilities. Inspector scans Lambda functions and their associated layers for software vulnerabilities in application package dependencies.
+
+        **Why this matters**
+
+        - **Serverless security**: Detects vulnerabilities in Lambda function code dependencies and layers.
+        - **Automated scanning**: Automatically scans functions when they are deployed or updated.
+        - **Code scanning**: Identifies vulnerabilities in application package dependencies used by Lambda functions.
+        - **Continuous protection**: Re-scans when new CVEs are published to catch newly discovered vulnerabilities.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the Amazon Inspector console.
+            2. Choose **Account management**.
+            3. Enable scanning for **AWS Lambda** functions.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws inspector2 enable --resource-types LAMBDA LAMBDA_CODE
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html
+        title: Scanning AWS Lambda functions with Amazon Inspector
+  - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.inspector.coverages.where(resourceType == "AWS_LAMBDA_FUNCTION" && statusCode == "ACTIVE").length > 0
+  - uid: mondoo-aws-security-ssm-parameter-encryption
+    title: Ensure SSM SecureString parameters use KMS encryption
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-ssm-parameter-encryption-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS Systems Manager Parameter Store parameters of type SecureString have an explicit KMS key configured for encryption. While SSM SecureString parameters are always encrypted, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
+
+        **Why this matters**
+
+        - **Explicit configuration**: Specifying a KMS key ensures encryption settings are intentional rather than relying on implicit defaults.
+        - **Audit trail**: All KMS key usage is logged in CloudTrail, providing visibility into who accessed encrypted parameters.
+        - **Compliance alignment**: Many regulatory frameworks require explicit encryption key configuration for sensitive data.
+        - **Key rotation**: Explicitly configured keys support automatic rotation, improving security posture.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to **AWS Systems Manager** > **Parameter Store**.
+            2. Select a SecureString parameter.
+            3. Create a new version of the parameter with a customer-managed KMS key.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ssm put-parameter --name <parameter-name> --value <value> --type SecureString --key-id <kms-key-id> --overwrite
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-securestring.html
+        title: AWS SSM SecureString parameters
+  - uid: mondoo-aws-security-ssm-parameter-encryption-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ssm.parameters.where(type == "SecureString").all(kmsKey != empty)
+  - uid: mondoo-aws-security-dms-replication-not-public
+    title: Ensure DMS replication instances are not publicly accessible
+    impact: 90
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    variants:
+      - uid: mondoo-aws-security-dms-replication-not-public-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS Database Migration Service (DMS) replication instances are not publicly accessible. Public replication instances expose database migration traffic to the internet, increasing the risk of data interception.
+
+        **Why this matters**
+
+        - **Data exposure**: DMS replication instances handle sensitive database traffic that should not traverse the public internet.
+        - **Attack surface**: Publicly accessible instances can be targeted by attackers attempting to intercept or manipulate migration data.
+        - **Network security**: Keeping replication instances private ensures all traffic stays within trusted VPC boundaries.
+        - **Compliance alignment**: Data protection regulations often require that database traffic remains within private networks.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **AWS DMS** console.
+            2. Select **Replication instances**.
+            3. Select the instance and choose **Modify**.
+            4. Uncheck **Publicly accessible**.
+            5. Apply the changes.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws dms modify-replication-instance --replication-instance-arn <arn> --no-publicly-accessible
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.html
+        title: AWS DMS Replication Instances
+  - uid: mondoo-aws-security-dms-replication-not-public-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.dms.replicationInstances.all(_["PubliclyAccessible"] == false)
+  - uid: mondoo-aws-security-dms-replication-encrypted
+    title: Ensure DMS replication instances use encryption
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-dms-replication-encrypted-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS Database Migration Service (DMS) replication instances have storage encryption enabled using KMS. Encrypting replication instance storage protects data at rest during the migration process.
+
+        **Why this matters**
+
+        - **Data protection**: Encrypts the storage used by replication instances to protect sensitive data at rest.
+        - **Compliance alignment**: Regulatory requirements often mandate encryption of data at rest for database workloads.
+        - **Risk mitigation**: Prevents unauthorized access to migration data stored on replication instance volumes.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **AWS DMS** console.
+            2. Create a new replication instance with **KMS key** specified under encryption settings.
+
+            Note: Encryption cannot be enabled on existing replication instances. You must create a new encrypted instance and migrate tasks to it.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws dms create-replication-instance --replication-instance-identifier <id> --replication-instance-class <class> --kms-key-id <kms-key-arn>
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.html
+        title: AWS DMS Security
+  - uid: mondoo-aws-security-dms-replication-encrypted-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.dms.replicationInstances.all(_["KmsKeyId"] != "" && _["KmsKeyId"] != empty)
+  - uid: mondoo-aws-security-drs-replication-ebs-encrypted
+    title: Ensure DRS replication configurations use EBS encryption
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-drs-replication-ebs-encrypted-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS Elastic Disaster Recovery (DRS) source server replication configurations have EBS encryption enabled. Encrypting replicated EBS volumes protects disaster recovery data at rest.
+
+        **Why this matters**
+
+        - **Data protection**: Ensures replicated volumes in the staging area are encrypted, preventing unauthorized access to DR data.
+        - **Compliance alignment**: Regulatory requirements mandate encryption of data at rest, including disaster recovery copies.
+        - **Consistent encryption**: Maintains encryption parity between source and replicated volumes.
+        - **Risk mitigation**: Protects against data exposure if staging area resources are compromised.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **AWS Elastic Disaster Recovery** console.
+            2. Select **Source servers**.
+            3. Choose the source server and go to **Replication Settings**.
+            4. Set **EBS encryption** to **Default** or **Custom** with a specific KMS key.
+            5. Save the changes.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws drs update-replication-configuration --source-server-id <id> --ebs-encryption DEFAULT
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/drs/latest/userguide/replication-settings.html
+        title: AWS DRS Replication Settings
+  - uid: mondoo-aws-security-drs-replication-ebs-encrypted-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.drs.sourceServers.all(
+        replicationConfiguration.ebsEncryption != "NONE" && replicationConfiguration.ebsEncryption != ""
+      )
+  - uid: mondoo-aws-security-timestream-database-encrypted
+    title: Ensure Amazon Timestream databases use KMS encryption
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-timestream-database-encrypted-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon Timestream for LiveAnalytics databases have an explicit KMS key configured for encryption. While Timestream encrypts data by default, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
+
+        **Why this matters**
+
+        - **Explicit configuration**: Specifying a KMS key ensures encryption settings are intentional rather than relying on implicit defaults.
+        - **Audit trail**: KMS key usage is logged in CloudTrail, providing visibility into data access patterns.
+        - **Compliance alignment**: Explicit encryption key configuration may be required by regulatory frameworks for time-series data.
+        - **Key lifecycle management**: Organizations can rotate, disable, or revoke keys as needed.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **Amazon Timestream** console.
+            2. When creating a database, select a **Customer managed key** under encryption settings.
+
+            Note: The KMS key must be specified at database creation time and cannot be changed afterward.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws timestream-write create-database --database-name <name> --kms-key-id <kms-key-arn>
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/timestream/latest/developerguide/EncryptionAtRest.html
+        title: Amazon Timestream encryption at rest
+  - uid: mondoo-aws-security-timestream-database-encrypted-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.timestream.liveanalytics.databases.all(kmsKeyId != empty)
+  - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp
+    title: Ensure network ACLs do not allow unrestricted inbound SSH or RDP access
+    impact: 90
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    variants:
+      - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that VPC network ACLs do not contain inbound rules that allow unrestricted access (0.0.0.0/0 or ::/0) to SSH (port 22) or RDP (port 3389). Unrestricted network ACL rules expose management ports to the entire internet.
+
+        **Why this matters**
+
+        - **Attack surface reduction**: Restricting SSH and RDP access at the network ACL level provides defense-in-depth beyond security groups.
+        - **Brute force prevention**: Open management ports are prime targets for automated brute force attacks.
+        - **Compliance alignment**: CIS AWS Foundations Benchmark and other frameworks require restricting management port access.
+        - **Defense in depth**: Network ACLs provide a stateless firewall layer that complements security group rules.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **VPC** console and select **Network ACLs**.
+            2. Review inbound rules for entries allowing ports 22 or 3389 from 0.0.0.0/0.
+            3. Modify the rules to restrict the source CIDR to known, trusted IP ranges.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ec2 replace-network-acl-entry --network-acl-id <acl-id> --rule-number <number> --protocol tcp --port-range From=22,To=22 --cidr-block <trusted-cidr> --rule-action allow --ingress
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
+        title: Network ACLs - Amazon VPC
+  - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.networkAcls.all(
+        entries.none(egress == false && ruleAction == "allow" && portRange.from <= 22 && portRange.to >= 22 && cidrBlock == "0.0.0.0/0")
+      )
+      aws.ec2.networkAcls.all(
+        entries.none(egress == false && ruleAction == "allow" && portRange.from <= 22 && portRange.to >= 22 && ipv6CidrBlock == "::/0")
+      )
+      aws.ec2.networkAcls.all(
+        entries.none(egress == false && ruleAction == "allow" && portRange.from <= 3389 && portRange.to >= 3389 && cidrBlock == "0.0.0.0/0")
+      )
+      aws.ec2.networkAcls.all(
+        entries.none(egress == false && ruleAction == "allow" && portRange.from <= 3389 && portRange.to >= 3389 && ipv6CidrBlock == "::/0")
+      )
+  - uid: mondoo-aws-security-default-nacl-restrictive
+    title: Ensure the default network ACL restricts all traffic
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    variants:
+      - uid: mondoo-aws-security-default-nacl-restrictive-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that the default network ACL in each VPC is configured to deny all inbound and outbound traffic. The default NACL is automatically associated with subnets that are not explicitly associated with a custom NACL, so a permissive default NACL can inadvertently expose resources.
+
+        **Why this matters**
+
+        - **Principle of least privilege**: Default deny ensures that only explicitly allowed traffic can flow through the network.
+        - **Misconfiguration prevention**: New subnets without a custom NACL automatically inherit the default NACL rules.
+        - **Defense in depth**: A restrictive default NACL provides a safety net against misconfigured security groups.
+        - **Compliance alignment**: CIS AWS Foundations Benchmark recommends restricting the default NACL.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to **VPC** > **Network ACLs**.
+            2. Identify the default NACL (marked as "Yes" in the Default column).
+            3. Modify inbound and outbound rules to deny all traffic.
+            4. Ensure all subnets use custom NACLs with appropriate rules.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            Replace permissive rules with deny-all rules:
+
+            ```bash
+            aws ec2 replace-network-acl-entry --network-acl-id <default-acl-id> --rule-number 100 --protocol -1 --rule-action deny --cidr-block 0.0.0.0/0 --ingress
+            aws ec2 replace-network-acl-entry --network-acl-id <default-acl-id> --rule-number 100 --protocol -1 --rule-action deny --cidr-block 0.0.0.0/0 --egress
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
+        title: Network ACLs - Amazon VPC
+  - uid: mondoo-aws-security-default-nacl-restrictive-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.networkAcls.where(isDefault == true).all(
+        entries.where(ruleAction == "allow").length == 0
+      )
+  - uid: mondoo-aws-security-ec2-keypair-type
+    title: Ensure EC2 key pairs use ED25519 or RSA key types
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+    variants:
+      - uid: mondoo-aws-security-ec2-keypair-type-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that EC2 key pairs use modern key types (ED25519 or RSA). Legacy or unsupported key types may use weaker cryptographic algorithms that are more susceptible to attacks.
+
+        **Why this matters**
+
+        - **Cryptographic strength**: ED25519 and RSA keys provide strong cryptographic security for SSH authentication.
+        - **Modern standards**: ED25519 offers better performance and security properties than older key types.
+        - **Compliance alignment**: Security frameworks recommend the use of strong cryptographic algorithms for authentication.
+        - **SSH security**: Using modern key types reduces the risk of key compromise through cryptographic attacks.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to **EC2** > **Key Pairs**.
+            2. Create a new key pair using **ED25519** or **RSA** type.
+            3. Update instances to use the new key pair.
+            4. Delete the old key pair.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ec2 create-key-pair --key-name my-key --key-type ed25519
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
+        title: Amazon EC2 key pairs
+  - uid: mondoo-aws-security-ec2-keypair-type-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.keypairs.all(type == "ed25519" || type == "rsa")
+  - uid: mondoo-aws-security-rds-instance-iam-auth
+    title: Ensure RDS database instances have IAM authentication enabled
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+    variants:
+      - uid: mondoo-aws-security-rds-instance-iam-auth-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon RDS database instances have IAM database authentication enabled. IAM authentication allows managing database access through AWS IAM policies instead of relying solely on database-level passwords.
+
+        **Why this matters**
+
+        - **Centralized access control**: IAM authentication integrates database access with AWS identity management, eliminating the need for separate database credentials.
+        - **Temporary credentials**: IAM database authentication uses short-lived authentication tokens rather than long-lived passwords.
+        - **Audit trail**: Authentication attempts are logged in CloudTrail, providing visibility into database access patterns.
+        - **Compliance alignment**: Eliminates shared database passwords and aligns with least-privilege access principles.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **RDS** console.
+            2. Select the database instance.
+            3. Choose **Modify**.
+            4. Under **Database authentication**, select **Password and IAM database authentication**.
+            5. Apply the changes.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws rds modify-db-instance --db-instance-identifier <instance-id> --enable-iam-database-authentication --apply-immediately
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
+        title: IAM database authentication for Amazon RDS
+  - uid: mondoo-aws-security-rds-instance-iam-auth-aws
+    filters: asset.platform == "aws-rds-dbinstance"
+    mql: aws.rds.dbinstance.iamDatabaseAuthentication == true
+  - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes
+    title: Ensure EBS encryption by default is enabled for EKS node group volumes
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that EKS managed node groups have EBS volume encryption enabled by verifying that EBS encryption by default is active in all regions where EKS node groups are deployed. Node group EBS volumes inherit the account-level EBS encryption setting.
+
+        **Why this matters**
+
+        - **Data protection**: EKS worker node EBS volumes contain container images, ephemeral storage, and potentially sensitive application data.
+        - **Consistent encryption**: Account-level EBS encryption ensures all new volumes, including those created by auto-scaling, are encrypted.
+        - **Compliance alignment**: Meets requirements for encryption of data at rest on compute resources.
+        - **Defense in depth**: Encrypting node volumes protects data even if physical storage media is compromised.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to **EC2** > **EBS Encryption** (under Account attributes).
+            2. Enable **Always encrypt new EBS volumes** in all regions where EKS clusters are deployed.
+            3. Optionally set a default KMS key for EBS encryption.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ec2 enable-ebs-encryption-by-default --region <region>
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html
+        title: Amazon EKS managed node groups
+  - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.ebsEncryptionByDefault.all(value == true)
+  - uid: mondoo-aws-security-eks-cluster-iam-auth-mode
+    title: Ensure EKS clusters use API-based IAM authentication mode
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+    variants:
+      - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon EKS clusters are configured to use API-based IAM authentication mode (API or API_AND_CONFIG_MAP) rather than relying solely on the legacy aws-auth ConfigMap. API-based authentication provides a more robust and auditable authentication mechanism.
+
+        **Why this matters**
+
+        - **Improved security**: API-based authentication mode uses the EKS API for managing cluster access, providing better auditability through CloudTrail.
+        - **Centralized management**: Access entries can be managed through the EKS API, Terraform, or CloudFormation rather than editing a ConfigMap.
+        - **Reduced risk**: The aws-auth ConfigMap can be accidentally deleted or misconfigured, potentially locking out cluster administrators.
+        - **Compliance alignment**: API-based authentication provides better audit trails for access management.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **EKS** console.
+            2. Select the cluster and go to the **Access** tab.
+            3. Update the authentication mode to **EKS API and ConfigMap** or **EKS API**.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws eks update-cluster-config --name <cluster-name> --access-config authenticationMode=API_AND_CONFIG_MAP
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html
+        title: Grant IAM users and roles access to Kubernetes APIs
+  - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-aws
+    filters: asset.platform == "aws-eks-cluster"
+    mql: |
+      aws.eks.cluster.authenticationMode == "API" || aws.eks.cluster.authenticationMode == "API_AND_CONFIG_MAP"
+  - uid: mondoo-aws-security-eks-addon-healthy
+    title: Ensure EKS cluster add-ons are in a healthy state
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+    variants:
+      - uid: mondoo-aws-security-eks-addon-healthy-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that all EKS cluster add-ons are in an ACTIVE status. Degraded or failed add-ons can indicate security vulnerabilities, missing patches, or operational issues that affect cluster security.
+
+        **Why this matters**
+
+        - **Security patching**: Add-ons like CoreDNS, kube-proxy, and VPC CNI include important security patches. Unhealthy add-ons may be running outdated versions.
+        - **Cluster reliability**: Failed or degraded add-ons can impact cluster networking, DNS resolution, and pod scheduling.
+        - **Operational visibility**: Monitoring add-on health ensures that critical cluster components are functioning correctly.
+        - **Compliance alignment**: Maintaining healthy infrastructure components is a requirement of most security frameworks.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **EKS** console.
+            2. Select the cluster and go to the **Add-ons** tab.
+            3. Review the status of each add-on.
+            4. Update or reconfigure any add-ons that are not in **Active** status.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            List and update add-ons:
+
+            ```bash
+            aws eks list-addons --cluster-name <cluster-name>
+            aws eks update-addon --cluster-name <cluster-name> --addon-name <addon-name> --addon-version <latest-version>
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
+        title: Amazon EKS add-ons
+  - uid: mondoo-aws-security-eks-addon-healthy-aws
+    filters: asset.platform == "aws-eks-cluster"
+    mql: |
+      aws.eks.cluster.addons.all(status == "ACTIVE")
+  - uid: mondoo-aws-security-ecs-cluster-container-insights
+    title: Ensure ECS clusters have Container Insights enabled
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    variants:
+      - uid: mondoo-aws-security-ecs-cluster-container-insights-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon ECS clusters have Container Insights enabled. Container Insights collects, aggregates, and summarizes metrics and logs from containerized applications and microservices.
+
+        **Why this matters**
+
+        - **Security monitoring**: Container Insights provides visibility into container-level metrics that can help detect anomalous behavior.
+        - **Operational visibility**: Collects CPU, memory, disk, and network metrics at the task and service level.
+        - **Incident response**: Detailed metrics and logs facilitate faster identification and resolution of security incidents.
+        - **Compliance alignment**: Logging and monitoring of container workloads is required by many security frameworks.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **ECS** console.
+            2. Select the cluster and choose **Update cluster**.
+            3. Under **Monitoring**, enable **Container Insights**.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ecs update-cluster-settings --cluster <cluster-name> --settings name=containerInsights,value=enabled
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html
+        title: Amazon ECS Container Insights
+  - uid: mondoo-aws-security-ecs-cluster-container-insights-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ecs.clusters.all(
+        configuration["containerInsights"] == "enabled"
+      )
+  - uid: mondoo-aws-security-ecs-cluster-fargate-encryption
+    title: Ensure ECS clusters use KMS encryption for Fargate ephemeral storage
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    variants:
+      - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that Amazon ECS clusters have a KMS key configured for encrypting Fargate ephemeral storage. Fargate tasks use ephemeral storage for scratch space, and encrypting this storage with a customer-managed KMS key provides additional data protection.
+
+        **Why this matters**
+
+        - **Data protection**: Ephemeral storage may contain sensitive data processed by containers during task execution.
+        - **Enhanced control**: Customer-managed KMS keys allow organizations to manage the encryption key lifecycle.
+        - **Compliance alignment**: Encryption of all storage volumes, including ephemeral storage, is required by many regulatory frameworks.
+        - **Audit trail**: KMS key usage is logged in CloudTrail for auditing purposes.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to the **ECS** console.
+            2. Select the cluster and choose **Update cluster**.
+            3. Under **Encryption**, configure a **KMS key** for Fargate ephemeral storage encryption.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws ecs put-cluster-capacity-providers --cluster <cluster-name> --managed-storage-configuration fargateEphemeralStorageKmsKeyId=<kms-key-arn>
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-storage.html
+        title: Fargate task storage
+  - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ecs.clusters.all(fargateEphemeralStorageKmsKey != empty)
+  - uid: mondoo-aws-security-acm-certificate-key-algorithm
+    title: Ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    variants:
+      - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
+        tags:
+          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/icon: "aws"
+    docs:
+      desc: |
+        This check ensures that AWS Certificate Manager (ACM) certificates use strong key algorithms. Certificates should use RSA-2048 or higher, or ECDSA key algorithms to provide adequate cryptographic strength.
+
+        **Why this matters**
+
+        - **Cryptographic strength**: RSA keys below 2048 bits are considered weak and may be vulnerable to cryptographic attacks.
+        - **Modern standards**: ECDSA keys (P-256, P-384, P-521) offer equivalent security to much larger RSA keys with better performance.
+        - **Compliance alignment**: PCI DSS, NIST, and other frameworks require minimum key sizes for TLS certificates.
+        - **Future-proofing**: Stronger key algorithms provide better protection against advances in computing power.
+      remediation:
+        - id: console
+          desc: |
+            **Using AWS Console**
+
+            1. Navigate to **AWS Certificate Manager**.
+            2. Request a new certificate with **RSA 2048** or higher, or an **ECDSA P256/P384** key algorithm.
+            3. Replace any certificates using weaker key algorithms.
+        - id: cli
+          desc: |
+            **Using AWS CLI**
+
+            ```bash
+            aws acm request-certificate --domain-name example.com --key-algorithm RSA_2048
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html
+        title: AWS Certificate Manager certificates
+  - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.acm.certificates.all(
+        keyAlgorithm == "RSA_2048" || keyAlgorithm == "RSA_3072" || keyAlgorithm == "RSA_4096" ||
+        keyAlgorithm == "EC_prime256v1" || keyAlgorithm == "EC_secp384r1" || keyAlgorithm == "EC_secp521r1"
       )

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 4.0.0
+    version: 5.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -22,9 +22,11 @@ policies:
         This policy provides security checks across key Azure services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 
         - App Service
+        - Application Gateway
         - Azure Batch
         - Azure Cache for Redis
         - Azure Cosmos DB
+        - Azure Databricks
         - Azure Firewall
         - Azure Kubernetes Service (AKS)
         - Compute (virtual machines and disks)
@@ -34,6 +36,7 @@ policies:
         - SQL Database, PostgreSQL, and MySQL
         - Storage (accounts and data protection)
         - Subscription (diagnostic settings and activity log alerts)
+        - VPN Gateway
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
@@ -49,6 +52,8 @@ policies:
           - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled
           - uid: mondoo-azure-security-storage-sftp-disabled
           - uid: mondoo-azure-security-storage-shared-key-access-disabled
+          - uid: mondoo-azure-security-storage-smb-versions
+          - uid: mondoo-azure-security-storage-smb-channel-encryption
       - title: Azure SQL
         checks:
           - uid: mondoo-azure-security-sql-server-audit-on
@@ -60,6 +65,14 @@ policies:
           - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days
           - uid: mondoo-azure-security-sql-threat-detection-enabled
           - uid: mondoo-azure-security-sql-ad-admin-configured
+          - uid: mondoo-azure-security-sql-server-min-tls-12
+          - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled
+          - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption
+          - uid: mondoo-azure-security-postgresql-server-min-tls-version
+          - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled
+          - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption
+          - uid: mondoo-azure-security-mysql-server-min-tls-version
+          - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled
       - title: Azure Key Vault
         checks:
           - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv
@@ -68,6 +81,7 @@ policies:
           - uid: mondoo-azure-security-keyvault-public-access-disabled
           - uid: mondoo-azure-security-keyvault-rbac-enabled
           - uid: mondoo-azure-security-keyvault-key-auto-rotation
+          - uid: mondoo-azure-security-keyvault-private-endpoints
       - title: Azure Compute
         checks:
           - uid: mondoo-azure-security-ensure-os-disk-are-encrypted
@@ -75,6 +89,7 @@ policies:
           - uid: mondoo-azure-security-compute-vm-no-public-ip
           - uid: mondoo-azure-security-compute-managed-disks-only
           - uid: mondoo-azure-security-compute-unattached-disks-encrypted
+          - uid: mondoo-azure-security-compute-disk-public-access-disabled
       - title: Azure Network
         checks:
           - uid: mondoo-azure-security-ssh-access-restricted-from-internet
@@ -84,8 +99,10 @@ policies:
           - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group
           - uid: mondoo-azure-security-network-watcher-flow-logs-enabled
           - uid: mondoo-azure-security-network-ddos-protection-enabled
+          - uid: mondoo-azure-security-network-vnet-vm-protection-enabled
           - uid: mondoo-azure-security-network-subnet-default-outbound-disabled
           - uid: mondoo-azure-security-network-database-ports-restricted
+          - uid: mondoo-azure-security-vpn-gateway-generation2
       - title: Azure Subscription
         checks:
           - uid: mondoo-azure-security-diagnostic-settings-essential-categories
@@ -104,6 +121,9 @@ policies:
           - uid: mondoo-azure-security-defender-for-cosmosdb-enabled
           - uid: mondoo-azure-security-defender-for-open-source-databases-enabled
           - uid: mondoo-azure-security-defender-cspm-enabled
+          - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled
+          - uid: mondoo-azure-security-defender-for-endpoint-enabled
+          - uid: mondoo-azure-security-defender-for-apis-enabled
       - title: Azure Kubernetes Service (AKS)
         checks:
           - uid: mondoo-azure-security-aks-rbac-enabled
@@ -113,6 +133,18 @@ policies:
           - uid: mondoo-azure-security-aks-run-command-disabled
           - uid: mondoo-azure-security-aks-azure-policy-addon-enabled
           - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled
+          - uid: mondoo-azure-security-aks-defender-enabled
+          - uid: mondoo-azure-security-aks-image-cleaner-enabled
+          - uid: mondoo-azure-security-aks-workload-identity-enabled
+          - uid: mondoo-azure-security-aks-encryption-at-host-enabled
+          - uid: mondoo-azure-security-aks-no-kubenet
+          - uid: mondoo-azure-security-aks-container-insights-enabled
+          - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled
+          - uid: mondoo-azure-security-aks-disk-encryption-set
+          - uid: mondoo-azure-security-aks-auto-upgrade-enabled
+          - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled
+          - uid: mondoo-azure-security-aks-local-accounts-disabled
+          - uid: mondoo-azure-security-aks-public-network-access-disabled
       - title: App Service
         checks:
           - uid: mondoo-azure-security-app-service-https-only
@@ -127,12 +159,15 @@ policies:
           - uid: mondoo-azure-security-app-service-cors-no-wildcard
           - uid: mondoo-azure-security-function-app-authentication-enabled
           - uid: mondoo-azure-security-function-app-private-endpoints
+          - uid: mondoo-azure-security-app-service-e2e-encryption-enabled
+          - uid: mondoo-azure-security-app-service-min-tls-cipher-suite
       - title: Azure Cache for Redis
         checks:
           - uid: mondoo-azure-security-redis-ssl-only
           - uid: mondoo-azure-security-redis-public-access-disabled
           - uid: mondoo-azure-security-redis-min-tls-version
           - uid: mondoo-azure-security-redis-latest-version
+          - uid: mondoo-azure-security-redis-auth-required
       - title: Azure Cosmos DB
         checks:
           - uid: mondoo-azure-security-cosmosdb-public-access-disabled
@@ -143,6 +178,12 @@ policies:
           - uid: mondoo-azure-security-cosmosdb-min-tls-version
           - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none
           - uid: mondoo-azure-security-cosmosdb-cmk-encryption
+          - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured
+          - uid: mondoo-azure-security-cosmosdb-private-endpoints
+          - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard
+          - uid: mondoo-azure-security-cosmosdb-continuous-backup
+          - uid: mondoo-azure-security-cosmosdb-multi-region-write
+          - uid: mondoo-azure-security-cosmosdb-strong-consistency
       - title: Azure Firewall
         checks:
           - uid: mondoo-azure-security-firewall-threat-intel-deny
@@ -155,6 +196,17 @@ policies:
           - uid: mondoo-azure-security-batch-aad-auth-only
           - uid: mondoo-azure-security-batch-encryption-configured
           - uid: mondoo-azure-security-batch-diagnostic-settings-enabled
+          - uid: mondoo-azure-security-batch-private-endpoints-configured
+          - uid: mondoo-azure-security-batch-pool-disk-encryption
+      - title: Application Gateway
+        checks:
+          - uid: mondoo-azure-security-appgw-ssl-policy-tls12
+      - title: VPN Gateway
+        checks:
+          - uid: mondoo-azure-security-vpn-gateway-ikev2
+      - title: Azure Databricks
+        checks:
+          - uid: mondoo-azure-security-databricks-public-access-disabled
     scoring_system: highest impact
 queries:
   - uid: mondoo-azure-security-ensure-os-disk-are-encrypted
@@ -680,7 +732,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties.EnableHTTPSTrafficOnly == true
+      azure.subscription.storage.account.enableHttpsTrafficOnly == true
     docs:
       desc: |
         This check ensures that "Secure transfer required" is enabled. This setting enforces the use of HTTPS for data operations, ensuring that data transmitted to and from Azure storage accounts is secured.
@@ -762,7 +814,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties.AllowBlobPublicAccess == "false"
+      azure.subscription.storage.account.allowBlobPublicAccess == false
     docs:
       desc: |
         This check ensures that anonymous access to blob containers is disabled and public access on storage accounts is disabled.
@@ -876,7 +928,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties.NetworkRuleSet.defaultAction == "Deny"
+      azure.subscription.storage.account.networkRuleDefaultAction == "Deny"
     docs:
       desc: |
         This check ensures that Azure storage accounts have their default network access rule set to "Deny". This configuration is critical for enhancing security by ensuring that only explicitly allowed networks can access the storage accounts.
@@ -986,8 +1038,8 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties.NetworkRuleSet.bypass.contains("AzureServices")
-      azure.subscription.storage.account.properties.NetworkRuleSet.defaultAction == "Deny"
+      azure.subscription.storage.account.networkRuleBypass.contains("AzureServices")
+      azure.subscription.storage.account.networkRuleDefaultAction == "Deny"
     docs:
       desc: |
         This check ensures that "Trusted Microsoft Services" is enabled for storage account access.
@@ -1325,10 +1377,10 @@ queries:
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(identity.type != empty)
-      azure.subscription.web.apps.all(identity.principalId != empty)
+      azure.subscription.webService.appsite.identity.type != empty
+      azure.subscription.webService.appsite.identity.principalId != empty
     docs:
       desc: |
         This check ensures that Managed Identities are enabled for Azure App Services to securely authenticate with Microsoft Entra ID.
@@ -1422,7 +1474,7 @@ queries:
     filters: |
       asset.platform == "azure-keyvault-vault"
     mql: |
-      azure.subscription.keyVault.vault.properties.enablePurgeProtection == true
+      azure.subscription.keyVault.vault.enablePurgeProtection == true
     docs:
       desc: |
         This check ensures that Azure Key Vaults are configured with purge protection to prevent accidental or malicious deletion of key vaults and their contents.
@@ -1510,9 +1562,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(configuration.properties.minTlsVersion == "1.2")
+      azure.subscription.webService.appsite.configuration.minTlsVersion == "1.2"
     docs:
       desc: |
         This check ensures that Azure App Services use the latest available version of TLS encryption for secure Web App connections.
@@ -2406,7 +2458,7 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.properties.publicNetworkAccess == "Disabled"
+      azure.subscription.sql.server.publicNetworkAccess == "Disabled"
         || azure.subscription.sql.server.virtualNetworkRules != empty || azure.subscription.sql.server.firewallRules != empty
     docs:
       desc: |
@@ -2514,9 +2566,9 @@ queries:
     filters: |
       asset.platform == "azure-keyvault-vault"
     mql: |
-      azure.subscription.keyVault.vault.properties.all(publicNetworkAccess == "Disabled")
-        || azure.subscription.keyVault.vault.properties.networkAcls.ipRules != empty
-        || azure.subscription.keyVault.vault.properties.networkAcls.virtualNetworkRules != empty
+      azure.subscription.keyVault.vault.publicNetworkAccess == "Disabled"
+        || azure.subscription.keyVault.vault.networkAcls.ipRules != empty
+        || azure.subscription.keyVault.vault.networkAcls.virtualNetworkSubnetIds != empty
     docs:
       desc: |
         This check ensures that public network access to Azure Key Vault is either disabled or restricted to selected networks, significantly reducing exposure to potential attacks.
@@ -3409,7 +3461,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties["minimumTlsVersion"] == "TLS1_2"
+      azure.subscription.storage.account.minimumTlsVersion == "TLS1_2"
     docs:
       desc: |
         This check ensures that Azure Storage accounts enforce a minimum TLS version of 1.2 for all connections, preventing the use of older, vulnerable TLS versions.
@@ -3781,6 +3833,94 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/keys/how-to-configure-key-rotation
         title: Configure key auto-rotation in Azure Key Vault
+  - uid: mondoo-azure-security-keyvault-private-endpoints
+    title: Ensure Azure Key Vault has private endpoint connections configured
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-keyvault-vault"
+    mql: |
+      azure.subscription.keyVault.vault.privateEndpointConnections.length > 0
+    docs:
+      desc: |
+        This check ensures that Azure Key Vault instances have at least one private endpoint connection configured, enabling secure access through private network connectivity.
+
+        **Why this matters**
+
+        Configuring private endpoints for Key Vault provides several critical benefits:
+
+        - **Network isolation**: Private endpoints allow access to Key Vault over a private IP address within your virtual network, eliminating exposure to the public internet.
+        - **Data exfiltration prevention**: Private Link ensures that traffic between the virtual network and Key Vault traverses the Microsoft backbone network, preventing data leakage.
+        - **Defense in depth**: Even with firewall rules and network ACLs, private endpoints provide an additional layer of network security for accessing secrets, keys, and certificates.
+        - **Compliance alignment**: Many regulatory frameworks require private network connectivity for sensitive credential stores to meet data protection requirements.
+
+        By configuring private endpoint connections, organizations ensure that Key Vault access occurs entirely over private network paths, significantly reducing the attack surface.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Key Vaults** in the Azure Portal.
+        2. Select the Key Vault.
+        3. Go to **Networking** under **Settings**.
+        4. Select the **Private endpoint connections** tab.
+        5. Verify that at least one private endpoint connection exists and is in the **Approved** state.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az keyvault private-endpoint-connection list --vault-name <VaultName> -o table
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Key Vaults** in the Azure Portal.
+            2. Select the Key Vault.
+            3. Go to **Networking** under **Settings**.
+            4. Select the **Private endpoint connections** tab.
+            5. Select **+ Create** to add a new private endpoint.
+            6. Configure the private endpoint with the appropriate virtual network, subnet, and DNS settings.
+            7. Select **Review + create**, then **Create**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az network private-endpoint create \
+              --name <PrivateEndpointName> \
+              --resource-group <ResourceGroupName> \
+              --vnet-name <VNetName> \
+              --subnet <SubnetName> \
+              --private-connection-resource-id $(az keyvault show --name <VaultName> --query id -o tsv) \
+              --group-id vault \
+              --connection-name <ConnectionName>
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_private_endpoint" "keyvault" {
+              name                = "example-keyvault-pe"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              subnet_id           = azurerm_subnet.example.id
+
+              private_service_connection {
+                name                           = "example-keyvault-psc"
+                private_connection_resource_id = azurerm_key_vault.example.id
+                subresource_names              = ["vault"]
+                is_manual_connection           = false
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/key-vault/general/private-link-service
+        title: Integrate Key Vault with Azure Private Link
   - uid: mondoo-azure-security-compute-data-disks-encrypted
     title: Ensure data disks use Customer Managed Key encryption for Azure virtual machines
     impact: 80
@@ -4515,9 +4655,9 @@ queries:
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aks.clusters.all(rbacEnabled == true)
+      azure.subscription.aksService.cluster.rbacEnabled == true
     docs:
       desc: |
         This check ensures that Role-Based Access Control (RBAC) is enabled on all Azure Kubernetes Service (AKS) clusters to enforce proper access control for Kubernetes resources.
@@ -4605,12 +4745,10 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-1
     filters: |
-      asset.platform == "azure"
-      azure.subscription.aks.clusters.any(apiServerAccessProfile["enablePrivateCluster"] != true)
+      asset.platform == "azure-aks-cluster"
+      azure.subscription.aksService.cluster.enablePrivateCluster != true
     mql: |
-      azure.subscription.aks.clusters
-        .where(apiServerAccessProfile["enablePrivateCluster"] != true)
-        .all(apiServerAccessProfile["authorizedIPRanges"] != empty)
+      azure.subscription.aksService.cluster.apiServerAuthorizedIPRanges != empty
     docs:
       desc: |
         This check ensures that non-private AKS clusters have API server authorized IP ranges configured to restrict access to the Kubernetes API server from known, trusted networks. Private clusters are excluded from this check as they use private endpoints for API server access, which provides stronger network isolation.
@@ -4697,9 +4835,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aks.clusters.all(networkProfile["networkPolicy"] != empty)
+      azure.subscription.aksService.cluster.networkProfile["networkPolicy"] != empty
     docs:
       desc: |
         This check ensures that AKS clusters have a network policy configured (such as Azure Network Policy or Calico) to control traffic flow between pods.
@@ -4790,9 +4928,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(properties["httpsOnly"] == true)
+      azure.subscription.webService.appsite.httpsOnly == true
     docs:
       desc: |
         This check ensures that Azure App Service web applications are configured to enforce HTTPS-only access, automatically redirecting HTTP requests to HTTPS.
@@ -4867,9 +5005,9 @@ queries:
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(ftp.allow == false)
+      azure.subscription.webService.appsite.ftp.allow == false
     docs:
       desc: |
         This check ensures that basic authentication for FTP publishing is disabled on Azure App Service web apps, preventing the use of username/password credentials for file deployment.
@@ -4947,9 +5085,9 @@ queries:
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(scm.allow == false)
+      azure.subscription.webService.appsite.scm.allow == false
     docs:
       desc: |
         This check ensures that basic authentication for SCM (Kudu) site publishing is disabled on Azure App Service web apps, preventing the use of username/password credentials for deployment via the SCM endpoint.
@@ -5038,9 +5176,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cache-redis-instance"
     mql: |
-      azure.subscription.cache.redis.all(enableNonSslPort == false)
+      azure.subscription.cacheService.redisInstance.enableNonSslPort == false
     docs:
       desc: |
         This check ensures that the non-SSL port (6379) is disabled on Azure Cache for Redis instances, requiring all connections to use TLS-encrypted communication.
@@ -5116,9 +5254,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cache-redis-instance"
     mql: |
-      azure.subscription.cache.redis.all(publicNetworkAccess == "Disabled")
+      azure.subscription.cacheService.redisInstance.publicNetworkAccess == "Disabled"
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Cache for Redis instances, requiring connections to go through private endpoints.
@@ -5194,9 +5332,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aks.clusters.all(apiServerAccessProfile["enablePrivateCluster"] == true)
+      azure.subscription.aksService.cluster.enablePrivateCluster == true
     docs:
       desc: |
         This check ensures that Azure Kubernetes Service (AKS) clusters are configured as private clusters, making the API server accessible only through private endpoints within the virtual network.
@@ -5296,9 +5434,9 @@ queries:
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-de-cm-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aks.clusters.all(securityProfile["runCommandDisabled"] == true)
+      azure.subscription.aksService.cluster.disableRunCommand == true
     docs:
       desc: |
         This check ensures that the run command feature is disabled on Azure Kubernetes Service (AKS) clusters, preventing remote command execution through the Azure API.
@@ -5394,9 +5532,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aks.clusters.all(addonProfiles.any(_["azurepolicy"]["enabled"] == true))
+      azure.subscription.aksService.cluster.addonProfiles.any(_["azurepolicy"]["enabled"] == true)
     docs:
       desc: |
         This check ensures that the Azure Policy add-on is enabled on Azure Kubernetes Service (AKS) clusters, allowing organizations to enforce governance and compliance policies at the cluster level.
@@ -5495,9 +5633,10 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-aks-cluster"
+      azure.subscription.aksService.cluster.enablePrivateCluster == true
     mql: |
-      azure.subscription.aks.clusters.where(apiServerAccessProfile["enablePrivateCluster"] == true).all(apiServerAccessProfile["enablePrivateClusterPublicFQDN"] == false)
+      azure.subscription.aksService.cluster.enablePrivateClusterPublicFQDN == false
     docs:
       desc: |
         This check ensures that private AKS clusters do not expose a public fully qualified domain name (FQDN), preventing DNS resolution of the API server from outside the private network.
@@ -5582,6 +5721,314 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/private-clusters
         title: Create a private Azure Kubernetes Service (AKS) cluster
+  - uid: mondoo-azure-security-aks-defender-enabled
+    title: Ensure Microsoft Defender profile is enabled for AKS clusters
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.defenderEnabled == true
+    docs:
+      desc: |
+        This check ensures that Microsoft Defender for Containers is enabled on Azure Kubernetes Service (AKS) clusters, providing cloud-native Kubernetes security including environment hardening, workload protection, and runtime threat detection.
+
+        **Why this matters**
+
+        Enabling the Microsoft Defender profile on AKS clusters provides several critical benefits:
+
+        - **Runtime threat detection**: Detects container-specific attacks such as crypto mining, suspicious process execution, and anomalous API calls in real time.
+        - **Environment hardening**: Provides recommendations for hardening the Kubernetes control plane and workload configurations.
+        - **Vulnerability assessment**: Scans container images for known vulnerabilities and provides actionable remediation guidance.
+        - **Compliance alignment**: Meets the Azure security baseline requirement (LT-1) for threat detection on container workloads.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Kubernetes services** in the Azure Portal.
+        2. Select an AKS cluster and go to **Settings** > **Microsoft Defender for Cloud**.
+        3. Verify that the Defender profile is enabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "securityProfile.defender"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-defender
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-containers-introduction
+        title: Microsoft Defender for Containers
+  - uid: mondoo-azure-security-aks-image-cleaner-enabled
+    title: Ensure Image Cleaner is enabled for AKS clusters
+    impact: 50
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.imageCleanerEnabled == true
+    docs:
+      desc: |
+        This check ensures that the Image Cleaner feature is enabled on AKS clusters, automatically detecting and removing stale, unused, and potentially vulnerable container images cached on nodes.
+
+        **Why this matters**
+
+        Enabling Image Cleaner on AKS clusters provides several critical benefits:
+
+        - **Reduced attack surface**: Removes stale and vulnerable images from nodes, preventing exploitation of cached images that are no longer in use.
+        - **Automated cleanup**: Eliminates the need for manual image pruning, ensuring that dangling images don't accumulate over time.
+        - **Vulnerability mitigation**: Even after workloads using vulnerable images are removed, images can persist on nodes indefinitely without the Image Cleaner.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Kubernetes services** in the Azure Portal.
+        2. Select an AKS cluster and go to **Settings** > **Properties**.
+        3. Verify that the Image Cleaner is enabled under the security profile.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "securityProfile.imageCleaner"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-image-cleaner
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/image-cleaner
+        title: Use Image Cleaner to clean up stale images on your AKS cluster
+  - uid: mondoo-azure-security-aks-workload-identity-enabled
+    title: Ensure workload identity is enabled for AKS clusters
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.workloadIdentityEnabled == true
+    docs:
+      desc: |
+        This check ensures that workload identity is enabled on AKS clusters, allowing pods to authenticate to Azure services using Azure AD federated credentials instead of storing secrets in the cluster.
+
+        **Why this matters**
+
+        Enabling workload identity on AKS clusters provides several critical benefits:
+
+        - **Eliminates stored credentials**: Pods authenticate using Azure AD federated credentials, removing the need for stored service principal credentials or connection strings.
+        - **Centralized identity management**: Leverages Azure AD for identity lifecycle management, conditional access, and audit trails.
+        - **Principle of least privilege**: Enables fine-grained, per-workload identity assignments instead of shared cluster-wide credentials.
+        - **Compliance alignment**: Meets the Azure security baseline requirement (IM-3) for workload identity management.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Kubernetes services** in the Azure Portal.
+        2. Select an AKS cluster and go to **Settings** > **Properties**.
+        3. Verify that workload identity is enabled under the security profile.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "securityProfile.workloadIdentity"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-workload-identity
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
+        title: Use Azure AD workload identity with AKS
+  - uid: mondoo-azure-security-aks-encryption-at-host-enabled
+    title: Ensure AKS agent pool nodes have encryption at host enabled
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.agentPoolProfiles.all(_["enableEncryptionAtHost"] == true)
+    docs:
+      desc: |
+        This check ensures that host-based encryption is enabled on all agent pool nodes in AKS clusters, providing end-to-end encryption for temporary disks, OS disks, and cached data.
+
+        **Why this matters**
+
+        Enabling encryption at host on AKS agent pool nodes provides several critical benefits:
+
+        - **End-to-end encryption**: Data stored on the VM host is encrypted at rest and flows encrypted to the Azure Storage service.
+        - **Temporary disk protection**: Temporary disks used for ephemeral storage are encrypted, preventing data leakage from decommissioned VMs.
+        - **OS disk cache encryption**: OS disk caches are encrypted, protecting boot-time secrets and configuration data.
+        - **Compliance alignment**: Meets the Azure security baseline requirement (DP-4) for encryption of data at rest on compute resources.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "agentPoolProfiles[].{Name:name, EncryptionAtHost:enableEncryptionAtHost}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            Encryption at host must be enabled when creating or adding a node pool:
+
+            ```bash
+            az aks nodepool add --cluster-name <ClusterName> --resource-group <ResourceGroupName> --name <NodePoolName> --enable-encryption-at-host
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/enable-host-encryption
+        title: Host-based encryption on AKS
+  - uid: mondoo-azure-security-aks-no-kubenet
+    title: Ensure AKS clusters use Azure CNI or overlay networking instead of kubenet
+    impact: 50
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.networkProfile["networkPlugin"] != "kubenet"
+    docs:
+      desc: |
+        This check ensures that AKS clusters do not use the kubenet network plugin, which has limited security capabilities compared to Azure CNI or Azure CNI Overlay.
+
+        **Why this matters**
+
+        Using Azure CNI instead of kubenet provides several critical benefits:
+
+        - **Pod-level NSG support**: Azure CNI provides Network Security Group support at the pod level, enabling fine-grained network traffic control.
+        - **Direct VNET integration**: Pods receive IP addresses directly from the virtual network, enabling proper network isolation and security group enforcement.
+        - **Better network policy compatibility**: Azure CNI provides better compatibility with Kubernetes network policies for micro-segmentation.
+        - **No UDR requirement**: Kubenet requires user-defined routes for pod connectivity, which adds management complexity and potential for misconfiguration.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "networkProfile.networkPlugin"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            The network plugin cannot be changed on existing clusters. Create a new cluster with Azure CNI:
+
+            ```bash
+            az aks create --name <ClusterName> --resource-group <ResourceGroupName> --network-plugin azure
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/concepts-network
+        title: Network concepts for applications in AKS
+  - uid: mondoo-azure-security-aks-container-insights-enabled
+    title: Ensure Container Insights monitoring is enabled for AKS clusters
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.addonProfiles.any(_["omsagent"]["enabled"] == true)
+    docs:
+      desc: |
+        This check ensures that Container Insights (via the OMS agent add-on) is enabled on AKS clusters, collecting container logs, performance metrics, and Kubernetes events for Azure Monitor.
+
+        **Why this matters**
+
+        Enabling Container Insights on AKS clusters provides several critical benefits:
+
+        - **Security monitoring**: Provides visibility into container behavior, enabling detection of anomalous activity and security incidents.
+        - **Incident response**: Container logs and Kubernetes events are essential for forensic analysis during security investigations.
+        - **Operational visibility**: Performance metrics and resource utilization data enable proactive identification of issues.
+        - **Compliance alignment**: Meets the Azure security baseline requirement (LT-4) for logging and monitoring on container workloads.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "addonProfiles.omsagent"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks enable-addons --addon monitoring --name <ClusterName> --resource-group <ResourceGroupName>
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview
+        title: Container Insights overview
+  - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled
+    title: Ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters
+    impact: 50
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.addonProfiles.any(_["azureKeyvaultSecretsProvider"]["enabled"] == true)
+    docs:
+      desc: |
+        This check ensures that the Azure Key Vault Secrets Provider (Secrets Store CSI Driver) is enabled on AKS clusters, enabling pods to retrieve secrets directly from Azure Key Vault.
+
+        **Why this matters**
+
+        Enabling the Key Vault Secrets Provider on AKS clusters provides several critical benefits:
+
+        - **Secure secret storage**: Secrets are stored in Azure Key Vault rather than as Kubernetes Secrets, which are only base64-encoded by default.
+        - **Centralized secret management**: Secrets are managed through Azure Key Vault, providing audit trails, access policies, and rotation capabilities.
+        - **Reduced secret sprawl**: Eliminates the need to embed secrets in container images, config maps, or Kubernetes Secret objects.
+        - **Compliance alignment**: Meets the Azure security baseline requirement (IM-8) for secure secret management in workloads.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "addonProfiles.azureKeyvaultSecretsProvider"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks enable-addons --addon azure-keyvault-secrets-provider --name <ClusterName> --resource-group <ResourceGroupName>
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver
+        title: Use the Azure Key Vault Provider for Secrets Store CSI Driver in AKS
   - uid: mondoo-azure-security-app-service-client-cert-enabled
     title: Ensure client certificate authentication is enabled for App Service web apps
     impact: 60
@@ -5594,9 +6041,9 @@ queries:
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(properties["clientCertEnabled"] == true)
+      azure.subscription.webService.appsite.clientCertEnabled == true
     docs:
       desc: |
         This check ensures that client certificate authentication (mutual TLS) is enabled for Azure App Service web applications, requiring clients to present a valid certificate to establish a connection.
@@ -5685,9 +6132,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(configuration.properties["remoteDebuggingEnabled"] == false)
+      azure.subscription.webService.appsite.configuration.remoteDebuggingEnabled == false
     docs:
       desc: |
         This check ensures that remote debugging is disabled for Azure App Service web applications, preventing the exposure of debugging ports and interfaces to the network.
@@ -5776,9 +6223,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(configuration.properties["http20Enabled"] == true)
+      azure.subscription.webService.appsite.configuration.http20Enabled == true
     docs:
       desc: |
         This check ensures that HTTP 2.0 is enabled for Azure App Service web applications, providing improved performance and security features over HTTP 1.1.
@@ -5867,9 +6314,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(configuration.properties["ftpsState"] != "AllAllowed")
+      azure.subscription.webService.appsite.configuration.ftpsState != "AllAllowed"
     docs:
       desc: |
         This check ensures that Azure App Service apps do not allow unencrypted FTP connections for file deployment, requiring either FTPS (FTP over TLS) or disabling FTP entirely.
@@ -5945,13 +6392,11 @@ queries:
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.web.apps.all(
-        configuration.properties["cors"] == null ||
-        configuration.properties["cors"]["allowedOrigins"] == null ||
-        configuration.properties["cors"]["allowedOrigins"].none(_ == "*")
-      )
+      azure.subscription.webService.appsite.configuration.properties["cors"] == null ||
+      azure.subscription.webService.appsite.configuration.properties["cors"]["allowedOrigins"] == null ||
+      azure.subscription.webService.appsite.configuration.properties["cors"]["allowedOrigins"].none(_ == "*")
     docs:
       desc: |
         This check ensures that Azure App Service apps do not have Cross-Origin Resource Sharing (CORS) configured with a wildcard (`*`) origin, which would allow any website to make cross-origin requests to the application.
@@ -6031,9 +6476,10 @@ queries:
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
+      azure.subscription.webService.appsite.kind == /functionapp/
     mql: |
-      azure.subscription.web.apps.where(kind == /functionapp/).all(authenticationSettings.properties["enabled"] == true)
+      azure.subscription.webService.appsite.authenticationSettings.properties["enabled"] == true
     docs:
       desc: |
         This check ensures that Azure Function apps have App Service Authentication (Easy Auth) enabled, requiring callers to authenticate before reaching the function endpoints.
@@ -6118,9 +6564,10 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-app-service-webapp"
+      azure.subscription.webService.appsite.kind == /functionapp/
     mql: |
-      azure.subscription.web.apps.where(kind == /functionapp/).all(privateEndpointConnections.length > 0)
+      azure.subscription.webService.appsite.privateEndpointConnections.length > 0
     docs:
       desc: |
         This check ensures that Azure Function apps are configured with private endpoints, restricting network access to only traffic from within the virtual network.
@@ -6201,9 +6648,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cache-redis-instance"
     mql: |
-      azure.subscription.cache.redis.all(properties["minimumTlsVersion"] == "1.2")
+      azure.subscription.cacheService.redisInstance.minimumTlsVersion == "1.2"
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are configured to require a minimum TLS version of 1.2 for all connections, preventing the use of older, vulnerable TLS versions.
@@ -6291,9 +6738,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-id-ra-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cache-redis-instance"
     mql: |
-      azure.subscription.cache.redis.all(semver(redisVersion) >= semver("6"))
+      semver(azure.subscription.cacheService.redisInstance.redisVersion) >= semver("6")
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are running a supported version (version 6 or later), as older versions may lack important security patches and features.
@@ -6370,6 +6817,83 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview
         title: About Azure Cache for Redis
+  - uid: mondoo-azure-security-redis-auth-required
+    title: Ensure Azure Cache for Redis requires authentication
+    impact: 90
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+    filters: |
+      asset.platform == "azure-cache-redis-instance"
+    mql: |
+      azure.subscription.cacheService.redisInstance.properties["redisConfiguration"]["authnotrequired"] != "yes"
+    docs:
+      desc: |
+        This check ensures that Azure Cache for Redis instances require authentication for all connections, preventing unauthorized access to cached data.
+
+        **Why this matters**
+
+        Requiring authentication on Redis instances provides several critical benefits:
+
+        - **Prevent unauthorized access**: Without authentication, any client that can reach the Redis endpoint can read, modify, or delete cached data without credentials.
+        - **Data protection**: Redis caches often store sensitive application data including session tokens, user information, and API responses that must be protected from unauthorized access.
+        - **Compliance alignment**: Security standards universally require authentication for data stores, and disabling authentication violates CIS benchmarks and Azure security baselines.
+        - **Defense in depth**: Even with network-level controls, authentication provides an additional layer of protection against lateral movement within a compromised network.
+
+        Microsoft explicitly states that disabling authentication is "highly discouraged from a security point of view." By ensuring authentication is required, organizations protect cached data from unauthorized access.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Cache for Redis** in the Azure Portal.
+        2. Select the Redis cache instance.
+        3. Go to **Advanced settings**.
+        4. Verify that the **authnotrequired** setting is not set to **yes**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az redis show --name <RedisCacheName> --resource-group <ResourceGroupName> --query "redisConfiguration.authnotrequired"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Azure Cache for Redis** in the Azure Portal.
+            2. Select the Redis cache instance.
+            3. Go to **Authentication** under **Settings**.
+            4. Ensure that **Redis access keys authentication** is enabled or that **Microsoft Entra Authentication** is configured.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set redisConfiguration.authnotrequired=no
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_redis_cache" "example" {
+              name                = "example-redis"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              capacity            = 1
+              family              = "C"
+              sku_name            = "Standard"
+              minimum_tls_version = "1.2"
+
+              redis_configuration {
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/security/benchmark/azure/baselines/azure-cache-for-redis-security-baseline
+        title: Azure security baseline for Azure Cache for Redis
   - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled
     title: Ensure cross-tenant replication is disabled for Azure Storage accounts
     impact: 80
@@ -6384,7 +6908,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties["allowCrossTenantReplication"] == false
+      azure.subscription.storage.account.allowCrossTenantReplication == false
     docs:
       desc: |
         This check ensures that cross-tenant replication is disabled for Azure Storage accounts, preventing data from being replicated to storage accounts in different Microsoft Entra ID tenants.
@@ -6473,7 +6997,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties["isSftpEnabled"] == false
+      azure.subscription.storage.account.isSftpEnabled == false
     docs:
       desc: |
         This check ensures that SFTP (SSH File Transfer Protocol) is disabled on Azure Storage accounts unless there is a specific business requirement for it, reducing the attack surface.
@@ -6562,7 +7086,7 @@ queries:
     filters: |
       asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.account.properties["allowSharedKeyAccess"] == false
+      azure.subscription.storage.account.allowSharedKeyAccess == false
     docs:
       desc: |
         This check ensures that shared key access is disabled for Azure Storage accounts, requiring all requests to be authorized using Microsoft Entra ID.
@@ -7049,6 +7573,88 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview
         title: Azure DDoS Protection overview
+  - uid: mondoo-azure-security-network-vnet-vm-protection-enabled
+    title: Ensure VM protection is enabled on virtual networks
+    impact: 40
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.network.virtualNetworks.all(enableVmProtection == true)
+    docs:
+      desc: |
+        This check ensures that VM protection is enabled on all Azure virtual networks to help prevent unauthorized traffic from reaching virtual machines.
+
+        **Why this matters**
+
+        Enabling VM protection on virtual networks provides several critical benefits:
+
+        - **Traffic filtering enforcement**: VM protection ensures that all subnets in the virtual network have network security group rules applied, preventing unfiltered traffic from reaching virtual machines.
+        - **Defense in depth**: Even if individual VM-level network security groups are misconfigured, virtual network-level VM protection provides an additional layer of security to block unauthorized access.
+        - **Reduced attack surface**: VM protection helps prevent scenarios where virtual machines are deployed without adequate network security rules, which is a common misconfiguration risk.
+        - **Compliance alignment**: Many security frameworks require network-level protections for compute resources to enforce segmentation and access control policies.
+
+        By enabling VM protection on virtual networks, organizations add a defense-in-depth layer that helps ensure virtual machines are not inadvertently exposed to unauthorized network traffic.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Virtual networks** in the Azure Portal.
+        2. Select a virtual network.
+        3. Under **Overview** or **Properties**, verify that VM protection is set to **Enabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az network vnet list --query "[].{Name:name, ResourceGroup:resourceGroup, VMProtection:enableVmProtection}" -o table
+        ```
+
+        **Automated Audit with PowerShell:**
+
+        ```powershell
+        Get-AzVirtualNetwork | Select-Object Name, ResourceGroupName, EnableVmProtection | Format-Table
+        ```
+
+        Ensure all virtual networks have EnableVmProtection set to True.
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az network vnet update --resource-group <ResourceGroupName> --name <VNetName> --vm-protection true
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            ```powershell
+            $vnet = Get-AzVirtualNetwork -ResourceGroupName <ResourceGroupName> -Name <VNetName>
+            $vnet.EnableVmProtection = $true
+            Set-AzVirtualNetwork -VirtualNetwork $vnet
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_virtual_network" "example" {
+              name                = "example-vnet"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              address_space       = ["10.0.0.0/16"]
+              vm_protection_enabled = true
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-overview
+        title: Azure Virtual Network overview
   - uid: mondoo-azure-security-network-subnet-default-outbound-disabled
     title: Ensure default outbound access is disabled on subnets
     impact: 60
@@ -7063,7 +7669,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.network.virtualNetworks.all(subnets.all(properties["defaultOutboundAccess"] == false))
+      azure.subscription.network.virtualNetworks.all(subnets.all(defaultOutboundAccess == false))
     docs:
       desc: |
         This check ensures that default outbound access is disabled on all subnets within Azure virtual networks, enforcing explicit outbound connectivity configurations.
@@ -7533,9 +8139,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["publicNetworkAccess"] == "Disabled")
+      azure.subscription.cosmosDbService.account.publicNetworkAccess == "Disabled"
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Cosmos DB accounts, requiring all connections to go through private endpoints or approved virtual networks.
@@ -7622,9 +8228,9 @@ queries:
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["disableLocalAuth"] == true)
+      azure.subscription.cosmosDbService.account.disableLocalAuth == true
     docs:
       desc: |
         This check ensures that local authentication (key-based access) is disabled on Azure Cosmos DB accounts, requiring the use of Microsoft Entra ID (formerly Azure Active Directory) for authentication.
@@ -7711,9 +8317,10 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
+      azure.subscription.cosmosDbService.account.publicNetworkAccess != "Disabled"
     mql: |
-      azure.subscription.cosmosDb.accounts.where(properties["publicNetworkAccess"] != "Disabled").all(properties["isVirtualNetworkFilterEnabled"] == true)
+      azure.subscription.cosmosDbService.account.isVirtualNetworkFilterEnabled == true
     docs:
       desc: |
         This check ensures that virtual network filtering is enabled on Azure Cosmos DB accounts, restricting access to traffic from approved virtual networks and subnets.
@@ -7805,9 +8412,9 @@ queries:
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["disableKeyBasedMetadataWriteAccess"] == true)
+      azure.subscription.cosmosDbService.account.disableKeyBasedMetadataWriteAccess == true
     docs:
       desc: |
         This check ensures that key-based metadata write access is disabled on Azure Cosmos DB accounts, preventing clients using account keys from modifying databases, containers, and throughput settings.
@@ -7893,9 +8500,10 @@ queries:
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
+      azure.subscription.cosmosDbService.account.properties["locations"].length > 1
     mql: |
-      azure.subscription.cosmosDb.accounts.where(properties["locations"].length > 1).all(properties["enableAutomaticFailover"] == true)
+      azure.subscription.cosmosDbService.account.enableAutomaticFailover == true
     docs:
       desc: |
         This check ensures that automatic failover is enabled on Azure Cosmos DB accounts, providing high availability by automatically failing over to a secondary region during an outage.
@@ -7991,9 +8599,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["minimalTlsVersion"] == "Tls12")
+      azure.subscription.cosmosDbService.account.minimalTlsVersion == "Tls12"
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured to require a minimum TLS version of 1.2 for all connections, rejecting clients that attempt to connect using older, insecure TLS versions.
@@ -8079,9 +8687,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["networkAclBypass"] == "None")
+      azure.subscription.cosmosDbService.account.properties["networkAclBypass"] == "None"
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts have the network ACL bypass set to `None`, preventing Azure services from bypassing firewall rules.
@@ -8167,9 +8775,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDb.accounts.all(properties["keyVaultKeyUri"] != empty)
+      azure.subscription.cosmosDbService.account.properties["keyVaultKeyUri"] != empty
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with customer-managed keys (CMK) via Azure Key Vault for data-at-rest encryption, rather than relying on the default Microsoft-managed keys.
@@ -8244,6 +8852,288 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-cmk
         title: Configure customer-managed keys for your Azure Cosmos DB account
+  - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured
+    title: Ensure Azure Cosmos DB accounts with public access have IP firewall rules configured
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-cosmosdb"
+      azure.subscription.cosmosDbService.account.publicNetworkAccess != "Disabled"
+    mql: |
+      azure.subscription.cosmosDbService.account.ipRangeFilter.length > 0
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts with public network access enabled have IP firewall rules configured, restricting which IP addresses can connect to the account.
+
+        **Why this matters**
+
+        Configuring IP firewall rules on publicly accessible Cosmos DB accounts provides several critical benefits:
+
+        - **Access restriction**: Limits which IP addresses or CIDR ranges can connect to the account, preventing unauthorized access from the internet.
+        - **Defense in depth**: Even when private endpoints are not feasible, IP firewall rules provide network-level protection against unauthorized access.
+        - **Compliance alignment**: Maps directly to the Azure Policy "Azure Cosmos DB accounts should have firewall rules" and the CIS Azure Foundations Benchmark.
+        - **Risk reduction**: An account with public access enabled but no IP rules is completely open to the internet.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+        2. Select a Cosmos DB account and go to **Networking**.
+        3. Verify that IP firewall rules are configured under **Public network access**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "{PublicAccess:publicNetworkAccess, IPRules:ipRules}"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+            2. Select the Cosmos DB account and go to **Networking**.
+            3. Under **Public network access**, add the IP addresses or CIDR ranges that should have access.
+            4. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --ip-range-filter "203.0.113.0/24,198.51.100.0/24"
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall
+        title: Configure IP firewall in Azure Cosmos DB
+  - uid: mondoo-azure-security-cosmosdb-private-endpoints
+    title: Ensure Azure Cosmos DB accounts have private endpoint connections configured
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-cosmosdb"
+    mql: |
+      azure.subscription.cosmosDbService.account.properties["privateEndpointConnections"].length > 0
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts have private endpoint connections configured, providing network-level isolation through the Azure private network.
+
+        **Why this matters**
+
+        Configuring private endpoints for Cosmos DB accounts provides several critical benefits:
+
+        - **Network isolation**: Access to Cosmos DB is restricted to traffic through the Azure private network backbone, not through the public internet.
+        - **Data protection**: All traffic between the virtual network and Cosmos DB stays on the Microsoft backbone network, reducing the risk of data interception.
+        - **Complement to public access controls**: While disabling public network access blocks the public path, private endpoints provide the private path for legitimate access.
+        - **Compliance alignment**: Meets the Microsoft cloud security benchmark requirement (NS-2) for network segmentation of PaaS services.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+        2. Select a Cosmos DB account and go to **Networking** > **Private endpoint connections**.
+        3. Verify that at least one private endpoint connection exists.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "privateEndpointConnections"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+            2. Select the Cosmos DB account and go to **Networking** > **Private endpoint connections**.
+            3. Select **+ Private endpoint** and configure a private endpoint in the target virtual network.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-private-endpoints
+        title: Configure Azure Private Link for an Azure Cosmos DB account
+  - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard
+    title: Ensure Azure Cosmos DB accounts do not allow wildcard CORS origins
+    impact: 50
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+    filters: |
+      asset.platform == "azure-cosmosdb"
+    mql: |
+      azure.subscription.cosmosDbService.account.properties["cors"] == null ||
+      azure.subscription.cosmosDbService.account.properties["cors"].none(_["allowedOrigins"] == "*")
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts do not have Cross-Origin Resource Sharing (CORS) configured with a wildcard (`*`) origin, which would allow any website to make cross-origin requests.
+
+        **Why this matters**
+
+        Restricting CORS origins on Cosmos DB accounts provides several critical benefits:
+
+        - **Cross-site data theft prevention**: Wildcard CORS origins allow any website to make requests to the Cosmos DB account, which combined with compromised credentials could enable cross-site data theft.
+        - **Principle of least privilege**: CORS origins should be restricted to specific, trusted domains that legitimately need access.
+        - **Attack surface reduction**: Limiting allowed origins reduces the potential for exploitation through cross-origin requests.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+        2. Select a Cosmos DB account and go to **Settings** > **CORS**.
+        3. Verify that allowed origins do not include `*`.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "cors"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+            2. Select the Cosmos DB account and go to **Settings** > **CORS**.
+            3. Replace the wildcard `*` origin with specific, trusted domain origins.
+            4. Select **Save**.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-configure-cross-origin-resource-sharing
+        title: Configure Cross-Origin Resource Sharing in Azure Cosmos DB
+  - uid: mondoo-azure-security-cosmosdb-continuous-backup
+    title: Ensure Azure Cosmos DB accounts use continuous backup policy
+    impact: 50
+    tags:
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+    filters: |
+      asset.platform == "azure-cosmosdb"
+    mql: |
+      azure.subscription.cosmosDbService.account.properties["backupPolicy"]["type"] == "Continuous"
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts are configured with a continuous backup policy, providing point-in-time restore capabilities with fine-grained recovery points.
+
+        **Why this matters**
+
+        Using continuous backup on Cosmos DB accounts provides several critical benefits:
+
+        - **Point-in-time restore**: Enables recovery to any point in time within the retention window, minimizing data loss from accidental deletion or corruption.
+        - **Fine-grained recovery**: Compared to periodic backup (which only captures snapshots at intervals), continuous backup provides much finer recovery granularity.
+        - **Disaster recovery**: Critical for meeting RPO (Recovery Point Objective) requirements for production data stores.
+        - **Security incident response**: Enables restoration to a point before a security incident, aiding in recovery from data tampering or ransomware.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Cosmos DB** in the Azure Portal.
+        2. Select a Cosmos DB account and go to **Settings** > **Backup & Restore**.
+        3. Verify that the backup policy is set to **Continuous**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "backupPolicy"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --backup-policy-type Continuous
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/continuous-backup-restore-introduction
+        title: Continuous backup with point-in-time restore in Azure Cosmos DB
+  - uid: mondoo-azure-security-cosmosdb-multi-region-write
+    title: Ensure multi-region Azure Cosmos DB accounts have multi-region write enabled
+    impact: 40
+    tags:
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+    filters: |
+      asset.platform == "azure-cosmosdb"
+      azure.subscription.cosmosDbService.account.properties["locations"].length > 1
+    mql: |
+      azure.subscription.cosmosDbService.account.enableMultipleWriteLocations == true
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts distributed across multiple regions have multi-region write enabled, reducing write latency and improving availability.
+
+        **Why this matters**
+
+        Enabling multi-region write on multi-region Cosmos DB accounts provides several critical benefits:
+
+        - **Reduced write latency**: Writes can be performed in the nearest region, reducing latency for globally distributed applications.
+        - **Improved availability**: Eliminates the single point of failure for write operations during regional outages.
+        - **Business continuity**: Complements automatic failover by enabling write operations to continue in any region during outages.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "{EnableMultipleWriteLocations:enableMultipleWriteLocations, Locations:locations[].locationName}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-multiple-write-locations true
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-multi-master
+        title: Configure multi-region writes in Azure Cosmos DB
+  - uid: mondoo-azure-security-cosmosdb-strong-consistency
+    title: Ensure Azure Cosmos DB accounts use bounded staleness or strong consistency
+    impact: 30
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+    filters: |
+      asset.platform == "azure-cosmosdb"
+    mql: |
+      azure.subscription.cosmosDbService.account.properties["consistencyPolicy"]["defaultConsistencyLevel"] == "Strong" ||
+      azure.subscription.cosmosDbService.account.properties["consistencyPolicy"]["defaultConsistencyLevel"] == "BoundedStaleness"
+    docs:
+      desc: |
+        This check ensures that Azure Cosmos DB accounts are configured with strong or bounded staleness consistency, providing stronger data integrity guarantees for security-sensitive workloads.
+
+        **Why this matters**
+
+        Using strong or bounded staleness consistency provides several critical benefits:
+
+        - **Data integrity**: Ensures reads always return the most recent committed write, preventing stale reads that could be exploited in security-sensitive scenarios.
+        - **Financial data protection**: For accounts handling financial, medical, or compliance-critical data, strong consistency prevents data integrity issues.
+        - **Audit reliability**: Ensures audit trail reads are consistent with the latest writes, preventing gaps in security monitoring.
+
+        Note: Many workloads legitimately use session consistency for better performance. This check is most appropriate for high-security environments.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query "consistencyPolicy.defaultConsistencyLevel"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --default-consistency-level BoundedStaleness
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels
+        title: Consistency levels in Azure Cosmos DB
   - uid: mondoo-azure-security-firewall-threat-intel-deny
     title: Ensure Azure Firewall threat intelligence is set to Deny mode
     impact: 80
@@ -8631,9 +9521,9 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-batch-account"
     mql: |
-      azure.subscription.batch.accounts.all(publicNetworkAccess == "Disabled")
+      azure.subscription.batchService.account.publicNetworkAccess == "Disabled"
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Batch accounts, requiring all connections to go through private endpoints.
@@ -8719,13 +9609,11 @@ queries:
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-batch-account"
     mql: |
-      azure.subscription.batch.accounts.all(
-        allowedAuthenticationModes.length > 0 &&
-        allowedAuthenticationModes.none(_ == "SharedKey") &&
-        allowedAuthenticationModes.any(_ == "AAD")
-      )
+      azure.subscription.batchService.account.allowedAuthenticationModes.length > 0 &&
+      azure.subscription.batchService.account.allowedAuthenticationModes.none(_ == "SharedKey") &&
+      azure.subscription.batchService.account.allowedAuthenticationModes.any(_ == "AAD")
     docs:
       desc: |
         This check ensures that Azure Batch accounts do not allow Shared Key authentication, requiring the use of Entra ID (Azure Active Directory) for all authentication operations.
@@ -8812,9 +9700,9 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-batch-account"
     mql: |
-      azure.subscription.batch.accounts.all(encryption["keySource"] == "Microsoft.KeyVault")
+      azure.subscription.batchService.account.encryption["keySource"] == "Microsoft.KeyVault"
     docs:
       desc: |
         This check ensures that Azure Batch accounts have encryption configured, protecting data at rest with either platform-managed or customer-managed encryption keys.
@@ -8903,9 +9791,9 @@ queries:
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-batch-account"
     mql: |
-      azure.subscription.batch.accounts.all(diagnosticSettings.length > 0)
+      azure.subscription.batchService.account.diagnosticSettings.length > 0
     docs:
       desc: |
         This check ensures that diagnostic settings are enabled on Azure Batch accounts, providing visibility into service operations, errors, and security events through centralized logging.
@@ -8987,3 +9875,1586 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/batch/monitor-batch
         title: Monitor Azure Batch
+  - uid: mondoo-azure-security-batch-private-endpoints-configured
+    title: Ensure Azure Batch accounts have private endpoint connections configured
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-batch-account"
+    mql: |
+      azure.subscription.batchService.account.privateEndpointConnections.length > 0
+    docs:
+      desc: |
+        This check ensures that Azure Batch accounts have at least one private endpoint connection configured, enabling secure access through private network connectivity.
+
+        **Why this matters**
+
+        Configuring private endpoints for Batch accounts provides several critical benefits:
+
+        - **Network isolation**: Private endpoints allow access to the Batch account over a private IP address within your virtual network, eliminating exposure to the public internet.
+        - **Data exfiltration prevention**: Private Link ensures that traffic between the virtual network and the Batch account traverses the Microsoft backbone network, preventing data leakage.
+        - **Secure job submission**: Private endpoints ensure that job submissions, pool management, and task operations are performed over private network paths.
+        - **Compliance alignment**: Azure Policy built-in definition requires private endpoint connections on Batch accounts for regulatory compliance frameworks.
+
+        By configuring private endpoint connections, organizations ensure that Batch account access occurs entirely over private network paths, significantly reducing the attack surface.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Batch accounts** in the Azure Portal.
+        2. Select the Batch account.
+        3. Go to **Networking** under **Settings**.
+        4. Select the **Private endpoint connections** tab.
+        5. Verify that at least one private endpoint connection exists and is in the **Approved** state.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az batch account show --name <BatchAccountName> --resource-group <ResourceGroupName> --query "privateEndpointConnections"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Batch accounts** in the Azure Portal.
+            2. Select the Batch account.
+            3. Go to **Networking** under **Settings**.
+            4. Select the **Private endpoint connections** tab.
+            5. Select **+ Private endpoint** to add a new private endpoint.
+            6. Configure the private endpoint with the appropriate virtual network, subnet, and DNS settings.
+            7. Select **Review + create**, then **Create**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az network private-endpoint create \
+              --name <PrivateEndpointName> \
+              --resource-group <ResourceGroupName> \
+              --vnet-name <VNetName> \
+              --subnet <SubnetName> \
+              --private-connection-resource-id $(az batch account show --name <BatchAccountName> --resource-group <ResourceGroupName> --query id -o tsv) \
+              --group-id batchAccount \
+              --connection-name <ConnectionName>
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_private_endpoint" "batch" {
+              name                = "example-batch-pe"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              subnet_id           = azurerm_subnet.example.id
+
+              private_service_connection {
+                name                           = "example-batch-psc"
+                private_connection_resource_id = azurerm_batch_account.example.id
+                subresource_names              = ["batchAccount"]
+                is_manual_connection           = false
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/batch/private-connectivity
+        title: Use private endpoints with Azure Batch accounts
+  - uid: mondoo-azure-security-batch-pool-disk-encryption
+    title: Ensure Azure Batch pools have disk encryption enabled
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    filters: |
+      asset.platform == "azure-batch-account"
+    mql: |
+      azure.subscription.batchService.account.pools.all(
+        properties["deploymentConfiguration"]["virtualMachineConfiguration"]["diskEncryptionConfiguration"] != null &&
+        properties["deploymentConfiguration"]["virtualMachineConfiguration"]["diskEncryptionConfiguration"]["targets"] != empty
+      )
+    docs:
+      desc: |
+        This check ensures that Azure Batch pool compute nodes have disk encryption configured, protecting data at rest on OS and temporary disks.
+
+        **Why this matters**
+
+        Enabling disk encryption on Batch pools provides several critical benefits:
+
+        - **Data protection**: Batch compute nodes have an OS disk and a local temporary SSD where task data, temporary files, and output are stored. Without disk encryption, this data could be exposed if storage media is compromised.
+        - **Compliance alignment**: Azure Policy built-in definition requires disk encryption on Batch pools, and it is required by multiple regulatory frameworks for cryptographic protection of data at rest.
+        - **Defense in depth**: Disk encryption provides an additional layer of protection beyond network and identity controls, ensuring data remains protected even in physical security breach scenarios.
+        - **Industry best practice**: Microsoft recommends enabling disk encryption for Batch pools handling sensitive workloads to protect against unauthorized data access.
+
+        By enabling disk encryption on Batch pools, organizations ensure that task data and temporary files stored on compute nodes are encrypted at rest.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Batch accounts** in the Azure Portal.
+        2. Select the Batch account.
+        3. Go to **Pools** under **Features**.
+        4. Select each pool and review the **Disk Encryption Configuration** under the deployment configuration.
+        5. Verify that disk encryption targets are specified (OsDisk, TemporaryDisk).
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az batch pool list --account-name <BatchAccountName> --account-endpoint <BatchAccountEndpoint> --query "[].{Name:id, DiskEncryption:deploymentConfiguration.virtualMachineConfiguration.diskEncryptionConfiguration}"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Batch accounts** in the Azure Portal.
+            2. Select the Batch account.
+            3. Go to **Pools** under **Features**.
+            4. When creating a new pool, expand **Disk Encryption Configuration**.
+            5. Select the disk encryption targets: **OsDisk** and/or **TemporaryDisk**.
+            6. Complete the pool creation.
+
+            Note: Disk encryption configuration can only be set at pool creation time. Existing pools must be recreated with the encryption configuration.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            Disk encryption must be specified at pool creation time:
+
+            ```bash
+            az batch pool create \
+              --account-name <BatchAccountName> \
+              --id <PoolId> \
+              --vm-size Standard_D2s_v3 \
+              --image canonical:0001-com-ubuntu-server-focal:20_04-lts \
+              --disk-encryption-targets OsDisk TemporaryDisk
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_batch_pool" "example" {
+              name                = "example-pool"
+              resource_group_name = azurerm_resource_group.example.name
+              account_name        = azurerm_batch_account.example.name
+              vm_size             = "Standard_D2s_v3"
+
+              storage_image_reference {
+                publisher = "Canonical"
+                offer     = "0001-com-ubuntu-server-focal"
+                sku       = "20_04-lts"
+                version   = "latest"
+              }
+
+              disk_encryption {
+                disk_encryption_target = "OsDisk"
+              }
+
+              disk_encryption {
+                disk_encryption_target = "TemporaryDisk"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/batch/disk-encryption
+        title: Create a pool with disk encryption enabled
+  - uid: mondoo-azure-security-sql-server-min-tls-12
+    title: Ensure Azure SQL servers enforce minimal TLS version 1.2
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-sql-server"
+    mql: |
+      azure.subscription.sql.server.minimalTlsVersion == "1.2"
+    docs:
+      desc: |
+        This check ensures that Azure SQL servers enforce a minimum TLS version of 1.2 for all connections, preventing the use of older, less secure TLS versions.
+
+        **Why this matters**
+
+        - **Protocol security**: TLS 1.0 and 1.1 have known vulnerabilities including BEAST, POODLE, and other attacks that can compromise encrypted communications.
+        - **Data protection**: Enforcing TLS 1.2 ensures that all data in transit to and from the SQL server is protected by strong encryption.
+        - **Compliance alignment**: Industry standards such as PCI DSS 3.2.1 and NIST SP 800-52 require TLS 1.2 as a minimum for secure communications.
+        - **Deprecation**: Microsoft has deprecated TLS 1.0 and 1.1 for Azure services, making TLS 1.2 the minimum recommended version.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az sql server list --query "[].{Name:name, MinTLS:minimalTlsVersion}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az sql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version 1.2
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-sql/database/connectivity-settings
+        title: Azure SQL connectivity settings
+  - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled
+    title: Ensure PostgreSQL flexible servers disable public network access
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-postgresql-flexible-server"
+    mql: |
+      azure.subscription.postgreSql.flexibleServer.publicNetworkAccess == "Disabled"
+    docs:
+      desc: |
+        This check ensures that public network access is disabled on Azure Database for PostgreSQL flexible servers, restricting connections to private endpoints only.
+
+        **Why this matters**
+
+        - **Reduced attack surface**: Disabling public network access prevents connections from the public internet, significantly reducing exposure to potential attacks.
+        - **Network isolation**: Private endpoints ensure that database traffic stays within your virtual network, providing network-level isolation.
+        - **Data protection**: Restricting access to private connections helps prevent unauthorized access and data exfiltration.
+        - **Compliance alignment**: Many security frameworks require database services to be accessible only through private network connections.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az postgres flexible-server list --query "[].{Name:name, PublicAccess:network.publicNetworkAccess}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking-private
+        title: Private access networking for Azure Database for PostgreSQL Flexible Server
+  - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption
+    title: Ensure PostgreSQL flexible servers enforce customer-managed key encryption
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    filters: |
+      asset.platform == "azure-postgresql-flexible-server"
+    mql: |
+      azure.subscription.postgreSql.flexibleServer.dataEncryptionType == "AzureKeyVault"
+    docs:
+      desc: |
+        This check ensures that Azure Database for PostgreSQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys, providing additional control over encryption keys.
+
+        **Why this matters**
+
+        - **Key control**: Customer-managed keys give organizations full control over the encryption keys used to protect their data, including the ability to rotate, disable, and revoke access.
+        - **Separation of duties**: Using CMK separates key management from data management, enabling better access control and audit capabilities.
+        - **Compliance alignment**: Many regulatory frameworks require organizations to manage their own encryption keys for sensitive data.
+        - **Enhanced security**: CMK encryption with Azure Key Vault provides hardware-backed key storage and additional protection layers.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az postgres flexible-server show --name <ServerName> --resource-group <ResourceGroupName> --query "dataEncryption"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            Configure customer-managed key encryption when creating or updating the server:
+
+            ```bash
+            az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-data-encryption
+        title: Data encryption with customer-managed key for Azure Database for PostgreSQL Flexible Server
+  - uid: mondoo-azure-security-postgresql-server-min-tls-version
+    title: Ensure PostgreSQL servers enforce minimum TLS version 1.2
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-postgresql-server"
+    mql: |
+      azure.subscription.postgreSql.server.minimalTlsVersion == "TLS1_2"
+    docs:
+      desc: |
+        This check ensures that Azure Database for PostgreSQL single servers enforce a minimum TLS version of 1.2 for all connections.
+
+        **Why this matters**
+
+        - **Protocol security**: TLS 1.0 and 1.1 have known vulnerabilities that can compromise encrypted communications.
+        - **Data protection**: Enforcing TLS 1.2 ensures all data in transit is protected by strong encryption algorithms.
+        - **Compliance alignment**: Industry standards such as PCI DSS and NIST require TLS 1.2 as a minimum for secure communications.
+        - **Deprecation**: Microsoft has deprecated TLS 1.0 and 1.1 for Azure services.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az postgres server list --query "[].{Name:name, MinTLS:minimalTlsVersion}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az postgres server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/single-server/concepts-tls
+        title: TLS connectivity in Azure Database for PostgreSQL Single Server
+  - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled
+    title: Ensure MySQL flexible servers disable public network access
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure-mysql-flexible-server"
+    mql: |
+      azure.subscription.mySql.flexibleServer.properties["network"]["publicNetworkAccess"] == "Disabled"
+    docs:
+      desc: |
+        This check ensures that public network access is disabled on Azure Database for MySQL flexible servers, restricting connections to private endpoints only.
+
+        **Why this matters**
+
+        - **Reduced attack surface**: Disabling public network access prevents connections from the public internet, significantly reducing exposure to potential attacks.
+        - **Network isolation**: Private endpoints ensure that database traffic stays within your virtual network, providing network-level isolation.
+        - **Data protection**: Restricting access to private connections helps prevent unauthorized access and data exfiltration.
+        - **Compliance alignment**: Many security frameworks require database services to be accessible only through private network connections.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az mysql flexible-server list --query "[].{Name:name, PublicAccess:network.publicNetworkAccess}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-networking-private-link
+        title: Private access networking for Azure Database for MySQL Flexible Server
+  - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption
+    title: Ensure MySQL flexible servers enforce customer-managed key encryption
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    filters: |
+      asset.platform == "azure-mysql-flexible-server"
+    mql: |
+      azure.subscription.mySql.flexibleServer.properties["dataEncryption"] != null &&
+      azure.subscription.mySql.flexibleServer.properties["dataEncryption"]["type"] == "AzureKeyVault"
+    docs:
+      desc: |
+        This check ensures that Azure Database for MySQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys, providing additional control over encryption keys.
+
+        **Why this matters**
+
+        - **Key control**: Customer-managed keys give organizations full control over the encryption keys used to protect their data, including the ability to rotate, disable, and revoke access.
+        - **Separation of duties**: Using CMK separates key management from data management, enabling better access control and audit capabilities.
+        - **Compliance alignment**: Many regulatory frameworks require organizations to manage their own encryption keys for sensitive data.
+        - **Enhanced security**: CMK encryption with Azure Key Vault provides hardware-backed key storage and additional protection layers.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az mysql flexible-server show --name <ServerName> --resource-group <ResourceGroupName> --query "dataEncryption"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            Configure customer-managed key encryption when creating or updating the server:
+
+            ```bash
+            az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-customer-managed-key
+        title: Data encryption with customer-managed key for Azure Database for MySQL Flexible Server
+  - uid: mondoo-azure-security-mysql-server-min-tls-version
+    title: Ensure MySQL servers enforce minimum TLS version 1.2
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-mysql-server"
+    mql: |
+      azure.subscription.mySql.server.minimalTlsVersion == "TLS1_2"
+    docs:
+      desc: |
+        This check ensures that Azure Database for MySQL single servers enforce a minimum TLS version of 1.2 for all connections.
+
+        **Why this matters**
+
+        - **Protocol security**: TLS 1.0 and 1.1 have known vulnerabilities that can compromise encrypted communications.
+        - **Data protection**: Enforcing TLS 1.2 ensures all data in transit is protected by strong encryption algorithms.
+        - **Compliance alignment**: Industry standards such as PCI DSS and NIST require TLS 1.2 as a minimum for secure communications.
+        - **Deprecation**: Microsoft has deprecated TLS 1.0 and 1.1 for Azure services.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az mysql server list --query "[].{Name:name, MinTLS:minimalTlsVersion}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az mysql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-ssl-connection-security
+        title: TLS connectivity in Azure Database for MySQL Single Server
+  - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled
+    title: Ensure Microsoft Defender for SQL Servers on Machines is enabled
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.cloudDefender.defenderForSqlServersOnMachines["enabled"] == true
+    docs:
+      desc: |
+        This check ensures that Microsoft Defender for SQL Servers on Machines is enabled to provide advanced threat detection for SQL Server instances running on Azure VMs, on-premises, and in hybrid environments.
+
+        **Why this matters**
+
+        - **Hybrid coverage**: Extends threat detection beyond Azure SQL Database to SQL Server instances running on IaaS VMs and on-premises machines connected to Azure Arc.
+        - **Vulnerability assessment**: Provides continuous vulnerability scanning and actionable recommendations for SQL Server instances regardless of where they run.
+        - **Advanced threat detection**: Detects anomalous database activities, potential SQL injection attacks, and suspicious access patterns across all SQL Server deployments.
+        - **Compliance alignment**: Helps meet security monitoring requirements for database workloads as mandated by frameworks such as CIS, NIST, and PCI DSS.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az security pricing show --name SqlServerVirtualMachines --query "pricingTier"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az security pricing create --name SqlServerVirtualMachines --tier Standard
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-sql-introduction
+        title: Microsoft Defender for SQL
+  - uid: mondoo-azure-security-aks-disk-encryption-set
+    title: Ensure AKS clusters have disk CSI driver enabled for node pool encryption
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.storageProfile["diskCSIDriver"]["enabled"] == true
+    docs:
+      desc: |
+        This check ensures that AKS clusters have the disk CSI driver enabled in the storage profile. The disk CSI driver enables advanced disk features including customer-managed key encryption, Azure Disk encryption sets, and dynamic provisioning with encryption for cluster nodes.
+
+        **Why this matters**
+
+        - **CSI driver support**: The disk CSI driver enables advanced disk features including customer-managed key encryption, Azure Disk encryption sets, and dynamic provisioning with encryption.
+        - **Compliance alignment**: Many regulatory frameworks require encryption of all data at rest on compute infrastructure, including temporary storage.
+        - **Dynamic provisioning**: The CSI driver allows Kubernetes persistent volumes to be dynamically provisioned with encryption configurations applied automatically.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "{EncryptionAtHost: agentPoolProfiles[].enableEncryptionAtHost, DiskCSI: storageProfile.diskCSIDriver.enabled}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            Enable encryption at host when creating or adding a node pool:
+
+            ```bash
+            az aks nodepool add --cluster-name <ClusterName> --resource-group <ResourceGroupName> --name <PoolName> --enable-encryption-at-host
+            ```
+
+            Enable disk CSI driver on the cluster:
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-disk-driver
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/azure-disk-customer-managed-keys
+        title: Bring your own keys (BYOK) with Azure disks in Azure Kubernetes Service
+  - uid: mondoo-azure-security-appgw-ssl-policy-tls12
+    title: Ensure Application Gateways have SSL policy configured with TLS 1.2 or higher
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.network.applicationGateways.where(
+        properties["sslPolicy"] != null
+      ).all(
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_2" ||
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_3"
+      )
+      azure.subscription.network.applicationGateways.none(
+        properties["sslPolicy"] == null
+      )
+    docs:
+      desc: |
+        This check ensures that all Azure Application Gateways have an SSL policy configured that enforces TLS 1.2 or higher as the minimum protocol version, preventing the use of deprecated TLS versions.
+
+        **Why this matters**
+
+        - **Protocol security**: TLS 1.0 and 1.1 have known vulnerabilities including BEAST, POODLE, and other attacks that can compromise encrypted communications at the gateway level.
+        - **Frontend protection**: Application Gateways handle TLS termination for backend services, making the SSL policy a critical security control for all traffic flowing through the gateway.
+        - **Compliance alignment**: Industry standards such as PCI DSS 3.2.1 require TLS 1.2 as a minimum for secure communications.
+        - **Cipher suite control**: Newer TLS versions support stronger cipher suites and deprecate weak algorithms, providing better overall encryption.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az network application-gateway list --query "[].{Name:name, SSLPolicy:sslPolicy}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --min-protocol-version TLSv1_2 --policy-type Custom
+            ```
+
+            Or use a predefined policy that enforces TLS 1.2:
+
+            ```bash
+            az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --policy-type Predefined --name AppGwSslPolicy20220101S
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview
+        title: Application Gateway SSL policy overview
+  - uid: mondoo-azure-security-vpn-gateway-ikev2
+    title: Ensure VPN gateways use route-based type for IKEv2 protocol support
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.network.virtualNetworkGateways.where(gatewayType == "Vpn").all(
+        vpnType == "RouteBased"
+      )
+    docs:
+      desc: |
+        This check ensures that Azure VPN gateways use the route-based VPN type, which supports the IKEv2 protocol. Policy-based VPN gateways only support IKEv1, which has known security limitations.
+
+        **Why this matters**
+
+        - **Protocol security**: IKEv2 provides significant security improvements over IKEv1, including built-in NAT traversal, stronger cryptographic algorithms, and improved resistance to denial-of-service attacks.
+        - **Modern connectivity**: Route-based VPN gateways support IKEv2 and are required for point-to-site VPN connections, VNet-to-VNet connections, and multi-site connections.
+        - **Reliability**: IKEv2 includes built-in keep-alive and reconnection mechanisms, providing more reliable VPN connections compared to IKEv1.
+        - **Compliance alignment**: Security best practices recommend IKEv2 over IKEv1 for VPN connections due to its improved security features and resistance to known attacks.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az network vnet-gateway list --query "[?gatewayType=='Vpn'].{Name:name, VpnType:vpnType}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            VPN type must be specified when creating the gateway. Policy-based gateways must be recreated as route-based:
+
+            ```bash
+            az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw1
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings
+        title: About VPN Gateway configuration settings
+  - uid: mondoo-azure-security-databricks-public-access-disabled
+    title: Ensure Azure Databricks workspaces disable public network access
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.databricks.workspaces.all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+    docs:
+      desc: |
+        This check ensures that Azure Databricks workspaces have public network access disabled, restricting connectivity to private endpoints only.
+
+        **Why this matters**
+
+        - **Reduced attack surface**: Disabling public network access prevents connections from the public internet, significantly reducing exposure to unauthorized access and data exfiltration.
+        - **Data protection**: Databricks workspaces often process sensitive data. Restricting access to private networks ensures that data and compute resources are only accessible within controlled network boundaries.
+        - **Network isolation**: Private connectivity through VNet injection and private endpoints ensures that all traffic stays within the organization's network perimeter.
+        - **Compliance alignment**: Many regulatory standards and security frameworks require data processing services to be accessible only through private network connections.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Databricks** in the Azure Portal.
+        2. Select a workspace.
+        3. Go to **Networking**.
+        4. Verify that **Public network access** is set to **Disabled** or **No Public Access**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az databricks workspace list --query "[].{Name:name, PublicAccess:publicNetworkAccess}" -o table
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Azure Databricks** in the Azure Portal.
+            2. Select the workspace.
+            3. Go to **Networking**.
+            4. Set **Public network access** to **Disabled**.
+            5. Configure private endpoints for connectivity.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az databricks workspace update --name <WorkspaceName> --resource-group <ResourceGroupName> --public-network-access Disabled
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_databricks_workspace" "example" {
+              name                        = "example-workspace"
+              resource_group_name         = azurerm_resource_group.example.name
+              location                    = azurerm_resource_group.example.location
+              sku                         = "premium"
+              public_network_access_enabled = false
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/databricks/security/network/front-end/public-access
+        title: Configure public network access for Azure Databricks
+  - uid: mondoo-azure-security-defender-for-endpoint-enabled
+    title: Ensure Microsoft Defender for Endpoint integration is enabled
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.cloudDefender.settingsWDATP.properties["enabled"] == true
+    docs:
+      desc: |
+        This check ensures that Microsoft Defender for Endpoint (WDATP) integration is enabled in Microsoft Defender for Cloud, providing endpoint detection and response (EDR) capabilities for Azure resources.
+
+        **Why this matters**
+
+        - **Endpoint detection and response**: Defender for Endpoint provides advanced threat detection, investigation, and response capabilities for servers and workstations connected to Azure.
+        - **Unified security management**: Integration with Defender for Cloud enables centralized security monitoring, correlating endpoint alerts with cloud workload protection data.
+        - **Threat intelligence**: Leverages Microsoft's global threat intelligence network to detect known and emerging threats targeting endpoints.
+        - **Automated investigation**: Provides automated investigation and remediation workflows to reduce response time and analyst workload.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
+        2. Select **Environment settings** and choose the subscription.
+        3. Go to **Integrations**.
+        4. Verify that **Microsoft Defender for Endpoint** is enabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az security setting show --name WDATP --query "kind"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
+            2. Select **Environment settings** and choose the subscription.
+            3. Go to **Integrations**.
+            4. Enable **Allow Microsoft Defender for Endpoint to access my data**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az security setting create --name WDATP --setting-kind DataExportSettings --enabled true
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/integration-defender-for-endpoint
+        title: Defender for Endpoint integration with Defender for Cloud
+  - uid: mondoo-azure-security-defender-for-apis-enabled
+    title: Ensure Microsoft Defender for APIs is enabled
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.cloudDefender.defenderForApis.enabled == true
+    docs:
+      desc: |
+        This check ensures that Microsoft Defender for APIs is enabled to provide threat protection for APIs published through Azure API Management.
+
+        **Why this matters**
+
+        - **API threat detection**: Defender for APIs monitors API traffic for suspicious patterns, including SQL injection, cross-site scripting, and other OWASP API top 10 threats.
+        - **Sensitive data exposure**: Identifies APIs that may expose sensitive data without proper protection, helping prevent data leaks.
+        - **Usage anomaly detection**: Detects unusual API usage patterns that may indicate credential theft, data exfiltration, or abuse.
+        - **Security posture**: Provides security recommendations specific to API configurations and helps prioritize remediation efforts.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
+        2. Select **Environment settings** and choose the subscription.
+        3. Under **Defender plans**, verify that **APIs** is set to **On**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az security pricing show --name Api --query "pricingTier"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
+            2. Select **Environment settings** and choose the subscription.
+            3. Under **Defender plans**, set **APIs** to **On**.
+            4. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az security pricing create --name Api --tier Standard
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_security_center_subscription_pricing" "apis" {
+              tier          = "Standard"
+              resource_type = "Api"
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-apis-introduction
+        title: Overview of Microsoft Defender for APIs
+  - uid: mondoo-azure-security-app-service-min-tls-cipher-suite
+    title: Ensure App Service web apps use a strong minimum TLS cipher suite
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-app-service-webapp"
+    mql: |
+      azure.subscription.webService.appsite.configuration.minTlsCipherSuite == "TLS_AES_256_GCM_SHA384"
+    docs:
+      desc: |
+        This check ensures that Azure App Service web applications are configured with a strong minimum TLS cipher suite, specifically TLS_AES_256_GCM_SHA384, which provides the highest level of encryption strength.
+
+        **Why this matters**
+
+        - **Cipher strength**: TLS_AES_256_GCM_SHA384 uses 256-bit AES encryption in GCM mode, providing the strongest available symmetric encryption for TLS connections.
+        - **Forward secrecy**: Modern TLS cipher suites with ECDHE key exchange provide perfect forward secrecy, ensuring that past sessions cannot be decrypted even if the server's private key is compromised.
+        - **Protection against downgrade attacks**: Setting a minimum cipher suite prevents clients from negotiating weaker ciphers that may have known vulnerabilities.
+        - **Compliance alignment**: Many security frameworks require the use of strong encryption algorithms, and AES-256-GCM meets the highest standards for data protection.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **App Services** in the Azure Portal.
+        2. Select a web app.
+        3. Go to **Configuration** > **General settings**.
+        4. Verify the **Minimum TLS Cipher Suite** setting.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az webapp config show --name <WebAppName> --resource-group <ResourceGroupName> --query "minTlsCipherSuite"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **App Services** in the Azure Portal.
+            2. Select the web app.
+            3. Go to **Configuration** > **General settings**.
+            4. Set **Minimum TLS Cipher Suite** to **TLS_AES_256_GCM_SHA384**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az webapp config set --name <WebAppName> --resource-group <ResourceGroupName> --min-tls-cipher-suite TLS_AES_256_GCM_SHA384
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_linux_web_app" "example" {
+              name                = "example-webapp"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              service_plan_id     = azurerm_service_plan.example.id
+
+              site_config {
+                minimum_tls_cipher_suite = "TLS_AES_256_GCM_SHA384"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
+        title: Secure a custom DNS name with a TLS/SSL binding in Azure App Service
+  - uid: mondoo-azure-security-app-service-e2e-encryption-enabled
+    title: Ensure end-to-end encryption is enabled for App Service web apps
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-app-service-webapp"
+    mql: |
+      azure.subscription.webService.appsite.endToEndEncryptionEnabled == true
+    docs:
+      desc: |
+        This check ensures that end-to-end TLS encryption is enabled for Azure App Service web applications, encrypting traffic between the Azure front-end load balancer and the application worker process.
+
+        **Why this matters**
+
+        - **Full traffic encryption**: Without end-to-end encryption, traffic between the Azure front-end and the worker may traverse internal networks unencrypted, potentially exposing sensitive data.
+        - **Defense in depth**: End-to-end encryption adds a layer of protection beyond HTTPS-only enforcement, ensuring data remains encrypted throughout the entire request path.
+        - **Compliance alignment**: Regulations such as PCI DSS and HIPAA require encryption of data in transit at all stages, not just at the network edge.
+        - **Insider threat protection**: Encrypting internal traffic helps protect against potential insider threats or compromised internal network components.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **App Services** in the Azure Portal.
+        2. Select a web app.
+        3. Go to **Configuration** > **General settings**.
+        4. Verify that **End-to-end TLS encryption** is set to **On**.
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **App Services** in the Azure Portal.
+            2. Select the web app.
+            3. Go to **Configuration** > **General settings**.
+            4. Set **End-to-end TLS encryption** to **On**.
+            5. Select **Save**.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
+        title: Secure a custom DNS name with a TLS/SSL binding in Azure App Service
+  - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled
+    title: Ensure AKS clusters have node OS auto-upgrade enabled
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.autoUpgradeProfile.nodeOSUpgradeChannel != "None"
+      azure.subscription.aksService.cluster.autoUpgradeProfile.nodeOSUpgradeChannel != "Unmanaged"
+    docs:
+      desc: |
+        This check ensures that AKS clusters have node OS auto-upgrade enabled, which automatically applies security patches to the underlying node operating system images.
+
+        **Why this matters**
+
+        - **Timely patching**: Node OS auto-upgrade ensures that security patches are applied automatically, reducing the window of exposure to known vulnerabilities.
+        - **Reduced operational burden**: Automatic upgrades eliminate the need for manual patching cycles, freeing operations teams to focus on other tasks.
+        - **Consistent security posture**: All nodes in the cluster receive patches consistently, preventing drift where some nodes have different patch levels.
+        - **Compliance alignment**: Many security frameworks require timely application of security patches, and auto-upgrade helps meet these requirements automatically.
+
+        Supported upgrade channels include **NodeImage** (full node image updates), **SecurityPatch** (OS security patches only), and **Unmanaged** (no auto-upgrade). Using "None" or "Unmanaged" leaves nodes vulnerable to known OS-level CVEs.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "autoUpgradeProfile.nodeOSUpgradeChannel"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --node-os-upgrade-channel SecurityPatch
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-cluster"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              dns_prefix          = "example"
+              node_os_upgrade_channel = "SecurityPatch"
+
+              default_node_pool {
+                name       = "default"
+                node_count = 1
+                vm_size    = "Standard_D2_v2"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os
+        title: Auto-upgrade AKS cluster node OS images
+  - uid: mondoo-azure-security-aks-local-accounts-disabled
+    title: Ensure local accounts are disabled on AKS clusters
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.disableLocalAccounts == true
+    docs:
+      desc: |
+        This check ensures that local accounts are disabled on Azure Kubernetes Service (AKS) clusters, requiring all authentication to go through Microsoft Entra ID (Azure Active Directory).
+
+        **Why this matters**
+
+        Disabling local accounts on AKS clusters provides several critical benefits:
+
+        - **Centralized identity management**: All cluster access is managed through Microsoft Entra ID, providing a single pane of glass for identity and access management.
+        - **Stronger authentication**: Entra ID supports multi-factor authentication, conditional access policies, and Privileged Identity Management, which local Kubernetes accounts do not.
+        - **Auditability**: All authentication events are logged in Entra ID sign-in logs, providing complete visibility into who accessed the cluster and when.
+        - **Credential lifecycle management**: Entra ID handles credential rotation, expiration, and revocation centrally, eliminating the risk of stale or shared local credentials.
+        - **Compliance alignment**: Many security frameworks require centralized identity management and prohibit shared or local accounts for administrative access.
+
+        When local accounts are disabled, the `clusterAdmin` and `clusterUser` credential-based kubeconfigs are disabled, and users must authenticate via `az aks get-credentials` with Entra ID.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Kubernetes services** in the Azure Portal.
+        2. Select an AKS cluster.
+        3. Go to **Cluster configuration** under **Settings**.
+        4. Verify that **Local accounts** is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks list --query "[].{Name:name, ResourceGroup:resourceGroup, DisableLocalAccounts:disableLocalAccounts}" -o table
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --disable-local-accounts
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                   = "example-aks"
+              location               = azurerm_resource_group.example.location
+              resource_group_name    = azurerm_resource_group.example.name
+              dns_prefix             = "example"
+              local_account_disabled = true
+
+              azure_active_directory_role_based_access_control {
+                azure_rbac_enabled = true
+                managed            = true
+              }
+
+              default_node_pool {
+                name       = "default"
+                node_count = 1
+                vm_size    = "Standard_D2_v2"
+              }
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad
+        title: Disable local accounts on AKS
+  - uid: mondoo-azure-security-aks-public-network-access-disabled
+    title: Ensure public network access is disabled on AKS clusters
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.publicNetworkAccess == "Disabled"
+    docs:
+      desc: |
+        This check ensures that public network access is disabled on Azure Kubernetes Service (AKS) clusters, restricting API server access to private networks only.
+
+        **Why this matters**
+
+        Disabling public network access on AKS clusters provides several critical benefits:
+
+        - **Reduced attack surface**: When public network access is disabled, the Kubernetes API server is only accessible from within the virtual network or peered networks, preventing internet-based attacks against the control plane.
+        - **Stronger than private cluster alone**: While enabling a private cluster ensures the API server has a private IP, disabling public network access goes further by removing the public endpoint entirely, eliminating the risk of misconfigured authorized IP ranges.
+        - **Data exfiltration prevention**: Restricting API server access to private networks helps prevent unauthorized data access and exfiltration through the Kubernetes API.
+        - **Compliance alignment**: Many security frameworks require management plane access to be restricted to private networks, especially for container orchestration platforms handling sensitive workloads.
+        - **Defense in depth**: Combined with private cluster, authorized IP ranges, and Azure Private Link, disabling public network access provides the strongest network isolation for the AKS control plane.
+
+        When public network access is disabled, administrators must access the API server through a private endpoint, VPN, or Azure ExpressRoute connection.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Kubernetes services** in the Azure Portal.
+        2. Select an AKS cluster.
+        3. Go to **Networking** under **Settings**.
+        4. Verify that **Public network access** is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks list --query "[].{Name:name, ResourceGroup:resourceGroup, PublicNetworkAccess:apiServerAccessProfile.enableVnetIntegration}" -o table
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-private-cluster --disable-public-fqdn
+            ```
+
+            To fully disable public network access on an existing private cluster:
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --api-server-authorized-ip-ranges ""
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              dns_prefix          = "example"
+
+              private_cluster_enabled             = true
+              private_cluster_public_fqdn_enabled = false
+              public_network_access_enabled       = false
+
+              default_node_pool {
+                name       = "default"
+                node_count = 1
+                vm_size    = "Standard_D2_v2"
+              }
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/private-clusters
+        title: Create a private AKS cluster
+      - url: https://learn.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges
+        title: Restrict AKS API server access
+  - uid: mondoo-azure-security-aks-auto-upgrade-enabled
+    title: Ensure AKS clusters have auto-upgrade enabled
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+    filters: |
+      asset.platform == "azure-aks-cluster"
+    mql: |
+      azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel != "none"
+    docs:
+      desc: |
+        This check ensures that AKS clusters have auto-upgrade enabled to automatically receive Kubernetes version updates, including security patches and bug fixes.
+
+        **Why this matters**
+
+        - **Security patching**: Kubernetes regularly releases security patches for vulnerabilities. Auto-upgrade ensures clusters receive these patches promptly without manual intervention.
+        - **Version currency**: Running outdated Kubernetes versions increases exposure to known vulnerabilities and may result in loss of support from Microsoft.
+        - **Reduced operational overhead**: Automatic upgrades reduce the burden on operations teams and eliminate the risk of missed upgrade windows.
+        - **Compliance alignment**: Security frameworks require systems to be kept up to date with the latest security patches.
+
+        Available upgrade channels include **patch** (latest patch version), **stable** (latest supported patch for N-1 minor version), **rapid** (latest supported patch for latest minor version), and **node-image** (latest node image). A channel of "none" disables auto-upgrade entirely.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az aks show --name <ClusterName> --resource-group <ResourceGroupName> --query "autoUpgradeProfile.upgradeChannel"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az aks update --name <ClusterName> --resource-group <ResourceGroupName> --auto-upgrade-channel stable
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-cluster"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              dns_prefix          = "example"
+              automatic_upgrade_channel = "stable"
+
+              default_node_pool {
+                name       = "default"
+                node_count = 1
+                vm_size    = "Standard_D2_v2"
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster
+        title: Automatically upgrade an AKS cluster
+  - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled
+    title: Ensure password-only authentication is disabled on PostgreSQL flexible servers
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+    filters: |
+      asset.platform == "azure-postgresql-flexible-server"
+    mql: |
+      azure.subscription.postgreSql.flexibleServer.passwordAuth == "Disabled"
+    docs:
+      desc: |
+        This check ensures that password-based authentication is disabled on Azure Database for PostgreSQL flexible servers, enforcing Microsoft Entra ID (Azure Active Directory) as the sole authentication method.
+
+        **Why this matters**
+
+        - **Centralized identity management**: Disabling password authentication forces all connections through Microsoft Entra ID, providing centralized identity governance and audit trails.
+        - **Multi-factor authentication**: Entra ID supports MFA and conditional access policies, significantly strengthening authentication security beyond simple passwords.
+        - **Elimination of credential risks**: Password-based authentication is vulnerable to brute force attacks, credential stuffing, and password reuse. Removing passwords eliminates these attack vectors.
+        - **Compliance alignment**: Many security frameworks recommend or require centralized identity providers with strong authentication mechanisms for database access.
+
+        **Note**: Before disabling password authentication, ensure Microsoft Entra authentication is configured and all applications use Entra ID-based connection methods.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az postgres flexible-server show --name <ServerName> --resource-group <ResourceGroupName> --query "authConfig.passwordAuth"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            First, ensure Entra ID authentication is enabled, then disable password authentication:
+
+            ```bash
+            az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --active-directory-auth Enabled --password-auth Disabled
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                = "example-psql-server"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              authentication {
+                active_directory_auth_enabled = true
+                password_auth_enabled         = false
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-azure-ad-authentication
+        title: Microsoft Entra authentication with Azure Database for PostgreSQL Flexible Server
+  - uid: mondoo-azure-security-storage-smb-versions
+    title: Ensure Azure Storage accounts only allow SMB 3.0 and later
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-storage-account"
+    mql: |
+      azure.subscription.storage.account.fileProperties.protocolSettings.smb.versions != empty
+      azure.subscription.storage.account.fileProperties.protocolSettings.smb.versions != /SMB2/
+    docs:
+      desc: |
+        This check ensures that Azure Storage accounts restrict SMB file share access to SMB 3.0 and later versions only, blocking older protocol versions that have known security vulnerabilities.
+
+        **Why this matters**
+
+        - **Protocol security**: SMB 2.1 and earlier versions lack built-in encryption, making file share traffic vulnerable to eavesdropping and man-in-the-middle attacks.
+        - **Encryption in transit**: SMB 3.0 introduced encryption support, and SMB 3.1.1 added mandatory encryption negotiation, ensuring data is protected in transit.
+        - **Known vulnerabilities**: Older SMB versions have well-documented vulnerabilities that have been exploited in major security incidents.
+        - **Compliance alignment**: Security frameworks require the use of current and secure protocol versions for data transfer.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Storage accounts** in the Azure Portal.
+        2. Select a storage account.
+        3. Go to **File shares** > **File share settings**.
+        4. Verify that only **SMB 3.0** and **SMB 3.1.1** are selected under **SMB security settings**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az storage account file-service-properties show --account-name <StorageAccountName> --query "protocolSettings.smb.versions"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Storage accounts** in the Azure Portal.
+            2. Select the storage account.
+            3. Go to **File shares** > **File share settings**.
+            4. Under **SMB security settings**, uncheck **SMB 2.1** and ensure only **SMB 3.0** and **SMB 3.1.1** are selected.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --versions "SMB3.0;SMB3.1.1"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_storage_account" "example" {
+              name                     = "examplestorageaccount"
+              resource_group_name      = azurerm_resource_group.example.name
+              location                 = azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "LRS"
+
+              share_properties {
+                smb {
+                  versions = ["SMB3.0", "SMB3.1.1"]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/files/files-smb-protocol
+        title: SMB file shares in Azure Files
+  - uid: mondoo-azure-security-storage-smb-channel-encryption
+    title: Ensure Azure Storage accounts use strong SMB channel encryption
+    impact: 70
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure-storage-account"
+    mql: |
+      azure.subscription.storage.account.fileProperties.protocolSettings.smb.channelEncryption != empty
+      azure.subscription.storage.account.fileProperties.protocolSettings.smb.channelEncryption.contains("AES-256-GCM")
+    docs:
+      desc: |
+        This check ensures that Azure Storage accounts are configured to use strong SMB channel encryption, specifically requiring AES-256-GCM support for file share connections.
+
+        **Why this matters**
+
+        - **Strong encryption**: AES-256-GCM provides 256-bit encryption with authenticated encryption, offering the highest level of confidentiality and integrity for SMB traffic.
+        - **Protection against downgrade attacks**: Explicitly requiring strong encryption prevents clients from negotiating weaker cipher suites that may be vulnerable to cryptographic attacks.
+        - **Data confidentiality**: Strong channel encryption protects file share data in transit from eavesdropping, even on untrusted network segments.
+        - **Compliance alignment**: Many regulatory standards require the use of strong encryption algorithms such as AES-256 for protecting data in transit.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Storage accounts** in the Azure Portal.
+        2. Select a storage account.
+        3. Go to **File shares** > **File share settings**.
+        4. Under **SMB security settings**, verify that **AES-256-GCM** is included in the channel encryption options.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az storage account file-service-properties show --account-name <StorageAccountName> --query "protocolSettings.smb.channelEncryption"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Storage accounts** in the Azure Portal.
+            2. Select the storage account.
+            3. Go to **File shares** > **File share settings**.
+            4. Under **SMB security settings**, ensure **AES-256-GCM** is selected for channel encryption.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --channel-encryption "AES-128-CCM;AES-128-GCM;AES-256-GCM"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_storage_account" "example" {
+              name                     = "examplestorageaccount"
+              resource_group_name      = azurerm_resource_group.example.name
+              location                 = azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "LRS"
+
+              share_properties {
+                smb {
+                  channel_encryption_type = ["AES-128-CCM", "AES-128-GCM", "AES-256-GCM"]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/files/files-smb-protocol
+        title: SMB file shares in Azure Files
+  - uid: mondoo-azure-security-vpn-gateway-generation2
+    title: Ensure VPN gateways use Generation2 for stronger cryptographic standards
+    impact: 60
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.network.virtualNetworkGateways.where(gatewayType == "Vpn").all(
+        vpnGatewayGeneration == "Generation2"
+      )
+    docs:
+      desc: |
+        This check ensures that Azure VPN gateways use the Generation2 SKU, which supports higher throughput, more tunnels, and stronger cryptographic standards compared to Generation1 gateways.
+
+        **Why this matters**
+
+        - **Stronger cryptography**: Generation2 gateways support the latest cryptographic algorithms and higher key sizes, providing stronger protection for VPN tunnels.
+        - **Higher performance**: Generation2 SKUs offer significantly higher throughput (up to 10 Gbps) compared to Generation1, reducing the risk of performance-related security workarounds.
+        - **More tunnels**: Supports more site-to-site tunnels, reducing the need to consolidate traffic through fewer, potentially less secure paths.
+        - **Future-proofing**: Generation1 gateways are legacy SKUs. Microsoft recommends Generation2 for all new deployments and migration of existing gateways.
+      audit: |
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az network vnet-gateway list --query "[?gatewayType=='Vpn'].{Name:name, Generation:vpnGatewayGeneration, Sku:sku.name}"
+        ```
+      remediation:
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            VPN gateway generation must be specified at creation time. Existing Generation1 gateways must be recreated as Generation2:
+
+            ```bash
+            az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw2 --vpn-gateway-generation Generation2
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_virtual_network_gateway" "example" {
+              name                = "example-vpn-gateway"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              type                = "Vpn"
+              vpn_type            = "RouteBased"
+              sku                 = "VpnGw2"
+              generation          = "Generation2"
+
+              ip_configuration {
+                name                 = "vnetGatewayConfig"
+                public_ip_address_id = azurerm_public_ip.example.id
+                subnet_id            = azurerm_subnet.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings
+        title: About VPN Gateway configuration settings
+  - uid: mondoo-azure-security-compute-disk-public-access-disabled
+    title: Ensure public network access is disabled for Azure managed disks
+    impact: 80
+    tags:
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.compute.disks.all(
+        publicNetworkAccess == "Disabled"
+      )
+    docs:
+      desc: |
+        This check ensures that public network access is disabled for all Azure managed disks, preventing disk data from being accessed over the public internet during export or upload operations.
+
+        **Why this matters**
+
+        - **Data exfiltration prevention**: When public network access is enabled, anyone with valid credentials and a SAS URI can download disk data over the internet, increasing the risk of data theft.
+        - **Network isolation**: Disabling public access ensures that disk export and upload operations can only occur through private endpoints within your virtual network.
+        - **Defense in depth**: Even if disk access credentials are compromised, disabling public network access prevents data extraction from outside your network perimeter.
+        - **Compliance alignment**: Many security frameworks require that data storage and transfer be restricted to private network paths, especially for sensitive workloads.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Disks** in the Azure Portal.
+        2. Select a managed disk.
+        3. Go to **Networking**.
+        4. Verify that **Public network access** is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az disk list --query "[].{Name:name, PublicAccess:publicNetworkAccess, NetworkPolicy:networkAccessPolicy}" -o table
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            **Using Azure Portal**
+
+            1. Navigate to **Disks** in the Azure Portal.
+            2. Select the managed disk.
+            3. Go to **Networking**.
+            4. Set **Public network access** to **Disabled**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            **Using Azure CLI**
+
+            ```bash
+            az disk update --name <DiskName> --resource-group <ResourceGroupName> --public-network-access Disabled --network-access-policy DenyAll
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_managed_disk" "example" {
+              name                   = "example-disk"
+              location               = azurerm_resource_group.example.location
+              resource_group_name    = azurerm_resource_group.example.name
+              storage_account_type   = "Standard_LRS"
+              create_option          = "Empty"
+              disk_size_gb           = 128
+              public_network_access_enabled = false
+              network_access_policy  = "DenyAll"
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-private-links-for-import-export-portal
+        title: Restrict import/export access for managed disks using Azure Private Link


### PR DESCRIPTION
- Add 44 new AWS security checks across EC2, RDS, S3, EKS, Lambda, and more
- Add 24 new Azure security checks including VNet VM protection and AKS
  public network access
- Use resource-specific Azure platforms (azure-aks-cluster,
  azure-keyvault-vault, etc.) for targeted check filtering
- Modernize 3 Azure checks to use native typed fields instead of properties
  dict access (Key Vault purge protection, Key Vault public network access,
  subnet default outbound access)