### PR TITLE
Switch ElastiCache checks to per-asset cluster scanning

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -15079,9 +15079,9 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/soc2-2017: soc2-control-cc6-1-10
     variants:
-      - uid: mondoo-aws-security-elasticache-encryption-at-rest-aws
+      - uid: mondoo-aws-security-elasticache-encryption-at-rest-cluster
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS ElastiCache Cluster
           mondoo.com/icon: aws
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-hcl
         tags:
@@ -15166,9 +15166,9 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
         title: AWS Documentation - ElastiCache at-rest encryption
-  - uid: mondoo-aws-security-elasticache-encryption-at-rest-aws
-    filters: asset.platform == "aws"
-    mql: aws.elasticache.cacheClusters.where(engine == "redis").all(atRestEncryptionEnabled == true)
+  - uid: mondoo-aws-security-elasticache-encryption-at-rest-cluster
+    filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
+    mql: aws.elasticache.cluster.atRestEncryptionEnabled == true
   - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticache_replication_group")
     mql: |
@@ -15199,9 +15199,9 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/soc2-2017: soc2-control-cc6-7-2
     variants:
-      - uid: mondoo-aws-security-elasticache-encryption-in-transit-aws
+      - uid: mondoo-aws-security-elasticache-encryption-in-transit-cluster
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS ElastiCache Cluster
           mondoo.com/icon: aws
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-hcl
         tags:
@@ -15282,9 +15282,9 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html
         title: AWS Documentation - ElastiCache in-transit encryption
-  - uid: mondoo-aws-security-elasticache-encryption-in-transit-aws
-    filters: asset.platform == "aws"
-    mql: aws.elasticache.cacheClusters.where(engine == "redis").all(transitEncryptionEnabled == true)
+  - uid: mondoo-aws-security-elasticache-encryption-in-transit-cluster
+    filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
+    mql: aws.elasticache.cluster.transitEncryptionEnabled == true
   - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticache_replication_group")
     mql: |
@@ -15315,9 +15315,9 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
       compliance/soc2-2017: soc2-control-cc6-1-4
     variants:
-      - uid: mondoo-aws-security-elasticache-redis-auth-enabled-aws
+      - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cluster
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS ElastiCache Cluster
           mondoo.com/icon: aws
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-hcl
         tags:
@@ -15401,9 +15401,9 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html
         title: AWS Documentation - Authenticating with the Redis AUTH command
-  - uid: mondoo-aws-security-elasticache-redis-auth-enabled-aws
-    filters: asset.platform == "aws"
-    mql: aws.elasticache.cacheClusters.where(engine == "redis").all(authTokenEnabled == true)
+  - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cluster
+    filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
+    mql: aws.elasticache.cluster.authTokenEnabled == true
   - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticache_replication_group")
     mql: |


### PR DESCRIPTION
## Summary
- Replace account-level ElastiCache Redis checks (`asset.platform == "aws"`) with per-asset checks (`asset.platform == "aws-elasticache-cluster"`)
- Each ElastiCache cluster is now scanned individually using `aws.elasticache.cluster` (singular) instead of iterating all clusters with `aws.elasticache.cacheClusters.where(...).all(...)`
- The Redis engine filter is moved into the asset filter: `aws.elasticache.cluster.engine == "redis"`
- Affected checks: encryption at rest, encryption in transit, Redis AUTH enabled
- The serverless CMK encryption check remains account-level (no per-asset type for serverless caches)

## Test plan
- [ ] `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` passes
- [ ] Verify checks apply correctly when scanning AWS ElastiCache clusters as individual assets
- [ ] Confirm Terraform HCL/Plan/State variants are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)