### PR TITLE
Split policy remediation sections into console and CLI formats

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-arista-eos-security
     name: Mondoo Arista EOS Security
-    version: 1.0.0
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -134,20 +134,23 @@ queries:
         - Accountability for privileged operations is lost, undermining trust in administrative actions.
 
         Enabling command accounting ensures that all activity is logged and available for audit, investigation, and compliance reporting.
-      remediation: |
-        Enable AAA accounting for all commands:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa accounting commands all default start-stop logging
-        ```
+            Enable AAA accounting for all commands:
 
-        Configure syslog server to receive accounting records:
+            ```
+            configure
+            aaa accounting commands all default start-stop logging
+            ```
 
-        ```
-        logging host <syslog-server-ip>
-        ```
+            Configure syslog server to receive accounting records:
 
+            ```
+            logging host <syslog-server-ip>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -178,14 +181,17 @@ queries:
         - Investigating unauthorized access becomes significantly harder without session data.
 
         Enabling exec session accounting ensures that all access activity is captured for monitoring, compliance, and forensic purposes.
-      remediation: |
-        Enable AAA accounting for exec sessions:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa accounting exec default start-stop logging
-        ```
+            Enable AAA accounting for exec sessions:
 
+            ```
+            configure
+            aaa accounting exec default start-stop logging
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -216,14 +222,17 @@ queries:
         - Unauthorized system changes may go undetected.
 
         Enabling system event accounting provides the visibility needed to detect unauthorized changes and maintain a complete audit record.
-      remediation: |
-        Enable AAA accounting for system events:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa accounting system default start-stop logging
-        ```
+            Enable AAA accounting for system events:
 
+            ```
+            configure
+            aaa accounting system default start-stop logging
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -255,17 +264,20 @@ queries:
         - Managing user accounts individually across multiple devices becomes error-prone and impractical.
 
         Configuring AAA ensures centralized, scalable authentication with comprehensive audit trails across the network infrastructure.
-      remediation: |
-        Configure AAA authentication for console and remote access:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa authentication login default group <radius|tacacs+> local
-        aaa authentication login console group <radius|tacacs+> local
-        ```
+            Configure AAA authentication for console and remote access:
 
-        The `local` fallback ensures access is maintained if AAA servers are unreachable.
+            ```
+            configure
+            aaa authentication login default group <radius|tacacs+> local
+            aaa authentication login console group <radius|tacacs+> local
+            ```
 
+            The `local` fallback ensures access is maintained if AAA servers are unreachable.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -297,20 +309,23 @@ queries:
         - Compliance requirements for intrusion detection cannot be met.
 
         Enabling authentication failure logging ensures that all failed login attempts are captured, supporting both proactive security monitoring and incident investigation.
-      remediation: |
-        Enable authentication failure logging:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa authentication policy on-failure log
-        ```
+            Enable authentication failure logging:
 
-        Configure log monitoring and alerting for authentication failures:
+            ```
+            configure
+            aaa authentication policy on-failure log
+            ```
 
-        ```
-        logging host <siem-server-ip>
-        ```
+            Configure log monitoring and alerting for authentication failures:
 
+            ```
+            logging host <siem-server-ip>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -341,15 +356,18 @@ queries:
         - Authorization decisions are not tracked for compliance reporting.
 
         Enabling console authorization ensures that users can only perform operations appropriate to their role, reducing the risk of accidental or intentional misuse.
-      remediation: |
-        Enable AAA authorization for console access:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa authorization console
-        aaa authorization commands all default local
-        ```
+            Enable AAA authorization for console access:
 
+            ```
+            configure
+            aaa authorization console
+            aaa authorization commands all default local
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -384,14 +402,17 @@ queries:
         - Using weak encryption for this account exposes the emergency credential to compromise.
 
         Maintaining an admin account with SHA-512 encryption ensures reliable emergency access while protecting the credential with the strongest available hashing algorithm.
-      remediation: |
-        Configure an admin account with SHA-512 password encryption:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        username admin privilege 15 role network-admin secret sha512 <strong-password>
-        ```
+            Configure an admin account with SHA-512 password encryption:
 
+            ```
+            configure
+            username admin privilege 15 role network-admin secret sha512 <strong-password>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -421,15 +442,18 @@ queries:
         - Physical access security requirements for compliance cannot be met.
 
         Configuring console timeouts ensures that idle sessions are terminated, limiting the window of opportunity for unauthorized physical access.
-      remediation: |
-        Configure absolute timeout for console sessions:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        line console
-        absolute-timeout 10
-        ```
+            Configure absolute timeout for console sessions:
 
+            ```
+            configure
+            line console
+            absolute-timeout 10
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -461,14 +485,17 @@ queries:
         - Identification of the device in logs and management systems is less reliable.
 
         Configuring a domain name ensures that the device can fully participate in secured communications and is properly identifiable across the network.
-      remediation: |
-        Configure the IP domain name:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        ip domain-name <your-domain.com>
-        ```
+            Configure the IP domain name:
 
+            ```
+            configure
+            ip domain-name <your-domain.com>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -499,15 +526,18 @@ queries:
         - Connection resources remain consumed by idle sessions, potentially blocking legitimate access.
 
         Configuring exec timeouts ensures that idle sessions are automatically closed, reducing the attack surface and freeing resources for active users.
-      remediation: |
-        Configure exec timeout (10 minutes recommended):
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        line vty
-        exec-timeout 10
-        ```
+            Configure exec timeout (10 minutes recommended):
 
+            ```
+            configure
+            line vty
+            exec-timeout 10
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -540,16 +570,19 @@ queries:
         - Security standards requiring unique device identification cannot be met.
 
         Setting a descriptive hostname that includes location, function, or other identifying information ensures the device is easily recognizable across all operational and security workflows.
-      remediation: |
-        Configure a descriptive, unique hostname:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        hostname <unique-descriptive-name>
-        ```
+            Configure a descriptive, unique hostname:
 
-        Use naming conventions that include location, function, or other identifying information.
+            ```
+            configure
+            hostname <unique-descriptive-name>
+            ```
 
+            Use naming conventions that include location, function, or other identifying information.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -582,16 +615,19 @@ queries:
         - Security standards requiring encrypted management interfaces cannot be met.
 
         Disabling HTTP and using only HTTPS ensures that all management API communications are encrypted and protected from eavesdropping and tampering.
-      remediation: |
-        Disable HTTP and enable HTTPS for the management API:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        management api http-commands
-        no protocol http
-        protocol https
-        ```
+            Disable HTTP and enable HTTPS for the management API:
 
+            ```
+            configure
+            management api http-commands
+            no protocol http
+            protocol https
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
         title: Arista EOS Management API Configuration Guide
@@ -623,15 +659,18 @@ queries:
         - Security standards requiring encrypted management interfaces cannot be satisfied.
 
         Enabling HTTPS ensures that all API access is encrypted, authenticated, and integrity-protected, meeting both security best practices and compliance requirements.
-      remediation: |
-        Enable HTTPS for the management API:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        management api http-commands
-        protocol https
-        ```
+            Enable HTTPS for the management API:
 
+            ```
+            configure
+            management api http-commands
+            protocol https
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
         title: Arista EOS Management API Configuration Guide
@@ -665,17 +704,20 @@ queries:
         - Troubleshooting network issues is slower without knowing what each interface connects to.
 
         Adding descriptions to all active interfaces ensures that the network configuration is self-documenting, supporting faster troubleshooting, better change management, and more effective security reviews.
-      remediation: |
-        Configure descriptive names for all interfaces:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        interface <interface-name>
-        description <purpose and connection details>
-        ```
+            Configure descriptive names for all interfaces:
 
-        For example: `description Uplink to Core Switch 1 Gi0/1`
+            ```
+            configure
+            interface <interface-name>
+            description <purpose and connection details>
+            ```
 
+            For example: `description Uplink to Core Switch 1 Gi0/1`
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -705,14 +747,17 @@ queries:
         - Log handling may be less efficient without a dedicated buffer.
 
         Configuring buffered logging ensures that recent log messages are always available on the device for rapid diagnosis, while also providing a safety net if remote logging is temporarily unavailable.
-      remediation: |
-        Configure buffered logging with appropriate size:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        logging buffered 100000 informational
-        ```
+            Configure buffered logging with appropriate size:
 
+            ```
+            configure
+            logging buffered 100000 informational
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -744,14 +789,17 @@ queries:
         - There is no audit trail documenting system activities.
 
         Enabling system logging is a foundational security control that supports incident detection, investigation, compliance reporting, and day-to-day operations.
-      remediation: |
-        Enable system logging:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        logging on
-        ```
+            Enable system logging:
 
+            ```
+            configure
+            logging on
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -783,15 +831,18 @@ queries:
         - An attacker who compromises the device can delete local logs to cover their tracks.
 
         Configuring remote syslog ensures that log data is preserved, centrally accessible, and tamper-resistant, enabling effective security monitoring and compliance.
-      remediation: |
-        Configure one or more remote syslog servers:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        logging host <syslog-server-ip>
-        logging trap informational
-        ```
+            Configure one or more remote syslog servers:
 
+            ```
+            configure
+            logging host <syslog-server-ip>
+            logging trap informational
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -822,15 +873,18 @@ queries:
         - Compliance requirements that specify minimum logging levels cannot be verified.
 
         Configuring logging levels ensures the right balance between capturing security-relevant events and maintaining system performance.
-      remediation: |
-        Configure logging levels for important subsystems (informational or debugging):
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        logging level all informational
-        logging level security debugging
-        ```
+            Configure logging levels for important subsystems (informational or debugging):
 
+            ```
+            configure
+            logging level all informational
+            logging level security debugging
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
         title: Arista EOS Logging Configuration Guide
@@ -862,20 +916,23 @@ queries:
         - Prosecution of unauthorized access may be more difficult without a clear warning.
 
         Configuring a login banner with appropriate legal language establishes the terms of access and strengthens the organization's legal position in the event of unauthorized use.
-      remediation: |
-        Configure a login banner with appropriate legal language:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        banner login
-        UNAUTHORIZED ACCESS TO THIS DEVICE IS PROHIBITED
-        You must have explicit, authorized permission to access this device.
-        Unauthorized attempts and actions to access or use this system may
-        result in civil and/or criminal penalties. All activities performed
-        on this device are logged and monitored.
-        EOF
-        ```
+            Configure a login banner with appropriate legal language:
 
+            ```
+            configure
+            banner login
+            UNAUTHORIZED ACCESS TO THIS DEVICE IS PROHIBITED
+            You must have explicit, authorized permission to access this device.
+            Unauthorized attempts and actions to access or use this system may
+            result in civil and/or criminal penalties. All activities performed
+            on this device are logged and monitored.
+            EOF
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -909,21 +966,24 @@ queries:
         - Compliance frameworks that require privilege separation and least-privilege access cannot be satisfied.
 
         Assigning specific roles to non-admin users ensures that each person can only perform operations appropriate to their responsibilities, limiting the blast radius of any compromised or misused account.
-      remediation: |
-        Assign appropriate roles to users instead of granting blanket privilege 15:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        username <username> privilege 1 role <appropriate-role>
-        ```
+            Assign appropriate roles to users instead of granting blanket privilege 15:
 
-        Create custom roles if needed:
+            ```
+            configure
+            username <username> privilege 1 role <appropriate-role>
+            ```
 
-        ```
-        role <role-name>
-           <privilege statements>
-        ```
+            Create custom roles if needed:
 
+            ```
+            role <role-name>
+               <privilege statements>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -954,16 +1014,19 @@ queries:
         - Users are not informed of scheduled maintenance or other operational notices.
 
         Configuring an MOTD banner ensures that all users are presented with relevant security notices and operational information each time they access the device.
-      remediation: |
-        Configure an MOTD banner:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        banner motd
-        <your message here>
-        EOF
-        ```
+            Configure an MOTD banner:
 
+            ```
+            configure
+            banner motd
+            <your message here>
+            EOF
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -994,16 +1057,19 @@ queries:
         - Administrative accounts, which are the most valuable targets, remain protected only by a password.
 
         Configuring MFA for console access ensures that stolen or guessed passwords alone are not sufficient to compromise the device, significantly raising the bar for attackers.
-      remediation: |
-        Configure console authentication to use RADIUS or TACACS+ with MFA:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        aaa authentication login console group radius local
-        ```
+            Configure console authentication to use RADIUS or TACACS+ with MFA:
 
-        Ensure the RADIUS/TACACS+ server is configured for multifactor authentication (e.g., RSA SecurID, Duo Security, or certificate-based authentication).
+            ```
+            configure
+            aaa authentication login console group radius local
+            ```
 
+            Ensure the RADIUS/TACACS+ server is configured for multifactor authentication (e.g., RSA SecurID, Duo Security, or certificate-based authentication).
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -1034,17 +1100,20 @@ queries:
         - Automated attack tools actively scan for and exploit accounts without passwords.
 
         Ensuring all accounts require strong password authentication prevents unauthorized access and maintains accountability for all device activity.
-      remediation: |
-        Remove the `nopassword` configuration from all user accounts:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        no username <username> nopassword
-        username <username> secret <strong-password>
-        ```
+            Remove the `nopassword` configuration from all user accounts:
 
-        Ensure all accounts use strong, encrypted passwords (preferably SHA-512).
+            ```
+            configure
+            no username <username> nopassword
+            username <username> secret <strong-password>
+            ```
 
+            Ensure all accounts use strong, encrypted passwords (preferably SHA-512).
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1075,17 +1144,20 @@ queries:
         - Audit log reliability is undermined by inaccurate timestamps.
 
         Enabling NTP ensures that the device maintains accurate time, which is foundational to security monitoring, incident response, and compliance.
-      remediation: |
-        Configure NTP servers for time synchronization:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        ntp server <ntp-server-1>
-        ntp server <ntp-server-2>
-        ```
+            Configure NTP servers for time synchronization:
 
-        Use multiple NTP servers for redundancy.
+            ```
+            configure
+            ntp server <ntp-server-1>
+            ntp server <ntp-server-2>
+            ```
 
+            Use multiple NTP servers for redundancy.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1116,17 +1188,20 @@ queries:
         - Accurate audit logging required for compliance depends on reliable time synchronization.
 
         Configuring at least two NTP servers from trusted sources ensures redundant, reliable time synchronization for the device.
-      remediation: |
-        Configure at least two NTP servers for redundancy:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        ntp server <primary-ntp-server>
-        ntp server <secondary-ntp-server>
-        ```
+            Configure at least two NTP servers for redundancy:
 
-        Use NTP servers from reliable sources (e.g., NIST, internal stratum 1/2 servers).
+            ```
+            configure
+            ntp server <primary-ntp-server>
+            ntp server <secondary-ntp-server>
+            ```
 
+            Use NTP servers from reliable sources (e.g., NIST, internal stratum 1/2 servers).
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1159,17 +1234,20 @@ queries:
         - The device is more vulnerable to dictionary and brute-force attacks.
 
         Configuring a minimum password length of at least 15 characters for administrative accounts provides substantial protection against credential-based attacks.
-      remediation: |
-        Configure a minimum password length (15 characters recommended for high security):
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        management security
-        password minimum length 15
-        ```
+            Configure a minimum password length (15 characters recommended for high security):
 
-        For environments requiring compliance with specific standards (e.g., DISA STIG), 15 characters is mandatory.
+            ```
+            configure
+            management security
+            password minimum length 15
+            ```
 
+            For environments requiring compliance with specific standards (e.g., DISA STIG), 15 characters is mandatory.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1200,16 +1278,19 @@ queries:
         - An additional layer of defense-in-depth protection is missing.
 
         Enabling service password encryption prevents casual observation of passwords in configuration files. Note that this uses Type 7 encryption, which can be reversed, so stronger hashing such as SHA-512 should still be used for user passwords.
-      remediation: |
-        Enable service password encryption:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        service password-encryption
-        ```
+            Enable service password encryption:
 
-        This encrypts passwords that would otherwise be stored in plain text in the configuration.
+            ```
+            configure
+            service password-encryption
+            ```
 
+            This encrypts passwords that would otherwise be stored in plain text in the configuration.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1242,22 +1323,25 @@ queries:
         - Compliance with security standards that prohibit default credentials is violated.
 
         Removing default community strings and replacing them with strong, unique values treats SNMP access with the same rigor as any other authentication credential.
-      remediation: |
-        Remove default community strings and configure secure, unique strings:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        no snmp-server community public
-        no snmp-server community private
-        snmp-server community <strong-unique-string> ro
-        ```
+            Remove default community strings and configure secure, unique strings:
 
-        Consider using SNMPv3 with authentication and encryption instead of community strings:
+            ```
+            configure
+            no snmp-server community public
+            no snmp-server community private
+            snmp-server community <strong-unique-string> ro
+            ```
 
-        ```
-        snmp-server user <username> <group> v3 auth sha <password> priv aes128 <privpassword>
-        ```
+            Consider using SNMPv3 with authentication and encryption instead of community strings:
 
+            ```
+            snmp-server user <username> <group> v3 auth sha <password> priv aes128 <privpassword>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
         title: Arista EOS SNMP Configuration Guide
@@ -1290,14 +1374,17 @@ queries:
         - The overall SNMP security posture is undermined even if polling uses strong strings.
 
         Configuring SNMP traps with secure, unique community strings ensures that event notifications are only readable by authorized monitoring systems.
-      remediation: |
-        Configure SNMP traps with secure community strings:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        snmp-server host <server-ip> version 2c <secure-community-string>
-        ```
+            Configure SNMP traps with secure community strings:
 
+            ```
+            configure
+            snmp-server host <server-ip> version 2c <secure-community-string>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
         title: Arista EOS SNMP Configuration Guide
@@ -1329,21 +1416,24 @@ queries:
         - Compliance with all major security frameworks that mandate encrypted management access cannot be achieved.
 
         Enabling SSH ensures that all remote management sessions are encrypted, authenticated, and protected from interception.
-      remediation: |
-        Enable SSH management access:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        management ssh
-        no shutdown
-        ```
+            Enable SSH management access:
 
-        Configure SSH server settings for enhanced security:
+            ```
+            configure
+            management ssh
+            no shutdown
+            ```
 
-        ```
-        ip ssh version 2
-        ```
+            Configure SSH server settings for enhanced security:
 
+            ```
+            ip ssh version 2
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1375,22 +1465,25 @@ queries:
         - Compliance with virtually all security frameworks that prohibit Telnet is violated.
 
         Disabling Telnet and using SSH as the sole remote management protocol ensures that all management communications are encrypted and protected from interception.
-      remediation: |
-        Disable Telnet management access:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        management telnet
-        shutdown
-        ```
+            Disable Telnet management access:
 
-        Ensure SSH is enabled as a secure alternative:
+            ```
+            configure
+            management telnet
+            shutdown
+            ```
 
-        ```
-        management ssh
-        no shutdown
-        ```
+            Ensure SSH is enabled as a secure alternative:
 
+            ```
+            management ssh
+            no shutdown
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1421,14 +1514,17 @@ queries:
         - The industry standard practice of using UTC for infrastructure logging is not followed.
 
         Setting the timezone to UTC or GMT ensures consistent timestamps across all devices, enabling accurate event correlation and streamlined incident analysis.
-      remediation: |
-        Configure the timezone to UTC or GMT:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        clock timezone UTC
-        ```
+            Configure the timezone to UTC or GMT:
 
+            ```
+            configure
+            clock timezone UTC
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -1464,17 +1560,20 @@ queries:
         - Compliance frameworks that require disabling unused ports cannot be satisfied.
 
         Disabling unused interfaces and documenting the intended purpose of reserved ports reduces the physical attack surface and prevents unauthorized network access.
-      remediation: |
-        Disable unused interfaces:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        interface <interface-name>
-        shutdown
-        ```
+            Disable unused interfaces:
 
-        For interfaces that may be used in the future, add a description noting their intended purpose.
+            ```
+            configure
+            interface <interface-name>
+            shutdown
+            ```
 
+            For interfaces that may be used in the future, add a description noting their intended purpose.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -1505,15 +1604,18 @@ queries:
         - Industry best practices for VLAN security are not followed.
 
         Moving all access ports to dedicated user VLANs ensures proper traffic separation and reduces the risk of VLAN-based attacks.
-      remediation: |
-        Move all access ports from VLAN 1 to appropriate user VLANs:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        interface <interface>
-        switchport access vlan <appropriate-vlan>
-        ```
+            Move all access ports from VLAN 1 to appropriate user VLANs:
 
+            ```
+            configure
+            interface <interface>
+            switchport access vlan <appropriate-vlan>
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -1546,16 +1648,19 @@ queries:
         - A single exposed configuration file could compromise every account on the device.
 
         Using SHA-512 or SHA-256 for all user passwords ensures that credentials remain protected even if the device configuration is inadvertently exposed or backed up insecurely.
-      remediation: |
-        Update all user accounts to use SHA-512 password encryption:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        username <username> secret sha512 <password>
-        ```
+            Update all user accounts to use SHA-512 password encryption:
 
-        SHA-512 is preferred over SHA-256 for maximum security.
+            ```
+            configure
+            username <username> secret sha512 <password>
+            ```
 
+            SHA-512 is preferred over SHA-256 for maximum security.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1587,17 +1692,20 @@ queries:
         - Configuration errors are more likely when administrators cannot easily distinguish between VLANs.
 
         Naming VLANs descriptively ensures that the network configuration is clear and understandable, supporting efficient operations, better change management, and more effective security audits.
-      remediation: |
-        Configure descriptive names for all VLANs:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        vlan <vlan-id>
-        name <descriptive-name>
-        ```
+            Configure descriptive names for all VLANs:
 
-        For example: `name GUEST_WIFI`, `name PROD_SERVERS`, `name MGMT_NETWORK`
+            ```
+            configure
+            vlan <vlan-id>
+            name <descriptive-name>
+            ```
 
+            For example: `name GUEST_WIFI`, `name PROD_SERVERS`, `name MGMT_NETWORK`
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -1631,17 +1739,20 @@ queries:
         - The device's default configuration becomes a known attack vector.
 
         Configuring a dedicated, unused VLAN as the native VLAN on trunk ports eliminates VLAN hopping risks and separates control plane traffic from user data.
-      remediation: |
-        Configure a dedicated native VLAN (other than 1) for trunk ports:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        configure
-        interface <interface>
-        switchport trunk native vlan <vlan-id>
-        ```
+            Configure a dedicated native VLAN (other than 1) for trunk ports:
 
-        Consider using an unused VLAN as the native VLAN and don't assign any access ports to it.
+            ```
+            configure
+            interface <interface>
+            switchport trunk native vlan <vlan-id>
+            ```
 
+            Consider using an unused VLAN as the native VLAN and don't assign any access ports to it.
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-junos-security
     name: Mondoo Juniper Junos Security
-    version: 1.0.0
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -123,21 +123,24 @@ queries:
         - The principle of least privilege is violated, increasing the blast radius of a compromised credential.
 
         By denying root login, organizations enforce individual accountability and reduce the risk of unauthorized privileged access to the device.
-      remediation: |
-        Disable root login via SSH:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh root-login deny
-        commit
-        ```
+            Disable root login via SSH:
 
-        Or allow key-based root login only:
+            ```
+            set system services ssh root-login deny
+            commit
+            ```
 
-        ```
-        set system services ssh root-login deny-password
-        commit
-        ```
+            Or allow key-based root login only:
 
+            ```
+            set system services ssh root-login deny-password
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/root-login-edit-system-services-ssh.html
         title: Junos SSH Root Login Configuration
@@ -176,18 +179,21 @@ queries:
         - Modern security standards and compliance frameworks require AES-128 or stronger encryption for management traffic.
 
         By restricting SSH to strong ciphers, organizations ensure that management sessions remain confidential and resistant to known cryptographic attacks.
-      remediation: |
-        Configure only strong ciphers:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh ciphers aes256-ctr
-        set system services ssh ciphers aes128-ctr
-        set system services ssh ciphers aes256-gcm@openssh.com
-        set system services ssh ciphers aes128-gcm@openssh.com
-        set system services ssh ciphers chacha20-poly1305@openssh.com
-        commit
-        ```
+            Configure only strong ciphers:
 
+            ```
+            set system services ssh ciphers aes256-ctr
+            set system services ssh ciphers aes128-ctr
+            set system services ssh ciphers aes256-gcm@openssh.com
+            set system services ssh ciphers aes128-gcm@openssh.com
+            set system services ssh ciphers chacha20-poly1305@openssh.com
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/ciphers-edit-system-services-ssh.html
         title: Junos SSH Ciphers Configuration
@@ -225,17 +231,20 @@ queries:
         - NIST and industry standards require SHA-256 or stronger algorithms for integrity verification.
 
         By configuring only strong MACs, organizations protect the integrity of management sessions and meet compliance requirements for cryptographic controls.
-      remediation: |
-        Configure only strong MACs:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh macs hmac-sha2-256
-        set system services ssh macs hmac-sha2-512
-        set system services ssh macs hmac-sha2-256-etm@openssh.com
-        set system services ssh macs hmac-sha2-512-etm@openssh.com
-        commit
-        ```
+            Configure only strong MACs:
 
+            ```
+            set system services ssh macs hmac-sha2-256
+            set system services ssh macs hmac-sha2-512
+            set system services ssh macs hmac-sha2-256-etm@openssh.com
+            set system services ssh macs hmac-sha2-512-etm@openssh.com
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/macs-edit-system-services-ssh.html
         title: Junos SSH MACs Configuration
@@ -270,18 +279,21 @@ queries:
         - Without strong key exchange, forward secrecy is undermined, meaning past sessions could be decrypted if long-term keys are later compromised.
 
         By restricting key exchange to strong algorithms, organizations ensure secure session negotiation and maintain forward secrecy for all management connections.
-      remediation: |
-        Configure only strong key exchange algorithms:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh key-exchange group-exchange-sha2
-        set system services ssh key-exchange ecdh-sha2-nistp256
-        set system services ssh key-exchange ecdh-sha2-nistp384
-        set system services ssh key-exchange ecdh-sha2-nistp521
-        set system services ssh key-exchange curve25519-sha256
-        commit
-        ```
+            Configure only strong key exchange algorithms:
 
+            ```
+            set system services ssh key-exchange group-exchange-sha2
+            set system services ssh key-exchange ecdh-sha2-nistp256
+            set system services ssh key-exchange ecdh-sha2-nistp384
+            set system services ssh key-exchange ecdh-sha2-nistp521
+            set system services ssh key-exchange curve25519-sha256
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/key-exchange-edit-system-services-ssh.html
         title: Junos SSH Key Exchange Configuration
@@ -312,14 +324,17 @@ queries:
         - Compromised accounts can be leveraged to pivot through the network device and reach otherwise isolated network segments.
 
         By disabling TCP forwarding, organizations prevent the SSH service from being misused as a network proxy and maintain the integrity of their firewall and segmentation controls.
-      remediation: |
-        Disable SSH TCP forwarding:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh no-tcp-forwarding
-        commit
-        ```
+            Disable SSH TCP forwarding:
 
+            ```
+            set system services ssh no-tcp-forwarding
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/no-tcp-forwarding-edit-system-services-ssh.html
         title: Junos SSH TCP Forwarding Configuration
@@ -350,14 +365,17 @@ queries:
         - Legitimate administrators may be unable to connect to the device during an active attack due to resource exhaustion.
 
         By setting a connection limit, organizations ensure that the SSH service remains available to authorized users even during brute-force or denial-of-service attempts.
-      remediation: |
-        Configure an SSH connection limit:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh connection-limit 5
-        commit
-        ```
+            Configure an SSH connection limit:
 
+            ```
+            set system services ssh connection-limit 5
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/connection-limit-edit-system-services-ssh.html
         title: Junos SSH Connection Limit Configuration
@@ -388,14 +406,17 @@ queries:
         - Attackers face no throttling penalty, making brute-force attacks significantly more likely to succeed.
 
         By configuring a rate limit, organizations slow down automated attacks and reduce the likelihood of successful credential compromise while keeping the SSH service responsive for authorized administrators.
-      remediation: |
-        Configure an SSH rate limit:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system services ssh rate-limit 4
-        commit
-        ```
+            Configure an SSH rate limit:
 
+            ```
+            set system services ssh rate-limit 4
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/rate-limit-edit-system-services-ssh.html
         title: Junos SSH Rate Limit Configuration
@@ -429,21 +450,24 @@ queries:
         - Credentialless accounts are trivial targets that require no effort for an attacker to exploit.
 
         By ensuring every account has credentials, organizations close a fundamental authentication gap and prevent unauthorized access through unprotected accounts.
-      remediation: |
-        Set a password for user accounts:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system login user <username> authentication encrypted-password "<hash>"
-        commit
-        ```
+            Set a password for user accounts:
 
-        Or configure SSH key authentication:
+            ```
+            set system login user <username> authentication encrypted-password "<hash>"
+            commit
+            ```
 
-        ```
-        set system login user <username> authentication ssh-rsa "<public-key>"
-        commit
-        ```
+            Or configure SSH key authentication:
 
+            ```
+            set system login user <username> authentication ssh-rsa "<public-key>"
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-authentication.html
         title: Junos User Authentication Configuration
@@ -474,23 +498,26 @@ queries:
         - A compromised super-user account gives an attacker complete control over the device, and limiting these accounts reduces that exposure.
 
         By restricting the number of super-user accounts, organizations minimize the risk of privileged credential compromise and enforce least-privilege access across their network infrastructure.
-      remediation: |
-        Reassign users to more restrictive login classes:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system login user <username> class operator
-        commit
-        ```
+            Reassign users to more restrictive login classes:
 
-        Or create a custom login class with targeted permissions:
+            ```
+            set system login user <username> class operator
+            commit
+            ```
 
-        ```
-        set system login class limited-admin permissions configure
-        set system login class limited-admin permissions view
-        set system login user <username> class limited-admin
-        commit
-        ```
+            Or create a custom login class with targeted permissions:
 
+            ```
+            set system login class limited-admin permissions configure
+            set system login class limited-admin permissions view
+            set system login user <username> class limited-admin
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-login-classes.html
         title: Junos Login Classes Configuration
@@ -524,15 +551,18 @@ queries:
         - Data transmitted over Telnet has no integrity verification, meaning commands and responses can be silently altered in transit.
 
         By disabling Telnet and using SSH exclusively, organizations protect management credentials and session data from interception and tampering.
-      remediation: |
-        Disable Telnet:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        delete system services telnet
-        set system services ssh
-        commit
-        ```
+            Disable Telnet:
 
+            ```
+            delete system services telnet
+            set system services ssh
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -563,26 +593,29 @@ queries:
         - FTP server implementations have a long history of exploitable vulnerabilities that can provide an additional attack vector.
 
         By disabling FTP and using SCP instead, organizations ensure that file transfers to and from the device are encrypted and authenticated.
-      remediation: |
-        Disable FTP and use SCP instead:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        delete system services ftp
-        commit
-        ```
+            Disable FTP and use SCP instead:
 
-        SCP is automatically available when SSH is enabled. Verify SSH is configured:
+            ```
+            delete system services ftp
+            commit
+            ```
 
-        ```
-        show system services ssh
-        ```
+            SCP is automatically available when SSH is enabled. Verify SSH is configured:
 
-        To transfer files using SCP from an external host:
+            ```
+            show system services ssh
+            ```
 
-        ```
-        scp <file> <user>@<junos-device>:/var/tmp/
-        ```
+            To transfer files using SCP from an external host:
 
+            ```
+            scp <file> <user>@<junos-device>:/var/tmp/
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -613,14 +646,17 @@ queries:
         - The protocol provides no authentication or access controls, meaning anyone with network access can query it.
 
         By disabling the finger service, organizations eliminate an unnecessary information disclosure vector and reduce the data available for attacker reconnaissance.
-      remediation: |
-        Disable the finger service:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        delete system services finger
-        commit
-        ```
+            Disable the finger service:
 
+            ```
+            delete system services finger
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html
         title: Junos Remote Access Configuration
@@ -656,17 +692,20 @@ queries:
         - If a default read-write community string is present, attackers can remotely modify the device configuration to create backdoors or disable security features.
 
         By replacing default community strings with unique, complex values, organizations prevent trivial unauthorized access to device information through SNMP.
-      remediation: |
-        Remove default communities and configure unique strings:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        delete snmp community public
-        delete snmp community private
-        set snmp community <unique-string> authorization read-only
-        set snmp community <unique-string> clients <management-network>/24
-        commit
-        ```
+            Remove default communities and configure unique strings:
 
+            ```
+            delete snmp community public
+            delete snmp community private
+            set snmp community <unique-string> authorization read-only
+            set snmp community <unique-string> clients <management-network>/24
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -697,14 +736,17 @@ queries:
         - SNMPv1 and v2c community strings are transmitted in clear text, meaning read-write credentials can be captured from network traffic.
 
         By restricting all SNMP communities to read-only access, organizations prevent unauthorized remote configuration changes and limit the impact of a compromised community string.
-      remediation: |
-        Change all SNMP communities to read-only:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set snmp community <community-name> authorization read-only
-        commit
-        ```
+            Change all SNMP communities to read-only:
 
+            ```
+            set snmp community <community-name> authorization read-only
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -735,15 +777,18 @@ queries:
         - Unrestricted access makes it easier for attackers to conduct brute-force community string guessing from any location on the network.
 
         By restricting SNMP access to specific management hosts or networks, organizations reduce the attack surface and add a layer of access control beyond perimeter firewalls.
-      remediation: |
-        Restrict SNMP communities to specific client addresses:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set snmp community <community-name> clients <management-host>/32
-        set snmp community <community-name> clients <management-network>/24
-        commit
-        ```
+            Restrict SNMP communities to specific client addresses:
 
+            ```
+            set snmp community <community-name> clients <management-host>/32
+            set snmp community <community-name> clients <management-network>/24
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
         title: Junos SNMP Configuration
@@ -778,16 +823,19 @@ queries:
         - Integration with SIEM platforms and security monitoring tools is not possible without remote log forwarding.
 
         By configuring remote syslog, organizations create a tamper-resistant audit trail that supports threat detection, incident response, and compliance requirements.
-      remediation: |
-        Configure a remote syslog host:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system syslog host <syslog-server> any notice
-        set system syslog host <syslog-server> authorization info
-        set system syslog host <syslog-server> interactive-commands info
-        commit
-        ```
+            Configure a remote syslog host:
 
+            ```
+            set system syslog host <syslog-server> any notice
+            set system syslog host <syslog-server> authorization info
+            set system syslog host <syslog-server> interactive-commands info
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
         title: Junos Syslog Configuration
@@ -819,21 +867,24 @@ queries:
         - TLS transport provides both encryption and reliable delivery, addressing all of these concerns.
 
         By requiring TCP or TLS transport for syslog, organizations ensure that audit data is delivered reliably and protected from interception or manipulation.
-      remediation: |
-        Configure syslog with TCP or TLS transport:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set system syslog host <syslog-server> transport tcp
-        commit
-        ```
+            Configure syslog with TCP or TLS transport:
 
-        Or for encrypted syslog:
+            ```
+            set system syslog host <syslog-server> transport tcp
+            commit
+            ```
 
-        ```
-        set system syslog host <syslog-server> transport tls
-        commit
-        ```
+            Or for encrypted syslog:
 
+            ```
+            set system syslog host <syslog-server> transport tls
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
         title: Junos Syslog Configuration
@@ -868,15 +919,18 @@ queries:
         - Forensic reconstruction of attack timelines requires session logs that document the sequence of permitted and denied connections.
 
         By enabling session logging on all security policies, organizations gain the visibility needed for threat detection, incident response, and compliance auditing.
-      remediation: |
-        Enable logging on security policies:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security policies from-zone <src> to-zone <dst> policy <name> then log session-init
-        set security policies from-zone <src> to-zone <dst> policy <name> then log session-close
-        commit
-        ```
+            Enable logging on security policies:
 
+            ```
+            set security policies from-zone <src> to-zone <dst> policy <name> then log session-init
+            set security policies from-zone <src> to-zone <dst> policy <name> then log session-close
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-policy-logging.html
         title: Junos Security Policy Logging
@@ -908,18 +962,21 @@ queries:
         - Attack traffic that could be efficiently dropped at the perimeter instead consumes resources during full policy evaluation.
 
         By applying screen profiles to untrust zones, organizations establish a high-performance first line of defense that mitigates common network attacks before they reach the policy engine.
-      remediation: |
-        Create and apply a screen profile to the untrust zone:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option untrust-screen icmp ping-death
-        set security screen ids-option untrust-screen ip source-route-option
-        set security screen ids-option untrust-screen tcp syn-flood
-        set security screen ids-option untrust-screen tcp land
-        set security zones security-zone untrust screen untrust-screen
-        commit
-        ```
+            Create and apply a screen profile to the untrust zone:
 
+            ```
+            set security screen ids-option untrust-screen icmp ping-death
+            set security screen ids-option untrust-screen ip source-route-option
+            set security screen ids-option untrust-screen tcp syn-flood
+            set security screen ids-option untrust-screen tcp land
+            set security zones security-zone untrust screen untrust-screen
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -960,18 +1017,21 @@ queries:
         - Using the "all" keyword enables every host-inbound service, including insecure ones, creating maximum exposure.
 
         By restricting host-inbound services on the untrust zone to only essential encrypted protocols, organizations minimize the control plane attack surface exposed to untrusted networks.
-      remediation: |
-        Remove unnecessary host-inbound services from the untrust zone:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        delete security zones security-zone untrust host-inbound-traffic system-services telnet
-        delete security zones security-zone untrust host-inbound-traffic system-services ftp
-        delete security zones security-zone untrust host-inbound-traffic system-services finger
-        delete security zones security-zone untrust host-inbound-traffic system-services http
-        delete security zones security-zone untrust host-inbound-traffic system-services snmp
-        commit
-        ```
+            Remove unnecessary host-inbound services from the untrust zone:
 
+            ```
+            delete security zones security-zone untrust host-inbound-traffic system-services telnet
+            delete security zones security-zone untrust host-inbound-traffic system-services ftp
+            delete security zones security-zone untrust host-inbound-traffic system-services finger
+            delete security zones security-zone untrust host-inbound-traffic system-services http
+            delete security zones security-zone untrust host-inbound-traffic system-services snmp
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-zone-configuration.html
         title: Junos Security Zone Configuration
@@ -1006,16 +1066,19 @@ queries:
         - Junos SYN flood protection uses SYN proxy to validate connections before committing device resources, efficiently mitigating these attacks.
 
         By enabling SYN flood protection, organizations defend against a common and effective denial-of-service attack vector while ensuring continued availability of critical services.
-      remediation: |
-        Enable SYN flood protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> tcp syn-flood alarm-threshold 1024
-        set security screen ids-option <screen-name> tcp syn-flood attack-threshold 200
-        set security screen ids-option <screen-name> tcp syn-flood timeout 20
-        commit
-        ```
+            Enable SYN flood protection:
 
+            ```
+            set security screen ids-option <screen-name> tcp syn-flood alarm-threshold 1024
+            set security screen ids-option <screen-name> tcp syn-flood attack-threshold 200
+            set security screen ids-option <screen-name> tcp syn-flood timeout 20
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1046,14 +1109,17 @@ queries:
         - An entire class of ICMP-based attacks is left unmitigated at the perimeter, allowing them to reach internal systems.
 
         By enabling ping-of-death protection, organizations block oversized ICMP packets at the perimeter and protect internal systems from this class of attacks.
-      remediation: |
-        Enable ping-of-death protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> icmp ping-death
-        commit
-        ```
+            Enable ping-of-death protection:
 
+            ```
+            set security screen ids-option <screen-name> icmp ping-death
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1085,14 +1151,17 @@ queries:
         - There is no legitimate use case for source routing in modern production networks, so blocking it carries no operational impact.
 
         By blocking source-routed packets, organizations eliminate an attack technique that can bypass firewalls and enable spoofing, with no impact on legitimate traffic.
-      remediation: |
-        Enable source route option protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> ip source-route-option
-        commit
-        ```
+            Enable source route option protection:
 
+            ```
+            set security screen ids-option <screen-name> ip source-route-option
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1123,14 +1192,17 @@ queries:
         - Land attacks are a well-known and easily executed attack type that should be blocked at the perimeter as a basic security measure.
 
         By enabling land attack protection, organizations block a well-known denial-of-service technique and prevent unnecessary resource consumption on their network devices.
-      remediation: |
-        Enable land attack protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> tcp land
-        commit
-        ```
+            Enable land attack protection:
 
+            ```
+            set security screen ids-option <screen-name> tcp land
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1161,14 +1233,17 @@ queries:
         - Leaving this protection disabled allows an entire class of IP fragmentation attacks to pass through the perimeter unmitigated.
 
         By enabling teardrop protection, organizations block malformed fragmented packets at the perimeter and prevent fragmentation-based attacks from reaching internal systems.
-      remediation: |
-        Enable teardrop protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> ip tear-drop
-        commit
-        ```
+            Enable teardrop protection:
 
+            ```
+            set security screen ids-option <screen-name> ip tear-drop
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1199,14 +1274,17 @@ queries:
         - An entire class of OOB-based TCP attacks passes through the perimeter unblocked, potentially affecting any vulnerable internal system.
 
         By enabling WinNuke protection, organizations block out-of-band TCP attacks at the perimeter and protect internal systems from this class of exploits.
-      remediation: |
-        Enable WinNuke protection:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        set security screen ids-option <screen-name> tcp winnuke
-        commit
-        ```
+            Enable WinNuke protection:
 
+            ```
+            set security screen ids-option <screen-name> tcp winnuke
+            commit
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
         title: Junos Screen IDS Configuration
@@ -1240,19 +1318,22 @@ queries:
         - Security features required for regulatory compliance may stop functioning, creating compliance gaps that go unnoticed until the next audit.
 
         By monitoring license status and renewing before expiration, organizations ensure that all licensed security features remain active and the device continues to provide the expected level of protection.
-      remediation: |
-        Check license status:
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        show system license
-        ```
+            Check license status:
 
-        Install renewed licenses:
+            ```
+            show system license
+            ```
 
-        ```
-        request system license add <license-key>
-        ```
+            Install renewed licenses:
 
+            ```
+            request system license add <license-key>
+            ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/system-mgmt/topics/topic-map/license-management.html
         title: Junos License Management

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 1.0.1
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -72,26 +72,31 @@ queries:
         - The firewall loses its ability to act as a network-level malware prevention tool.
 
         Maintaining current antivirus content ensures the firewall can identify and block known malware before it reaches internal systems.
-      remediation: |
-        Check the current antivirus content version and trigger an update:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, navigate to **Device → Dynamic Updates**
-        2. Click **Check Now** to retrieve the latest available content versions
-        3. Locate the **Antivirus** entry and click **Download**, then **Install**
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click **Check Now** to retrieve the latest available content versions
+            3. Locate the **Antivirus** entry and click **Download**, then **Install**
 
-        To configure automatic updates so content stays current:
+            To configure automatic updates so content stays current:
 
-        1. Navigate to **Device → Dynamic Updates**
-        2. Click the schedule link next to **Antivirus**
-        3. Set the recurrence (hourly recommended) and enable **Install**
-        4. Click **OK** and commit the configuration
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click the schedule link next to **Antivirus**
+            3. Set the recurrence (hourly recommended) and enable **Install**
+            4. Click **OK** and commit the configuration
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        From the CLI:
+            Download and install the latest antivirus content:
 
-        ```
-        request content upgrade download latest
-        request content upgrade install version latest
-        ```
+            ```
+            request content upgrade download latest
+            request content upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -124,27 +129,32 @@ queries:
         - Risk assessment becomes unreliable because the firewall cannot distinguish between legitimate and risky applications.
 
         Keeping application content up to date ensures the firewall can enforce application-aware security policies and provide accurate network visibility.
-      remediation: |
-        Check the current App-ID content version and trigger an update:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, navigate to **Device → Dynamic Updates**
-        2. Click **Check Now** to retrieve the latest available content versions
-        3. Locate the **Applications and Threats** entry and click **Download**, then **Install**
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click **Check Now** to retrieve the latest available content versions
+            3. Locate the **Applications and Threats** entry and click **Download**, then **Install**
 
-        To configure automatic updates:
+            To configure automatic updates:
 
-        1. Navigate to **Device → Dynamic Updates**
-        2. Click the schedule link next to **Applications and Threats**
-        3. Set the recurrence (daily recommended) and enable **Install**
-        4. Enable **Threshold**, which delays installation until the content has been available for a set number of hours, reducing the risk of deploying a faulty update
-        5. Click **OK** and commit the configuration
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click the schedule link next to **Applications and Threats**
+            3. Set the recurrence (daily recommended) and enable **Install**
+            4. Enable **Threshold**, which delays installation until the content has been available for a set number of hours, reducing the risk of deploying a faulty update
+            5. Click **OK** and commit the configuration
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        From the CLI:
+            Download and install the latest application and threat content:
 
-        ```
-        request content upgrade download latest
-        request content upgrade install version latest
-        ```
+            ```
+            request content upgrade download latest
+            request content upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -181,16 +191,28 @@ queries:
         - The firewall misses an entire layer of threat detection that complements traditional traffic inspection.
 
         DNS Security provides an additional layer of protection by analyzing DNS traffic for malicious activity, catching threats that might bypass other security controls.
-      remediation: |
-        Purchase and activate a DNS Security license:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a DNS Security subscription
-        2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
-        3. In the PAN-OS web interface, navigate to **Device → Licenses**
-        4. Click **Retrieve license keys from license server** to activate the subscription
-        5. Navigate to **Objects → Security Profiles → Anti-Spyware** and enable DNS Security in the relevant profiles
-        6. Ensure the Anti-Spyware profile with DNS Security is applied to your security policy rules
-        7. Commit the configuration
+            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a DNS Security subscription
+            2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
+            3. Navigate to **Device → Licenses**
+            4. Click **Retrieve license keys from license server** to activate the subscription
+            5. Navigate to **Objects → Security Profiles → Anti-Spyware** and enable DNS Security in the relevant profiles
+            6. Ensure the Anti-Spyware profile with DNS Security is applied to your security policy rules
+            7. Commit the configuration
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Retrieve the license key after purchase and verify activation:
+
+            ```
+            request license fetch
+            show system license
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
@@ -221,25 +243,30 @@ queries:
         - Protection gaps widen over time as new vulnerabilities and attack techniques emerge without corresponding updates.
 
         Organizations must maintain active licenses to ensure continuous protection against evolving threats.
-      remediation: |
-        Identify and renew expired licenses:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, navigate to **Device → Licenses** to review the status and expiration date of each subscription
-        2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com)
-        3. Navigate to **Assets → Devices** and select the device with expired licenses
-        4. Renew the required subscriptions through your Palo Alto Networks sales representative or authorized reseller
-        5. After renewal, return to **Device → Licenses** in the PAN-OS web interface
-        6. Click **Retrieve license keys from license server** to activate the renewed subscriptions
-        7. Verify all licenses now show as active with updated expiration dates
+            1. Navigate to **Device → Licenses** to review the status and expiration date of each subscription
+            2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com)
+            3. Navigate to **Assets → Devices** and select the device with expired licenses
+            4. Renew the required subscriptions through your Palo Alto Networks sales representative or authorized reseller
+            5. After renewal, return to **Device → Licenses** in the PAN-OS web interface
+            6. Click **Retrieve license keys from license server** to activate the renewed subscriptions
+            7. Verify all licenses now show as active with updated expiration dates
 
-        From the CLI:
+            Set up license expiration alerts to avoid future lapses by configuring email notifications in the Customer Support Portal.
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        request license fetch
-        show system license
-        ```
+            Fetch renewed license keys and verify their status:
 
-        Set up license expiration alerts to avoid future lapses by configuring email notifications in the Customer Support Portal.
+            ```
+            request license fetch
+            show system license
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -272,31 +299,36 @@ queries:
         - Underlying hardware failures may be present that compromise the device's reliability.
 
         Devices should operate in normal mode to provide continuous security protection for network traffic.
-      remediation: |
-        Investigate and resolve the non-normal operational mode:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, check **Dashboard → General Information** to confirm the current operational mode
-        2. Review **Monitor → System Logs** for errors or warnings that indicate why the device entered a non-normal state
+            1. Check **Dashboard → General Information** to confirm the current operational mode
+            2. Review **Monitor → System Logs** for errors or warnings that indicate why the device entered a non-normal state
 
-        If the device is in maintenance mode:
+            If the device is in maintenance mode:
 
-        1. Connect to the device via console cable
-        2. Review the maintenance mode menu for options to reboot into normal mode or restore the configuration
-        3. If prompted, select **Continue with normal boot** or **Reboot to normal mode**
+            1. Connect to the device via console cable
+            2. Review the maintenance mode menu for options to reboot into normal mode or restore the configuration
+            3. If prompted, select **Continue with normal boot** or **Reboot to normal mode**
 
-        If the device entered maintenance mode after a failed software upgrade:
+            If the device entered maintenance mode after a failed software upgrade:
 
-        1. From the maintenance mode menu, select **Reboot** to attempt a normal boot
-        2. If the device re-enters maintenance mode, use the option to restore the previous software version
+            1. From the maintenance mode menu, select **Reboot** to attempt a normal boot
+            2. If the device re-enters maintenance mode, use the option to restore the previous software version
 
-        From the CLI (if accessible):
+            If the device cannot return to normal mode, contact [Palo Alto Networks Support](https://support.paloaltonetworks.com) for assistance.
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        show system info | match oper
-        request restart system
-        ```
+            Check the current operational mode and restart the system if needed:
 
-        If the device cannot return to normal mode, contact [Palo Alto Networks Support](https://support.paloaltonetworks.com) for assistance.
+            ```
+            show system info | match oper
+            request restart system
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/getting-started/integrate-the-firewall-into-your-management-network
@@ -327,29 +359,34 @@ queries:
         - Behavioral analysis and heuristics for detecting unknown threats are unavailable.
 
         Maintaining up-to-date threat content is fundamental to the firewall's security function and should be verified regularly.
-      remediation: |
-        Check the current threat content version and trigger an update:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, navigate to **Device → Dynamic Updates**
-        2. Click **Check Now** to retrieve the latest available content versions
-        3. Locate the **Applications and Threats** entry and click **Download**, then **Install**
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click **Check Now** to retrieve the latest available content versions
+            3. Locate the **Applications and Threats** entry and click **Download**, then **Install**
 
-        To configure automatic updates so threat content stays current:
+            To configure automatic updates so threat content stays current:
 
-        1. Navigate to **Device → Dynamic Updates**
-        2. Click the schedule link next to **Applications and Threats**
-        3. Set the recurrence (daily recommended) and enable **Install**
-        4. Enable **Threshold** to delay installation until the content has been available for a set number of hours, reducing the risk of deploying a faulty update
-        5. Click **OK** and commit the configuration
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click the schedule link next to **Applications and Threats**
+            3. Set the recurrence (daily recommended) and enable **Install**
+            4. Enable **Threshold** to delay installation until the content has been available for a set number of hours, reducing the risk of deploying a faulty update
+            5. Click **OK** and commit the configuration
 
-        From the CLI:
+            Note: Threat content and application content are delivered together in the Applications and Threats update package. An active Threat Prevention license is required to receive these updates.
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        request content upgrade download latest
-        request content upgrade install version latest
-        ```
+            Download and install the latest threat content:
 
-        Note: Threat content and application content are delivered together in the Applications and Threats update package. An active Threat Prevention license is required to receive these updates.
+            ```
+            request content upgrade download latest
+            request content upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -386,18 +423,32 @@ queries:
         - Threat detection signatures stop receiving updates, leaving the firewall blind to new attack techniques.
 
         Threat Prevention is considered a core security subscription and should be maintained on all production firewalls to protect against the vast majority of network threats.
-      remediation: |
-        Purchase and activate a Threat Prevention license:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a Threat Prevention subscription
-        2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
-        3. In the PAN-OS web interface, navigate to **Device → Licenses**
-        4. Click **Retrieve license keys from license server** to activate the subscription
-        5. Navigate to **Device → Dynamic Updates** and download the latest **Applications and Threats** content
-        6. Configure **Security Profiles** (Anti-Spyware, Vulnerability Protection) and attach them to your security policy rules
-        7. Commit the configuration
+            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a Threat Prevention subscription
+            2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
+            3. Navigate to **Device → Licenses**
+            4. Click **Retrieve license keys from license server** to activate the subscription
+            5. Navigate to **Device → Dynamic Updates** and download the latest **Applications and Threats** content
+            6. Configure **Security Profiles** (Anti-Spyware, Vulnerability Protection) and attach them to your security policy rules
+            7. Commit the configuration
 
-        Threat Prevention is considered a core security subscription and should be maintained on all production firewalls.
+            Threat Prevention is considered a core security subscription and should be maintained on all production firewalls.
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Retrieve the license key after purchase, download the latest content, and verify:
+
+            ```
+            request license fetch
+            show system license
+            request content upgrade download latest
+            request content upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
@@ -433,18 +484,30 @@ queries:
         - Risk-based reputation scoring is unavailable, preventing informed policy decisions about borderline sites.
 
         URL Filtering is essential for protecting users from web-based threats, enforcing acceptable use policies, and preventing phishing attacks.
-      remediation: |
-        Purchase and activate a URL Filtering license:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a URL Filtering subscription (Advanced URL Filtering is recommended over the legacy PAN-DB option)
-        2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
-        3. In the PAN-OS web interface, navigate to **Device → Licenses**
-        4. Click **Retrieve license keys from license server** to activate the subscription
-        5. Navigate to **Objects → Security Profiles → URL Filtering** and create or configure a URL Filtering profile
-        6. Attach the URL Filtering profile to your security policy rules that handle outbound web traffic
-        7. Commit the configuration
+            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a URL Filtering subscription (Advanced URL Filtering is recommended over the legacy PAN-DB option)
+            2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
+            3. Navigate to **Device → Licenses**
+            4. Click **Retrieve license keys from license server** to activate the subscription
+            5. Navigate to **Objects → Security Profiles → URL Filtering** and create or configure a URL Filtering profile
+            6. Attach the URL Filtering profile to your security policy rules that handle outbound web traffic
+            7. Commit the configuration
 
-        This subscription is recommended for all environments where users access the internet through the firewall.
+            This subscription is recommended for all environments where users access the internet through the firewall.
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Retrieve the license key after purchase and verify activation:
+
+            ```
+            request license fetch
+            show system license
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
@@ -475,29 +538,34 @@ queries:
         - Advanced persistent threats that rely on novel malware go unidentified at the network perimeter.
 
         WildFire content ensures the firewall can leverage cloud-based threat intelligence to prevent sophisticated attacks that evade traditional signature-based detection.
-      remediation: |
-        Check the current WildFire content version and trigger an update:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. In the PAN-OS web interface, navigate to **Device → Dynamic Updates**
-        2. Click **Check Now** to retrieve the latest available content versions
-        3. Locate the **WildFire** entry and click **Download**, then **Install**
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click **Check Now** to retrieve the latest available content versions
+            3. Locate the **WildFire** entry and click **Download**, then **Install**
 
-        To configure automatic updates so WildFire content stays current:
+            To configure automatic updates so WildFire content stays current:
 
-        1. Navigate to **Device → Dynamic Updates**
-        2. Click the schedule link next to **WildFire**
-        3. Set the recurrence to **Every Minute** (recommended, as WildFire signatures are published every five minutes)
-        4. Enable **Install**
-        5. Click **OK** and commit the configuration
+            1. Navigate to **Device → Dynamic Updates**
+            2. Click the schedule link next to **WildFire**
+            3. Set the recurrence to **Every Minute** (recommended, as WildFire signatures are published every five minutes)
+            4. Enable **Install**
+            5. Click **OK** and commit the configuration
 
-        From the CLI:
+            Note: An active WildFire license is required to receive content updates at the every-minute interval. Without a license, WildFire signatures are delivered only through the daily Applications and Threats update.
+        - id: cli
+          desc: |
+            **Using the CLI**
 
-        ```
-        request wildfire upgrade download latest
-        request wildfire upgrade install version latest
-        ```
+            Download and install the latest WildFire content:
 
-        Note: An active WildFire license is required to receive content updates at the every-minute interval. Without a license, WildFire signatures are delivered only through the daily Applications and Threats update.
+            ```
+            request wildfire upgrade download latest
+            request wildfire upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
@@ -534,19 +602,33 @@ queries:
         - The firewall loses access to global threat intelligence derived from millions of sensors worldwide.
 
         WildFire is critical for protecting against sophisticated, targeted attacks and zero-day exploits that traditional signature-based detection cannot identify.
-      remediation: |
-        Purchase and activate a WildFire license:
+      remediation:
+        - id: console
+          desc: |
+            **Using the PAN-OS Web Interface**
 
-        1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a WildFire subscription
-        2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
-        3. In the PAN-OS web interface, navigate to **Device → Licenses**
-        4. Click **Retrieve license keys from license server** to activate the subscription
-        5. Navigate to **Device → Dynamic Updates** and configure the WildFire update schedule to **Every Minute** for near real-time signature delivery
-        6. Navigate to **Objects → Security Profiles → WildFire Analysis** and create or configure a WildFire Analysis profile
-        7. Attach the WildFire Analysis profile to your security policy rules
-        8. Commit the configuration
+            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a WildFire subscription
+            2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
+            3. Navigate to **Device → Licenses**
+            4. Click **Retrieve license keys from license server** to activate the subscription
+            5. Navigate to **Device → Dynamic Updates** and configure the WildFire update schedule to **Every Minute** for near real-time signature delivery
+            6. Navigate to **Objects → Security Profiles → WildFire Analysis** and create or configure a WildFire Analysis profile
+            7. Attach the WildFire Analysis profile to your security policy rules
+            8. Commit the configuration
 
-        WildFire is strongly recommended for all production firewalls, especially those protecting sensitive environments.
+            WildFire is strongly recommended for all production firewalls, especially those protecting sensitive environments.
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Retrieve the license key after purchase, configure WildFire updates, and verify:
+
+            ```
+            request license fetch
+            show system license
+            request wildfire upgrade download latest
+            request wildfire upgrade install version latest
+            ```
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices


### PR DESCRIPTION
## Summary
- Split all PAN-OS remediation sections into separate `console` and `cli` entries, matching the structure used in the AWS policy
- All 10 PAN-OS checks now have both `console` and `cli` remediation sections
- Convert all Arista EOS (37 checks) and Junos (27 checks) remediation sections to the `- id: cli` list format

## Test plan
- [ ] Verify `cnspec policy lint` passes for all three modified policy files
- [ ] Spot-check rendered Markdown for remediation formatting (numbered lists, code blocks)
- [ ] Confirm no changes to `desc`, `mql`, `refs`, `impact`, `tags`, or other non-remediation fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)