### PR TITLE
🐛 fix scan progress-bar deduplication

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1219,11 +1219,12 @@ func createProgressBar(discoveredAssets *discovery.DiscoveredAssets, disableProg
 		for i := range discoveredAssets.Assets {
 			asset := discoveredAssets.Assets[i].Asset
 			slices.Sort(asset.PlatformIds)
-			if presentAsset, present := progressBarElements[asset.PlatformIds[0]]; present {
-				return nil, fmt.Errorf("asset %s and %s have the same platform id %s", presentAsset, asset.Name, asset.PlatformIds[0])
+			key := strings.Join(asset.PlatformIds, "\x00")
+			if presentAsset, present := progressBarElements[key]; present {
+				return nil, fmt.Errorf("asset %s and %s have the same platform ids", presentAsset, asset.Name)
 			}
-			progressBarElements[asset.PlatformIds[0]] = asset.Name
-			orderedKeys = append(orderedKeys, asset.PlatformIds[0])
+			progressBarElements[key] = asset.Name
+			orderedKeys = append(orderedKeys, key)
 		}
 		var err error
 		multiprogress, err = progress.NewMultiProgressBars(progressBarElements, orderedKeys, progress.WithScore())


### PR DESCRIPTION
If multiple assets have the same first platform id (e.g. hostname or ssh-key) their progress bars would get deduped here and squashed into one.