### PR TITLE
🐛 lazy-load asset detection bundle to avoid early debug

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1019,11 +1019,21 @@ func (s *localAssetScanner) mapPropOverrides() (*policy.PropsReq, error) {
 	return &propsReq, nil
 }
 
-var assetDetectBundle = mustCompile("asset { kind platform runtime version family }")
+var (
+	assetDetectBundle     *llx.CodeBundle
+	assetDetectBundleOnce sync.Once
+)
+
+func getAssetDetectBundle() *llx.CodeBundle {
+	assetDetectBundleOnce.Do(func() {
+		assetDetectBundle = mustCompile("asset { kind platform runtime version family }")
+	})
+	return assetDetectBundle
+}
 
 func (s *localAssetScanner) fetchPublicRegistryBundle() error {
 	features := mql.GetFeatures(s.job.Ctx)
-	_, res, err := executor.ExecuteQuery(s.Runtime, assetDetectBundle, nil, features)
+	_, res, err := executor.ExecuteQuery(s.Runtime, getAssetDetectBundle(), nil, features)
 	if err != nil {
 		return errors.Wrap(err, "failed to run asset detection query")
 	}

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -521,6 +521,12 @@ func (s *LocalScannerSuite) TestRunIncognito_Frameworks_Exceptions_OutOfScope() 
 	}
 }
 
+func TestGetAssetDetectBundle(t *testing.T) {
+	bundle := getAssetDetectBundle()
+	require.NotNil(t, bundle)
+	require.NotEmpty(t, bundle.CodeV2.Id)
+}
+
 func TestLocalScannerSuite(t *testing.T) {
 	suite.Run(t, new(LocalScannerSuite))
 }


### PR DESCRIPTION
We got an early debug message on startup, before the logger was initialized, which is caused by the asset detection bundle `mustCompile`d. Now that it is pulled when it is needed, this debug message disappears. Mitigation: To avoid errors with vaulty MQL code we have added tests to this one.