### PR TITLE
Remove Azure MariaDB checks from Azure policies

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -7976,7 +7976,7 @@ queries:
       azure.subscription.cloudDefender.defenderForOpenSourceDatabases.enabled == true
     docs:
       desc: |
-        This check ensures that Microsoft Defender for open-source relational databases is enabled to provide threat protection for Azure Database for MySQL, PostgreSQL, and MariaDB.
+        This check ensures that Microsoft Defender for open-source relational databases is enabled to provide threat protection for Azure Database for MySQL and PostgreSQL.
 
         **Why this matters**
 
@@ -7984,10 +7984,10 @@ queries:
 
         - **Anomalous access detection**: Identifies unusual login patterns, access from unexpected locations, and brute force attacks targeting open-source database services.
         - **SQL injection detection**: Detects potential SQL injection attacks and anomalous query patterns that could indicate exploitation attempts.
-        - **Vulnerability alerts**: Monitors for known vulnerabilities and suspicious activities specific to MySQL, PostgreSQL, and MariaDB database engines.
+        - **Vulnerability alerts**: Monitors for known vulnerabilities and suspicious activities specific to MySQL and PostgreSQL database engines.
         - **Compliance alignment**: Many security standards require advanced threat detection for all database services, including open-source relational databases.
 
-        By enabling Defender for open-source relational databases, organizations can detect and respond to threats targeting their MySQL, PostgreSQL, and MariaDB database infrastructure.
+        By enabling Defender for open-source relational databases, organizations can detect and respond to threats targeting their MySQL and PostgreSQL database infrastructure.
       audit: |
         **Manual Audit via Azure Portal:**
 

--- a/content/querypacks/mondoo-asset-count.mql.yaml
+++ b/content/querypacks/mondoo-asset-count.mql.yaml
@@ -70,7 +70,6 @@ packs:
           - uid: mondoo-asset-count-azure-subscription-name
           - uid: mondoo-asset-count-azure-cosmosdb-accounts
           - uid: mondoo-asset-count-azure-vaults
-          - uid: mondoo-asset-count-azure-mariaDb-servers
           - uid: mondoo-asset-count-azure-mySql-servers
           - uid: mondoo-asset-count-azure-postgreSql-servers
           - uid: mondoo-asset-count-azure-application-gateways
@@ -194,13 +193,6 @@ queries:
       desc: Returns the number of Key Vaults in the Azure subscription.
     mql: |
       azure.subscription.keyVault.vaults.length
-
-  - uid: mondoo-asset-count-azure-mariaDb-servers
-    title: Azure MariaDB servers
-    docs:
-      desc: Returns the number of MariaDB servers in the Azure subscription.
-    mql: |
-      azure.subscription.mariaDb.servers.length
 
   - uid: mondoo-asset-count-azure-mySql-servers
     title: Azure MySQL servers

--- a/content/querypacks/mondoo-azure-inventory.mql.yaml
+++ b/content/querypacks/mondoo-azure-inventory.mql.yaml
@@ -53,7 +53,6 @@ packs:
           - uid: mondoo-asset-inventory-azure-postgresql-firewallrules
           - uid: mondoo-asset-inventory-azure-mysql
           - uid: mondoo-asset-inventory-azure-mysql-firewallrules
-          - uid: mondoo-asset-inventory-azure-mariaDb
       - uid: mondoo-asset-inventory-azure-keyvault-group
         title: Azure Key Vault
         filters: asset.runtime == "azure"
@@ -293,21 +292,6 @@ queries:
   - uid: mondoo-asset-inventory-azure-mysql-flexible
     filters: asset.platform == "azure-mysql-flexible-server"
     mql: azure.subscription.mySql.flexibleServer
-
-  - uid: mondoo-asset-inventory-azure-mariaDb
-    title: Azure MariaDB servers
-    docs:
-      desc: |
-        This query retrieves data for all Azure MariaDB servers
-    variants:
-      - uid: mondoo-asset-inventory-azure-mariaDb-single
-      - uid: mondoo-asset-inventory-azure-mariaDb-api
-  - uid: mondoo-asset-inventory-azure-mariaDb-api
-    filters: asset.platform == "azure"
-    mql: azure.subscription.mariaDb.servers
-  - uid: mondoo-asset-inventory-azure-mariaDb-single
-    filters: asset.platform == "azure-mariadb-server"
-    mql: azure.subscription.mariaDb.server
 
   - uid: mondoo-asset-inventory-azure-diagnosticSettings
     title: Azure diagnostic settings


### PR DESCRIPTION
## Summary
- Remove MariaDB references from the Defender for open-source databases check description in `mondoo-azure-security.mql.yaml`
- Remove `mondoo-asset-count-azure-mariaDb-servers` query from `mondoo-asset-count.mql.yaml`
- Remove `mondoo-asset-inventory-azure-mariaDb` and its variants from `mondoo-azure-inventory.mql.yaml`

Azure Database for MariaDB has been retired by Microsoft, so these checks are no longer applicable.

## Test plan
- [ ] Run `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` to verify policy validity
- [ ] Run `cnspec policy lint ./content/querypacks/mondoo-asset-count.mql.yaml`
- [ ] Run `cnspec policy lint ./content/querypacks/mondoo-azure-inventory.mql.yaml`
- [ ] Verify no remaining MariaDB references in Azure policy files

🤖 Generated with [Claude Code](https://claude.com/claude-code)