### PR TITLE
Fix GCP security terraform testdata to match new policy checks

### DIFF
--- a/content/testdata/mondoo-gcp-security-tf-pass/logging.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/logging.tf
@@ -1,0 +1,22 @@
+# Create a Cloud Logging sink for log export
+resource "google_logging_project_sink" "audit_log_sink" {
+  name        = "audit-log-sink"
+  destination = "storage.googleapis.com/${google_storage_bucket.log_bucket.name}"
+
+  filter = "logName:\"logs/cloudaudit.googleapis.com\""
+
+  unique_writer_identity = true
+}
+
+# Create a Cloud Storage bucket for log storage
+resource "google_storage_bucket" "log_bucket" {
+  name          = "audit-logs-${random_id.rnd.hex}"
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  retention_policy {
+    retention_period = 2592000 # 30 days in seconds
+  }
+}

--- a/content/testdata/mondoo-gcp-security-tf-pass/mysql.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/mysql.tf
@@ -38,6 +38,11 @@ resource "google_sql_database_instance" "mysql_public_instance" {
       value = "on"
     }
 
+    # Enable password validation policy
+    password_validation_policy {
+      enable_password_policy = true
+    }
+
     # Enable maintenance window
     maintenance_window {
       day          = 7 # Sunday

--- a/content/testdata/mondoo-gcp-security-tf-pass/postgres.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/postgres.tf
@@ -43,6 +43,11 @@ resource "google_sql_database_instance" "postgres_public_instance" {
       value = "default"
     }
 
+    # Enable password validation policy
+    password_validation_policy {
+      enable_password_policy = true
+    }
+
     # Enable maintenance window
     maintenance_window {
       day          = 7 # Sunday

--- a/content/testdata/mondoo-gcp-security-tf-pass/sqlserver.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/sqlserver.tf
@@ -26,6 +26,11 @@ resource "google_sql_database_instance" "sqlserver_public_instance" {
       start_time = "00:00"
     }
 
+    # Enable password validation policy
+    password_validation_policy {
+      enable_password_policy = true
+    }
+
     # Enable maintenance window
     maintenance_window {
       day          = 7 # Sunday


### PR DESCRIPTION
Two recently added GCP security checks caused TestBundles/mondoo-gcp-security-tf-pass
to fail, dropping the score from the expected 60 (0x3c) to 30 (0x1e).

Root cause:
New policy checks were added to `mondoo-gcp-security.mql.yaml` without updating the
corresponding "pass" testdata to satisfy them:

- https://github.com/mondoohq/cnspec/commit/e5a8c58c21c69ad5a6f530f9a7a5e4fd109e583a (https://github.com/mondoohq/cnspec/pull/2115) "Add 106 new checks across AWS, Azure, and GCP security policies"
  added `mondoo-gcp-security-logging-sinks-configured` (impact 60), which requires at
  least one `google_logging_project_sink` resource. The testdata had none, so the check
  failed with a score floor of 40.

- https://github.com/mondoohq/cnspec/commit/ae7b5a35d01bea945a427ab7aa366b29b9c34901 (https://github.com/mondoohq/cnspec/pull/2131) "Support new GCP platforms + add 28 new checks"
  added `mondoo-gcp-security-cloud-sql-password-policy-enabled` (impact 70), which
  requires all `google_sql_database_instance` resources to have a
  `password_validation_policy` block. All three SQL instances (MySQL, PostgreSQL,
  SQL Server) in the testdata were missing this block, so the check failed with a
  score floor of 30.

Since the policy uses highest-impact scoring (worst score wins), the final score
became min(60, 40, 30) = 30 instead of the expected 60.

Fix:
- Add `logging.tf` with a `google_logging_project_sink` resource and storage bucket
- Add `password_validation_policy` blocks to `mysql.tf`, `postgres.tf`, `sqlserver.tf`

The expected score of 60 remains correct — the only intentionally failing check is
the pre-existing KMS keyring `location = "global"` check (impact 40, score = 60).