### PR TITLE
Update provider requires in Azure and Kubernetes policies

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -10,7 +10,6 @@ policies:
       mondoo.com/platform: azure,cloud
     require:
       - provider: azure
-      - provider: terraform
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -9,6 +9,7 @@ policies:
       mondoo.com/category: security
       mondoo.com/platform: kubernetes
     require:
+      - provider: os
       - provider: k8s
     authors:
       - name: Mondoo, Inc.


### PR DESCRIPTION
## Summary
- Remove incorrect `terraform` provider requirement from the Azure security policy
- Add missing `os` provider requirement to the Kubernetes security policy

## Test plan
- [ ] Verify Azure security policy lints cleanly without the terraform require
- [ ] Verify Kubernetes security policy lints cleanly with the os provider require
- [ ] Run `cnspec policy lint` against both modified policy files

🤖 Generated with [Claude Code](https://claude.com/claude-code)