### PR TITLE
fix: auditd checks failing after remediation on Debian

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -5695,9 +5695,9 @@ queries:
       desiredRules32.containsAll(syscalls_32bit)
 
       // Watch rule for /etc/localtime
-      auditd.rules.syscalls.contains(
-        fields.contains(key == "path" && value == "/etc/localtime")
-        && fields.contains(key == "perm" && value == "wa")
+      auditd.rules.files.contains(
+        path == "/etc/localtime"
+        && permissions == "wa"
         && keyname == "time-change"
       )
     docs:
@@ -6213,7 +6213,7 @@ queries:
         syscalls.in(syscalls_64bit)
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -6224,7 +6224,7 @@ queries:
         syscalls.in(syscalls_32bit)
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -6413,7 +6413,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "exit" && value == "-EPERM")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm64.containsAll(syscalls_64bit)
@@ -6424,7 +6424,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "exit" && value == "-EACCES")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces64.containsAll(syscalls_64bit)
@@ -6435,7 +6435,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "exit" && value == "-EPERM")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm32.containsAll(syscalls_64bit)
@@ -6446,7 +6446,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "exit" && value == "-EACCES")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces32.containsAll(syscalls_64bit)
@@ -6752,13 +6752,13 @@ queries:
         syscalls.contains("mount")
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "mounts"
       ) || auditd.rules.syscalls.contains(
         syscalls.contains("mount")
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "mounts"
       )
     docs:
@@ -6883,14 +6883,14 @@ queries:
       deleteRules64 = auditd.rules.syscalls.where(
         fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "delete"
       ).map(syscalls).flat
 
       deleteRules32 = auditd.rules.syscalls.where(
         fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))
+        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
         && keyname == "delete"
       ).map(syscalls).flat
 


### PR DESCRIPTION
## Summary

Fix two bugs in `mondoo-linux-security` causing auditd checks to fail even when rules are correctly configured per remediation guidance.

Fixes #2125

## Root Cause

### Bug 1: `/etc/localtime` watch rule searched in wrong collection

**Check:** "Ensure events that modify date and time information are audited"

The `/etc/localtime` rule is a file watch rule (`-w /etc/localtime -p wa -k time-change`). The MQL check searched for it in `auditd.rules.syscalls`, which only contains syscall rules (`-a always,exit ...`). File watch rules live in `auditd.rules.files` — a separate collection of `auditd.rule.file` resources with `path`, `permissions`, and `keyname` fields.

**Fix:** Changed to `auditd.rules.files.contains(path == "/etc/localtime" && permissions == "wa" && keyname == "time-change")`, matching the pattern already used by other file watch checks in the same policy (sudoers, MAC modification).

### Bug 2: `fields.any()` with `value.in()` fails in `where()` predicates

**Checks:** "Ensure unsuccessful unauthorized file access attempts are audited" + 3 others

The pattern `fields.any(key == "auid" && op == "!=" && value.in(["unset", "4294967295", "-1"]))` causes the enclosing `.where()` filter to malfunction. The shell test without auid conditions passes, but the policy check with auid conditions fails — returning only `ftruncate` instead of all 5 expected syscalls.

**Fix:** Replaced with `fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")` — the two-step pattern proven in production alma-linux policies. This avoids `value.in()` entirely.

## Changes (1 file, 13 lines)

| Check | Fix |
|---|---|
| Date/time modification (watch rule) | `auditd.rules.syscalls` → `auditd.rules.files` with correct field access |
| DAC permission modification (2 blocks) | `fields.any(... value.in(...))` → `fields.where(...).any(value == ... \|\| ...)` |
| Unauthorized file access (4 blocks) | Same auid fix |
| File system mounts (2 blocks) | Same auid fix |
| File deletion events (2 blocks) | Same auid fix |

## Verification

- All modified queries confirmed compilable via MQL compiler
- `cnspec policy lint` passes
- No other files in the repo use the broken patterns