### PR TITLE
Pin mondoohq/actions/cnspec-lint to commit SHA

### DIFF
--- a/.github/workflows/policies_lint.yaml
+++ b/.github/workflows/policies_lint.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Lint cnspec policies and output SARIF
-        uses: mondoohq/actions/cnspec-lint@main
+        uses: mondoohq/actions/cnspec-lint@b34b9555d2bbcd8481050c13c4b875d11a5398b9 # main
         with:
           path: ./content
           output-file: "results.sarif"


### PR DESCRIPTION
## Summary
- Pins `mondoohq/actions/cnspec-lint` from `@main` branch reference to a specific commit SHA (`b34b9555d2bbcd8481050c13c4b875d11a5398b9`)
- This was the only unpinned third-party action across all 13 workflows (59/60 were already pinned)
- Enables Dependabot to track and auto-update this action, matching the pattern used by all other actions in the repo

## Test plan
- [ ] Verify the `Lint Policies` workflow still runs successfully on a PR that modifies `content/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)