### PR TITLE
Fix GCP Cloud DNS check filters to use correct platform name

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -5756,7 +5756,7 @@ queries:
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
     filters: |
-      asset.platform == "gcp-dns-managedzone"
+      asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility == "public"
     mql: |
       gcp.dns.managedzone.dnssecConfig['state'] == 'on'
@@ -5899,7 +5899,7 @@ queries:
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
     filters: |
-      asset.platform == "gcp-dns-managedzone"
+      asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility != "private"
     mql: |
       gcp.dns.managedzone.dnssecConfig['state'] == 'on'
@@ -6050,7 +6050,7 @@ queries:
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-gcp
     filters: |
-      asset.platform == "gcp-dns-managedzone"
+      asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility != "private"
     mql: |
       gcp.dns.managedzone.dnssecConfig['state'] == 'on'
@@ -6191,7 +6191,7 @@ queries:
         title: RFC 9276 - NSEC3 Guidance for DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-gcp
     filters: |
-      asset.platform == "gcp-dns-managedzone"
+      asset.platform == "gcp-dns-zone"
       gcp.dns.managedzone.visibility == "public"
     mql: |
       gcp.dns.managedzone.dnssecConfig['state'] == 'on'


### PR DESCRIPTION
## Summary
- The 4 Cloud DNS security checks (`dnssec-enabled`, `rsasha1-ksk-not-used`, `rsasha1-zsk-not-used`, `dnssec-nsec3-enabled`) used `gcp-dns-managedzone` as the platform filter
- The GCP provider registers the platform as `gcp-dns-zone`, so these checks never matched discovered DNS zone assets
- Updated all 4 filters from `gcp-dns-managedzone` to `gcp-dns-zone`

## Test plan
- [ ] Verify `gcp-dns-zone` matches the platform name in the GCP provider's `platform.go` (`GetTitleForPlatformName`)
- [ ] Run `cnspec policy lint content/mondoo-gcp-security.mql.yaml` to confirm no lint errors
- [ ] Scan a GCP project with DNS zones to confirm the checks now execute against discovered DNS zone assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)