### PR TITLE
feat: add Terraform remediation to 26 Azure security checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,9 +2,8 @@ AAAAA
 AAD
 AAWG
 ACCOUNTADMIN
-ACTIVEMQ
-AMQP
 acr
+ACTIVEMQ
 Adddays
 adduser
 ADH
@@ -15,11 +14,13 @@ aiplatform
 AKIAIOSFODNN
 alpm
 ampl
+AMQP
 ANVA
 apigatewayv
 apikey
 apparmor
 appgroup
+appgw
 appspot
 arcfour
 armv
@@ -309,9 +310,9 @@ sacl
 savecore
 scandb
 SCENo
-SCPs
 SCHANNEL
 scm
+SCPs
 screensharing
 sctp
 secadmin

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -5773,6 +5773,23 @@ queries:
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-defender
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              microsoft_defender {
+                log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-containers-introduction
         title: Microsoft Defender for Containers
@@ -5821,6 +5838,22 @@ queries:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-image-cleaner
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              image_cleaner_enabled        = true
+              image_cleaner_interval_hours = 48
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/image-cleaner
@@ -5872,6 +5905,22 @@ queries:
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-workload-identity
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              workload_identity_enabled = true
+              oidc_issuer_enabled       = true
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
         title: Use Azure AD workload identity with AKS
@@ -5917,6 +5966,38 @@ queries:
 
             ```bash
             az aks nodepool add --cluster-name <ClusterName> --resource-group <ResourceGroupName> --name <NodePoolName> --enable-encryption-at-host
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              default_node_pool {
+                name                   = "default"
+                host_encryption_enabled = true
+
+                ...
+              }
+            }
+            ```
+
+            For additional node pools:
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster_node_pool" "example" {
+              name                    = "extra"
+              kubernetes_cluster_id   = azurerm_kubernetes_cluster.example.id
+              host_encryption_enabled = true
+
+              ...
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/enable-host-encryption
@@ -5964,6 +6045,23 @@ queries:
             ```bash
             az aks create --name <ClusterName> --resource-group <ResourceGroupName> --network-plugin azure
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              network_profile {
+                network_plugin = "azure"
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/concepts-network
         title: Network concepts for applications in AKS
@@ -6008,6 +6106,23 @@ queries:
             ```bash
             az aks enable-addons --addon monitoring --name <ClusterName> --resource-group <ResourceGroupName>
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              oms_agent {
+                log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview
         title: Container Insights overview
@@ -6051,6 +6166,23 @@ queries:
 
             ```bash
             az aks enable-addons --addon azure-keyvault-secrets-provider --name <ClusterName> --resource-group <ResourceGroupName>
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              key_vault_secrets_provider {
+                secret_rotation_enabled = true
+              }
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver
@@ -8937,6 +9069,21 @@ queries:
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --ip-range-filter "203.0.113.0/24,198.51.100.0/24"
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_cosmosdb_account" "example" {
+              name                = "example-cosmosdb"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              ip_range_filter = ["203.0.113.0/24", "198.51.100.0/24"]
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall
         title: Configure IP firewall in Azure Cosmos DB
@@ -8987,6 +9134,25 @@ queries:
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account and go to **Networking** > **Private endpoint connections**.
             3. Select **+ Private endpoint** and configure a private endpoint in the target virtual network.
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_private_endpoint" "example" {
+              name                = "example-cosmosdb-pe"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              subnet_id           = azurerm_subnet.example.id
+
+              private_service_connection {
+                name                           = "example-cosmosdb-psc"
+                private_connection_resource_id = azurerm_cosmosdb_account.example.id
+                is_manual_connection           = false
+                subresource_names              = ["Sql"]
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-private-endpoints
         title: Configure Azure Private Link for an Azure Cosmos DB account
@@ -9038,6 +9204,26 @@ queries:
             2. Select the Cosmos DB account and go to **Settings** > **CORS**.
             3. Replace the wildcard `*` origin with specific, trusted domain origins.
             4. Select **Save**.
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_cosmosdb_account" "example" {
+              name                = "example-cosmosdb"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              cors_rule {
+                allowed_origins = ["https://example.com"]
+                allowed_methods = ["GET", "POST"]
+                allowed_headers = ["Content-Type", "Authorization"]
+                exposed_headers = ["ETag"]
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-configure-cross-origin-resource-sharing
         title: Configure Cross-Origin Resource Sharing in Azure Cosmos DB
@@ -9088,6 +9274,23 @@ queries:
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --backup-policy-type Continuous
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_cosmosdb_account" "example" {
+              name                = "example-cosmosdb"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              backup {
+                type = "Continuous"
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/continuous-backup-restore-introduction
         title: Continuous backup with point-in-time restore in Azure Cosmos DB
@@ -9131,6 +9334,30 @@ queries:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-multiple-write-locations true
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_cosmosdb_account" "example" {
+              name                            = "example-cosmosdb"
+              location                        = azurerm_resource_group.example.location
+              resource_group_name             = azurerm_resource_group.example.name
+              multiple_write_locations_enabled = true
+
+              ...
+
+              geo_location {
+                location          = "eastus"
+                failover_priority = 0
+              }
+
+              geo_location {
+                location          = "westus"
+                failover_priority = 1
+              }
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-multi-master
@@ -9177,6 +9404,25 @@ queries:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --default-consistency-level BoundedStaleness
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_cosmosdb_account" "example" {
+              name                = "example-cosmosdb"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              consistency_policy {
+                consistency_level       = "BoundedStaleness"
+                max_interval_in_seconds = 300
+                max_staleness_prefix    = 100000
+              }
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels
@@ -10155,6 +10401,21 @@ queries:
             ```bash
             az sql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version 1.2
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_mssql_server" "example" {
+              name                         = "example-sql-server"
+              resource_group_name          = azurerm_resource_group.example.name
+              location                     = azurerm_resource_group.example.location
+              version                      = "12.0"
+              administrator_login          = "sqladmin"
+              administrator_login_password = var.sql_admin_password
+              minimum_tls_version          = "1.2"
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-sql/database/connectivity-settings
         title: Azure SQL connectivity settings
@@ -10196,6 +10457,22 @@ queries:
 
             ```bash
             az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                   = "example-postgresql"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              delegated_subnet_id    = azurerm_subnet.example.id
+              private_dns_zone_id    = azurerm_private_dns_zone.example.id
+              public_network_access_enabled = false
+
+              ...
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking-private
@@ -10241,6 +10518,29 @@ queries:
             ```bash
             az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_postgresql_flexible_server" "example" {
+              name                = "example-postgresql"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              ...
+
+              customer_managed_key {
+                key_vault_key_id                  = azurerm_key_vault_key.example.id
+                primary_user_assigned_identity_id = azurerm_user_assigned_identity.example.id
+              }
+
+              identity {
+                type         = "UserAssigned"
+                identity_ids = [azurerm_user_assigned_identity.example.id]
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-data-encryption
         title: Data encryption with customer-managed key for Azure Database for PostgreSQL Flexible Server
@@ -10282,6 +10582,20 @@ queries:
 
             ```bash
             az postgres server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_postgresql_server" "example" {
+              name                = "example-postgresql"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              ssl_minimal_tls_version_enforced = "TLS1_2"
+
+              ...
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/postgresql/single-server/concepts-tls
@@ -10325,6 +10639,23 @@ queries:
             ```bash
             az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_mysql_flexible_server" "example" {
+              name                   = "example-mysql"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              delegated_subnet_id    = azurerm_subnet.example.id
+              private_dns_zone_id    = azurerm_private_dns_zone.example.id
+
+              ...
+            }
+            ```
+
+            When `delegated_subnet_id` is set, public network access is automatically disabled.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-networking-private-link
         title: Private access networking for Azure Database for MySQL Flexible Server
@@ -10370,6 +10701,29 @@ queries:
             ```bash
             az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_mysql_flexible_server" "example" {
+              name                = "example-mysql"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              ...
+
+              customer_managed_key {
+                key_vault_key_id                  = azurerm_key_vault_key.example.id
+                primary_user_assigned_identity_id = azurerm_user_assigned_identity.example.id
+              }
+
+              identity {
+                type         = "UserAssigned"
+                identity_ids = [azurerm_user_assigned_identity.example.id]
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-customer-managed-key
         title: Data encryption with customer-managed key for Azure Database for MySQL Flexible Server
@@ -10412,6 +10766,20 @@ queries:
             ```bash
             az mysql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_mysql_server" "example" {
+              name                = "example-mysql"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              ssl_minimal_tls_version_enforced = "TLS1_2"
+
+              ...
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-ssl-connection-security
         title: TLS connectivity in Azure Database for MySQL Single Server
@@ -10453,6 +10821,16 @@ queries:
 
             ```bash
             az security pricing create --name SqlServerVirtualMachines --tier Standard
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_security_center_subscription_pricing" "example" {
+              tier          = "Standard"
+              resource_type = "SqlServerVirtualMachines"
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-sql-introduction
@@ -10502,6 +10880,23 @@ queries:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-disk-driver
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_kubernetes_cluster" "example" {
+              name                = "example-aks"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              ...
+
+              storage_profile {
+                disk_driver_enabled = true
+              }
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/azure-disk-customer-managed-keys
@@ -10559,6 +10954,24 @@ queries:
             ```bash
             az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --policy-type Predefined --name AppGwSslPolicy20220101S
             ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_application_gateway" "example" {
+              name                = "example-appgw"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              ...
+
+              ssl_policy {
+                policy_type = "Predefined"
+                policy_name = "AppGwSslPolicy20220101S"
+              }
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview
         title: Application Gateway SSL policy overview
@@ -10604,6 +11017,26 @@ queries:
 
             ```bash
             az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw1
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_virtual_network_gateway" "example" {
+              name                = "example-vpn-gateway"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              type                = "Vpn"
+              vpn_type            = "RouteBased"
+              sku                 = "VpnGw1"
+
+              ip_configuration {
+                public_ip_address_id          = azurerm_public_ip.example.id
+                private_ip_address_allocation = "Dynamic"
+                subnet_id                     = azurerm_subnet.example.id
+              }
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings
@@ -10736,6 +11169,16 @@ queries:
 
             ```bash
             az security setting create --name WDATP --setting-kind DataExportSettings --enabled true
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            ```hcl
+            resource "azurerm_security_center_setting" "example" {
+              setting_name = "WDATP"
+              enabled      = true
+            }
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/integration-defender-for-endpoint
@@ -10922,6 +11365,39 @@ queries:
             3. Go to **Configuration** > **General settings**.
             4. Set **End-to-end TLS encryption** to **On**.
             5. Select **Save**.
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            __Linux Web App__
+
+            ```hcl
+            resource "azurerm_linux_web_app" "example" {
+              name                = "example-webapp"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              service_plan_id     = azurerm_service_plan.example.id
+
+              site_config {}
+
+              https_only = true
+            }
+            ```
+
+            __Windows Web App__
+
+            ```hcl
+            resource "azurerm_windows_web_app" "example" {
+              name                = "example-webapp"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              service_plan_id     = azurerm_service_plan.example.id
+
+              site_config {}
+
+              https_only = true
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
         title: Secure a custom DNS name with a TLS/SSL binding in Azure App Service


### PR DESCRIPTION
## Summary
- Add Terraform IaC remediation examples to all 26 Azure security checks that were missing them
- Covers AKS (8), Cosmos DB (6), PostgreSQL (3), MySQL (3), SQL Server (2), Application Gateway (1), VPN Gateway (1), Defender (1), and App Service (1) checks
- All 135 remediation sections in the Azure policy now include Terraform examples

## Test plan
- [x] `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` passes
- [ ] Review Terraform resource types and attribute names match current azurerm provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)