### PR TITLE
:broom: Clean up spell check workflow

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -18,13 +18,11 @@ jobs:
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
-    if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
-      # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-      - name: check-spelling
+      - name: Check spelling
         id: spelling
         uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
@@ -47,11 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: spelling
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: (success() || failure()) && needs.spelling.outputs.followup
     steps:
-      - name: comment
+      - name: Post comment
         uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
           checkout: true


### PR DESCRIPTION
## Summary
- Remove redundant `if` condition — workflow only triggers on `pull_request`, so the `push` check was dead code
- Remove stale comment about `cancel-in-progress` that contradicted the actual setting
- Reduce `comment` job permissions from `contents: write` to `contents: read` (it only posts PR comments)
- Improve step names for consistency with other workflows

## Test plan
- [ ] Verify spell check workflow runs on a PR
- [ ] Verify the comment job still posts results on spelling errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)