### PR TITLE
:bug: Fix empty .data checks in windows policy

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -4204,7 +4204,7 @@ queries:
     title: "Ensure no shares can be accessed anonymously"
     impact: 85
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionShares' ).data == ""
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionShares' ).data == empty
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -5841,4 +5841,4 @@ queries:
     filters: |
       windows.computerInfo.OsProductType != 2
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionPipes' ).data == ""
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionPipes' ).data == empty


### PR DESCRIPTION
Needs these changes https://github.com/mondoohq/mql/pull/6996 to correctly fix the behavior differences between .value and .data