### PR TITLE
Fix incorrect compliance framework mappings

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -19802,9 +19802,9 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/nist-csf-2: nist-csf-2-pr-ps-06
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-2
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
     variants:
       - uid: mondoo-aws-security-ec2-uefi-boot-mode-aws
         tags:
@@ -19870,9 +19870,9 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/nist-csf-2: nist-csf-2-pr-ps-06
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-2
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
     variants:
       - uid: mondoo-aws-security-ec2-no-paravirtual-instances-aws
         tags:
@@ -20012,9 +20012,9 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
     variants:
       - uid: mondoo-aws-security-route53-dnssec-enabled-aws
         tags:

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -10995,9 +10995,9 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nis-2: nis-2-21-2-j
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
     filters: |
       asset.platform == "azure-aks-cluster"
     mql: |


### PR DESCRIPTION
## Summary

- Corrected 8 compliance tag values across 4 checks after semantic audit comparing what each check does vs. what each framework control requires

### Fixes

| Check | Tag | Old | New | Reason |
|-------|-----|-----|-----|--------|
| ec2-uefi-boot-mode | nist-csf-2 | PR.PS-06 | PR.PS-01 | Config management, not SDLC |
| ec2-uefi-boot-mode | nist-csf-1 | PR.IP-2 | PR.IP-1 | Baseline config, not SDLC |
| ec2-no-paravirtual-instances | nist-csf-2 | PR.PS-06 | PR.PS-01 | Config management, not SDLC |
| ec2-no-paravirtual-instances | nist-csf-1 | PR.IP-2 | PR.IP-1 | Baseline config, not SDLC |
| route53-dnssec-enabled | nist-csf-2 | PR.DS-01 | PR.DS-02 | DNSSEC protects data in transit, not at rest |
| route53-dnssec-enabled | nist-csf-1 | PR.DS-1 | PR.DS-2 | DNSSEC protects data in transit, not at rest |
| aks-local-accounts-disabled | nist-csf-2 | DE.CM-09 | PR.AA-03 | Authentication control, not monitoring |
| aks-local-accounts-disabled | nist-csf-1 | DE.CM-1 | PR.AC-7 | Authentication control, not monitoring |

## Test plan

- [x] Verify YAML validity with `cnspec policy lint` on modified files
- [x] Validate tag values reference valid framework control UIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)