### PR TITLE
🧹 Use machine.cpu.model in Linux inventory pack

### DIFF
--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -160,13 +160,7 @@ packs:
         title: CPU type
         docs:
           desc: Returns the CPU model name for hardware inventory.
-        filters: mondoo.capabilities.contains("run-command")
-        mql: |
-          if (asset.arch == /aarch/) {
-            return command("lscpu").stdout.lines.where(_.contains("Model name")).first().split(":").last().trim()
-          } else {
-            return file("/proc/cpuinfo").content.lines.where(_.contains("model name")).first().split(":").last().trim()
-          }
+        mql: machine.cpu.model
       - uid: mondoo-linux-root-volume
         title: Root volume size and filesystem type
         docs:


### PR DESCRIPTION
## Summary
- Replace `lscpu` and `/proc/cpuinfo` command parsing with the `machine.cpu.model` resource for CPU type detection in the Linux inventory query pack
- Removes architecture-specific branching (aarch vs x86) and the `run-command` capability filter since the resource doesn't require command execution

## Test plan
- [ ] Run `cnspec scan local -f content/querypacks/mondoo-linux-inventory.mql.yaml` on a Linux host and verify CPU type is returned
- [ ] Test on both x86 and ARM architectures to confirm `machine.cpu.model` works cross-platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)