### PR TITLE
Use azure-virtual-network platform for vnet queries

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -7499,7 +7499,7 @@ queries:
     title: Ensure DDoS Protection is enabled on virtual networks
     impact: 40
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-virtual-network"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
@@ -7509,7 +7509,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-4
     mql: |
-      azure.subscription.network.virtualNetworks.all(enableDdosProtection == true)
+      azure.subscription.network.virtualNetwork.enableDdosProtection == true
     docs:
       desc: |
         This check ensures that Azure DDoS Protection is enabled on all virtual networks to defend against distributed denial-of-service attacks.
@@ -7603,7 +7603,7 @@ queries:
     title: Ensure VM protection is enabled on virtual networks
     impact: 40
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-virtual-network"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
@@ -7613,7 +7613,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-4
     mql: |
-      azure.subscription.network.virtualNetworks.all(enableVmProtection == true)
+      azure.subscription.network.virtualNetwork.enableVmProtection == true
     docs:
       desc: |
         This check ensures that VM protection is enabled on all Azure virtual networks to help prevent unauthorized traffic from reaching virtual machines.
@@ -7685,7 +7685,7 @@ queries:
     title: Ensure default outbound access is disabled on subnets
     impact: 60
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-virtual-network"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
@@ -7695,7 +7695,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-1-5
     mql: |
-      azure.subscription.network.virtualNetworks.all(subnets.all(defaultOutboundAccess == false))
+      azure.subscription.network.virtualNetwork.subnets.all(defaultOutboundAccess == false)
     docs:
       desc: |
         This check ensures that default outbound access is disabled on all subnets within Azure virtual networks, enforcing explicit outbound connectivity configurations.


### PR DESCRIPTION
## Summary
- Update three Azure Virtual Network security queries to use the `azure-virtual-network` platform filter instead of the generic `azure` platform
- Change MQL from plural `virtualNetworks.all(...)` pattern to singular `virtualNetwork...` pattern, consistent with other resource-specific platform queries (e.g., `azure-storage-account`, `azure-network-security-group`)
- Affected queries: DDoS protection, VM protection, and subnet default outbound access

## Test plan
- [ ] Lint the policy file: `cnspec policy lint content/mondoo-azure-security.mql.yaml`
- [ ] Verify queries execute correctly against Azure virtual network assets
- [ ] Confirm no regressions for other Azure security checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)