### PR TITLE
Update Azure Defender checks for typed resource fields

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -4095,7 +4095,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForServers["enabled"] == true
+      azure.subscription.cloudDefender.defenderForServers.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Servers is enabled to provide advanced threat protection for Azure virtual machines and on-premises servers connected to Azure.
@@ -4166,7 +4166,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForAppServices["enabled"] == true
+      azure.subscription.cloudDefender.defenderForAppServices.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for App Service is enabled to detect threats targeting applications hosted on Azure App Service.
@@ -4236,7 +4236,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForSqlDatabases["enabled"] == true
+      azure.subscription.cloudDefender.defenderForSqlDatabases.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Azure SQL Databases is enabled to provide advanced threat detection for Azure SQL Database instances.
@@ -4306,7 +4306,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForStorageAccounts["enabled"] == true
+      azure.subscription.cloudDefender.defenderForStorageAccounts.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Storage is enabled to detect unusual and potentially harmful attempts to access or exploit Azure Storage accounts.
@@ -4376,7 +4376,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForKeyVaults["enabled"] == true
+      azure.subscription.cloudDefender.defenderForKeyVaults.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Key Vault is enabled to detect unusual and potentially harmful attempts to access or exploit Azure Key Vault resources.
@@ -4446,7 +4446,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForContainers["enabled"] == true
+      azure.subscription.cloudDefender.defenderForContainers.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Containers is enabled to provide threat protection for Azure Kubernetes Service (AKS) clusters and container workloads.
@@ -4516,7 +4516,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForResourceManager["enabled"] == true
+      azure.subscription.cloudDefender.defenderForResourceManager.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Resource Manager is enabled to monitor Azure management operations and detect suspicious resource management activities.
@@ -7890,7 +7890,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForCosmosDb["enabled"] == true
+      azure.subscription.cloudDefender.defenderForCosmosDb.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for Cosmos DB is enabled to detect threats targeting Azure Cosmos DB accounts.
@@ -7973,7 +7973,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForOpenSourceDatabases["enabled"] == true
+      azure.subscription.cloudDefender.defenderForOpenSourceDatabases.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for open-source relational databases is enabled to provide threat protection for Azure Database for MySQL, PostgreSQL, and MariaDB.
@@ -10352,7 +10352,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForSqlServersOnMachines["enabled"] == true
+      azure.subscription.cloudDefender.defenderForSqlServersOnMachines.enabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for SQL Servers on Machines is enabled to provide advanced threat detection for SQL Server instances running on Azure VMs, on-premises, and in hybrid environments.


### PR DESCRIPTION
## Summary
- Update 10 Azure Defender security checks to use typed resource property access (`.enabled`) instead of dict-style access (`["enabled"]`), required by [cnquery#6694](https://github.com/mondoohq/cnquery/pull/6694) which converts Azure Defender dict values into typed resources
- Affected checks: `defenderForServers`, `defenderForAppServices`, `defenderForSqlDatabases`, `defenderForStorageAccounts`, `defenderForKeyVaults`, `defenderForContainers`, `defenderForResourceManager`, `defenderForCosmosDb`, `defenderForOpenSourceDatabases`, `defenderForSqlServersOnMachines`
- Checks already using typed resource access (`defenderCSPM`, `defenderForApis`) are unaffected

## Test plan
- [ ] Lint the updated policy: `cnspec policy lint content/mondoo-azure-security.mql.yaml`
- [ ] Verify all 10 updated checks compile correctly against the new cnquery provider
- [ ] Test against an Azure subscription to confirm Defender checks still evaluate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)