### PR TITLE
:bug: Fix broken multi-line filter conditions in Azure Cosmos DB checks

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -8335,7 +8335,7 @@ queries:
     title: Ensure virtual network filtering is enabled for Azure Cosmos DB accounts
     impact: 60
     filters: |
-      asset.platform == "azure-cosmosdb"
+      asset.platform == "azure-cosmosdb" &&
       azure.subscription.cosmosDbService.account.publicNetworkAccess != "Disabled"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
@@ -8518,7 +8518,7 @@ queries:
     title: Ensure automatic failover is enabled for Azure Cosmos DB accounts
     impact: 60
     filters: |
-      asset.platform == "azure-cosmosdb"
+      asset.platform == "azure-cosmosdb" &&
       azure.subscription.cosmosDbService.account.properties["locations"].length > 1
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
@@ -8882,7 +8882,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts with public access have IP firewall rules configured
     impact: 80
     filters: |
-      asset.platform == "azure-cosmosdb"
+      asset.platform == "azure-cosmosdb" &&
       azure.subscription.cosmosDbService.account.publicNetworkAccess != "Disabled"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -9092,7 +9092,7 @@ queries:
     title: Ensure multi-region Azure Cosmos DB accounts have multi-region write enabled
     impact: 40
     filters: |
-      asset.platform == "azure-cosmosdb"
+      asset.platform == "azure-cosmosdb" &&
       azure.subscription.cosmosDbService.account.properties["locations"].length > 1
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-14


### PR DESCRIPTION
## Summary
- Four Azure Cosmos DB policy filters were missing the `&&` operator between the `asset.platform` check and the additional condition on the second line
- Without `&&`, the second line was treated as a separate statement rather than part of the filter, causing checks to run on assets where they shouldn't apply (e.g., accounts with public access disabled, or single-region accounts)
- Affected checks: virtual network filtering, automatic failover, IP firewall rules, multi-region write

## Test plan
- [ ] `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` passes
- [ ] Verify affected checks only apply to the correct subset of Cosmos DB assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)