### PR TITLE
🐛 fix delayed discovery progress bar being stuck

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -526,9 +526,11 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 
 			// Register all tasks in the batch before scanning so the TODO list
 			// knows the full set and does not quit after the first completion.
+			// Skip assets with DelayDiscovery since their platform IDs may
+			// change during discovery; they are registered after discovery.
 			for i := range batch {
 				a := batch[i].Asset
-				if len(a.PlatformIds) > 0 {
+				if len(a.PlatformIds) > 0 && !a.Connections[0].DelayDiscovery {
 					multiprogress.AddTask(a.PlatformIds[0], a)
 				}
 			}


### PR DESCRIPTION
With the current version the progress bar gets stuck on assets that have delayed discovery because we add them twice. With this change it now works correctly:
```
cnspec scan docker debian:buster
```

This will be further simplified when we roll out the new discovery strategy