### PR TITLE
Fix spell check workflow permissions to allow PR comments

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   spelling:


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` to top-level workflow permissions
- The top-level `permissions` block caps the maximum token permissions for all jobs. Without `pull-requests: write` at the top level, the `comment` job cannot post spell check results back to PRs even though it requests `pull-requests: write` at the job level.

## Test plan
- [ ] Trigger a spell check failure on a PR and verify the bot posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)