### PR TITLE
V13: Update terraform deprecation check for typed requiredProviders resource

### DIFF
--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -45,7 +45,7 @@ queries:
     title: Ensure Terraform template provider is not used
     mql: |
       # ensure it is not used in required providers
-      terraform.settings.requiredProviders.keys.none("template")
+      terraform.settings.requiredProviders.none(name == "template")
       # ensure it is not used in data sources
       terraform.datasources.none ( nameLabel == "template_file")
     docs:


### PR DESCRIPTION
## Summary
- Adapt the template provider deprecation check in `terraform-deprecations.mql.yaml` to work with the new typed `terraform.settings.requiredProvider` resource list from [cnquery#6741](https://github.com/mondoohq/cnquery/pull/6741)
- Changes `terraform.settings.requiredProviders.keys.none("template")` → `terraform.settings.requiredProviders.none(name == "template")` since `requiredProviders` is now a list of typed resources with a `name` field instead of an opaque dict

## Test plan
- [ ] Lint the updated policy: `cnspec policy lint content/terraform-deprecations.mql.yaml`
- [ ] Test against a Terraform directory that uses the template provider to verify the check still triggers
- [ ] Test against a Terraform directory without the template provider to verify no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)