### PR TITLE
Standardize policy descriptions to use 'Why this matters' format

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -20,16 +20,16 @@ policies:
 
         This policy covers the following critical security areas:
 
-        - **User Account Security**: Validates user authentication, password policies, and privilege management
-        - **Authentication & Authorization**: Ensures proper AAA configuration and multifactor authentication
-        - **Protocol Security**: Verifies secure protocols are used and insecure protocols are disabled
-        - **Interface Management**: Validates interface configurations and security settings
-        - **VLAN Security**: Ensures proper VLAN configuration and native VLAN protection
-        - **SNMP Hardening**: Validates SNMP configuration security
-        - **NTP Synchronization**: Ensures accurate time synchronization for logging and auditing
-        - **Logging & Auditing**: Validates comprehensive logging configuration
-        - **Access Control**: Ensures proper console and remote access controls
-        - **System Hardening**: Validates security banners, timeouts, and system configuration
+        - Validates user authentication, password policies, and privilege management
+        - Ensures proper AAA configuration and multifactor authentication
+        - Verifies secure protocols are used and insecure protocols are disabled
+        - Validates interface configurations and security settings
+        - Ensures proper VLAN configuration and native VLAN protection
+        - Validates SNMP configuration security
+        - Ensures accurate time synchronization for logging and auditing
+        - Validates comprehensive logging configuration
+        - Ensures proper console and remote access controls
+        - Validates security banners, timeouts, and system configuration
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
@@ -122,19 +122,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /aaa accounting commands all default start-stop/)
     docs:
       desc: |
-        This check verifies that AAA accounting is configured to log all command executions.
+        This check verifies that AAA accounting is configured to log all command executions. Command accounting creates a detailed audit trail of every command run on the device, which is essential for security monitoring and compliance.
 
-        ## Rationale
+        **Why this matters**
 
-        Command accounting is essential for security auditing:
+        Without command accounting enabled, the device has no record of what administrators have done. If command accounting is not configured:
 
-        - **Forensic Analysis**: Provides detailed logs of all commands executed on the device
-        - **Compliance**: Required by frameworks like DISA STIG, PCI DSS, and HIPAA
-        - **Incident Response**: Critical for investigating security incidents
-        - **Change Tracking**: Documents who made configuration changes and when
-        - **Accountability**: Creates an audit trail for all privileged operations
+        - There is no forensic evidence of commands executed during a security incident.
+        - Compliance requirements from frameworks like DISA STIG, PCI DSS, and HIPAA cannot be met.
+        - It becomes impossible to determine who made configuration changes or when they occurred.
+        - Accountability for privileged operations is lost, undermining trust in administrative actions.
 
-        Without command accounting, there is no record of what commands administrators executed, making it impossible to track unauthorized changes or investigate incidents.
+        Enabling command accounting ensures that all activity is logged and available for audit, investigation, and compliance reporting.
       remediation: |
         Enable AAA accounting for all commands:
 
@@ -167,17 +166,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /aaa accounting exec default start-stop/)
     docs:
       desc: |
-        This check verifies that AAA accounting logs exec session start and stop events.
+        This check verifies that AAA accounting logs exec session start and stop events. Exec session accounting records login and logout activity, providing visibility into who accessed the device and for how long.
 
-        ## Rationale
+        **Why this matters**
 
-        Exec session accounting provides login tracking:
+        Without exec session accounting, the device cannot track user login activity. If session accounting is not enabled:
 
-        - **Session Tracking**: Records when users log in and out
-        - **Connection Duration**: Tracks how long users were connected
-        - **Access Monitoring**: Identifies unusual access patterns
-        - **Compliance**: Required for audit and compliance reporting
-        - **Forensics**: Critical for investigating unauthorized access
+        - There is no record of when users logged in or out.
+        - Unusual access patterns, such as logins at odd hours, go undetected.
+        - Compliance and audit reporting requirements cannot be fulfilled.
+        - Investigating unauthorized access becomes significantly harder without session data.
+
+        Enabling exec session accounting ensures that all access activity is captured for monitoring, compliance, and forensic purposes.
       remediation: |
         Enable AAA accounting for exec sessions:
 
@@ -204,16 +204,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /aaa accounting system default start-stop/)
     docs:
       desc: |
-        This check verifies that AAA accounting logs system-level events.
+        This check verifies that AAA accounting logs system-level events. System event accounting captures critical device activities such as reboots, reloads, and configuration modifications.
 
-        ## Rationale
+        **Why this matters**
 
-        System event accounting tracks critical device activities:
+        Without system event accounting, important device-level activities go unrecorded. If system accounting is not configured:
 
-        - **Configuration Changes**: Logs system-level configuration modifications
-        - **System Events**: Tracks reboots, reloads, and other system events
-        - **Compliance**: Required for comprehensive audit trails
-        - **Incident Detection**: Helps identify unauthorized system changes
+        - System-level configuration modifications are not logged.
+        - Reboots, reloads, and other significant events cannot be tracked.
+        - Comprehensive audit trails required for compliance are incomplete.
+        - Unauthorized system changes may go undetected.
+
+        Enabling system event accounting provides the visibility needed to detect unauthorized changes and maintain a complete audit record.
       remediation: |
         Enable AAA accounting for system events:
 
@@ -240,20 +242,19 @@ queries:
       arista.eos.runningConfig.content.lines.where(_ == /^aaa authentication/).length > 0
     docs:
       desc: |
-        This check verifies that Authentication, Authorization, and Accounting (AAA) is configured on the switch.
+        This check verifies that Authentication, Authorization, and Accounting (AAA) is configured on the switch. AAA integrates with enterprise identity management systems to provide centralized authentication, access control, and audit logging.
 
-        ## Rationale
+        **Why this matters**
 
-        AAA is fundamental to network device security:
+        Without AAA configured, the switch relies solely on local authentication, which is difficult to manage at scale. If AAA is not enabled:
 
-        - **Centralized Authentication**: Integrates with enterprise identity management systems
-        - **Access Control**: Enforces authentication before granting access
-        - **Accountability**: Tracks who accessed the device and what they did
-        - **Compliance**: Required by most security frameworks and regulations
-        - **Scalability**: Centralized user management across multiple devices
-        - **Audit Trails**: Comprehensive logging of authentication events
+        - The device cannot integrate with centralized identity management systems.
+        - There is no enforcement of authentication before granting access to the device.
+        - User activity cannot be tracked or audited effectively.
+        - Compliance with most security frameworks and regulations cannot be achieved.
+        - Managing user accounts individually across multiple devices becomes error-prone and impractical.
 
-        Without AAA, the switch relies solely on local authentication, which is difficult to manage at scale and provides limited audit capabilities.
+        Configuring AAA ensures centralized, scalable authentication with comprehensive audit trails across the network infrastructure.
       remediation: |
         Configure AAA authentication for console and remote access:
 
@@ -283,19 +284,19 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == "aaa authentication policy on-failure log")
     docs:
       desc: |
-        This check verifies that authentication failure events are logged for security monitoring.
+        This check verifies that authentication failure events are logged for security monitoring. Logging failed authentication attempts is one of the most important indicators for detecting attacks against the device.
 
-        ## Rationale
+        **Why this matters**
 
-        Authentication failure logging is critical for security monitoring:
+        Without authentication failure logging, the device cannot alert on or record suspicious login activity. If failure logging is not enabled:
 
-        - **Attack Detection**: Identifies brute-force and password-guessing attacks
-        - **Compromised Credentials**: Helps detect attempts to use stolen credentials
-        - **Security Monitoring**: Enables real-time alerting on suspicious activity
-        - **Forensics**: Provides evidence of attempted unauthorized access
-        - **Compliance**: Required by security frameworks for intrusion detection
+        - Brute-force and password-guessing attacks go undetected.
+        - Attempts to use stolen or compromised credentials are not recorded.
+        - Real-time alerting on suspicious authentication activity is not possible.
+        - Forensic evidence of attempted unauthorized access is lost.
+        - Compliance requirements for intrusion detection cannot be met.
 
-        Failed login attempts are a primary indicator of attack attempts and should be comprehensively logged.
+        Enabling authentication failure logging ensures that all failed login attempts are captured, supporting both proactive security monitoring and incident investigation.
       remediation: |
         Enable authentication failure logging:
 
@@ -328,19 +329,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == "aaa authorization console")
     docs:
       desc: |
-        This check verifies that AAA authorization is enabled for console access.
+        This check verifies that AAA authorization is enabled for console access. Console authorization controls which commands users can execute after they authenticate, enforcing the principle of least privilege.
 
-        ## Rationale
+        **Why this matters**
 
-        Console authorization ensures proper access control:
+        Without AAA authorization for the console, any authenticated user may have unrestricted command access. If console authorization is not enabled:
 
-        - **Command Authorization**: Controls which commands users can execute
-        - **Privilege Enforcement**: Ensures users can only perform authorized operations
-        - **Centralized Control**: Manages authorization policies from AAA servers
-        - **Compliance**: Required for separation of duties and least-privilege access
-        - **Audit Support**: Tracks authorization decisions for compliance reporting
+        - Users can execute commands beyond what their role requires.
+        - Separation of duties cannot be enforced.
+        - Authorization policies cannot be managed centrally from AAA servers.
+        - Authorization decisions are not tracked for compliance reporting.
 
-        Without authorization, authenticated users may have unrestricted access to execute any command they choose.
+        Enabling console authorization ensures that users can only perform operations appropriate to their role, reducing the risk of accidental or intentional misuse.
       remediation: |
         Enable AAA authorization for console access:
 
@@ -372,18 +372,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that an admin account with strong password encryption exists as an account of last resort.
+        This check verifies that an admin account with strong password encryption exists as an account of last resort. This account provides emergency access when external authentication systems are unavailable.
 
-        ## Rationale
+        **Why this matters**
 
-        An account of last resort is essential for recovery scenarios:
+        Without a properly configured admin account of last resort, the device may become completely inaccessible during authentication system failures. If this account does not exist:
 
-        - **Authentication Failure Recovery**: Provides access when AAA servers are unavailable
-        - **Emergency Access**: Enables critical maintenance during authentication system failures
-        - **Business Continuity**: Prevents complete lockout from the device
-        - **Strong Encryption**: SHA-512 provides the strongest password protection available on EOS
+        - There is no way to access the device when AAA servers are unavailable.
+        - Critical maintenance cannot be performed during authentication system outages.
+        - Complete lockout from the device could result in extended downtime.
+        - Using weak encryption for this account exposes the emergency credential to compromise.
 
-        The admin account should be protected with SHA-512 encrypted passwords and used only during emergencies.
+        Maintaining an admin account with SHA-512 encryption ensures reliable emergency access while protecting the credential with the strongest available hashing algorithm.
       remediation: |
         Configure an admin account with SHA-512 password encryption:
 
@@ -410,15 +410,17 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /absolute-timeout/)
     docs:
       desc: |
-        This check verifies that console sessions have a timeout configured.
+        This check verifies that console sessions have a timeout configured. An absolute timeout ensures that idle console sessions are automatically disconnected, reducing the risk of unauthorized physical access.
 
-        ## Rationale
+        **Why this matters**
 
-        Console timeouts prevent unauthorized physical access:
+        Without a console timeout, an idle session remains open indefinitely. If console timeouts are not configured:
 
-        - **Physical Security**: Disconnects idle console sessions
-        - **Unauthorized Access**: Prevents access to unattended console
-        - **Compliance**: Required for physical access security
+        - Idle console sessions can be accessed by anyone with physical access to the device.
+        - An unattended console connection could be used to make unauthorized changes.
+        - Physical access security requirements for compliance cannot be met.
+
+        Configuring console timeouts ensures that idle sessions are terminated, limiting the window of opportunity for unauthorized physical access.
       remediation: |
         Configure absolute timeout for console sessions:
 
@@ -447,16 +449,18 @@ queries:
       arista.eos.fqdn.contains(".") == true
     docs:
       desc: |
-        This check verifies that a domain name is configured for the device.
+        This check verifies that a domain name is configured for the device. A domain name is required for generating a fully qualified domain name (FQDN), which is used by several security-critical features.
 
-        ## Rationale
+        **Why this matters**
 
-        Domain name configuration enables important functionality:
+        Without a domain name configured, the device cannot generate an FQDN and several important features are affected. If the domain name is not set:
 
-        - **FQDN**: Provides fully qualified domain name for the device
-        - **SSH Keys**: Required for generating SSH RSA/DSA keys
-        - **Certificate Generation**: Needed for SSL/TLS certificate creation
-        - **DNS Integration**: Enables proper DNS registration
+        - SSH RSA/DSA key generation may fail or produce incomplete keys.
+        - SSL/TLS certificate creation requires an FQDN and will not work correctly.
+        - The device cannot be properly registered in DNS.
+        - Identification of the device in logs and management systems is less reliable.
+
+        Configuring a domain name ensures that the device can fully participate in secured communications and is properly identifiable across the network.
       remediation: |
         Configure the IP domain name:
 
@@ -483,16 +487,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /exec-timeout/)
     docs:
       desc: |
-        This check verifies that an exec timeout is configured to automatically disconnect idle sessions.
+        This check verifies that an exec timeout is configured to automatically disconnect idle sessions. Exec timeouts ensure that forgotten or unattended sessions are terminated before they can be exploited.
 
-        ## Rationale
+        **Why this matters**
 
-        Session timeouts prevent unauthorized access:
+        Without an exec timeout, idle management sessions remain open indefinitely. If exec timeouts are not configured:
 
-        - **Abandoned Sessions**: Disconnects forgotten sessions
-        - **Unauthorized Access**: Prevents access to unattended terminals
-        - **Compliance**: Required by security frameworks
-        - **Resource Management**: Frees up connection resources
+        - Forgotten sessions can be accessed by unauthorized users who gain access to the terminal.
+        - Unattended sessions on shared workstations pose a significant security risk.
+        - Security framework requirements for session management cannot be met.
+        - Connection resources remain consumed by idle sessions, potentially blocking legitimate access.
+
+        Configuring exec timeouts ensures that idle sessions are automatically closed, reducing the attack surface and freeing resources for active users.
       remediation: |
         Configure exec timeout (10 minutes recommended):
 
@@ -522,16 +528,18 @@ queries:
       arista.eos.hostname.downcase != "arista"
     docs:
       desc: |
-        This check verifies that a unique, descriptive hostname is configured.
+        This check verifies that a unique, descriptive hostname is configured. A meaningful hostname is essential for identifying the device in logs, alerts, and management systems.
 
-        ## Rationale
+        **Why this matters**
 
-        Proper hostname configuration is important for management:
+        Without a unique hostname, the device uses a generic default name that makes it difficult to manage effectively. If the hostname is not properly configured:
 
-        - **Identification**: Clearly identifies the device in logs and management systems
-        - **Logging**: Enables log correlation and analysis
-        - **Documentation**: Helps document network topology
-        - **Compliance**: Required by security standards
+        - The device cannot be clearly identified in logs or management platforms.
+        - Log correlation and analysis across multiple devices becomes unreliable.
+        - Network topology documentation is incomplete or ambiguous.
+        - Security standards requiring unique device identification cannot be met.
+
+        Setting a descriptive hostname that includes location, function, or other identifying information ensures the device is easily recognizable across all operational and security workflows.
       remediation: |
         Configure a descriptive, unique hostname:
 
@@ -561,19 +569,19 @@ queries:
       arista.eos.runningConfig.content.contains("management api http-commands") == false
     docs:
       desc: |
-        This check verifies that the insecure HTTP protocol is disabled for the management API.
+        This check verifies that the insecure HTTP protocol is disabled for the management API. HTTP transmits all data in clear text, making it unsuitable for device management.
 
-        ## Rationale
+        **Why this matters**
 
-        HTTP management interfaces are security vulnerabilities:
+        The management API provides powerful control over the device, and using HTTP exposes that access to interception. If HTTP is not disabled:
 
-        - **Unencrypted Traffic**: All API calls and credentials transmitted in clear text
-        - **Credential Theft**: Authentication tokens and passwords can be intercepted
-        - **Session Hijacking**: Unencrypted sessions can be hijacked by attackers
-        - **API Abuse**: Attackers can execute API commands if they intercept credentials
-        - **Compliance**: Security standards require encrypted management interfaces
+        - All API calls and credentials are transmitted in clear text and can be captured by anyone on the network.
+        - Authentication tokens and passwords are vulnerable to interception.
+        - Active sessions can be hijacked by attackers who observe the unencrypted traffic.
+        - Intercepted credentials can be used to execute arbitrary API commands against the device.
+        - Security standards requiring encrypted management interfaces cannot be met.
 
-        Only HTTPS should be used for API access to protect credentials and data in transit.
+        Disabling HTTP and using only HTTPS ensures that all management API communications are encrypted and protected from eavesdropping and tampering.
       remediation: |
         Disable HTTP and enable HTTPS for the management API:
 
@@ -603,16 +611,18 @@ queries:
       arista.eos.runningConfig.section(name: "management api http-commands").content.lines.contains("protocol https") == true
     docs:
       desc: |
-        This check verifies that HTTPS is enabled for secure API access.
+        This check verifies that HTTPS is enabled for secure API access. HTTPS encrypts all management API traffic using TLS, protecting credentials and data from interception.
 
-        ## Rationale
+        **Why this matters**
 
-        HTTPS provides essential security for management interfaces:
+        Without HTTPS enabled, the management API either operates over insecure HTTP or is not available at all. If HTTPS is not configured:
 
-        - **Encryption**: Protects credentials and data with TLS encryption
-        - **Authentication**: Server certificates validate device identity
-        - **Integrity**: Prevents tampering with API communications
-        - **Compliance**: Required by security standards for management interfaces
+        - Credentials and data exchanged with the API are not protected by encryption.
+        - The identity of the device cannot be validated through server certificates.
+        - API communications are vulnerable to tampering by a man-in-the-middle attacker.
+        - Security standards requiring encrypted management interfaces cannot be satisfied.
+
+        Enabling HTTPS ensures that all API access is encrypted, authenticated, and integrity-protected, meeting both security best practices and compliance requirements.
       remediation: |
         Enable HTTPS for the management API:
 
@@ -643,17 +653,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that active interfaces have descriptions configured.
+        This check verifies that active interfaces have descriptions configured. Interface descriptions document the purpose and connected endpoint of each port, which is essential for both security and operational clarity.
 
-        ## Rationale
+        **Why this matters**
 
-        Interface descriptions are important for security and operations:
+        Without interface descriptions, the purpose and expected connections for each port are undocumented. If descriptions are not configured:
 
-        - **Documentation**: Clarifies interface purpose and connections
-        - **Security**: Helps identify unauthorized connections
-        - **Change Management**: Reduces configuration errors
-        - **Audit**: Facilitates security audits and compliance reviews
-        - **Troubleshooting**: Speeds problem resolution
+        - It is difficult to determine whether a connection on a given port is authorized.
+        - Configuration errors are more likely when the purpose of an interface is unclear.
+        - Security audits and compliance reviews take longer and are less effective.
+        - Troubleshooting network issues is slower without knowing what each interface connects to.
+
+        Adding descriptions to all active interfaces ensures that the network configuration is self-documenting, supporting faster troubleshooting, better change management, and more effective security reviews.
       remediation: |
         Configure descriptive names for all interfaces:
 
@@ -683,15 +694,17 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /^logging buffered/)
     docs:
       desc: |
-        This check verifies that local buffered logging is configured.
+        This check verifies that local buffered logging is configured. Buffered logging stores log messages in the device's memory, providing immediate local access to recent events.
 
-        ## Rationale
+        **Why this matters**
 
-        Buffered logging provides local log storage:
+        Without buffered logging, log messages may only be available on the console or at a remote syslog server. If buffered logging is not configured:
 
-        - **Immediate Access**: Logs available locally for quick troubleshooting
-        - **Backup**: Provides redundancy if remote logging fails
-        - **Performance**: Buffer provides efficient log handling
+        - Logs are not available locally for quick troubleshooting during an incident.
+        - If remote logging fails, there is no local backup of recent events.
+        - Log handling may be less efficient without a dedicated buffer.
+
+        Configuring buffered logging ensures that recent log messages are always available on the device for rapid diagnosis, while also providing a safety net if remote logging is temporarily unavailable.
       remediation: |
         Configure buffered logging with appropriate size:
 
@@ -718,19 +731,19 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == "logging on")
     docs:
       desc: |
-        This check verifies that system logging is enabled on the switch.
+        This check verifies that system logging is enabled on the switch. Logging captures authentication failures, configuration changes, security events, and other system activities that are critical for monitoring and auditing.
 
-        ## Rationale
+        **Why this matters**
 
-        System logging is fundamental to security monitoring:
+        Without logging enabled, the device silently discards all event data. If system logging is not turned on:
 
-        - **Security Events**: Logs capture authentication failures, configuration changes, and security events
-        - **Incident Response**: Provides data for investigating security incidents
-        - **Compliance**: Required by virtually all security frameworks
-        - **Troubleshooting**: Essential for diagnosing operational issues
-        - **Audit Trails**: Documents all system activities for compliance reporting
+        - Security events such as authentication failures and configuration changes go unrecorded.
+        - Investigating security incidents is impossible without log data.
+        - Compliance with virtually all security frameworks requires active logging.
+        - Diagnosing operational issues becomes significantly harder without event records.
+        - There is no audit trail documenting system activities.
 
-        Without logging enabled, security events and configuration changes go unrecorded, making incident detection and investigation impossible.
+        Enabling system logging is a foundational security control that supports incident detection, investigation, compliance reporting, and day-to-day operations.
       remediation: |
         Enable system logging:
 
@@ -757,18 +770,19 @@ queries:
       arista.eos.runningConfig.content.lines.where(_ == /^logging host/).length > 0
     docs:
       desc: |
-        This check verifies that logs are sent to a remote syslog server for centralized management.
+        This check verifies that logs are sent to a remote syslog server for centralized management. Sending logs off-device protects them from loss due to device failure or compromise and enables correlation across the network.
 
-        ## Rationale
+        **Why this matters**
 
-        Centralized logging is critical for security:
+        Without a remote syslog server configured, all logs exist only on the local device. If remote logging is not set up:
 
-        - **Log Preservation**: Protects logs from local device failure or compromise
-        - **Centralized Analysis**: Enables correlation across multiple devices
-        - **Security Monitoring**: SIEM systems require remote log collection
-        - **Compliance**: Most frameworks require centralized log management
-        - **Tamper Protection**: Attackers cannot easily delete logs stored remotely
-        - **Capacity**: Remote servers provide unlimited log storage
+        - Logs are lost if the device fails, reboots, or is compromised.
+        - Correlating events across multiple devices is not possible without centralized collection.
+        - SIEM systems cannot ingest logs for real-time security monitoring.
+        - Most compliance frameworks require centralized log management.
+        - An attacker who compromises the device can delete local logs to cover their tracks.
+
+        Configuring remote syslog ensures that log data is preserved, centrally accessible, and tamper-resistant, enabling effective security monitoring and compliance.
       remediation: |
         Configure one or more remote syslog servers:
 
@@ -796,16 +810,18 @@ queries:
       arista.eos.runningConfig.content.lines.where(_ == /logging level/).length > 0
     docs:
       desc: |
-        This check verifies that logging levels are configured for capturing important events.
+        This check verifies that logging levels are configured for capturing important events. Setting appropriate logging levels ensures that security-relevant events are recorded without overwhelming the system with unnecessary detail.
 
-        ## Rationale
+        **Why this matters**
 
-        Proper logging levels ensure important events are captured:
+        Without explicit logging levels, the device may use defaults that miss important events or generate excessive noise. If logging levels are not configured:
 
-        - **Security Events**: Informational level captures authentication and authorization events
-        - **Debug Information**: Higher verbosity aids troubleshooting
-        - **Performance**: Appropriate levels balance detail with system performance
-        - **Compliance**: Security frameworks specify minimum logging levels
+        - Authentication and authorization events may not be captured at the default level.
+        - Troubleshooting is harder without sufficient log verbosity for the relevant subsystems.
+        - System performance can degrade if logging is too verbose across all subsystems.
+        - Compliance requirements that specify minimum logging levels cannot be verified.
+
+        Configuring logging levels ensures the right balance between capturing security-relevant events and maintaining system performance.
       remediation: |
         Configure logging levels for important subsystems (informational or debugging):
 
@@ -834,17 +850,18 @@ queries:
       arista.eos.runningConfig.content.contains("no banner login") == false
     docs:
       desc: |
-        This check verifies that a login banner is configured to display legal notice.
+        This check verifies that a login banner is configured to display legal notice. A login banner communicates that the device is for authorized use only and that activity may be monitored, which is important for legal protection.
 
-        ## Rationale
+        **Why this matters**
 
-        Login banners provide important legal protection:
+        Without a login banner, there is no legal notice presented to users before they access the device. If a login banner is not configured:
 
-        - **Legal Notice**: Establishes expectation of privacy and monitoring
-        - **Deterrence**: Warns unauthorized users of legal consequences
-        - **Compliance**: Required by many security frameworks and regulations
-        - **Legal Protection**: Supports prosecution of unauthorized access
-        - **Authorization**: Clearly states system is for authorized use only
+        - There is no established expectation of monitoring, weakening legal standing.
+        - Unauthorized users are not warned of the legal consequences of their actions.
+        - Compliance with security frameworks and regulations that require banners cannot be met.
+        - Prosecution of unauthorized access may be more difficult without a clear warning.
+
+        Configuring a login banner with appropriate legal language establishes the terms of access and strengthens the organization's legal position in the event of unauthorized use.
       remediation: |
         Configure a login banner with appropriate legal language:
 
@@ -879,19 +896,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that non-admin users don't have unrestricted privilege level 15 without role-based access control.
+        This check verifies that non-admin users don't have unrestricted privilege level 15 without role-based access control. Privilege level 15 grants full administrative access, which should be restricted through role assignments.
 
-        ## Rationale
+        **Why this matters**
 
-        Proper privilege separation is a fundamental security principle:
+        Without proper privilege separation, non-admin users may have full administrative access to the device. If role-based access control is not enforced:
 
-        - **Least Privilege**: Users should have only the minimum privileges needed for their role
-        - **Role-Based Access**: RBAC provides granular control over user permissions
-        - **Audit and Accountability**: Clear role assignments improve audit trails
-        - **Reduced Risk**: Limiting privileges reduces potential damage from compromised accounts
-        - **Compliance**: Many frameworks require privilege separation and least-privilege access
+        - Users operate with more privileges than their role requires, violating the principle of least privilege.
+        - There is no granular control over which commands each user can execute.
+        - Audit trails are less meaningful when all users share the same privilege level.
+        - A compromised non-admin account could cause the same damage as a compromised admin account.
+        - Compliance frameworks that require privilege separation and least-privilege access cannot be satisfied.
 
-        Privilege level 15 grants full administrative access. Non-admin users with this level should be assigned to specific roles that define their actual permitted operations.
+        Assigning specific roles to non-admin users ensures that each person can only perform operations appropriate to their responsibilities, limiting the blast radius of any compromised or misused account.
       remediation: |
         Assign appropriate roles to users instead of granting blanket privilege 15:
 
@@ -926,15 +943,17 @@ queries:
       arista.eos.runningConfig.content.contains("no banner motd") == false
     docs:
       desc: |
-        This check verifies that a message-of-the-day (MOTD) banner is configured.
+        This check verifies that a message-of-the-day (MOTD) banner is configured. An MOTD banner communicates important information to users upon login, including security policies, support contacts, and maintenance schedules.
 
-        ## Rationale
+        **Why this matters**
 
-        MOTD banners provide system information and warnings:
+        Without an MOTD banner, users receive no information upon login about the device's policies or status. If an MOTD banner is not configured:
 
-        - **Security Notices**: Communicates security policies and requirements
-        - **System Information**: Provides contact information for support
-        - **Maintenance Notices**: Informs users of scheduled maintenance
+        - Security policies and requirements are not communicated to users at login.
+        - Contact information for support is not readily available.
+        - Users are not informed of scheduled maintenance or other operational notices.
+
+        Configuring an MOTD banner ensures that all users are presented with relevant security notices and operational information each time they access the device.
       remediation: |
         Configure an MOTD banner:
 
@@ -963,19 +982,18 @@ queries:
       arista.eos.runningConfig.content.lines.where(_ == /aaa authentication/).one(_ == /aaa authentication login console group/)
     docs:
       desc: |
-        This check verifies that multifactor authentication (MFA) is configured for console access.
+        This check verifies that multifactor authentication (MFA) is configured for console access. MFA requires users to present multiple authentication factors, such as a password combined with a token or certificate, before gaining access.
 
-        ## Rationale
+        **Why this matters**
 
-        Multifactor authentication significantly enhances security:
+        Without multifactor authentication, a single compromised password is enough to gain full access to the device. If MFA is not configured:
 
-        - **Credential Protection**: Protects against compromised passwords
-        - **Phishing Resistance**: MFA tokens/certificates resist phishing attacks
-        - **Compliance**: Required by frameworks like NIST 800-171, PCI DSS v4.0, and Zero Trust
-        - **Attack Prevention**: Blocks attackers with stolen passwords
-        - **Privileged Access**: Especially critical for administrative accounts
+        - Compromised passwords provide immediate, unrestricted access.
+        - Phishing attacks that capture passwords succeed without a second factor to block them.
+        - Compliance with frameworks like NIST 800-171, PCI DSS v4.0, and Zero Trust architectures cannot be achieved.
+        - Administrative accounts, which are the most valuable targets, remain protected only by a password.
 
-        MFA uses multiple authentication factors: something you know (password), something you have (token/certificate), or something you are (biometric).
+        Configuring MFA for console access ensures that stolen or guessed passwords alone are not sufficient to compromise the device, significantly raising the bar for attackers.
       remediation: |
         Configure console authentication to use RADIUS or TACACS+ with MFA:
 
@@ -1003,19 +1021,19 @@ queries:
     mql: arista.eos.users.where(nopassword == true) == []
     docs:
       desc: |
-        This check verifies that all user accounts on the Arista switch have password protection enabled.
+        This check verifies that all user accounts on the Arista switch have password protection enabled. Accounts without passwords allow anyone with network or console access to log in without authentication.
 
-        ## Rationale
+        **Why this matters**
 
-        User accounts without password protection represent critical security vulnerabilities:
+        User accounts without password protection represent one of the most critical security vulnerabilities on a network device. If any account lacks a password:
 
-        - **Unauthorized Access**: Anyone can log in to accounts without passwords
-        - **Privilege Escalation**: Password-less accounts can be exploited to gain elevated privileges
-        - **Compliance Violations**: Security standards require password protection for all accounts
-        - **Audit Trail**: Password-less accounts compromise accountability and audit capabilities
-        - **Attack Surface**: These accounts are prime targets for attackers and automated attacks
+        - Anyone with access to the device can log in to that account without any credentials.
+        - Password-less accounts can be exploited to escalate privileges and gain administrative control.
+        - Security standards that require password protection for all accounts are violated.
+        - Accountability and audit capabilities are compromised because actions cannot be attributed to authenticated users.
+        - Automated attack tools actively scan for and exploit accounts without passwords.
 
-        All user accounts should require strong password authentication to ensure only authorized personnel can access the device.
+        Ensuring all accounts require strong password authentication prevents unauthorized access and maintains accountability for all device activity.
       remediation: |
         Remove the `nopassword` configuration from all user accounts:
 
@@ -1044,18 +1062,19 @@ queries:
     mql: arista.eos.ntp.status != "disabled"
     docs:
       desc: |
-        This check verifies that NTP time synchronization is enabled and operational.
+        This check verifies that NTP time synchronization is enabled and operational. Accurate time is essential for correlating events across devices, validating certificates, and maintaining reliable audit logs.
 
-        ## Rationale
+        **Why this matters**
 
-        Accurate time synchronization is critical for security and operations:
+        Without NTP synchronization, the device's clock may drift, causing timestamps to become inaccurate. If NTP is not enabled:
 
-        - **Log Correlation**: Accurate timestamps enable correlation of events across devices
-        - **Forensic Analysis**: Consistent time is essential for incident investigation
-        - **Compliance**: Many frameworks require accurate time synchronization
-        - **Certificate Validation**: TLS/SSL certificates require accurate time for validation
-        - **Authentication**: Time-based authentication protocols (Kerberos) require synchronized clocks
-        - **Audit Trails**: Inaccurate time undermines audit log reliability
+        - Log events from different devices cannot be correlated because their timestamps are inconsistent.
+        - Forensic analysis of security incidents is unreliable when event timing is uncertain.
+        - TLS/SSL certificate validation may fail if the clock is too far off.
+        - Time-based authentication protocols such as Kerberos stop working with unsynchronized clocks.
+        - Audit log reliability is undermined by inaccurate timestamps.
+
+        Enabling NTP ensures that the device maintains accurate time, which is foundational to security monitoring, incident response, and compliance.
       remediation: |
         Configure NTP servers for time synchronization:
 
@@ -1085,16 +1104,18 @@ queries:
       arista.eos.runningConfig.content.lines.where(_ == /^ntp server/).length > 0
     docs:
       desc: |
-        This check verifies that NTP servers are configured for time synchronization.
+        This check verifies that NTP servers are configured for time synchronization. Having explicitly configured NTP servers ensures the device synchronizes with trusted, reliable time sources.
 
-        ## Rationale
+        **Why this matters**
 
-        Configured NTP servers ensure reliable time synchronization:
+        Without configured NTP servers, the device cannot synchronize its clock even if NTP is enabled. If NTP servers are not specified:
 
-        - **Redundancy**: Multiple servers provide failover capability
-        - **Reliability**: Ensures time remains accurate even if one server fails
-        - **Security**: Use authenticated, trusted NTP sources
-        - **Compliance**: Required for accurate audit logging
+        - There is no time source for the device to synchronize against.
+        - A single server provides no failover if that source becomes unavailable.
+        - Using unauthenticated or untrusted NTP sources could allow time manipulation attacks.
+        - Accurate audit logging required for compliance depends on reliable time synchronization.
+
+        Configuring at least two NTP servers from trusted sources ensures redundant, reliable time synchronization for the device.
       remediation: |
         Configure at least two NTP servers for redundancy:
 
@@ -1125,19 +1146,19 @@ queries:
       arista.eos.runningConfig.content.contains("password minimum length") == true
     docs:
       desc: |
-        This check verifies that a minimum password length policy is configured on the switch.
+        This check verifies that a minimum password length policy is configured on the switch. Password length is the single most important factor in password strength, as longer passwords exponentially increase the time required for brute-force attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        Password length is a critical factor in password strength:
+        Without a minimum password length policy, users can set short passwords that are easily cracked. If a minimum length is not enforced:
 
-        - **Brute Force Resistance**: Longer passwords exponentially increase cracking time
-        - **Complexity**: Length provides more combinations than character variety alone
-        - **Industry Standards**: Most security frameworks require minimum password lengths
-        - **NIST Guidelines**: Current NIST recommendations emphasize password length over complexity
-        - **Attack Protection**: Protects against dictionary and brute-force attacks
+        - Short passwords can be brute-forced in seconds or minutes.
+        - The security benefit of character variety is minimal compared to what length provides.
+        - Compliance with security frameworks that mandate minimum password lengths cannot be achieved.
+        - Current NIST guidelines, which emphasize length over complexity, are not followed.
+        - The device is more vulnerable to dictionary and brute-force attacks.
 
-        A minimum password length of 15 characters is recommended for administrative accounts. Even a minimum of 12 characters provides substantial security improvements.
+        Configuring a minimum password length of at least 15 characters for administrative accounts provides substantial protection against credential-based attacks.
       remediation: |
         Configure a minimum password length (15 characters recommended for high security):
 
@@ -1167,18 +1188,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == "service password-encryption")
     docs:
       desc: |
-        This check verifies that password encryption service is enabled to protect passwords in configuration.
+        This check verifies that password encryption service is enabled to protect passwords in configuration. When enabled, this service encrypts passwords that would otherwise appear in plain text in the running configuration.
 
-        ## Rationale
+        **Why this matters**
 
-        Password encryption protects credentials in configuration files:
+        Without password encryption enabled, some passwords appear in clear text in the device configuration. If this service is not turned on:
 
-        - **Configuration Security**: Encrypts clear-text passwords in configuration
-        - **Backup Protection**: Protects passwords in configuration backups
-        - **Compliance**: Required by security standards
-        - **Defense in Depth**: Additional layer of credential protection
+        - Passwords in the configuration can be read by anyone who views the configuration file.
+        - Configuration backups contain plain-text passwords that could be exposed.
+        - Security standards requiring credential protection in configuration files are not met.
+        - An additional layer of defense-in-depth protection is missing.
 
-        Note: Service password encryption uses weak encryption (Type 7) that can be easily reversed, but it prevents casual observation of passwords. Use stronger password hashing (SHA-512) for user passwords.
+        Enabling service password encryption prevents casual observation of passwords in configuration files. Note that this uses Type 7 encryption, which can be reversed, so stronger hashing such as SHA-512 should still be used for user passwords.
       remediation: |
         Enable service password encryption:
 
@@ -1208,19 +1229,19 @@ queries:
       arista.eos.runningConfig.content.contains("snmp-server community private") == false
     docs:
       desc: |
-        This check verifies that default SNMP community strings (public/private) are not configured.
+        This check verifies that default SNMP community strings (public/private) are not configured. Default community strings are publicly known and are among the first things attackers try when probing network devices.
 
-        ## Rationale
+        **Why this matters**
 
-        Default SNMP community strings are well-known security vulnerabilities:
+        Using default SNMP community strings is equivalent to leaving the device unprotected. If default strings are not removed:
 
-        - **Unauthorized Access**: Default strings are publicly known and commonly exploited
-        - **Information Disclosure**: Attackers can query device information using default strings
-        - **Network Mapping**: Default SNMP access enables network reconnaissance
-        - **Configuration Exposure**: SNMP write access with defaults allows configuration changes
-        - **Compliance**: Security standards prohibit default credentials of any kind
+        - Attackers can use the well-known "public" and "private" strings to access the device.
+        - Device information, including configuration details, can be queried by anyone.
+        - Network reconnaissance is trivial when default SNMP access is available.
+        - Write access with default strings allows attackers to modify the device configuration.
+        - Compliance with security standards that prohibit default credentials is violated.
 
-        SNMP community strings should be treated like passwords and must be changed from defaults.
+        Removing default community strings and replacing them with strong, unique values treats SNMP access with the same rigor as any other authentication credential.
       remediation: |
         Remove default community strings and configure secure, unique strings:
 
@@ -1258,15 +1279,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that SNMP trap notifications don't use default community strings.
+        This check verifies that SNMP trap notifications don't use default community strings. SNMP traps send device status and event information to monitoring servers, and using default strings exposes this data to interception.
 
-        ## Rationale
+        **Why this matters**
 
-        SNMP traps can expose sensitive information:
+        Without securing SNMP trap community strings, sensitive device and network information may be exposed. If default strings are used for traps:
 
-        - **Network Events**: Traps reveal device status and network topology
-        - **Security Events**: May disclose security-relevant information
-        - **Default Strings**: Using default community strings in traps compromises security
+        - Device status and network topology information is sent using well-known community strings.
+        - Security-relevant event notifications can be intercepted by unauthorized parties.
+        - The overall SNMP security posture is undermined even if polling uses strong strings.
+
+        Configuring SNMP traps with secure, unique community strings ensures that event notifications are only readable by authorized monitoring systems.
       remediation: |
         Configure SNMP traps with secure community strings:
 
@@ -1294,17 +1317,18 @@ queries:
       arista.eos.runningConfig.section(name: "management ssh").content.lines.contains("shutdown") == false
     docs:
       desc: |
-        This check verifies that SSH is enabled for secure remote management access.
+        This check verifies that SSH is enabled for secure remote management access. SSH encrypts all management traffic, including credentials, and is the universally accepted standard for secure remote device administration.
 
-        ## Rationale
+        **Why this matters**
 
-        SSH is the secure standard for remote device management:
+        Without SSH enabled, secure remote management of the device is not possible. If SSH is disabled or shut down:
 
-        - **Encryption**: All traffic including credentials is encrypted
-        - **Authentication**: Supports strong authentication methods including public key
-        - **Integrity**: Prevents tampering with management sessions
-        - **Industry Standard**: Universally accepted as the secure management protocol
-        - **Compliance**: Required by all major security frameworks
+        - Remote management must rely on insecure protocols like Telnet, which transmit credentials in clear text.
+        - Strong authentication methods such as public key authentication are not available.
+        - Management sessions are vulnerable to tampering and eavesdropping.
+        - Compliance with all major security frameworks that mandate encrypted management access cannot be achieved.
+
+        Enabling SSH ensures that all remote management sessions are encrypted, authenticated, and protected from interception.
       remediation: |
         Enable SSH management access:
 
@@ -1339,19 +1363,18 @@ queries:
       arista.eos.runningConfig.content.contains("management telnet") == false
     docs:
       desc: |
-        This check verifies that the insecure Telnet protocol is disabled on the switch.
+        This check verifies that the insecure Telnet protocol is disabled on the switch. Telnet transmits all data, including passwords, in clear text and should never be used for network device management.
 
-        ## Rationale
+        **Why this matters**
 
-        Telnet is inherently insecure and must be disabled:
+        Telnet is inherently insecure and any credential transmitted over it should be considered compromised. If Telnet is not disabled:
 
-        - **Plaintext Transmission**: All data including passwords sent in clear text
-        - **Credential Exposure**: Passwords can be captured by network sniffers
-        - **Man-in-the-Middle**: No encryption allows traffic interception and modification
-        - **Compliance**: Prohibited by virtually all security frameworks
-        - **Modern Alternatives**: SSH provides secure encrypted replacement
+        - All data including passwords is sent in plain text and can be captured by anyone on the network.
+        - Network sniffers can passively harvest credentials from Telnet sessions.
+        - An attacker can intercept and modify management traffic in transit.
+        - Compliance with virtually all security frameworks that prohibit Telnet is violated.
 
-        Telnet should never be used for network device management. Any credential transmitted via Telnet should be considered compromised.
+        Disabling Telnet and using SSH as the sole remote management protocol ensures that all management communications are encrypted and protected from interception.
       remediation: |
         Disable Telnet management access:
 
@@ -1386,16 +1409,18 @@ queries:
       arista.eos.runningConfig.content.lines.one(_ == /clock timezone (UTC|GMT)/)
     docs:
       desc: |
-        This check verifies that the system timezone is set to UTC or GMT for consistent logging.
+        This check verifies that the system timezone is set to UTC or GMT for consistent logging. Using a standardized timezone across all infrastructure ensures that log timestamps can be directly compared without conversion.
 
-        ## Rationale
+        **Why this matters**
 
-        Standardized timezone configuration is essential:
+        Without a standardized timezone, log entries from different devices use different time references, complicating analysis. If the timezone is not set to UTC or GMT:
 
-        - **Log Correlation**: UTC provides a common time reference across global infrastructure
-        - **Forensic Analysis**: Simplifies analysis of multi-device incidents
-        - **Compliance**: Many frameworks require UTC/GMT for audit logs
-        - **Best Practice**: Industry standard for infrastructure logging
+        - Correlating events across devices in different locations requires manual time conversion.
+        - Forensic analysis of multi-device incidents is slower and more error-prone.
+        - Compliance frameworks that require UTC/GMT for audit logs are not satisfied.
+        - The industry standard practice of using UTC for infrastructure logging is not followed.
+
+        Setting the timezone to UTC or GMT ensures consistent timestamps across all devices, enabling accurate event correlation and streamlined incident analysis.
       remediation: |
         Configure the timezone to UTC or GMT:
 
@@ -1427,16 +1452,18 @@ queries:
       ).all(interfaceStatus == "disabled")
     docs:
       desc: |
-        This check identifies interfaces that are not connected, have no description, and should be disabled.
+        This check identifies interfaces that are not connected, have no description, and should be disabled. Shutting down unused interfaces prevents unauthorized devices from being connected to the network through open ports.
 
-        ## Rationale
+        **Why this matters**
 
-        Disabling unused interfaces prevents unauthorized access:
+        Unused interfaces that remain enabled provide potential entry points for attackers. If unused interfaces are not administratively disabled:
 
-        - **Rogue Devices**: Prevents connection of unauthorized devices
-        - **Attack Surface**: Reduces potential entry points for attackers
-        - **Physical Security**: Limits plug-and-play attacks
-        - **Compliance**: Many frameworks require disabling unused ports
+        - Unauthorized devices can be plugged into open ports and gain network access.
+        - The attack surface of the device is larger than necessary.
+        - Plug-and-play attacks that exploit enabled but unmonitored ports are possible.
+        - Compliance frameworks that require disabling unused ports cannot be satisfied.
+
+        Disabling unused interfaces and documenting the intended purpose of reserved ports reduces the physical attack surface and prevents unauthorized network access.
       remediation: |
         Disable unused interfaces:
 
@@ -1467,15 +1494,17 @@ queries:
       arista.eos.switchports.where(mode == "access").all(accessVlan != "1")
     docs:
       desc: |
-        This check verifies that no access ports are assigned to VLAN 1.
+        This check verifies that no access ports are assigned to VLAN 1. VLAN 1 is the default VLAN on most switches and should not carry user traffic because it is a common target for attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        VLAN 1 should be reserved for management only:
+        Using VLAN 1 for user traffic mixes it with management and control plane traffic, increasing security risk. If access ports remain on VLAN 1:
 
-        - **Security Isolation**: Separates user traffic from management traffic
-        - **Attack Prevention**: Reduces exposure to VLAN hopping attacks
-        - **Best Practice**: Industry standard to avoid VLAN 1 for user traffic
+        - User traffic is not isolated from management traffic, weakening network segmentation.
+        - The device is more exposed to VLAN hopping attacks that exploit VLAN 1's default status.
+        - Industry best practices for VLAN security are not followed.
+
+        Moving all access ports to dedicated user VLANs ensures proper traffic separation and reduces the risk of VLAN-based attacks.
       remediation: |
         Move all access ports from VLAN 1 to appropriate user VLANs:
 
@@ -1505,19 +1534,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all user accounts use strong password encryption algorithms (SHA-512 or SHA-256).
+        This check verifies that all user accounts use strong password encryption algorithms (SHA-512 or SHA-256). These cryptographically secure hash algorithms protect stored credentials from being recovered if the configuration is exposed.
 
-        ## Rationale
+        **Why this matters**
 
-        Strong password encryption is critical for protecting credentials:
+        Without strong password encryption, stored credentials are vulnerable to compromise. If weak algorithms like MD5 or plain text are used:
 
-        - **Cryptographic Strength**: SHA-512 and SHA-256 are cryptographically secure hash algorithms
-        - **Resistance to Attacks**: Modern algorithms resist rainbow table and brute-force attacks
-        - **Compliance**: Security standards require strong cryptographic algorithms
-        - **Protection from Exposure**: Encrypted passwords in configuration backups are protected
-        - **Deprecated Algorithms**: MD5 and plain text passwords are vulnerable to compromise
+        - Passwords can be cracked using rainbow tables or brute-force attacks in a short time.
+        - Configuration backups containing weakly hashed passwords put all accounts at risk.
+        - Compliance with security standards that require strong cryptographic algorithms is violated.
+        - A single exposed configuration file could compromise every account on the device.
 
-        Weak password encryption algorithms (MD5, plain text) should be avoided as they can be easily cracked if configuration files are compromised.
+        Using SHA-512 or SHA-256 for all user passwords ensures that credentials remain protected even if the device configuration is inadvertently exposed or backed up insecurely.
       remediation: |
         Update all user accounts to use SHA-512 password encryption:
 
@@ -1547,16 +1575,18 @@ queries:
       arista.eos.vlans.where(name.downcase != /^vlan/).length > 0
     docs:
       desc: |
-        This check verifies that VLANs have descriptive names rather than default names.
+        This check verifies that VLANs have descriptive names rather than default names. Descriptive VLAN names make the network configuration self-documenting, which is important for both operations and security.
 
-        ## Rationale
+        **Why this matters**
 
-        Descriptive VLAN names improve network management:
+        Without descriptive names, VLANs are identified only by their numeric IDs, making the configuration harder to understand and manage. If VLAN names are left as defaults:
 
-        - **Documentation**: Names clarify VLAN purpose and usage
-        - **Security**: Helps identify unauthorized or misconfigured VLANs
-        - **Troubleshooting**: Simplifies network issue diagnosis
-        - **Change Management**: Reduces configuration errors
+        - The purpose and usage of each VLAN is not apparent from the configuration.
+        - Unauthorized or misconfigured VLANs are harder to identify during security reviews.
+        - Diagnosing network issues takes longer when VLAN purposes are unclear.
+        - Configuration errors are more likely when administrators cannot easily distinguish between VLANs.
+
+        Naming VLANs descriptively ensures that the network configuration is clear and understandable, supporting efficient operations, better change management, and more effective security audits.
       remediation: |
         Configure descriptive names for all VLANs:
 
@@ -1589,16 +1619,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that trunk ports use a native VLAN other than VLAN 1.
+        This check verifies that trunk ports use a native VLAN other than VLAN 1. The native VLAN on trunk ports carries untagged traffic, and using the default VLAN 1 exposes the network to well-known attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        VLAN 1 as native VLAN creates security risks:
+        Using VLAN 1 as the native VLAN on trunk ports creates specific, exploitable security weaknesses. If VLAN 1 remains the native VLAN:
 
-        - **VLAN Hopping**: Attackers can exploit native VLAN 1 for VLAN hopping attacks
-        - **Spanning Tree**: VLAN 1 carries control plane traffic by default
-        - **Best Practice**: Security standards recommend avoiding VLAN 1 for user traffic
-        - **Attack Surface**: VLAN 1 is a common attack target due to its default status
+        - Attackers can perform VLAN hopping attacks by exploiting the default native VLAN configuration.
+        - Control plane traffic carried on VLAN 1 by spanning tree is mixed with user traffic.
+        - Security standards that recommend avoiding VLAN 1 for any traffic are not followed.
+        - The device's default configuration becomes a known attack vector.
+
+        Configuring a dedicated, unused VLAN as the native VLAN on trunk ports eliminates VLAN hopping risks and separates control plane traffic from user data.
       remediation: |
         Configure a dedicated native VLAN (other than 1) for trunk ports:
 

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -20,14 +20,14 @@ policies:
 
         This policy covers the following security areas:
 
-        - **SSH Hardening**: Root login restrictions, cryptographic algorithm validation, and brute-force protection
-        - **User Account Security**: Authentication enforcement and privilege restriction
-        - **Insecure Service Elimination**: Disabling Telnet, FTP, finger, and other cleartext protocols
-        - **SNMP Hardening**: Default community string removal, access restrictions, and read-only enforcement
-        - **Logging and Auditing**: Centralized syslog with secure transport for tamper-resistant audit trails
-        - **Security Zone Hardening**: Policy logging, screen profile enforcement, and untrust zone lockdown
-        - **IDS/IPS Screen Profiles**: Protection against SYN floods, land attacks, teardrop, and other network attacks
-        - **License Compliance**: Verification that security feature licenses remain valid
+        - Root login restrictions, cryptographic algorithm validation, and brute-force protection
+        - Authentication enforcement and privilege restriction
+        - Disabling Telnet, FTP, finger, and other cleartext protocols
+        - Default community string removal, access restrictions, and read-only enforcement
+        - Centralized syslog with secure transport for tamper-resistant audit trails
+        - Policy logging, screen profile enforcement, and untrust zone lockdown
+        - Protection against SYN floods, land attacks, teardrop, and other network attacks
+        - Verification that security feature licenses remain valid
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
@@ -111,14 +111,18 @@ queries:
       junos.sshConfig.rootLogin == "deny" || junos.sshConfig.rootLogin == "deny-password"
     docs:
       desc: |
-        This check verifies that root login via SSH is denied on the Junos device.
+        This check verifies that root login via SSH is denied on the Junos device. Denying root login ensures that administrators authenticate with individual accounts and only escalate privileges when needed.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Privilege Escalation**: Direct root access bypasses all role-based access controls
-        - **Audit Trail**: Root logins cannot be attributed to individual administrators
-        - **Brute Force**: The root account is a common target for brute-force attacks
-        - **Least Privilege**: Administrators should authenticate with personal accounts and escalate privileges only when needed
+        The root account has unrestricted access to the entire device. If direct root login via SSH is permitted:
+
+        - Attackers can target the root account directly with brute-force attacks, since it is a well-known username on every device.
+        - Successful logins cannot be attributed to individual administrators, undermining audit trails and accountability.
+        - All role-based access controls are bypassed, granting full device control without any privilege separation.
+        - The principle of least privilege is violated, increasing the blast radius of a compromised credential.
+
+        By denying root login, organizations enforce individual accountability and reduce the risk of unauthorized privileged access to the device.
       remediation: |
         Disable root login via SSH:
 
@@ -160,14 +164,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that no weak or deprecated SSH ciphers are configured on the Junos device.
+        This check verifies that no weak or deprecated SSH ciphers are configured on the Junos device. Using only strong ciphers protects the confidentiality of SSH sessions against cryptographic attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        - **RC4 (arcfour)**: Known biases in the keystream make it cryptographically weak
-        - **3DES**: Limited 64-bit block size vulnerable to Sweet32 birthday attacks
-        - **Blowfish/CAST128**: Older algorithms with 64-bit block sizes vulnerable to similar attacks
-        - **Compliance**: Modern security standards require AES-128 or stronger encryption
+        SSH ciphers protect the confidentiality of management sessions to the device. If weak ciphers are configured:
+
+        - RC4 (arcfour) ciphers have known keystream biases that make them cryptographically weak and susceptible to plaintext recovery.
+        - 3DES has a limited 64-bit block size that is vulnerable to Sweet32 birthday attacks, allowing data recovery from long-lived sessions.
+        - Blowfish and CAST128 share similar 64-bit block size weaknesses that expose them to the same class of attacks.
+        - Modern security standards and compliance frameworks require AES-128 or stronger encryption for management traffic.
+
+        By restricting SSH to strong ciphers, organizations ensure that management sessions remain confidential and resistant to known cryptographic attacks.
       remediation: |
         Configure only strong ciphers:
 
@@ -205,14 +213,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that no weak SSH message authentication codes (MACs) are configured.
+        This check verifies that no weak SSH message authentication codes (MACs) are configured. Strong MACs ensure that SSH session data has not been modified in transit.
 
-        ## Rationale
+        **Why this matters**
 
-        - **MD5-based MACs**: MD5 is cryptographically broken and vulnerable to collision attacks
-        - **Truncated MACs (96-bit)**: Provide reduced security compared to full-length variants
-        - **Data Integrity**: Strong MACs ensure SSH session data has not been modified in transit
-        - **Compliance**: NIST and industry standards require SHA-256 or stronger for integrity checks
+        MACs protect the integrity of data exchanged during SSH sessions. If weak MACs are allowed:
+
+        - MD5-based MACs rely on a cryptographically broken hash function that is vulnerable to collision attacks, allowing potential session tampering.
+        - Truncated 96-bit MAC variants provide reduced security compared to their full-length counterparts, making forgery more feasible.
+        - Compromised integrity checks could allow attackers to modify commands or data within an SSH session without detection.
+        - NIST and industry standards require SHA-256 or stronger algorithms for integrity verification.
+
+        By configuring only strong MACs, organizations protect the integrity of management sessions and meet compliance requirements for cryptographic controls.
       remediation: |
         Configure only strong MACs:
 
@@ -246,14 +258,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that weak SSH key exchange algorithms are not configured.
+        This check verifies that weak SSH key exchange algorithms are not configured. Strong key exchange algorithms ensure that session keys are securely negotiated and that past sessions remain protected.
 
-        ## Rationale
+        **Why this matters**
 
-        - **DH Group 1 (768-bit)**: Far too small for modern security, easily broken
-        - **SHA-1 based exchanges**: SHA-1 has known collision vulnerabilities
-        - **Forward Secrecy**: Strong key exchange algorithms ensure past sessions remain secure even if long-term keys are compromised
-        - **Logjam Attack**: Small DH groups are vulnerable to precomputation attacks
+        Key exchange algorithms establish the shared secret used to encrypt SSH sessions. If weak algorithms are permitted:
+
+        - DH Group 1 uses only 768-bit parameters, which are far too small for modern security and can be broken with current computing resources.
+        - SHA-1 based exchanges rely on a hash function with known collision vulnerabilities, weakening the key exchange process.
+        - Small Diffie-Hellman groups are vulnerable to Logjam precomputation attacks that can compromise session keys.
+        - Without strong key exchange, forward secrecy is undermined, meaning past sessions could be decrypted if long-term keys are later compromised.
+
+        By restricting key exchange to strong algorithms, organizations ensure secure session negotiation and maintain forward secrecy for all management connections.
       remediation: |
         Configure only strong key exchange algorithms:
 
@@ -285,13 +301,17 @@ queries:
       junos.sshConfig.tcpForwarding == false
     docs:
       desc: |
-        This check verifies that SSH TCP forwarding (port forwarding) is disabled on the Junos device.
+        This check verifies that SSH TCP forwarding (port forwarding) is disabled on the Junos device. Disabling TCP forwarding prevents the SSH service from being used as a proxy to tunnel unauthorized traffic through the device.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Network Bypass**: Allows users to tunnel traffic through the device, bypassing firewall rules
-        - **Data Exfiltration**: Can be used to exfiltrate data through encrypted SSH tunnels
-        - **Lateral Movement**: Enables attackers to pivot through the network device
+        SSH TCP forwarding allows users to create encrypted tunnels through the device. If this feature is enabled:
+
+        - Users can tunnel arbitrary traffic through the device, effectively bypassing firewall rules and security policies.
+        - Attackers can use the encrypted tunnels to exfiltrate sensitive data without detection by network monitoring tools.
+        - Compromised accounts can be leveraged to pivot through the network device and reach otherwise isolated network segments.
+
+        By disabling TCP forwarding, organizations prevent the SSH service from being misused as a network proxy and maintain the integrity of their firewall and segmentation controls.
       remediation: |
         Disable SSH TCP forwarding:
 
@@ -321,11 +341,15 @@ queries:
       desc: |
         This check verifies that a limit is configured for unauthenticated SSH connections, mitigating brute-force and denial-of-service attacks against the SSH service.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Brute Force Mitigation**: Limits the number of concurrent unauthenticated sessions
-        - **Resource Protection**: Prevents exhaustion of device resources by connection floods
-        - **Availability**: Ensures legitimate administrators can connect during an attack
+        The SSH connection limit controls how many unauthenticated sessions can be pending at once. Without a connection limit configured:
+
+        - Attackers can open a large number of concurrent unauthenticated sessions, enabling rapid brute-force credential guessing.
+        - Connection floods can exhaust device resources such as memory and CPU, degrading overall device performance.
+        - Legitimate administrators may be unable to connect to the device during an active attack due to resource exhaustion.
+
+        By setting a connection limit, organizations ensure that the SSH service remains available to authorized users even during brute-force or denial-of-service attempts.
       remediation: |
         Configure an SSH connection limit:
 
@@ -355,11 +379,15 @@ queries:
       desc: |
         This check verifies that a rate limit is configured for SSH authentication attempts, slowing down automated credential guessing attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Brute Force Protection**: Limits the rate of authentication attempts per minute
-        - **Automated Attack Defense**: Slows down automated credential guessing tools
-        - **Availability**: Prevents SSH service degradation under attack
+        The SSH rate limit controls how many authentication attempts are allowed per connection per minute. Without a rate limit:
+
+        - Automated credential guessing tools can attempt thousands of password combinations in a short time.
+        - The SSH service may become degraded under sustained brute-force attacks, affecting availability for legitimate users.
+        - Attackers face no throttling penalty, making brute-force attacks significantly more likely to succeed.
+
+        By configuring a rate limit, organizations slow down automated attacks and reduce the likelihood of successful credential compromise while keeping the SSH service responsive for authorized administrators.
       remediation: |
         Configure an SSH rate limit:
 
@@ -390,13 +418,17 @@ queries:
       junos.users.all(hasPassword == true || sshKeys.length > 0)
     docs:
       desc: |
-        This check verifies that every local user account has either a password or SSH keys configured for authentication. Accounts without credentials can be exploited for unauthorized access.
+        This check verifies that every local user account has either a password or SSH keys configured for authentication. Accounts without credentials represent a serious security gap that can be exploited for unauthorized access.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Unauthorized Access**: Accounts without passwords can be accessed without authentication
-        - **Compliance**: All security frameworks require proper authentication for all accounts
-        - **Attack Surface**: Credentialless accounts are trivial targets for unauthorized access
+        Local user accounts are a primary means of authenticating to the device. If any account lacks authentication credentials:
+
+        - The account can be accessed without providing any form of authentication, allowing anyone with network access to log in.
+        - All security frameworks and compliance standards require proper authentication for every account on network infrastructure.
+        - Credentialless accounts are trivial targets that require no effort for an attacker to exploit.
+
+        By ensuring every account has credentials, organizations close a fundamental authentication gap and prevent unauthorized access through unprotected accounts.
       remediation: |
         Set a password for user accounts:
 
@@ -431,13 +463,17 @@ queries:
       junos.users.where(class == "super-user").length <= 3
     docs:
       desc: |
-        This check verifies that no more than three user accounts are assigned the super-user login class. Excessive privileged accounts increase the attack surface.
+        This check verifies that no more than three user accounts are assigned the super-user login class. Limiting the number of privileged accounts reduces the attack surface and potential impact of credential compromise.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Attack Surface**: Each super-user account is a potential target for credential compromise
-        - **Least Privilege**: Most administrators do not need full super-user access
-        - **Blast Radius**: Limiting privileged accounts reduces damage from compromised credentials
+        The super-user login class grants unrestricted access to the device. If too many accounts have this privilege level:
+
+        - Each super-user account is a potential target for credential compromise, and more accounts mean a larger attack surface.
+        - Most administrators do not need full super-user access to perform their daily tasks, violating the principle of least privilege.
+        - A compromised super-user account gives an attacker complete control over the device, and limiting these accounts reduces that exposure.
+
+        By restricting the number of super-user accounts, organizations minimize the risk of privileged credential compromise and enforce least-privilege access across their network infrastructure.
       remediation: |
         Reassign users to more restrictive login classes:
 
@@ -477,13 +513,17 @@ queries:
       junos.services.none(name == "telnet")
     docs:
       desc: |
-        This check verifies that the Telnet service is not enabled. Telnet transmits all data including credentials in clear text.
+        This check verifies that the Telnet service is not enabled. Telnet transmits all data including credentials in clear text and should be replaced with SSH for all remote management access.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Credential Exposure**: Usernames and passwords are sent unencrypted and can be captured with packet sniffers
-        - **Session Hijacking**: Telnet sessions can be intercepted and manipulated
-        - **No Integrity**: Data transmitted via Telnet has no integrity verification
+        Telnet is an inherently insecure protocol with no encryption or integrity protection. If Telnet is enabled on the device:
+
+        - Usernames and passwords are sent in plain text and can be captured by anyone with access to a packet sniffer on the network path.
+        - Active Telnet sessions can be intercepted and hijacked, allowing an attacker to take over an administrative session.
+        - Data transmitted over Telnet has no integrity verification, meaning commands and responses can be silently altered in transit.
+
+        By disabling Telnet and using SSH exclusively, organizations protect management credentials and session data from interception and tampering.
       remediation: |
         Disable Telnet:
 
@@ -512,13 +552,17 @@ queries:
       junos.services.none(name == "ftp")
     docs:
       desc: |
-        This check verifies that the FTP service is not enabled. FTP transmits credentials and data in plain text.
+        This check verifies that the FTP service is not enabled. FTP transmits credentials and data in plain text and should be replaced with SCP or SFTP for secure file transfers.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Clear Text Credentials**: FTP authentication is unencrypted and easily intercepted
-        - **No Encryption**: File transfers can be captured and read by any observer on the network
-        - **Attack Surface**: FTP servers have a history of exploitable vulnerabilities
+        FTP is an unencrypted file transfer protocol with well-known security weaknesses. If FTP is enabled on the device:
+
+        - Authentication credentials are transmitted in clear text and can be easily intercepted by any observer on the network.
+        - File transfers are completely unencrypted, allowing sensitive configuration data or firmware images to be captured in transit.
+        - FTP server implementations have a long history of exploitable vulnerabilities that can provide an additional attack vector.
+
+        By disabling FTP and using SCP instead, organizations ensure that file transfers to and from the device are encrypted and authenticated.
       remediation: |
         Disable FTP and use SCP instead:
 
@@ -546,13 +590,17 @@ queries:
       junos.services.none(name == "finger")
     docs:
       desc: |
-        This check verifies that the finger service is not enabled. The finger protocol exposes user account information that aids attacker reconnaissance.
+        This check verifies that the finger service is not enabled. The finger protocol exposes user account information without any authentication, aiding attacker reconnaissance efforts.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Information Disclosure**: Reveals usernames, login times, and idle times to unauthenticated users
-        - **Reconnaissance**: Attackers use finger to enumerate valid user accounts for brute-force attacks
-        - **No Authentication**: The finger protocol has no security mechanisms
+        The finger protocol was designed for user information lookup but has no security mechanisms. If the finger service is enabled:
+
+        - It reveals usernames, login times, and idle times to any unauthenticated user who queries the service.
+        - Attackers use finger to enumerate valid user accounts, which are then targeted in brute-force authentication attacks.
+        - The protocol provides no authentication or access controls, meaning anyone with network access can query it.
+
+        By disabling the finger service, organizations eliminate an unnecessary information disclosure vector and reduce the data available for attacker reconnaissance.
       remediation: |
         Disable the finger service:
 
@@ -585,13 +633,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that default SNMP community strings ("public" and "private") are not configured. These are the first credentials attackers attempt.
+        This check verifies that default SNMP community strings ("public" and "private") are not configured. Default community strings are universally known and are the first credentials attackers attempt when probing SNMP services.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Unauthorized Access**: "public" and "private" are universally known and the first strings attackers try
-        - **Information Disclosure**: SNMP with default communities exposes device configuration, routing tables, and interface data
-        - **Device Compromise**: A read-write community string allows remote configuration modification
+        SNMP community strings act as passwords for accessing device information. If default strings remain configured:
+
+        - The strings "public" and "private" are universally known and are included in every automated scanning tool, making the device trivially accessible.
+        - An attacker with read access through SNMP can extract device configuration details, routing tables, interface data, and other sensitive information.
+        - If a default read-write community string is present, attackers can remotely modify the device configuration to create backdoors or disable security features.
+
+        By replacing default community strings with unique, complex values, organizations prevent trivial unauthorized access to device information through SNMP.
       remediation: |
         Remove default communities and configure unique strings:
 
@@ -622,13 +674,17 @@ queries:
       junos.snmpCommunities.all(authorization == "read-only")
     docs:
       desc: |
-        This check verifies that no SNMP community is configured with read-write access. Read-write SNMP allows remote configuration changes via SNMP SET operations.
+        This check verifies that no SNMP community is configured with read-write access. Read-write SNMP allows remote configuration changes via SNMP SET operations, which poses a significant risk to device integrity.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Remote Exploitation**: Attackers can modify device configuration via SNMP SET operations
-        - **Configuration Tampering**: SNMP write access can disable security features or create backdoors
-        - **No Encryption**: SNMPv1/v2c community strings are sent in clear text
+        SNMP read-write access grants the ability to modify device configuration remotely. If any community has read-write authorization:
+
+        - Attackers who obtain the community string can modify the device configuration via SNMP SET operations, potentially disabling security features or creating backdoors.
+        - SNMP write access enables configuration tampering that may go unnoticed, since changes made through SNMP may not generate the same audit trail as CLI changes.
+        - SNMPv1 and v2c community strings are transmitted in clear text, meaning read-write credentials can be captured from network traffic.
+
+        By restricting all SNMP communities to read-only access, organizations prevent unauthorized remote configuration changes and limit the impact of a compromised community string.
       remediation: |
         Change all SNMP communities to read-only:
 
@@ -656,13 +712,17 @@ queries:
       junos.snmpCommunities.all(clients.length > 0)
     docs:
       desc: |
-        This check verifies that all SNMP communities have client address restrictions configured, limiting which hosts can query the device.
+        This check verifies that all SNMP communities have client address restrictions configured, limiting which hosts can query the device via SNMP.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Exposure Reduction**: Unrestricted SNMP allows any host to query device information
-        - **Defense in Depth**: Application-level ACLs complement firewall rules
-        - **Brute Force Mitigation**: Limits exposure to community string guessing attacks
+        SNMP client lists control which IP addresses are allowed to communicate with the SNMP service. Without client restrictions:
+
+        - Any host on the network can query the device for sensitive information, greatly increasing the exposure of the SNMP service.
+        - Application-level access control lists provide an important defense-in-depth layer that complements network firewall rules.
+        - Unrestricted access makes it easier for attackers to conduct brute-force community string guessing from any location on the network.
+
+        By restricting SNMP access to specific management hosts or networks, organizations reduce the attack surface and add a layer of access control beyond perimeter firewalls.
       remediation: |
         Restrict SNMP communities to specific client addresses:
 
@@ -694,14 +754,18 @@ queries:
       junos.syslogHosts.length > 0
     docs:
       desc: |
-        This check verifies that at least one remote syslog host is configured. Without remote logging, an attacker who compromises the device can destroy all evidence of the intrusion.
+        This check verifies that at least one remote syslog host is configured. Remote logging ensures that audit records are preserved even if the device is compromised or fails.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Tamper Resistance**: Remote logs cannot be modified by an attacker who compromises the device
-        - **Log Preservation**: Local logs are lost if the device fails or is wiped
-        - **Correlation**: Centralized logs enable cross-device event correlation and threat detection
-        - **SIEM Integration**: Remote syslog enables integration with security monitoring platforms
+        Centralized remote logging is a critical component of security monitoring and incident response. Without a remote syslog host configured:
+
+        - An attacker who compromises the device can destroy all local log evidence of the intrusion, eliminating the audit trail.
+        - Local logs are lost if the device experiences a hardware failure, is wiped, or runs out of storage space.
+        - Security teams cannot correlate events across multiple devices, reducing their ability to detect coordinated attacks.
+        - Integration with SIEM platforms and security monitoring tools is not possible without remote log forwarding.
+
+        By configuring remote syslog, organizations create a tamper-resistant audit trail that supports threat detection, incident response, and compliance requirements.
       remediation: |
         Configure a remote syslog host:
 
@@ -731,14 +795,18 @@ queries:
       junos.syslogHosts.all(transport == "tcp" || transport == "tls")
     docs:
       desc: |
-        This check verifies that all syslog hosts use TCP or TLS transport instead of UDP. UDP syslog is unreliable and transmits log data in clear text.
+        This check verifies that all syslog hosts use TCP or TLS transport instead of UDP. Reliable and encrypted transport ensures that security-critical log data is delivered intact and protected from eavesdropping.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Message Loss**: UDP provides no delivery guarantee; security-critical logs can be silently dropped
-        - **No Encryption**: UDP syslog exposes sensitive log data to network observers
-        - **Spoofing**: UDP syslog messages can be spoofed to inject false log entries
-        - **TLS**: Provides both encryption and reliable delivery
+        The transport protocol determines the reliability and confidentiality of log delivery. If UDP syslog is used:
+
+        - UDP provides no delivery guarantee, meaning security-critical log messages can be silently dropped during network congestion without any indication of loss.
+        - Log data is transmitted in clear text, exposing sensitive information such as usernames, IP addresses, and security events to anyone monitoring the network.
+        - UDP syslog messages can be spoofed by an attacker to inject false log entries, potentially masking malicious activity or triggering false alerts.
+        - TLS transport provides both encryption and reliable delivery, addressing all of these concerns.
+
+        By requiring TCP or TLS transport for syslog, organizations ensure that audit data is delivered reliably and protected from interception or manipulation.
       remediation: |
         Configure syslog with TCP or TLS transport:
 
@@ -776,14 +844,18 @@ queries:
       junos.securityPolicies.all(logInit == true || logClose == true)
     docs:
       desc: |
-        This check verifies that all security policies have at least session-init or session-close logging enabled. Without policy logging, there is no visibility into what traffic the firewall permits or denies.
+        This check verifies that all security policies have at least session-init or session-close logging enabled. Policy logging provides essential visibility into the traffic flowing through the firewall.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Traffic Visibility**: Logs show what traffic is permitted or denied through the firewall
-        - **Threat Detection**: Unusual traffic patterns can be detected through policy logs
-        - **Incident Response**: Policy logs provide evidence of attack attempts and lateral movement
-        - **Forensics**: Session logs help reconstruct attack timelines
+        Security policy logs record which traffic is permitted or denied by the firewall. Without policy logging enabled:
+
+        - There is no visibility into what traffic the firewall is permitting or denying, making it impossible to verify that policies are working as intended.
+        - Unusual traffic patterns and potential threats cannot be detected because there is no record of firewall decisions to analyze.
+        - Incident response efforts are severely hampered without policy logs that show attack attempts, lateral movement, and data exfiltration.
+        - Forensic reconstruction of attack timelines requires session logs that document the sequence of permitted and denied connections.
+
+        By enabling session logging on all security policies, organizations gain the visibility needed for threat detection, incident response, and compliance auditing.
       remediation: |
         Enable logging on security policies:
 
@@ -812,14 +884,18 @@ queries:
       junos.securityZones.where(name == "untrust").all(screen != "")
     docs:
       desc: |
-        This check verifies that untrust security zones have IDS/IPS screen profiles applied. Screen profiles process packets before security policies and provide efficient attack mitigation.
+        This check verifies that untrust security zones have IDS/IPS screen profiles applied. Screen profiles inspect packets before security policies are evaluated, providing an efficient first line of defense against network attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        - **DoS Protection**: Screens detect and mitigate SYN floods, ICMP floods, and other denial-of-service attacks
-        - **Reconnaissance Prevention**: Blocks IP sweeps, port scans, and other reconnaissance techniques
-        - **Protocol Anomaly Detection**: Detects malformed packets and protocol violations
-        - **First Line of Defense**: Screen profiles inspect packets before security policies are evaluated
+        Screen profiles provide packet-level inspection at the perimeter before policy evaluation occurs. Without screen profiles on untrust zones:
+
+        - The device has no protection against denial-of-service attacks such as SYN floods, ICMP floods, and UDP floods that can overwhelm device resources.
+        - Reconnaissance techniques including IP sweeps, port scans, and OS fingerprinting go undetected and unblocked.
+        - Malformed packets and protocol violations pass through to internal systems without any anomaly detection.
+        - Attack traffic that could be efficiently dropped at the perimeter instead consumes resources during full policy evaluation.
+
+        By applying screen profiles to untrust zones, organizations establish a high-performance first line of defense that mitigates common network attacks before they reach the policy engine.
       remediation: |
         Create and apply a screen profile to the untrust zone:
 
@@ -862,12 +938,16 @@ queries:
       desc: |
         This check verifies that the untrust zone does not allow insecure or unnecessary host-inbound services. Exposing management services to untrusted networks gives attackers direct access to the device control plane.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Attack Surface**: Each enabled service is a potential entry point for attackers from untrusted networks
-        - **Insecure Protocols**: Telnet, FTP, finger, and HTTP should never be exposed to untrusted networks
-        - **SNMP Exposure**: SNMP on untrusted zones allows device reconnaissance and potential configuration changes
-        - **"all" keyword**: Allows every host-inbound service, including insecure ones
+        Host-inbound services determine which management protocols are accessible from a given security zone. If insecure services are exposed on the untrust zone:
+
+        - Each enabled service is a potential entry point for attackers coming from untrusted networks, expanding the device's attack surface.
+        - Insecure protocols like Telnet, FTP, finger, and HTTP transmit data in clear text and should never be exposed to untrusted networks.
+        - Enabling SNMP on untrusted zones allows external attackers to perform device reconnaissance and potentially modify the configuration.
+        - Using the "all" keyword enables every host-inbound service, including insecure ones, creating maximum exposure.
+
+        By restricting host-inbound services on the untrust zone to only essential encrypted protocols, organizations minimize the control plane attack surface exposed to untrusted networks.
       remediation: |
         Remove unnecessary host-inbound services from the untrust zone:
 
@@ -902,14 +982,18 @@ queries:
       junos.screenProfiles.all(tcpSynFlood == true)
     docs:
       desc: |
-        This check verifies that all screen profiles have TCP SYN flood protection enabled. SYN flood attacks exhaust device connection tables with half-open connections.
+        This check verifies that all screen profiles have TCP SYN flood protection enabled. SYN flood attacks exhaust device connection tables with half-open connections, disrupting legitimate traffic.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Resource Exhaustion**: SYN floods fill the connection table, blocking legitimate traffic
-        - **Service Disruption**: Critical services become unavailable when connection tables are full
-        - **Prevalent Attack**: SYN floods remain one of the most common denial-of-service techniques
-        - **SYN Proxy**: Junos SYN flood protection validates connections before committing device resources
+        TCP SYN flood attacks are among the most common denial-of-service techniques targeting network devices. Without SYN flood protection:
+
+        - Attackers can fill the device connection table with half-open connections, preventing legitimate traffic from being processed.
+        - Critical services behind the firewall become unavailable when the connection table is exhausted, causing widespread disruption.
+        - SYN floods remain one of the most prevalent and effective denial-of-service techniques used against network infrastructure.
+        - Junos SYN flood protection uses SYN proxy to validate connections before committing device resources, efficiently mitigating these attacks.
+
+        By enabling SYN flood protection, organizations defend against a common and effective denial-of-service attack vector while ensuring continued availability of critical services.
       remediation: |
         Enable SYN flood protection:
 
@@ -939,13 +1023,17 @@ queries:
       junos.screenProfiles.all(icmpPingDeath == true)
     docs:
       desc: |
-        This check verifies that all screen profiles have ICMP ping-of-death protection enabled. Oversized ICMP packets can cause buffer overflows in vulnerable systems.
+        This check verifies that all screen profiles have ICMP ping-of-death protection enabled. Ping-of-death attacks use oversized ICMP packets to cause buffer overflows and system instability in vulnerable systems.
 
-        ## Rationale
+        **Why this matters**
 
-        - **System Crash**: Oversized ICMP packets can cause buffer overflows and system instability
-        - **Network Disruption**: Can destabilize routers and firewalls in the packet path
-        - **Defense in Depth**: Blocks an entire class of ICMP-based attacks at the perimeter
+        Oversized ICMP packets exploit buffer handling weaknesses in network stacks. Without ping-of-death protection enabled:
+
+        - Oversized ICMP packets can trigger buffer overflows that cause system crashes or instability on vulnerable devices and hosts.
+        - Malicious ICMP traffic can destabilize routers and firewalls along the packet path, causing cascading network disruptions.
+        - An entire class of ICMP-based attacks is left unmitigated at the perimeter, allowing them to reach internal systems.
+
+        By enabling ping-of-death protection, organizations block oversized ICMP packets at the perimeter and protect internal systems from this class of attacks.
       remediation: |
         Enable ping-of-death protection:
 
@@ -973,14 +1061,18 @@ queries:
       junos.screenProfiles.all(ipSourceRoute == true)
     docs:
       desc: |
-        This check verifies that all screen profiles block IP packets with the source route option set. Source routing allows attackers to bypass firewall rules and routing policies.
+        This check verifies that all screen profiles block IP packets with the source route option set. Source routing allows senders to specify the route a packet takes through the network, which attackers exploit to bypass security controls.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Firewall Bypass**: Source-routed packets can circumvent firewall rules and routing policies
-        - **Spoofing**: Enables attackers to make packets appear to originate from trusted networks
-        - **Man-in-the-Middle**: Can redirect traffic through attacker-controlled devices
-        - **No Legitimate Use**: Source routing has no legitimate use in modern networks
+        IP source routing is a legacy feature with no legitimate use in modern networks. If source-routed packets are allowed:
+
+        - Attackers can use source routing to circumvent firewall rules and routing policies by specifying a path that avoids security inspection points.
+        - Source routing enables IP spoofing by making packets appear to originate from trusted network segments.
+        - Traffic can be redirected through attacker-controlled devices, enabling man-in-the-middle attacks on otherwise secure communications.
+        - There is no legitimate use case for source routing in modern production networks, so blocking it carries no operational impact.
+
+        By blocking source-routed packets, organizations eliminate an attack technique that can bypass firewalls and enable spoofing, with no impact on legitimate traffic.
       remediation: |
         Enable source route option protection:
 
@@ -1008,13 +1100,17 @@ queries:
       junos.screenProfiles.all(tcpLand == true)
     docs:
       desc: |
-        This check verifies that all screen profiles have TCP land attack protection enabled. Land attacks send packets with matching source and destination addresses, causing resource exhaustion.
+        This check verifies that all screen profiles have TCP land attack protection enabled. Land attacks send TCP packets where the source and destination addresses are identical, causing the device to enter a processing loop.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Resource Exhaustion**: Forces the device to continuously process self-addressed packets
-        - **Service Disruption**: Can cause CPU exhaustion and service degradation
-        - **Simple Detection**: Land attacks are well-known and should be blocked at the perimeter
+        Land attacks exploit TCP stack behavior by creating self-referencing connections. Without land attack protection:
+
+        - The device is forced to continuously process self-addressed packets, consuming CPU resources and degrading performance.
+        - Sustained land attacks can cause CPU exhaustion and service degradation, potentially taking the device offline.
+        - Land attacks are a well-known and easily executed attack type that should be blocked at the perimeter as a basic security measure.
+
+        By enabling land attack protection, organizations block a well-known denial-of-service technique and prevent unnecessary resource consumption on their network devices.
       remediation: |
         Enable land attack protection:
 
@@ -1042,13 +1138,17 @@ queries:
       junos.screenProfiles.all(ipTearDrop == true)
     docs:
       desc: |
-        This check verifies that all screen profiles have IP teardrop attack protection enabled. Teardrop attacks use malformed fragmented IP packets with overlapping offsets to crash systems during reassembly.
+        This check verifies that all screen profiles have IP teardrop attack protection enabled. Teardrop attacks use malformed fragmented IP packets with overlapping offsets that crash systems during packet reassembly.
 
-        ## Rationale
+        **Why this matters**
 
-        - **System Crash**: Overlapping fragments can crash operating systems during reassembly
-        - **Kernel Panic**: Some systems experience kernel panics when processing teardrop fragments
-        - **Defense in Depth**: Blocking malformed fragments prevents a class of fragmentation attacks
+        Teardrop attacks exploit IP fragment reassembly logic in network stacks. Without teardrop protection:
+
+        - Overlapping IP fragments can crash operating systems or network devices during the reassembly process, causing service outages.
+        - Some systems experience kernel panics when processing the malformed fragment offsets used in teardrop attacks.
+        - Leaving this protection disabled allows an entire class of IP fragmentation attacks to pass through the perimeter unmitigated.
+
+        By enabling teardrop protection, organizations block malformed fragmented packets at the perimeter and prevent fragmentation-based attacks from reaching internal systems.
       remediation: |
         Enable teardrop protection:
 
@@ -1076,13 +1176,17 @@ queries:
       junos.screenProfiles.all(tcpWinNuke == true)
     docs:
       desc: |
-        This check verifies that all screen profiles have TCP WinNuke attack protection enabled. WinNuke attacks send out-of-band data to TCP port 139 to crash vulnerable systems.
+        This check verifies that all screen profiles have TCP WinNuke attack protection enabled. WinNuke attacks send out-of-band TCP data to port 139, which can crash vulnerable systems running NetBIOS services.
 
-        ## Rationale
+        **Why this matters**
 
-        - **System Crash**: Can cause legacy systems to crash via out-of-band TCP data
-        - **Service Disruption**: May affect NetBIOS services on vulnerable systems
-        - **Defense in Depth**: Blocks this entire class of OOB-based attacks at the perimeter
+        WinNuke attacks target the TCP out-of-band data handling in network stacks. Without WinNuke protection:
+
+        - Legacy systems can crash when they receive out-of-band TCP data on port 139, causing service disruptions.
+        - NetBIOS services on vulnerable systems behind the firewall may be affected, leading to system instability or denial of service.
+        - An entire class of OOB-based TCP attacks passes through the perimeter unblocked, potentially affecting any vulnerable internal system.
+
+        By enabling WinNuke protection, organizations block out-of-band TCP attacks at the perimeter and protect internal systems from this class of exploits.
       remediation: |
         Enable WinNuke protection:
 
@@ -1113,13 +1217,17 @@ queries:
       junos.licenses.all(state != "expired")
     docs:
       desc: |
-        This check verifies that no installed feature licenses have expired. Expired licenses can silently disable critical security features such as IPS, UTM, and application identification.
+        This check verifies that no installed feature licenses have expired. Expired licenses can silently disable critical security features, leaving the device with reduced protection.
 
-        ## Rationale
+        **Why this matters**
 
-        - **Feature Loss**: Expired licenses may disable IPS, UTM, application identification, or URL filtering
-        - **Silent Degradation**: The device may fall back to basic forwarding without advanced security capabilities
-        - **Compliance Gap**: Security features required for regulatory compliance may stop functioning
+        Junos feature licenses control access to advanced security capabilities. If licenses are allowed to expire:
+
+        - Critical security features such as IPS, UTM, application identification, and URL filtering may be disabled without warning.
+        - The device may silently fall back to basic packet forwarding without the advanced security capabilities that were part of the security architecture.
+        - Security features required for regulatory compliance may stop functioning, creating compliance gaps that go unnoticed until the next audit.
+
+        By monitoring license status and renewing before expiration, organizations ensure that all licensed security features remain active and the device continues to provide the expected level of protection.
       remediation: |
         Check license status:
 

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -60,18 +60,18 @@ queries:
     mql: panos.system.avVersion != ""
     docs:
       desc: |
-        This check verifies that antivirus content is installed on the device.
+        This check verifies that antivirus content is installed on the device. Antivirus content provides the signature database used to identify known malware, viruses, and trojans as they traverse the network.
 
-        ## Rationale
+        **Why this matters**
 
-        Antivirus content provides:
+        Without antivirus content installed, the firewall cannot inspect files and traffic for known malware. If antivirus content is missing:
 
-        - **Malware Detection**: Signatures for identifying known malware, viruses, and trojans
-        - **File-Based Threats**: Protection against malicious files traversing the network
-        - **Email Protection**: Scanning of email attachments and content
-        - **Web Downloads**: Inspection of downloaded files for malware
+        - Malicious files can pass through the firewall undetected, potentially infecting endpoints and servers.
+        - Email attachments carrying malware will not be scanned or blocked.
+        - Web downloads containing trojans or viruses will reach end users without inspection.
+        - The firewall loses its ability to act as a network-level malware prevention tool.
 
-        Without antivirus content, malware can traverse the network undetected, potentially infecting endpoints and servers.
+        Maintaining current antivirus content ensures the firewall can identify and block known malware before it reaches internal systems.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -92,18 +92,18 @@ queries:
     mql: panos.system.appVersion != ""
     docs:
       desc: |
-        This check verifies that application identification content (App-ID) is installed on the device.
+        This check verifies that application identification content (App-ID) is installed on the device. App-ID content enables the firewall to identify applications regardless of port, protocol, or encryption.
 
-        ## Rationale
+        **Why this matters**
 
-        Application content enables:
+        Without current application content, the firewall cannot accurately identify applications traversing the network. If App-ID content is missing:
 
-        - **Application Visibility**: Identification of applications regardless of port or protocol
-        - **Security Policy Enforcement**: Application-based security rules rather than just port-based
-        - **Bandwidth Management**: Application-level QoS and traffic shaping
-        - **Risk Assessment**: Understanding what applications are running on the network
+        - Security policies fall back to port-based rules, which are easily circumvented by applications that use non-standard ports.
+        - Administrators lose visibility into what applications are running on the network.
+        - Application-level QoS and traffic shaping policies cannot function correctly.
+        - Risk assessment becomes unreliable because the firewall cannot distinguish between legitimate and risky applications.
 
-        Without current application content, the firewall cannot accurately identify applications, reducing policy effectiveness and network visibility.
+        Keeping application content up to date ensures the firewall can enforce application-aware security policies and provide accurate network visibility.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -128,17 +128,16 @@ queries:
         length > 0
     docs:
       desc: |-
-        This check verifies that an active DNS Security license is installed on the device.
+        This check verifies that an active DNS Security license is installed on the device. The DNS Security subscription enables DNS-layer threat analysis powered by machine learning and global threat intelligence.
 
-        ## Rationale
+        **Why this matters**
 
-        The DNS Security license provides DNS-layer protection:
+        Attackers increasingly leverage DNS for command-and-control communication and data exfiltration because DNS traffic is often allowed through firewalls without inspection. Without an active DNS Security license:
 
-        - **Malware C2 Blocking**: Prevention of DNS queries to known command-and-control servers
-        - **DNS Tunneling Detection**: Identification of data exfiltration through DNS
-        - **DGA Protection**: Detection of domain generation algorithm patterns
-        - **Real-Time Analysis**: Machine learning-powered DNS traffic analysis
-        - **Threat Intelligence**: DNS-based threat intelligence from WildFire
+        - Malware on internal systems can communicate with command-and-control servers via DNS queries without detection.
+        - Data exfiltration through DNS tunneling goes unidentified.
+        - Domain generation algorithm (DGA) patterns used by malware families are not flagged.
+        - The firewall misses an entire layer of threat detection that complements traditional traffic inspection.
 
         DNS Security provides an additional layer of protection by analyzing DNS traffic for malicious activity, catching threats that might bypass other security controls.
       remediation: |
@@ -161,16 +160,16 @@ queries:
     mql: panos.licenses.where(expired == "yes") == []
     docs:
       desc: |
-        This check verifies that no licenses on the PAN-OS device are expired.
+        This check verifies that no licenses on the PAN-OS device are expired. Expired licenses directly impact the device's ability to protect the network against current threats.
 
-        ## Rationale
+        **Why this matters**
 
-        Expired licenses create security gaps:
+        When licenses expire, the security capabilities they enable begin to degrade immediately. If any licenses are expired:
 
-        - **No Content Updates**: Expired subscriptions stop receiving threat intelligence and signature updates
-        - **Feature Degradation**: Advanced security features may be disabled or operate in limited mode
-        - **Compliance Issues**: Many compliance frameworks require active security subscriptions
-        - **Reduced Protection**: The device cannot protect against new threats discovered after license expiration
+        - The device stops receiving threat intelligence and signature updates, leaving it blind to newly discovered threats.
+        - Advanced security features may be disabled entirely or operate in a limited mode with reduced effectiveness.
+        - The organization may fall out of compliance with frameworks that require active security subscriptions.
+        - Protection gaps widen over time as new vulnerabilities and attack techniques emerge without corresponding updates.
 
         Organizations must maintain active licenses to ensure continuous protection against evolving threats.
       remediation: |
@@ -201,16 +200,16 @@ queries:
       panos.system.operationalMode == "Normal"
     docs:
       desc: |
-        This check verifies that the PAN-OS device is operating in normal mode rather than maintenance or other non-operational states.
+        This check verifies that the PAN-OS device is operating in normal mode rather than maintenance or other non-operational states. The operational mode reflects the overall health and readiness of the firewall.
 
-        ## Rationale
+        **Why this matters**
 
-        A device not in normal operational mode may indicate:
+        A device not in normal operational mode cannot reliably protect the network. If the device is in a non-normal state:
 
-        - **Degraded Security Posture**: The device may not be processing traffic or enforcing security policies
-        - **Service Interruption**: Network traffic may not be protected or may be blocked
-        - **Configuration Issues**: The device may be in maintenance mode due to configuration problems
-        - **Hardware Failures**: Non-normal modes can indicate underlying hardware issues
+        - The firewall may not be processing traffic or enforcing security policies, leaving the network unprotected.
+        - Network traffic may be blocked entirely, causing a service interruption.
+        - The device may be stuck in maintenance mode due to configuration problems that require immediate attention.
+        - Underlying hardware failures may be present that compromise the device's reliability.
 
         Devices should operate in normal mode to provide continuous security protection for network traffic.
 
@@ -231,18 +230,18 @@ queries:
     mql: panos.system.threatVersion != ""
     docs:
       desc: |
-        This check verifies that threat prevention content is installed on the device.
+        This check verifies that threat prevention content is installed on the device. Threat content includes the signatures, rules, and intelligence the firewall uses to detect and block network attacks.
 
-        ## Rationale
+        **Why this matters**
 
-        Threat prevention content provides critical intelligence for:
+        Without current threat prevention content, the firewall loses its core ability to detect and block attacks. If threat content is missing:
 
-        - **Threat Detection**: Signatures and intelligence for identifying known threats
-        - **IPS Protection**: Intrusion prevention system rules to block attacks
-        - **Vulnerability Protection**: Defense against known exploits and attack techniques
-        - **Zero-Day Protection**: Behavioral analysis and heuristics for unknown threats
+        - Known threats pass through the firewall undetected because there are no signatures to match against.
+        - The intrusion prevention system (IPS) has no rules to block exploit attempts.
+        - Known vulnerability exploits and attack techniques cannot be identified or stopped.
+        - Behavioral analysis and heuristics for detecting unknown threats are unavailable.
 
-        Without current threat content, the firewall cannot identify or block known threats, leaving the network vulnerable to attacks.
+        Maintaining up-to-date threat content is fundamental to the firewall's security function and should be verified regularly.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -267,18 +266,18 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active Threat Prevention license is installed on the device.
+        This check verifies that an active Threat Prevention license is installed on the device. Threat Prevention is the core security subscription that enables intrusion prevention, anti-spyware, and vulnerability protection.
 
-        ## Rationale
+        **Why this matters**
 
-        The Threat Prevention license is essential for core security capabilities:
+        Without an active Threat Prevention subscription, the firewall operates in a significantly degraded security state. If this license is missing or expired:
 
-        - **IPS/IDS**: Intrusion prevention and detection system capabilities
-        - **Anti-Spyware**: Protection against spyware, command-and-control traffic, and data exfiltration
-        - **Vulnerability Protection**: Defense against known software vulnerabilities
-        - **Signature Updates**: Regular updates to threat detection signatures
+        - Intrusion prevention and detection capabilities are disabled, allowing exploit attempts to pass through.
+        - Spyware, command-and-control traffic, and data exfiltration go undetected.
+        - Known software vulnerabilities cannot be defended against at the network layer.
+        - Threat detection signatures stop receiving updates, leaving the firewall blind to new attack techniques.
 
-        Without an active Threat Prevention subscription, the firewall operates in a significantly degraded security state and cannot protect against the vast majority of network threats.
+        Threat Prevention is considered a core security subscription and should be maintained on all production firewalls to protect against the vast majority of network threats.
       remediation: |
         Purchase and activate a Threat Prevention license for the device. This is considered a core security subscription and should be maintained on all production firewalls.
 
@@ -303,17 +302,17 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active URL Filtering license is installed on the device.
+        This check verifies that an active URL Filtering license is installed on the device. URL Filtering enables the firewall to categorize and control web traffic based on site reputation and content category.
 
-        ## Rationale
+        **Why this matters**
 
-        The URL Filtering license provides web security capabilities:
+        Without an active URL Filtering license, the firewall cannot inspect or control web traffic at the URL level. If this license is missing or expired:
 
-        - **Malicious Site Blocking**: Prevention of access to known malicious websites
-        - **Category-Based Control**: Blocking or allowing websites based on content categories
-        - **Phishing Protection**: Detection and blocking of phishing sites
-        - **Real-Time Updates**: Continuous updates to URL categorization database
-        - **Reputation Scoring**: Risk-based website reputation information
+        - Users can access known malicious websites that deliver malware or host exploit kits.
+        - Phishing sites are not detected or blocked, increasing the risk of credential theft.
+        - Administrators cannot enforce acceptable use policies based on website content categories.
+        - The URL categorization database stops receiving updates, reducing the accuracy of web traffic classification.
+        - Risk-based reputation scoring is unavailable, preventing informed policy decisions about borderline sites.
 
         URL Filtering is essential for protecting users from web-based threats, enforcing acceptable use policies, and preventing phishing attacks.
       remediation: |
@@ -336,18 +335,18 @@ queries:
     mql: panos.system.wildfireVersion != ""
     docs:
       desc: |
-        This check verifies that WildFire threat intelligence content is installed on the device.
+        This check verifies that WildFire threat intelligence content is installed on the device. WildFire content delivers signatures generated from cloud-based sandbox analysis of unknown files observed across Palo Alto Networks' global sensor network.
 
-        ## Rationale
+        **Why this matters**
 
-        WildFire provides advanced threat prevention through:
+        Without WildFire content, the firewall cannot benefit from cloud-based threat intelligence and advanced malware analysis. If WildFire content is missing:
 
-        - **Unknown File Analysis**: Cloud-based analysis of unknown files in a sandbox environment
-        - **Zero-Day Protection**: Detection and prevention of previously unknown malware
-        - **Rapid Updates**: Near real-time signature updates based on global threat intelligence
-        - **APT Detection**: Advanced persistent threat identification
+        - Unknown files that have been analyzed and identified as malicious in the cloud will not be blocked locally.
+        - The firewall loses access to near real-time signature updates derived from global threat intelligence.
+        - Previously unknown malware and zero-day threats cannot be detected using WildFire-generated signatures.
+        - Advanced persistent threats that rely on novel malware go unidentified at the network perimeter.
 
-        WildFire content ensures the firewall can leverage cloud-based threat intelligence to prevent sophisticated attacks.
+        WildFire content ensures the firewall can leverage cloud-based threat intelligence to prevent sophisticated attacks that evade traditional signature-based detection.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -372,16 +371,16 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active WildFire license is installed on the device.
+        This check verifies that an active WildFire license is installed on the device. WildFire provides cloud-based sandbox analysis and machine learning to detect and prevent previously unknown malware and zero-day exploits.
 
-        ## Rationale
+        **Why this matters**
 
-        The WildFire license provides advanced threat prevention:
+        Without an active WildFire license, the firewall cannot submit unknown files for cloud-based analysis or receive WildFire-generated threat intelligence. If this license is missing or expired:
 
-        - **Zero-Day Protection**: Detection and prevention of previously unknown malware
-        - **Sandbox Analysis**: Cloud-based file analysis in multiple virtual environments
-        - **Machine Learning**: Advanced analytics for threat detection
-        - **Global Intelligence**: Threat intelligence derived from millions of sensors worldwide
+        - Previously unknown malware and zero-day exploits pass through the firewall undetected.
+        - Unknown files cannot be submitted to the WildFire cloud for sandbox analysis across multiple virtual environments.
+        - Machine learning-based threat detection is unavailable, reducing the firewall's ability to identify novel attacks.
+        - The firewall loses access to global threat intelligence derived from millions of sensors worldwide.
 
         WildFire is critical for protecting against sophisticated, targeted attacks and zero-day exploits that traditional signature-based detection cannot identify.
       remediation: |


### PR DESCRIPTION
## Summary
- Updates PAN-OS (10 checks), Arista EOS (37 checks), and Junos (27 checks) security policy descriptions to follow the standard format used in Linux, AWS, and Kubernetes policies
- Replaces `## Rationale` markdown headings with `**Why this matters**` bold text
- Converts `**Bold Label**: description` bullet format to plain narrative sentences describing consequences and risks

## Test plan
- [ ] Verify `cnspec policy lint` passes for all three modified policy files
- [ ] Spot-check rendered Markdown output for a few checks in each policy
- [ ] Confirm no changes to `mql`, `remediation`, `refs`, `impact`, `tags`, or other non-desc fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)