### PR TITLE
🐛 run go-test even if only content changes

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -8,6 +8,7 @@ on:
       - "**.mod"
       - "**.ct"
       - "go.sum"
+      - "content/**"
       - ".github/workflows/pr-test-lint.yml"
 
 permissions:


### PR DESCRIPTION
This has caused a series of breaking PRs in cnspec because we currently don't run these tests when content changes. 

Here is an offender:

- https://github.com/mondoohq/cnspec/pull/2143 

and here are the subsequent PRs that fail:

- https://github.com/mondoohq/cnspec/pull/2123
- https://github.com/mondoohq/cnspec/pull/2122 etc