### PR TITLE
:bug: Fix Okta ThreatInsight action value from block_login to block

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -1383,7 +1383,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            ### Configure factor reset notifications
+            ### Configure password changed notifications
             1. In the Admin Console, go to **Security > General**.
             2. Under **Security Notification Emails**, select **Edit**.
             3. Set **Password changed notification email** to **Enabled**.
@@ -1406,7 +1406,7 @@ queries:
             ```
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
-    mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_factor_reset_enabled'] == true )
+    mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_password_changed_enabled'] == true )
     docs:
       remediation:
         - id: terraform
@@ -1645,7 +1645,7 @@ queries:
           mondoo.com/icon: "terraform"
     docs:
       desc: |
-        Specify the minimum number of lowercase characters in a password. Complex passwords increase the security of your users' accounts.
+        Specify the minimum number of numeric characters in a password. Complex passwords increase the security of your users' accounts.
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-password-policies.htm
         title: Okta Password Policies
@@ -1936,7 +1936,7 @@ queries:
           mondoo.com/icon: "terraform"
     docs:
       desc: |
-        This checks passwords against common password dictionary. Complex passwords increase the security of your users' accounts.
+        This checks passwords against a common password dictionary. Complex passwords increase the security of your users' accounts.
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-password-policies.htm
         title: Okta Password Policies
@@ -2412,11 +2412,11 @@ queries:
 
         - **none**: ThreatInsight is effectively disabled and takes no action.
         - **audit**: Suspicious attempts are logged in the System Log but not blocked, allowing attackers to continue trying credentials.
-        - **block_login** (recommended): Suspicious IP addresses are blocked from authenticating before credentials are evaluated, preventing brute-force and credential-stuffing attacks.
+        - **block** (recommended): Suspicious IP addresses are blocked from authenticating before credentials are evaluated, preventing brute-force and credential-stuffing attacks.
 
         ### Okta recommends
 
-        Set ThreatInsight action to "block_login" to proactively block authentication attempts from known malicious IP addresses. This blocks requests before password evaluation, which means:
+        Set ThreatInsight action to "block" to proactively block authentication attempts from known malicious IP addresses. This blocks requests before password evaluation, which means:
           - Locked-out users won't have their lockout count incremented by malicious attempts
           - Credential-stuffing attacks are stopped before they can validate stolen passwords
           - Brute-force attempts are blocked at the perimeter
@@ -2437,7 +2437,7 @@ queries:
         title: HealthInsight tasks and recommendations
   - uid: mondoo-okta-security-threatinsight-action-block-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.threatInsightSettings.action == "block_login"
+    mql: okta.organization.threatInsightSettings.action == "block"
     docs:
       remediation:
         - id: console


### PR DESCRIPTION
## Summary
- Fix false positive in ThreatInsight check: Okta API returns `"block"`, not `"block_login"`
- Fix wrong MQL in `password-changed-notifications-for-end-users-terraform-plan` that was checking `send_email_for_factor_reset_enabled` instead of `send_email_for_password_changed_enabled`
- Fix `password-settings-min-number` description that incorrectly said "lowercase" instead of "numeric"
- Fix mislabeled remediation heading ("factor reset" → "password changed")
- Fix grammar in dictionary lookup description

## Test plan
- [ ] Run `cnspec policy lint ./content/mondoo-okta-security.mql.yaml` to verify policy validity
- [ ] Scan an Okta org with ThreatInsight set to "Log and block" and confirm the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)