### PR TITLE
🐛 Report scan data upload failures to Mondoo platform

### DIFF
--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -140,10 +140,13 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		// Read a limited amount of the response body for diagnostics.
+		// Truncate to 512 bytes to avoid leaking sensitive details in Sentry tags.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		health.ReportError("cnspec", cnspec.Version, cnspec.Build,
 			fmt.Sprintf("upload failed with status %d", resp.StatusCode),
 			health.WithTags(map[string]string{
+				"assetMrn":     assetMrn,
 				"responseBody": string(body),
 			}),
 		)


### PR DESCRIPTION
## Summary
- When the scan data upload receives a non-2xx response (e.g. 403 `SignatureDoesNotMatch`), report the error to Mondoo Platform/Sentry with the response body included as a tag
- The user-facing error message stays clean (`upload failed with status 403`) while the full response body is available in Sentry for debugging

## Test plan
- [ ] Trigger a scan data upload failure (e.g. with an expired/invalid signed URL) and verify the error appears in Sentry with the `responseBody` tag
- [ ] Verify the console output remains clean without the raw XML/HTML response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)