### PR TITLE
:star: Add Mondoo Ubiquiti UniFi Security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -22,6 +22,7 @@ aslr
 assumeyes
 atlassian
 authnotrequired
+autobackup
 autoconfiguration
 autoremove
 autoscalers
@@ -81,6 +82,7 @@ datalakes
 dccp
 ddos
 deactivateduser
+deauth
 debconf
 decomp
 DGAs
@@ -238,6 +240,7 @@ pii
 pki
 pkr
 pmd
+pmf
 postgre
 prebuilt
 privs
@@ -256,6 +259,7 @@ restrictremotesam
 revertto
 rexec
 rsasha
+rstp
 rtadv
 rulebase
 rwx
@@ -327,6 +331,7 @@ UNDROP
 unifi
 uniformbucketlevelaccess
 unlinkat
+upnp
 userlist
 USLACKBOT
 VALUEX
@@ -346,6 +351,8 @@ WIFI
 winhttp
 winnuke
 wlans
+wpa
+wpaeap
 wpapsk
 workdir
 wtmp

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -37,6 +37,7 @@ policies:
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Wireless Security
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-no-open-wlans
           - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3
@@ -44,21 +45,25 @@ policies:
           - uid: mondoo-unifi-security-wlans-pmf-enabled
           - uid: mondoo-unifi-security-guest-wlans-isolated
       - title: Threat Management
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-ips-enabled
           - uid: mondoo-unifi-security-dns-filtering-enabled
           - uid: mondoo-unifi-security-honeypot-enabled
       - title: Gateway Security
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-upnp-disabled
           - uid: mondoo-unifi-security-broadcast-ping-disabled
           - uid: mondoo-unifi-security-icmp-redirects-disabled
           - uid: mondoo-unifi-security-syn-cookies-enabled
       - title: Switch Security
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-dhcp-snooping-enabled
           - uid: mondoo-unifi-security-stp-enabled
       - title: Management & Controller
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-ssh-disabled
           - uid: mondoo-unifi-security-ssh-password-auth-disabled
@@ -68,6 +73,7 @@ policies:
           - uid: mondoo-unifi-security-analytics-disabled
           - uid: mondoo-unifi-security-remote-syslog-enabled
       - title: Network Segmentation
+        filters: asset.platform == "unifi"
         checks:
           - uid: mondoo-unifi-security-no-port-forwards-to-mgmt
           - uid: mondoo-unifi-security-dns-over-https-enabled
@@ -668,6 +674,9 @@ queries:
         2. Enable **Remote Syslog**.
         3. Configure the syslog server IP address and port.
         4. Enable **Log All Contents** for comprehensive logging.
+    refs:
+      - url: https://help.ui.com/hc/en-us/articles/204909374
+        title: UniFi remote logging settings
 
   # ─── Network Segmentation ────────────────────────────────────────────────────
   - uid: mondoo-unifi-security-no-port-forwards-to-mgmt
@@ -695,6 +704,9 @@ queries:
         2. Review all enabled port forwarding rules.
         3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
         4. Use a VPN to access management interfaces remotely instead of port forwarding.
+    refs:
+      - url: https://help.ui.com/hc/en-us/articles/115003173168
+        title: UniFi port forwarding settings
 
   - uid: mondoo-unifi-security-dns-over-https-enabled
     title: Ensure DNS over HTTPS is enabled


### PR DESCRIPTION
## Summary
- New security policy for Ubiquiti UniFi controllers with 21 checks across 6 groups
- Built against the UniFi provider resources from https://github.com/mondoohq/mql-enterprise-providers/pull/441
- Covers wireless security (open networks, WPA2/WPA3, PMF, guest isolation), threat management (IPS, DNS filtering, honeypot), gateway hardening (UPnP, ICMP, SYN cookies), switch security (DHCP snooping, RSTP), management settings (SSH, backups, auto-upgrade, syslog), and network segmentation (port forwards, DoH)

## Test plan
- [ ] `cnspec policy lint content/mondoo-unifi-security.mql.yaml` passes
- [ ] Policy structure validates against the UniFi provider resources once the provider is available
- [ ] Review check MQL against resource field names in the provider PR
- [ ] Verify all check titles are ≤75 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)