### PR TITLE
Use crontab resource for AIDE filesystem integrity check

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -318,8 +318,8 @@ queries:
       asset.kind != "container-image"
     mql: |
       file("/etc/default/aide").exists && ["/etc/default/aide"].where(file(_).exists).all(parse.ini(_).params["CRON_DAILY_RUN"] == "yes") ||
-      command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide --check")) ||
-      command("crontab -u root -l | grep aide").stdout.lines.where(/^[^#]/).any(_.contains("aide.conf --check")) ||
+      crontab.entries.where(user == "root").any(command.contains("aide --check")) ||
+      crontab.entries.where(user == "root").any(command.contains("aide.conf --check")) ||
       service('aidecheck').enabled
     docs:
       desc: |


### PR DESCRIPTION
## Summary
- Replace `command("crontab -u root -l | grep aide")` with the built-in `crontab.entries` resource in the AIDE filesystem integrity check query
- Uses `crontab.entries.where(user == "root")` to filter root user cron entries and checks for `aide --check` and `aide.conf --check` commands

## Test plan
- [ ] Run `cnspec policy lint ./content/mondoo-linux-security.mql.yaml` to verify policy validity
- [ ] Test against a Linux system with AIDE cron configured to verify detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)