### PR TITLE
:broom: Extract remediation from descriptions into dedicated sections

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -32,6 +32,7 @@ policies:
         - **System Hardening**: Validates security banners, timeouts, and system configuration
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+
     groups:
       - title: User Account Security
         filters: asset.platform == "arista-eos"
@@ -134,9 +135,7 @@ queries:
         - **Accountability**: Creates an audit trail for all privileged operations
 
         Without command accounting, there is no record of what commands administrators executed, making it impossible to track unauthorized changes or investigate incidents.
-
-        ## Remediation
-
+      remediation: |
         Enable AAA accounting for all commands:
 
         ```
@@ -149,6 +148,7 @@ queries:
         ```
         logging host <syslog-server-ip>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -178,15 +178,14 @@ queries:
         - **Access Monitoring**: Identifies unusual access patterns
         - **Compliance**: Required for audit and compliance reporting
         - **Forensics**: Critical for investigating unauthorized access
-
-        ## Remediation
-
+      remediation: |
         Enable AAA accounting for exec sessions:
 
         ```
         configure
         aaa accounting exec default start-stop logging
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -215,15 +214,14 @@ queries:
         - **System Events**: Tracks reboots, reloads, and other system events
         - **Compliance**: Required for comprehensive audit trails
         - **Incident Detection**: Helps identify unauthorized system changes
-
-        ## Remediation
-
+      remediation: |
         Enable AAA accounting for system events:
 
         ```
         configure
         aaa accounting system default start-stop logging
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -256,9 +254,7 @@ queries:
         - **Audit Trails**: Comprehensive logging of authentication events
 
         Without AAA, the switch relies solely on local authentication, which is difficult to manage at scale and provides limited audit capabilities.
-
-        ## Remediation
-
+      remediation: |
         Configure AAA authentication for console and remote access:
 
         ```
@@ -268,6 +264,7 @@ queries:
         ```
 
         The `local` fallback ensures access is maintained if AAA servers are unreachable.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -299,9 +296,7 @@ queries:
         - **Compliance**: Required by security frameworks for intrusion detection
 
         Failed login attempts are a primary indicator of attack attempts and should be comprehensively logged.
-
-        ## Remediation
-
+      remediation: |
         Enable authentication failure logging:
 
         ```
@@ -314,6 +309,7 @@ queries:
         ```
         logging host <siem-server-ip>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -345,9 +341,7 @@ queries:
         - **Audit Support**: Tracks authorization decisions for compliance reporting
 
         Without authorization, authenticated users may have unrestricted access to execute any command they choose.
-
-        ## Remediation
-
+      remediation: |
         Enable AAA authorization for console access:
 
         ```
@@ -355,6 +349,7 @@ queries:
         aaa authorization console
         aaa authorization commands all default local
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -389,15 +384,14 @@ queries:
         - **Strong Encryption**: SHA-512 provides the strongest password protection available on EOS
 
         The admin account should be protected with SHA-512 encrypted passwords and used only during emergencies.
-
-        ## Remediation
-
+      remediation: |
         Configure an admin account with SHA-512 password encryption:
 
         ```
         configure
         username admin privilege 15 role network-admin secret sha512 <strong-password>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -425,9 +419,7 @@ queries:
         - **Physical Security**: Disconnects idle console sessions
         - **Unauthorized Access**: Prevents access to unattended console
         - **Compliance**: Required for physical access security
-
-        ## Remediation
-
+      remediation: |
         Configure absolute timeout for console sessions:
 
         ```
@@ -435,6 +427,7 @@ queries:
         line console
         absolute-timeout 10
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -464,15 +457,14 @@ queries:
         - **SSH Keys**: Required for generating SSH RSA/DSA keys
         - **Certificate Generation**: Needed for SSL/TLS certificate creation
         - **DNS Integration**: Enables proper DNS registration
-
-        ## Remediation
-
+      remediation: |
         Configure the IP domain name:
 
         ```
         configure
         ip domain-name <your-domain.com>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -501,9 +493,7 @@ queries:
         - **Unauthorized Access**: Prevents access to unattended terminals
         - **Compliance**: Required by security frameworks
         - **Resource Management**: Frees up connection resources
-
-        ## Remediation
-
+      remediation: |
         Configure exec timeout (10 minutes recommended):
 
         ```
@@ -511,6 +501,7 @@ queries:
         line vty
         exec-timeout 10
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -541,9 +532,7 @@ queries:
         - **Logging**: Enables log correlation and analysis
         - **Documentation**: Helps document network topology
         - **Compliance**: Required by security standards
-
-        ## Remediation
-
+      remediation: |
         Configure a descriptive, unique hostname:
 
         ```
@@ -552,6 +541,7 @@ queries:
         ```
 
         Use naming conventions that include location, function, or other identifying information.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -584,9 +574,7 @@ queries:
         - **Compliance**: Security standards require encrypted management interfaces
 
         Only HTTPS should be used for API access to protect credentials and data in transit.
-
-        ## Remediation
-
+      remediation: |
         Disable HTTP and enable HTTPS for the management API:
 
         ```
@@ -595,6 +583,7 @@ queries:
         no protocol http
         protocol https
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
         title: Arista EOS Management API Configuration Guide
@@ -624,9 +613,7 @@ queries:
         - **Authentication**: Server certificates validate device identity
         - **Integrity**: Prevents tampering with API communications
         - **Compliance**: Required by security standards for management interfaces
-
-        ## Remediation
-
+      remediation: |
         Enable HTTPS for the management API:
 
         ```
@@ -634,6 +621,7 @@ queries:
         management api http-commands
         protocol https
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
         title: Arista EOS Management API Configuration Guide
@@ -666,9 +654,7 @@ queries:
         - **Change Management**: Reduces configuration errors
         - **Audit**: Facilitates security audits and compliance reviews
         - **Troubleshooting**: Speeds problem resolution
-
-        ## Remediation
-
+      remediation: |
         Configure descriptive names for all interfaces:
 
         ```
@@ -678,6 +664,7 @@ queries:
         ```
 
         For example: `description Uplink to Core Switch 1 Gi0/1`
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -705,15 +692,14 @@ queries:
         - **Immediate Access**: Logs available locally for quick troubleshooting
         - **Backup**: Provides redundancy if remote logging fails
         - **Performance**: Buffer provides efficient log handling
-
-        ## Remediation
-
+      remediation: |
         Configure buffered logging with appropriate size:
 
         ```
         configure
         logging buffered 100000 informational
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -745,15 +731,14 @@ queries:
         - **Audit Trails**: Documents all system activities for compliance reporting
 
         Without logging enabled, security events and configuration changes go unrecorded, making incident detection and investigation impossible.
-
-        ## Remediation
-
+      remediation: |
         Enable system logging:
 
         ```
         configure
         logging on
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -784,9 +769,7 @@ queries:
         - **Compliance**: Most frameworks require centralized log management
         - **Tamper Protection**: Attackers cannot easily delete logs stored remotely
         - **Capacity**: Remote servers provide unlimited log storage
-
-        ## Remediation
-
+      remediation: |
         Configure one or more remote syslog servers:
 
         ```
@@ -794,6 +777,7 @@ queries:
         logging host <syslog-server-ip>
         logging trap informational
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -822,9 +806,7 @@ queries:
         - **Debug Information**: Higher verbosity aids troubleshooting
         - **Performance**: Appropriate levels balance detail with system performance
         - **Compliance**: Security frameworks specify minimum logging levels
-
-        ## Remediation
-
+      remediation: |
         Configure logging levels for important subsystems (informational or debugging):
 
         ```
@@ -832,6 +814,7 @@ queries:
         logging level all informational
         logging level security debugging
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -862,9 +845,7 @@ queries:
         - **Compliance**: Required by many security frameworks and regulations
         - **Legal Protection**: Supports prosecution of unauthorized access
         - **Authorization**: Clearly states system is for authorized use only
-
-        ## Remediation
-
+      remediation: |
         Configure a login banner with appropriate legal language:
 
         ```
@@ -877,6 +858,7 @@ queries:
         on this device are logged and monitored.
         EOF
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -910,9 +892,7 @@ queries:
         - **Compliance**: Many frameworks require privilege separation and least-privilege access
 
         Privilege level 15 grants full administrative access. Non-admin users with this level should be assigned to specific roles that define their actual permitted operations.
-
-        ## Remediation
-
+      remediation: |
         Assign appropriate roles to users instead of granting blanket privilege 15:
 
         ```
@@ -926,6 +906,7 @@ queries:
         role <role-name>
            <privilege statements>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -954,9 +935,7 @@ queries:
         - **Security Notices**: Communicates security policies and requirements
         - **System Information**: Provides contact information for support
         - **Maintenance Notices**: Informs users of scheduled maintenance
-
-        ## Remediation
-
+      remediation: |
         Configure an MOTD banner:
 
         ```
@@ -965,6 +944,7 @@ queries:
         <your message here>
         EOF
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -996,9 +976,7 @@ queries:
         - **Privileged Access**: Especially critical for administrative accounts
 
         MFA uses multiple authentication factors: something you know (password), something you have (token/certificate), or something you are (biometric).
-
-        ## Remediation
-
+      remediation: |
         Configure console authentication to use RADIUS or TACACS+ with MFA:
 
         ```
@@ -1007,6 +985,7 @@ queries:
         ```
 
         Ensure the RADIUS/TACACS+ server is configured for multifactor authentication (e.g., RSA SecurID, Duo Security, or certificate-based authentication).
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -1037,9 +1016,7 @@ queries:
         - **Attack Surface**: These accounts are prime targets for attackers and automated attacks
 
         All user accounts should require strong password authentication to ensure only authorized personnel can access the device.
-
-        ## Remediation
-
+      remediation: |
         Remove the `nopassword` configuration from all user accounts:
 
         ```
@@ -1049,6 +1026,7 @@ queries:
         ```
 
         Ensure all accounts use strong, encrypted passwords (preferably SHA-512).
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1078,9 +1056,7 @@ queries:
         - **Certificate Validation**: TLS/SSL certificates require accurate time for validation
         - **Authentication**: Time-based authentication protocols (Kerberos) require synchronized clocks
         - **Audit Trails**: Inaccurate time undermines audit log reliability
-
-        ## Remediation
-
+      remediation: |
         Configure NTP servers for time synchronization:
 
         ```
@@ -1090,6 +1066,7 @@ queries:
         ```
 
         Use multiple NTP servers for redundancy.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1118,9 +1095,7 @@ queries:
         - **Reliability**: Ensures time remains accurate even if one server fails
         - **Security**: Use authenticated, trusted NTP sources
         - **Compliance**: Required for accurate audit logging
-
-        ## Remediation
-
+      remediation: |
         Configure at least two NTP servers for redundancy:
 
         ```
@@ -1130,6 +1105,7 @@ queries:
         ```
 
         Use NTP servers from reliable sources (e.g., NIST, internal stratum 1/2 servers).
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1162,9 +1138,7 @@ queries:
         - **Attack Protection**: Protects against dictionary and brute-force attacks
 
         A minimum password length of 15 characters is recommended for administrative accounts. Even a minimum of 12 characters provides substantial security improvements.
-
-        ## Remediation
-
+      remediation: |
         Configure a minimum password length (15 characters recommended for high security):
 
         ```
@@ -1174,6 +1148,7 @@ queries:
         ```
 
         For environments requiring compliance with specific standards (e.g., DISA STIG), 15 characters is mandatory.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1204,9 +1179,7 @@ queries:
         - **Defense in Depth**: Additional layer of credential protection
 
         Note: Service password encryption uses weak encryption (Type 7) that can be easily reversed, but it prevents casual observation of passwords. Use stronger password hashing (SHA-512) for user passwords.
-
-        ## Remediation
-
+      remediation: |
         Enable service password encryption:
 
         ```
@@ -1215,6 +1188,7 @@ queries:
         ```
 
         This encrypts passwords that would otherwise be stored in plain text in the configuration.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1247,9 +1221,7 @@ queries:
         - **Compliance**: Security standards prohibit default credentials of any kind
 
         SNMP community strings should be treated like passwords and must be changed from defaults.
-
-        ## Remediation
-
+      remediation: |
         Remove default community strings and configure secure, unique strings:
 
         ```
@@ -1264,6 +1236,7 @@ queries:
         ```
         snmp-server user <username> <group> v3 auth sha <password> priv aes128 <privpassword>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
         title: Arista EOS SNMP Configuration Guide
@@ -1294,15 +1267,14 @@ queries:
         - **Network Events**: Traps reveal device status and network topology
         - **Security Events**: May disclose security-relevant information
         - **Default Strings**: Using default community strings in traps compromises security
-
-        ## Remediation
-
+      remediation: |
         Configure SNMP traps with secure community strings:
 
         ```
         configure
         snmp-server host <server-ip> version 2c <secure-community-string>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
         title: Arista EOS SNMP Configuration Guide
@@ -1333,9 +1305,7 @@ queries:
         - **Integrity**: Prevents tampering with management sessions
         - **Industry Standard**: Universally accepted as the secure management protocol
         - **Compliance**: Required by all major security frameworks
-
-        ## Remediation
-
+      remediation: |
         Enable SSH management access:
 
         ```
@@ -1349,6 +1319,7 @@ queries:
         ```
         ip ssh version 2
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1381,9 +1352,7 @@ queries:
         - **Modern Alternatives**: SSH provides secure encrypted replacement
 
         Telnet should never be used for network device management. Any credential transmitted via Telnet should be considered compromised.
-
-        ## Remediation
-
+      remediation: |
         Disable Telnet management access:
 
         ```
@@ -1398,6 +1367,7 @@ queries:
         management ssh
         no shutdown
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1426,15 +1396,14 @@ queries:
         - **Forensic Analysis**: Simplifies analysis of multi-device incidents
         - **Compliance**: Many frameworks require UTC/GMT for audit logs
         - **Best Practice**: Industry standard for infrastructure logging
-
-        ## Remediation
-
+      remediation: |
         Configure the timezone to UTC or GMT:
 
         ```
         configure
         clock timezone UTC
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -1468,9 +1437,7 @@ queries:
         - **Attack Surface**: Reduces potential entry points for attackers
         - **Physical Security**: Limits plug-and-play attacks
         - **Compliance**: Many frameworks require disabling unused ports
-
-        ## Remediation
-
+      remediation: |
         Disable unused interfaces:
 
         ```
@@ -1480,6 +1447,7 @@ queries:
         ```
 
         For interfaces that may be used in the future, add a description noting their intended purpose.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -1508,9 +1476,7 @@ queries:
         - **Security Isolation**: Separates user traffic from management traffic
         - **Attack Prevention**: Reduces exposure to VLAN hopping attacks
         - **Best Practice**: Industry standard to avoid VLAN 1 for user traffic
-
-        ## Remediation
-
+      remediation: |
         Move all access ports from VLAN 1 to appropriate user VLANs:
 
         ```
@@ -1518,6 +1484,7 @@ queries:
         interface <interface>
         switchport access vlan <appropriate-vlan>
         ```
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -1551,9 +1518,7 @@ queries:
         - **Deprecated Algorithms**: MD5 and plain text passwords are vulnerable to compromise
 
         Weak password encryption algorithms (MD5, plain text) should be avoided as they can be easily cracked if configuration files are compromised.
-
-        ## Remediation
-
+      remediation: |
         Update all user accounts to use SHA-512 password encryption:
 
         ```
@@ -1562,6 +1527,7 @@ queries:
         ```
 
         SHA-512 is preferred over SHA-256 for maximum security.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1591,9 +1557,7 @@ queries:
         - **Security**: Helps identify unauthorized or misconfigured VLANs
         - **Troubleshooting**: Simplifies network issue diagnosis
         - **Change Management**: Reduces configuration errors
-
-        ## Remediation
-
+      remediation: |
         Configure descriptive names for all VLANs:
 
         ```
@@ -1603,6 +1567,7 @@ queries:
         ```
 
         For example: `name GUEST_WIFI`, `name PROD_SERVERS`, `name MGMT_NETWORK`
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -1634,9 +1599,7 @@ queries:
         - **Spanning Tree**: VLAN 1 carries control plane traffic by default
         - **Best Practice**: Security standards recommend avoiding VLAN 1 for user traffic
         - **Attack Surface**: VLAN 1 is a common attack target due to its default status
-
-        ## Remediation
-
+      remediation: |
         Configure a dedicated native VLAN (other than 1) for trunk ports:
 
         ```
@@ -1646,6 +1609,7 @@ queries:
         ```
 
         Consider using an unused VLAN as the native VLAN and don't assign any access ports to it.
+
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -30,6 +30,7 @@ policies:
         - **License Compliance**: Verification that security feature licenses remain valid
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+
     groups:
       - title: SSH Hardening
         filters: asset.platform == "junos"
@@ -118,9 +119,7 @@ queries:
         - **Audit Trail**: Root logins cannot be attributed to individual administrators
         - **Brute Force**: The root account is a common target for brute-force attacks
         - **Least Privilege**: Administrators should authenticate with personal accounts and escalate privileges only when needed
-
-        ## Remediation
-
+      remediation: |
         Disable root login via SSH:
 
         ```
@@ -134,6 +133,7 @@ queries:
         set system services ssh root-login deny-password
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/root-login-edit-system-services-ssh.html
         title: Junos SSH Root Login Configuration
@@ -168,9 +168,7 @@ queries:
         - **3DES**: Limited 64-bit block size vulnerable to Sweet32 birthday attacks
         - **Blowfish/CAST128**: Older algorithms with 64-bit block sizes vulnerable to similar attacks
         - **Compliance**: Modern security standards require AES-128 or stronger encryption
-
-        ## Remediation
-
+      remediation: |
         Configure only strong ciphers:
 
         ```
@@ -181,6 +179,7 @@ queries:
         set system services ssh ciphers chacha20-poly1305@openssh.com
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/ciphers-edit-system-services-ssh.html
         title: Junos SSH Ciphers Configuration
@@ -214,9 +213,7 @@ queries:
         - **Truncated MACs (96-bit)**: Provide reduced security compared to full-length variants
         - **Data Integrity**: Strong MACs ensure SSH session data has not been modified in transit
         - **Compliance**: NIST and industry standards require SHA-256 or stronger for integrity checks
-
-        ## Remediation
-
+      remediation: |
         Configure only strong MACs:
 
         ```
@@ -226,6 +223,7 @@ queries:
         set system services ssh macs hmac-sha2-512-etm@openssh.com
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/macs-edit-system-services-ssh.html
         title: Junos SSH MACs Configuration
@@ -256,9 +254,7 @@ queries:
         - **SHA-1 based exchanges**: SHA-1 has known collision vulnerabilities
         - **Forward Secrecy**: Strong key exchange algorithms ensure past sessions remain secure even if long-term keys are compromised
         - **Logjam Attack**: Small DH groups are vulnerable to precomputation attacks
-
-        ## Remediation
-
+      remediation: |
         Configure only strong key exchange algorithms:
 
         ```
@@ -269,6 +265,7 @@ queries:
         set system services ssh key-exchange curve25519-sha256
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/key-exchange-edit-system-services-ssh.html
         title: Junos SSH Key Exchange Configuration
@@ -295,15 +292,14 @@ queries:
         - **Network Bypass**: Allows users to tunnel traffic through the device, bypassing firewall rules
         - **Data Exfiltration**: Can be used to exfiltrate data through encrypted SSH tunnels
         - **Lateral Movement**: Enables attackers to pivot through the network device
-
-        ## Remediation
-
+      remediation: |
         Disable SSH TCP forwarding:
 
         ```
         set system services ssh no-tcp-forwarding
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/no-tcp-forwarding-edit-system-services-ssh.html
         title: Junos SSH TCP Forwarding Configuration
@@ -330,15 +326,14 @@ queries:
         - **Brute Force Mitigation**: Limits the number of concurrent unauthenticated sessions
         - **Resource Protection**: Prevents exhaustion of device resources by connection floods
         - **Availability**: Ensures legitimate administrators can connect during an attack
-
-        ## Remediation
-
+      remediation: |
         Configure an SSH connection limit:
 
         ```
         set system services ssh connection-limit 5
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/connection-limit-edit-system-services-ssh.html
         title: Junos SSH Connection Limit Configuration
@@ -365,15 +360,14 @@ queries:
         - **Brute Force Protection**: Limits the rate of authentication attempts per minute
         - **Automated Attack Defense**: Slows down automated credential guessing tools
         - **Availability**: Prevents SSH service degradation under attack
-
-        ## Remediation
-
+      remediation: |
         Configure an SSH rate limit:
 
         ```
         set system services ssh rate-limit 4
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/rate-limit-edit-system-services-ssh.html
         title: Junos SSH Rate Limit Configuration
@@ -403,9 +397,7 @@ queries:
         - **Unauthorized Access**: Accounts without passwords can be accessed without authentication
         - **Compliance**: All security frameworks require proper authentication for all accounts
         - **Attack Surface**: Credentialless accounts are trivial targets for unauthorized access
-
-        ## Remediation
-
+      remediation: |
         Set a password for user accounts:
 
         ```
@@ -419,6 +411,7 @@ queries:
         set system login user <username> authentication ssh-rsa "<public-key>"
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-authentication.html
         title: Junos User Authentication Configuration
@@ -445,9 +438,7 @@ queries:
         - **Attack Surface**: Each super-user account is a potential target for credential compromise
         - **Least Privilege**: Most administrators do not need full super-user access
         - **Blast Radius**: Limiting privileged accounts reduces damage from compromised credentials
-
-        ## Remediation
-
+      remediation: |
         Reassign users to more restrictive login classes:
 
         ```
@@ -463,6 +454,7 @@ queries:
         set system login user <username> class limited-admin
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-login-classes.html
         title: Junos Login Classes Configuration
@@ -492,9 +484,7 @@ queries:
         - **Credential Exposure**: Usernames and passwords are sent unencrypted and can be captured with packet sniffers
         - **Session Hijacking**: Telnet sessions can be intercepted and manipulated
         - **No Integrity**: Data transmitted via Telnet has no integrity verification
-
-        ## Remediation
-
+      remediation: |
         Disable Telnet:
 
         ```
@@ -502,6 +492,7 @@ queries:
         set system services ssh
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -528,15 +519,14 @@ queries:
         - **Clear Text Credentials**: FTP authentication is unencrypted and easily intercepted
         - **No Encryption**: File transfers can be captured and read by any observer on the network
         - **Attack Surface**: FTP servers have a history of exploitable vulnerabilities
-
-        ## Remediation
-
+      remediation: |
         Disable FTP and use SCP instead:
 
         ```
         delete system services ftp
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -563,15 +553,14 @@ queries:
         - **Information Disclosure**: Reveals usernames, login times, and idle times to unauthenticated users
         - **Reconnaissance**: Attackers use finger to enumerate valid user accounts for brute-force attacks
         - **No Authentication**: The finger protocol has no security mechanisms
-
-        ## Remediation
-
+      remediation: |
         Disable the finger service:
 
         ```
         delete system services finger
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -603,9 +592,7 @@ queries:
         - **Unauthorized Access**: "public" and "private" are universally known and the first strings attackers try
         - **Information Disclosure**: SNMP with default communities exposes device configuration, routing tables, and interface data
         - **Device Compromise**: A read-write community string allows remote configuration modification
-
-        ## Remediation
-
+      remediation: |
         Remove default communities and configure unique strings:
 
         ```
@@ -615,6 +602,7 @@ queries:
         set snmp community <unique-string> clients <management-network>/24
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -641,15 +629,14 @@ queries:
         - **Remote Exploitation**: Attackers can modify device configuration via SNMP SET operations
         - **Configuration Tampering**: SNMP write access can disable security features or create backdoors
         - **No Encryption**: SNMPv1/v2c community strings are sent in clear text
-
-        ## Remediation
-
+      remediation: |
         Change all SNMP communities to read-only:
 
         ```
         set snmp community <community-name> authorization read-only
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -676,9 +663,7 @@ queries:
         - **Exposure Reduction**: Unrestricted SNMP allows any host to query device information
         - **Defense in Depth**: Application-level ACLs complement firewall rules
         - **Brute Force Mitigation**: Limits exposure to community string guessing attacks
-
-        ## Remediation
-
+      remediation: |
         Restrict SNMP communities to specific client addresses:
 
         ```
@@ -686,6 +671,7 @@ queries:
         set snmp community <community-name> clients <management-network>/24
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -716,9 +702,7 @@ queries:
         - **Log Preservation**: Local logs are lost if the device fails or is wiped
         - **Correlation**: Centralized logs enable cross-device event correlation and threat detection
         - **SIEM Integration**: Remote syslog enables integration with security monitoring platforms
-
-        ## Remediation
-
+      remediation: |
         Configure a remote syslog host:
 
         ```
@@ -727,6 +711,7 @@ queries:
         set system syslog host <syslog-server> interactive-commands info
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
         title: Junos Syslog Configuration
@@ -754,9 +739,7 @@ queries:
         - **No Encryption**: UDP syslog exposes sensitive log data to network observers
         - **Spoofing**: UDP syslog messages can be spoofed to inject false log entries
         - **TLS**: Provides both encryption and reliable delivery
-
-        ## Remediation
-
+      remediation: |
         Configure syslog with TCP or TLS transport:
 
         ```
@@ -770,6 +753,7 @@ queries:
         set system syslog host <syslog-server> transport tls
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
         title: Junos Syslog Configuration
@@ -800,9 +784,7 @@ queries:
         - **Threat Detection**: Unusual traffic patterns can be detected through policy logs
         - **Incident Response**: Policy logs provide evidence of attack attempts and lateral movement
         - **Forensics**: Session logs help reconstruct attack timelines
-
-        ## Remediation
-
+      remediation: |
         Enable logging on security policies:
 
         ```
@@ -810,6 +792,7 @@ queries:
         set security policies from-zone <src> to-zone <dst> policy <name> then log session-close
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-policy-logging.html
         title: Junos Security Policy Logging
@@ -837,9 +820,7 @@ queries:
         - **Reconnaissance Prevention**: Blocks IP sweeps, port scans, and other reconnaissance techniques
         - **Protocol Anomaly Detection**: Detects malformed packets and protocol violations
         - **First Line of Defense**: Screen profiles inspect packets before security policies are evaluated
-
-        ## Remediation
-
+      remediation: |
         Create and apply a screen profile to the untrust zone:
 
         ```
@@ -850,6 +831,7 @@ queries:
         set security zones security-zone untrust screen untrust-screen
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -886,9 +868,7 @@ queries:
         - **Insecure Protocols**: Telnet, FTP, finger, and HTTP should never be exposed to untrusted networks
         - **SNMP Exposure**: SNMP on untrusted zones allows device reconnaissance and potential configuration changes
         - **"all" keyword**: Allows every host-inbound service, including insecure ones
-
-        ## Remediation
-
+      remediation: |
         Remove unnecessary host-inbound services from the untrust zone:
 
         ```
@@ -899,6 +879,7 @@ queries:
         delete security zones security-zone untrust host-inbound-traffic system-services snmp
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-zone-configuration.html
         title: Junos Security Zone Configuration
@@ -929,9 +910,7 @@ queries:
         - **Service Disruption**: Critical services become unavailable when connection tables are full
         - **Prevalent Attack**: SYN floods remain one of the most common denial-of-service techniques
         - **SYN Proxy**: Junos SYN flood protection validates connections before committing device resources
-
-        ## Remediation
-
+      remediation: |
         Enable SYN flood protection:
 
         ```
@@ -940,6 +919,7 @@ queries:
         set security screen ids-option <screen-name> tcp syn-flood timeout 20
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -966,15 +946,14 @@ queries:
         - **System Crash**: Oversized ICMP packets can cause buffer overflows and system instability
         - **Network Disruption**: Can destabilize routers and firewalls in the packet path
         - **Defense in Depth**: Blocks an entire class of ICMP-based attacks at the perimeter
-
-        ## Remediation
-
+      remediation: |
         Enable ping-of-death protection:
 
         ```
         set security screen ids-option <screen-name> icmp ping-death
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1002,15 +981,14 @@ queries:
         - **Spoofing**: Enables attackers to make packets appear to originate from trusted networks
         - **Man-in-the-Middle**: Can redirect traffic through attacker-controlled devices
         - **No Legitimate Use**: Source routing has no legitimate use in modern networks
-
-        ## Remediation
-
+      remediation: |
         Enable source route option protection:
 
         ```
         set security screen ids-option <screen-name> ip source-route-option
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1037,15 +1015,14 @@ queries:
         - **Resource Exhaustion**: Forces the device to continuously process self-addressed packets
         - **Service Disruption**: Can cause CPU exhaustion and service degradation
         - **Simple Detection**: Land attacks are well-known and should be blocked at the perimeter
-
-        ## Remediation
-
+      remediation: |
         Enable land attack protection:
 
         ```
         set security screen ids-option <screen-name> tcp land
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1072,15 +1049,14 @@ queries:
         - **System Crash**: Overlapping fragments can crash operating systems during reassembly
         - **Kernel Panic**: Some systems experience kernel panics when processing teardrop fragments
         - **Defense in Depth**: Blocking malformed fragments prevents a class of fragmentation attacks
-
-        ## Remediation
-
+      remediation: |
         Enable teardrop protection:
 
         ```
         set security screen ids-option <screen-name> ip tear-drop
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1107,15 +1083,14 @@ queries:
         - **System Crash**: Can cause legacy systems to crash via out-of-band TCP data
         - **Service Disruption**: May affect NetBIOS services on vulnerable systems
         - **Defense in Depth**: Blocks this entire class of OOB-based attacks at the perimeter
-
-        ## Remediation
-
+      remediation: |
         Enable WinNuke protection:
 
         ```
         set security screen ids-option <screen-name> tcp winnuke
         commit
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1145,9 +1120,7 @@ queries:
         - **Feature Loss**: Expired licenses may disable IPS, UTM, application identification, or URL filtering
         - **Silent Degradation**: The device may fall back to basic forwarding without advanced security capabilities
         - **Compliance Gap**: Security features required for regulatory compliance may stop functioning
-
-        ## Remediation
-
+      remediation: |
         Check license status:
 
         ```
@@ -1159,6 +1132,7 @@ queries:
         ```
         request system license add <license-key>
         ```
+
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/system-mgmt/topics/topic-map/license-management.html
         title: Junos License Management

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -24,6 +24,7 @@ policies:
         - **System Configuration**: Validates operational mode and system parameters
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+
     groups:
       - title: System Configuration
         filters: asset.platform == "pan-os"
@@ -71,6 +72,7 @@ queries:
         - **Web Downloads**: Inspection of downloaded files for malware
 
         Without antivirus content, malware can traverse the network undetected, potentially infecting endpoints and servers.
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
         title: PAN-OS Administrator's Guide
@@ -102,6 +104,7 @@ queries:
         - **Risk Assessment**: Understanding what applications are running on the network
 
         Without current application content, the firewall cannot accurately identify applications, reducing policy effectiveness and network visibility.
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
         title: PAN-OS Administrator's Guide
@@ -138,10 +141,9 @@ queries:
         - **Threat Intelligence**: DNS-based threat intelligence from WildFire
 
         DNS Security provides an additional layer of protection by analyzing DNS traffic for malicious activity, catching threats that might bypass other security controls.
-
-        ## Remediation
-
+      remediation: |
         Purchase and activate a DNS Security license for enhanced DNS-layer threat prevention. This is increasingly important as attackers leverage DNS for command-and-control and data exfiltration.
+
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -171,9 +173,7 @@ queries:
         - **Reduced Protection**: The device cannot protect against new threats discovered after license expiration
 
         Organizations must maintain active licenses to ensure continuous protection against evolving threats.
-
-        ## Remediation
-
+      remediation: |
         Renew expired licenses through your Palo Alto Networks account or authorized partner:
 
         1. Log into the [Customer Support Portal](https://support.paloaltonetworks.com)
@@ -181,6 +181,7 @@ queries:
         3. Select the device with expired licenses
         4. Renew required subscriptions
         5. Activate licenses on the device
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
         title: PAN-OS Administrator's Guide
@@ -212,6 +213,7 @@ queries:
         - **Hardware Failures**: Non-normal modes can indicate underlying hardware issues
 
         Devices should operate in normal mode to provide continuous security protection for network traffic.
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/getting-started/integrate-the-firewall-into-your-management-network
         title: PAN-OS Device Management
@@ -241,6 +243,7 @@ queries:
         - **Zero-Day Protection**: Behavioral analysis and heuristics for unknown threats
 
         Without current threat content, the firewall cannot identify or block known threats, leaving the network vulnerable to attacks.
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
         title: PAN-OS Administrator's Guide
@@ -276,10 +279,9 @@ queries:
         - **Signature Updates**: Regular updates to threat detection signatures
 
         Without an active Threat Prevention subscription, the firewall operates in a significantly degraded security state and cannot protect against the vast majority of network threats.
-
-        ## Remediation
-
+      remediation: |
         Purchase and activate a Threat Prevention license for the device. This is considered a core security subscription and should be maintained on all production firewalls.
+
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -314,10 +316,9 @@ queries:
         - **Reputation Scoring**: Risk-based website reputation information
 
         URL Filtering is essential for protecting users from web-based threats, enforcing acceptable use policies, and preventing phishing attacks.
-
-        ## Remediation
-
+      remediation: |
         Purchase and activate a URL Filtering license. This subscription is recommended for environments where users access the internet through the firewall.
+
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -347,6 +348,7 @@ queries:
         - **APT Detection**: Advanced persistent threat identification
 
         WildFire content ensures the firewall can leverage cloud-based threat intelligence to prevent sophisticated attacks.
+
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
         title: PAN-OS Administrator's Guide
@@ -382,10 +384,9 @@ queries:
         - **Global Intelligence**: Threat intelligence derived from millions of sensors worldwide
 
         WildFire is critical for protecting against sophisticated, targeted attacks and zero-day exploits that traditional signature-based detection cannot identify.
-
-        ## Remediation
-
+      remediation: |
         Purchase and activate a WildFire license for enhanced zero-day protection. This is strongly recommended for all production firewalls, especially those protecting sensitive environments.
+
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices


### PR DESCRIPTION
## Summary
- Extracted inline `## Remediation` content from `desc` fields into proper `remediation:` fields in 3 policy files
- **arista-eos**: 37 remediation sections extracted
- **junos**: 27 remediation sections extracted
- **panos**: 5 remediation sections extracted
- Follows the pattern already used by `chef-infra-client` policy

## Test plan
- [x] All 3 files pass `cnspec policy lint`
- [x] All 3 files are valid YAML
- [x] Zero `## Remediation` markers remain in desc fields
- [ ] Verify remediation renders correctly in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)