### PR TITLE
:broom: Clean up policies lint workflow

### DIFF
--- a/.github/workflows/policies_lint.yaml
+++ b/.github/workflows/policies_lint.yaml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -29,22 +29,16 @@ jobs:
         with:
           path: ./content
           output-file: "results.sarif"
-      - name: Install jq
-        run: sudo apt-get install jq
       - name: Display SARIF file content
-        run: cat results.sarif | jq .
+        run: jq . results.sarif
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: results.sarif
-      - name: Check SARIF file content
-        id: check_sarif
+      - name: Check SARIF for errors
         run: |
-          echo "Checking SARIF file content..."
-          RESULTS_EMPTY=$(cat results.sarif | jq '.runs[0].results | map(select(.level != "warning" and .level != "note")) | length == 0')
-          if [ "$RESULTS_EMPTY" = "true" ]; then
-            echo "SARIF file content is as expected. No results found."
-          else
-            echo "SARIF file contains results, indicating issues were found. Please review the SARIF file content below for more details, or check the 'Security' tab for alerts once the file has been uploaded."
+          error_count=$(jq '[.runs[0].results[] | select(.level == "error")] | length' results.sarif)
+          if [ "$error_count" -gt 0 ]; then
+            echo "Found $error_count error(s). Check the Security tab or review the SARIF output above."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Remove unnecessary `jq` install step (preinstalled on ubuntu-latest)
- Rename job from `build` to `lint` to reflect its purpose
- Simplify SARIF error checking logic to directly count errors
- Fix misleading failure message that referenced output "below"

## Test plan
- [ ] Verify workflow runs successfully on a PR that modifies `content/`
- [ ] Confirm SARIF upload still works in the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)