### PR TITLE
🧹 Use nftables.tables resource in Phoenix PLC firewall check

### DIFF
--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -97,9 +97,8 @@ queries:
   - uid: phoenix-plcnext-02
     title: Ensure Firewall is active
     mql: |
-      command("nft list tables").stdout != ""
-      command("nft list tables").stdout.contains("plcnext_filter")
-      command("nft list tables").stdout.contains("plcnext_ip6_filter")
+      nftables.tables.contains(name == "plcnext_filter")
+      nftables.tables.contains(name == "plcnext_ip6_filter")
     docs:
       desc: |
         The hazards in public and even private networks are omnipresent, and nowadays no private user would come up with the idea to put a computer on the network without a proper firewall setting. So how would that be different when working with a PLC?


### PR DESCRIPTION
## Summary
- Replace `command("nft list tables")` shellout with `nftables.tables.contains()` resource queries in the `phoenix-plcnext-02` firewall check
- Uses idiomatic MQL pattern consistent with other resource-based checks in the codebase

## Test plan
- [ ] Lint the policy: `cnspec policy lint content/mondoo-phoenix-plcnext-security.mql.yaml`
- [ ] Test against a PLCnext target to verify `nftables.tables` resource returns expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)