### PR TITLE
Fix MQL false positives and unescaped regex dots across policies

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -15852,13 +15852,13 @@ queries:
         title: AWS Documentation - Supported protocols and ciphers between viewers and CloudFront
   - uid: mondoo-aws-security-cloudfront-minimum-tls-version-aws
     filters: asset.platform == "aws"
-    mql: aws.cloudfront.distributions.all(minimumProtocolVersion == /TLSv1.2/)
+    mql: aws.cloudfront.distributions.all(minimumProtocolVersion == /TLSv1\.2/)
   - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudfront_distribution")
     mql: |
       terraform.resources.where(nameLabel == "aws_cloudfront_distribution").all(
         blocks.where(type == "viewer_certificate").all(
-          arguments.minimum_protocol_version == /TLSv1.2/
+          arguments.minimum_protocol_version == /TLSv1\.2/
         )
       )
   - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-plan
@@ -15866,14 +15866,14 @@ queries:
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_cloudfront_distribution").all(
         change.after.viewer_certificate != empty &&
-        change.after.viewer_certificate.all(minimum_protocol_version == /TLSv1.2/)
+        change.after.viewer_certificate.all(minimum_protocol_version == /TLSv1\.2/)
       )
   - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloudfront_distribution")
     mql: |
       terraform.state.resources.where(type == "aws_cloudfront_distribution").all(
         values.viewer_certificate != empty &&
-        values.viewer_certificate.all(minimum_protocol_version == /TLSv1.2/)
+        values.viewer_certificate.all(minimum_protocol_version == /TLSv1\.2/)
       )
   - uid: mondoo-aws-security-cloudfront-waf-enabled
     title: Ensure CloudFront distributions have WAF web ACL associated

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -181,7 +181,7 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-1
     mql: |-
-      dns.mx.where(domainName == /l.google.com/).
+      dns.mx.where(domainName == /l\.google\.com\./).
         map(domainName.downcase).
         containsOnly(["aspmx.l.google.com.", "alt1.aspmx.l.google.com.", "alt2.aspmx.l.google.com.", "alt3.aspmx.l.google.com.", "alt4.aspmx.l.google.com."])
     docs:

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -37,7 +37,6 @@ policies:
         filters: |
           asset.platform == "dockerfile"
         checks:
-          - uid: mondoo-docker-security-no-insecure-certificate-validation-yum
           - uid: mondoo-docker-security-no-insecure-certificate-validation-apt
           - uid: mondoo-docker-security-no-insecure-certificate-validation-curl
           - uid: mondoo-docker-security-no-insecure-certificate-validation-wget
@@ -90,35 +89,6 @@ queries:
         title: Dockerfile Reference - EXPOSE
       - url: https://docs.docker.com/build/building/best-practices/
         title: Dockerfile Best Practices
-  - uid: mondoo-docker-security-no-insecure-certificate-validation-yum
-    title: Ensure package manager certificate validation is enabled
-    impact: 100
-    mql: |
-      docker.file.stages.all(run.none(script.contains("--nogpgcheck")))
-      docker.file.stages.all(run.none(script.contains("--no-check-certificate")))
-      docker.file.stages.all(run.none(script.contains("--no-gpg-check")))
-    docs:
-      desc: |
-        This check ensures that package managers like YUM, DNF, APT, and others in Dockerfiles do not disable SSL certificate validation.
-
-        **Why this matters**
-
-        Disabling SSL certificate validation in package managers can lead to significant security risks:
-
-        - **Man-in-the-middle attacks**: Without SSL validation, attackers can intercept and modify package data during download, potentially injecting malicious code.
-        - **Integrity issues**: Disabling certificate checks undermines the integrity of the software being installed, as there is no guarantee that the packages come from trusted sources.
-        - **Compliance risks**: Many security standards and best practices require SSL certificate validation to ensure secure communication and package integrity.
-        - **Operational risks**: Using insecure options can lead to the installation of compromised or outdated packages, increasing the risk of vulnerabilities in the container.
-
-        By ensuring SSL certificate validation is enabled, this check helps to maintain the integrity and security of the container's software environment, aligning with best practices and reducing potential risks.
-      remediation: |
-        - Review the Dockerfile and ensure that package managers are configured to use SSL certificate validation.
-        - Use secure practices for package installations to maintain system integrity: Remove any insecure options such as `--nogpgcheck`, `--no-check-certificate`, `--no-gpg-check`, and similar flags.
-    refs:
-      - url: https://docs.docker.com/build/building/best-practices/
-        title: Dockerfile Best Practices
-      - url: https://docs.docker.com/build/building/best-practices/#run
-        title: Dockerfile Best Practices - RUN
   - uid: mondoo-docker-security-no-insecure-certificate-validation-apt
     title: Don't disable certificate validation in APT
     impact: 100
@@ -150,8 +120,8 @@ queries:
     title: Don't disable certificate validation in curl
     impact: 100
     mql: |
-      docker.file.stages.all(run.none(script.contains("--insecure")))
-      docker.file.stages.all(run.none(script.contains("-k")))
+      docker.file.stages.all(run.where(script.contains("curl")).none(script.contains("--insecure")))
+      docker.file.stages.all(run.where(script.contains("curl")).none(script.contains(" -k")))
     docs:
       desc: |
         This check ensures that the `--insecure` or `-k` options are not used with `curl` in Docker containers.
@@ -206,7 +176,7 @@ queries:
     title: Don't run commands using sudo
     impact: 100
     mql: |
-      docker.file.stages.all(run.none(script.contains("sudo")))
+      docker.file.stages.all(run.none(script.contains("sudo ")))
     docs:
       desc: |
         This check ensures that `sudo` is not used in Dockerfiles to run commands.
@@ -231,13 +201,14 @@ queries:
       - url: https://docs.docker.com/build/building/best-practices/
         title: Dockerfile Best Practices
   - uid: mondoo-docker-security-no-gpg-skip-yum
-    title: Don't skip GPG validation in YUM/DNF
+    title: Don't skip GPG validation in YUM/DNF/zypper
     impact: 100
     mql: |
       docker.file.stages.all(run.none(script.contains("--nogpgcheck")))
+      docker.file.stages.all(run.none(script.contains("--no-gpg-check")))
     docs:
       desc: |
-        This check ensures that the `--nogpgcheck` option is not used with YUM or DNF in Dockerfile `RUN` instructions.
+        This check ensures that GPG signature verification bypass options (`--nogpgcheck` for YUM/DNF, `--no-gpg-check` for zypper) are not used in Dockerfile `RUN` instructions.
 
         **Why this matters**
 
@@ -250,8 +221,8 @@ queries:
 
         By ensuring GPG validation is enabled, this check helps maintain the integrity and security of the container's software environment, aligning with best practices and reducing potential risks.
       remediation: |
-        - Review the Dockerfile `RUN` instructions to ensure that YUM or DNF commands do not use the `--nogpgcheck` option.
-        - Configure YUM or DNF to perform GPG validation to enhance the security of your container configurations.
+        - Review the Dockerfile `RUN` instructions to ensure that YUM, DNF, or zypper commands do not use GPG bypass options (`--nogpgcheck` or `--no-gpg-check`).
+        - Configure package managers to perform GPG validation to enhance the security of your container configurations.
     refs:
       - url: https://docs.docker.com/build/building/best-practices/
         title: Dockerfile Best Practices

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -8210,7 +8210,7 @@ queries:
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
-        where(path == /ssh_host_.*key.pub$/).list {
+        where(path == /ssh_host_.*key\.pub$/).list {
           permissions.user_executable == false
           permissions.group_writeable == false
           permissions.group_executable == false

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -257,7 +257,7 @@ queries:
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
-        where(path == /ssh_host_.*key.pub$/).list {
+        where(path == /ssh_host_.*key\.pub$/).list {
           permissions.user_executable == false
           permissions.group_writeable == false
           permissions.group_executable == false

--- a/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
@@ -65,33 +65,33 @@ queries:
   - uid: mondoo-xz-vulnerability-policy-libs-alpine
     filters: asset.platform == 'alpine'
     mql: |
-      packages.where(name == /xz/).all(version != /5.6.1-r0/)
-      packages.where(name == /xz/).all(version != /5.6.1-r1/)
+      packages.where(name == /xz/).all(version != /5\.6\.1-r0/)
+      packages.where(name == /xz/).all(version != /5\.6\.1-r1/)
   - uid: mondoo-xz-vulnerability-policy-libs-fedora
     filters: |
       asset.platform == 'fedora'
       asset.version == '40' || asset.version == '41'
     mql: |
-      packages.where(name == /xz/).all(version != /5.6.0/)
-      packages.where(name == /xz/).all(version != /5.6.1/)
+      packages.where(name == /xz/).all(version != /5\.6\.0/)
+      packages.where(name == /xz/).all(version != /5\.6\.1/)
   - uid: mondoo-xz-vulnerability-policy-libs-debian
     filters: |
       asset.platform == 'debian'
       asset.version == 'trixie/sid'
     mql: |
-      packages.where(name == /xz/).all(version < '5.6.1' || version == /really5.4.5/)
+      packages.where(name == /xz/).all(version < '5.6.1' || version == /really5\.4\.5/)
   - uid: mondoo-xz-vulnerability-policy-libs-kali
     filters: |
       asset.platform == 'kali'
       asset.version == '2024.1'
     mql: |
-      packages.where(name == /xz/).all(version != /5.6.0/)
-      packages.where(name == /xz/).all(version != /5.6.1/)
+      packages.where(name == /xz/).all(version != /5\.6\.0/)
+      packages.where(name == /xz/).all(version != /5\.6\.1/)
   - uid: mondoo-xz-vulnerability-policy-libs-opensuse
     filters: |
       asset.platform == 'opensuse-tumbleweed'
     mql: |
-      packages.where(name == /xz/).all(version < '5.6.1' || version == /revertto5.4-2/)
+      packages.where(name == /xz/).all(version < '5.6.1' || version == /revertto5\.4-2/)
   - uid: mondoo-xz-vulnerability-policy-libs-archlinux
     filters: |
       asset.platform == 'arch'


### PR DESCRIPTION
## Summary
- **Dockerfile security**: Scope `--insecure`/`-k` checks to curl commands to eliminate false positives (e.g., `apt-key`, `--insecure-registry`), add trailing space to sudo check to avoid matching `visudo`/`sudoers`
- **Dockerfile security**: Remove duplicate `no-insecure-certificate-validation-yum` check (its flags were already covered by the wget and GPG skip checks), consolidate GPG validation to cover YUM/DNF/zypper
- **Cross-policy regex fixes**: Escape unescaped `.` metacharacters in regex patterns across 5 policies (linux, phoenix-plcnext, dns, aws, xz-vulnerability)

## Affected policies
| Policy | Fix |
|--------|-----|
| `mondoo-dockerfile-security` | Scope curl flags, fix sudo, remove duplicate check, consolidate GPG |
| `mondoo-linux-security` | Escape dot in `key.pub` SSH regex |
| `mondoo-phoenix-plcnext-security` | Escape dot in `key.pub` SSH regex |
| `mondoo-dns-security` | Escape dots in `l.google.com` MX regex |
| `mondoo-aws-security` | Escape dot in `TLSv1.2` CloudFront regex (4 occurrences) |
| `mondoo-xz-vulnerability` | Escape dots in version patterns (8 occurrences) |

## Test plan
- [x] All 6 modified files pass `cnspec policy lint`
- [ ] Verify curl check no longer flags `RUN curl https://example.com | apt-key add -`
- [ ] Verify sudo check no longer flags `RUN adduser --disabled-password --gecos '' user && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers`
- [ ] Verify escaped regex dots still match intended patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)