### PR TITLE
Fix PAN-OS platform filter to use correct identifier

### DIFF
--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -26,18 +26,18 @@ policies:
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: System Configuration
-        filters: asset.platform == "panos"
+        filters: asset.platform == "pan-os"
         checks:
           - uid: mondoo-panos-security-operational-mode-normal
       - title: Software and Content Versions
-        filters: asset.platform == "panos"
+        filters: asset.platform == "pan-os"
         checks:
           - uid: mondoo-panos-security-threat-content-installed
           - uid: mondoo-panos-security-antivirus-content-installed
           - uid: mondoo-panos-security-wildfire-content-installed
           - uid: mondoo-panos-security-app-content-installed
       - title: License Management
-        filters: asset.platform == "panos"
+        filters: asset.platform == "pan-os"
         checks:
           - uid: mondoo-panos-security-no-expired-licenses
           - uid: mondoo-panos-security-threat-prevention-license


### PR DESCRIPTION
## Summary
- Update `asset.platform` filter from `"panos"` to `"pan-os"` in the PAN-OS security policy to match the actual platform identifier
- Bump policy version from 1.0.0 to 1.0.1

## Test plan
- [ ] Run `cnspec policy lint content/mondoo-panos-security.mql.yaml`
- [ ] Verify policy applies correctly against a PAN-OS target

🤖 Generated with [Claude Code](https://claude.com/claude-code)