### PR TITLE
fix terminal output to be consistent between scans

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -507,6 +507,13 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 		sortedFailed := []string{}
 		sortedExceptions := []string{}
 
+		// Build a mapping from CodeId to the query MRN used in the resolved policy.
+		// QueryMap() deduplicates by CodeId, so when multiple queries share the same
+		// compiled code (same CodeId) but have different MRNs, it may pick one whose
+		// MRN doesn't match the score key in the report. This mapping lets us find the
+		// correct MRN via the reporting job graph.
+		codeIdToResolvedMrn := buildCodeIdToMrnMap(resolved)
+
 		for id, query := range queries {
 			_, ok := resolved.CollectorJob.ReportingQueries[id]
 			if !ok {
@@ -515,7 +522,22 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 
 			pscore, ok := report.Scores[query.Mrn]
 			if !ok {
-				r.out("Couldn't find any queries for score of " + id)
+				// QueryMap() may have mapped this CodeId to a different MRN than
+				// the one used during policy resolution. Fall back to the resolved
+				// policy's MRN for this CodeId.
+				if resolvedMrn, found := codeIdToResolvedMrn[id]; found {
+					pscore, ok = report.Scores[resolvedMrn]
+					if ok {
+						// Use the correct query from the bundle so that title,
+						// impact, and other metadata match the resolved policy.
+						if resolvedQuery, qFound := r.bundle.Queries[resolvedMrn]; qFound && resolvedQuery != nil {
+							query = resolvedQuery
+						}
+					}
+				}
+			}
+			if !ok {
+				log.Debug().Str("id", id).Str("mrn", query.Mrn).Msg("couldn't find score for query")
 				continue
 			}
 
@@ -827,6 +849,38 @@ func (r *defaultReporter) printCheck(score simpleScore, query *policy.Mquery, re
 }
 
 // ============================= ^^ ============================================
+
+// buildCodeIdToMrnMap builds a mapping from CodeId to the query MRN used in
+// the resolved policy. This is needed because QueryMap() deduplicates by
+// CodeId and may map a CodeId to a query whose MRN differs from the one
+// used during policy resolution (e.g. when multiple policies define checks
+// with the same MQL code but different MRNs).
+func buildCodeIdToMrnMap(resolved *policy.ResolvedPolicy) map[string]string {
+	if resolved == nil || resolved.CollectorJob == nil {
+		return nil
+	}
+
+	res := map[string]string{}
+	for _, rj := range resolved.CollectorJob.ReportingJobs {
+		if rj.Type != policy.ReportingJob_EXECUTION_QUERY {
+			continue
+		}
+		// EXECUTION_QUERY reporting jobs have QrId = CodeId.
+		// Their Notify list contains the UUIDs of parent reporting jobs
+		// (CHECK or CHECK_AND_DATA_QUERY), whose QrId is the query MRN.
+		for _, parentUUID := range rj.Notify {
+			parentRJ := resolved.CollectorJob.ReportingJobs[parentUUID]
+			if parentRJ == nil {
+				continue
+			}
+			if parentRJ.Type == policy.ReportingJob_CHECK || parentRJ.Type == policy.ReportingJob_CHECK_AND_DATA_QUERY {
+				res[rj.QrId] = parentRJ.QrId
+				break
+			}
+		}
+	}
+	return res
+}
 
 // buildExceptionSet builds a set of check MRNs that have exceptions applied,
 // by inspecting the ReportingJob.ChildJobs edges in the resolved policy for

--- a/cli/reporter/print_compact_test.go
+++ b/cli/reporter/print_compact_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+)
+
+func TestBuildCodeIdToMrnMap(t *testing.T) {
+	t.Run("nil resolved policy", func(t *testing.T) {
+		result := buildCodeIdToMrnMap(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("nil collector job", func(t *testing.T) {
+		result := buildCodeIdToMrnMap(&policy.ResolvedPolicy{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("maps execution query CodeId to parent check MRN", func(t *testing.T) {
+		resolved := &policy.ResolvedPolicy{
+			CollectorJob: &policy.CollectorJob{
+				ReportingJobs: map[string]*policy.ReportingJob{
+					"exec-uuid": {
+						Uuid:   "exec-uuid",
+						QrId:   "codeId123",
+						Type:   policy.ReportingJob_EXECUTION_QUERY,
+						Notify: []string{"check-uuid"},
+					},
+					"check-uuid": {
+						Uuid: "check-uuid",
+						QrId: "//policy.api.mondoo.app/queries/check-mrn",
+						Type: policy.ReportingJob_CHECK,
+					},
+				},
+			},
+		}
+
+		result := buildCodeIdToMrnMap(resolved)
+		require.NotNil(t, result)
+		assert.Equal(t, "//policy.api.mondoo.app/queries/check-mrn", result["codeId123"])
+	})
+
+	t.Run("skips non-check parents", func(t *testing.T) {
+		resolved := &policy.ResolvedPolicy{
+			CollectorJob: &policy.CollectorJob{
+				ReportingJobs: map[string]*policy.ReportingJob{
+					"exec-uuid": {
+						Uuid:   "exec-uuid",
+						QrId:   "codeId123",
+						Type:   policy.ReportingJob_EXECUTION_QUERY,
+						Notify: []string{"policy-uuid"},
+					},
+					"policy-uuid": {
+						Uuid: "policy-uuid",
+						QrId: "//policy.api.mondoo.app/policies/some-policy",
+						Type: policy.ReportingJob_POLICY,
+					},
+				},
+			},
+		}
+
+		result := buildCodeIdToMrnMap(resolved)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("handles CHECK_AND_DATA_QUERY parent", func(t *testing.T) {
+		resolved := &policy.ResolvedPolicy{
+			CollectorJob: &policy.CollectorJob{
+				ReportingJobs: map[string]*policy.ReportingJob{
+					"exec-uuid": {
+						Uuid:   "exec-uuid",
+						QrId:   "codeIdABC",
+						Type:   policy.ReportingJob_EXECUTION_QUERY,
+						Notify: []string{"both-uuid"},
+					},
+					"both-uuid": {
+						Uuid: "both-uuid",
+						QrId: "//policy.api.mondoo.app/queries/both-mrn",
+						Type: policy.ReportingJob_CHECK_AND_DATA_QUERY,
+					},
+				},
+			},
+		}
+
+		result := buildCodeIdToMrnMap(resolved)
+		require.NotNil(t, result)
+		assert.Equal(t, "//policy.api.mondoo.app/queries/both-mrn", result["codeIdABC"])
+	})
+
+	t.Run("picks first check parent when multiple exist", func(t *testing.T) {
+		resolved := &policy.ResolvedPolicy{
+			CollectorJob: &policy.CollectorJob{
+				ReportingJobs: map[string]*policy.ReportingJob{
+					"exec-uuid": {
+						Uuid:   "exec-uuid",
+						QrId:   "codeId123",
+						Type:   policy.ReportingJob_EXECUTION_QUERY,
+						Notify: []string{"policy-uuid", "check-uuid"},
+					},
+					"policy-uuid": {
+						Uuid: "policy-uuid",
+						QrId: "//policy.api.mondoo.app/policies/some-policy",
+						Type: policy.ReportingJob_POLICY,
+					},
+					"check-uuid": {
+						Uuid: "check-uuid",
+						QrId: "//policy.api.mondoo.app/queries/check-mrn",
+						Type: policy.ReportingJob_CHECK,
+					},
+				},
+			},
+		}
+
+		result := buildCodeIdToMrnMap(resolved)
+		require.NotNil(t, result)
+		assert.Equal(t, "//policy.api.mondoo.app/queries/check-mrn", result["codeId123"])
+	})
+
+	t.Run("ignores non-execution-query reporting jobs", func(t *testing.T) {
+		resolved := &policy.ResolvedPolicy{
+			CollectorJob: &policy.CollectorJob{
+				ReportingJobs: map[string]*policy.ReportingJob{
+					"check-uuid": {
+						Uuid:   "check-uuid",
+						QrId:   "//policy.api.mondoo.app/queries/check-mrn",
+						Type:   policy.ReportingJob_CHECK,
+						Notify: []string{"policy-uuid"},
+					},
+					"policy-uuid": {
+						Uuid: "policy-uuid",
+						QrId: "//policy.api.mondoo.app/policies/some-policy",
+						Type: policy.ReportingJob_POLICY,
+					},
+				},
+			},
+		}
+
+		result := buildCodeIdToMrnMap(resolved)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+}


### PR DESCRIPTION
We have inconsistent outputs when running cnspec scan local, this is only a visual bug, the correct results are still sent to server.





```
  1. QueryMap() (policy/bundle_map.go:296-306) builds a map of CodeId → *Mquery. If multiple queries compile to the same MQL code (same CodeId) but have different MRNs (e.g.,
  from different policies), only the last one wins — it's a lossy deduplication.
  2. ReportingQueries in the resolved policy is keyed by CodeId (set at resolved_policy_builder.go:355), so the filter at line 511 passes.
  3. report.Scores is keyed by QrId from ReportingJobs (internal/datalakes/inmemory/policyresolver.go:435). For check-type reporting jobs, QrId = n.queryMrn (the MRN used in
  the resolved policy, set at resolved_policy_builder.go:349).
  4. The lookup at line 516 does report.Scores[query.Mrn] — but query.Mrn comes from whichever Mquery happened to be last in the QueryMap() iteration for that CodeId. If that
  MRN differs from the one used in the resolved policy's ReportingJob, the score lookup fails.

```


