### PR TITLE
feat: add Terraform variant MQL queries to 12 GCP security checks

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -14295,7 +14295,9 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_sql_database_instance')
     mql: |
       terraform.resources('google_sql_database_instance').all(
+        blocks.where(type == 'settings') != empty &&
         blocks.where(type == 'settings').all(
+          blocks.where(type == 'password_validation_policy') != empty &&
           blocks.where(type == 'password_validation_policy').all(
             arguments.enable_password_policy == true
           )
@@ -17338,6 +17340,7 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_backup_dr_backup_vault')
     mql: |
       terraform.resources('google_backup_dr_backup_vault').all(
+        arguments.access_restriction != empty &&
         arguments.access_restriction != "UNRESTRICTED" &&
         arguments.access_restriction != "ACCESS_RESTRICTION_UNSPECIFIED"
       )
@@ -17346,6 +17349,7 @@ queries:
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_backup_dr_backup_vault')
     mql: |
       terraform.plan.resourceChanges.where(type == 'google_backup_dr_backup_vault').all(
+        change.after['access_restriction'] != empty &&
         change.after['access_restriction'] != "UNRESTRICTED" &&
         change.after['access_restriction'] != "ACCESS_RESTRICTION_UNSPECIFIED"
       )
@@ -17354,6 +17358,7 @@ queries:
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_backup_dr_backup_vault')
     mql: |
       terraform.state.resources.where(type == 'google_backup_dr_backup_vault').all(
+        values['access_restriction'] != empty &&
         values['access_restriction'] != "UNRESTRICTED" &&
         values['access_restriction'] != "ACCESS_RESTRICTION_UNSPECIFIED"
       )
@@ -18219,7 +18224,10 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_vertex_ai_feature_online_store')
     mql: |
       terraform.resources('google_vertex_ai_feature_online_store').all(
-        blocks.where(type == 'encryption_spec') != empty
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(
+          arguments.kms_key_name != empty
+        )
       )
   - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-terraform-plan
     filters: |


### PR DESCRIPTION
## Summary
- Adds `terraform-hcl`, `terraform-plan`, and `terraform-state` variant MQL queries to 12 GCP security checks that previously only had runtime GCP variants
- Enables scanning Terraform source code, plan output, and state files for these security misconfigurations

## Checks updated (12)
| Check | Terraform Resource |
|---|---|
| Cloud DNS DNSSEC NSEC3 | `google_dns_managed_zone` |
| Cloud Logging sinks configured | `google_logging_project_sink` |
| Compute subnetwork CIDR validation | `google_compute_subnetwork` |
| Redis Cluster IAM auth enabled | `google_redis_cluster` |
| Redis Cluster deletion protection | `google_redis_cluster` |
| Cloud SQL password policy enabled | `google_sql_database_instance` |
| Cloud SQL CMEK encryption | `google_sql_database_instance` |
| Backup & DR vault access restriction | `google_backup_dr_backup_vault` |
| Vertex AI endpoint CMEK encryption | `google_vertex_ai_endpoint` |
| Vertex AI endpoint Private Service Connect | `google_vertex_ai_endpoint` |
| Vertex AI dataset CMEK encryption | `google_vertex_ai_dataset` |
| Vertex AI feature online store CMEK | `google_vertex_ai_feature_online_store` |

## Intentionally skipped
- **Vertex AI model CMEK** — `google_vertex_ai_model` is not a standard Terraform provider resource
- **Vertex AI pipeline job checks** (3) — pipeline jobs are not Terraform-managed resources
- **Runtime-only checks** (5) — key rotation, cert expiry, disabled accounts cannot be validated in Terraform code

## Test plan
- [x] YAML validation passes
- [ ] Run `cnspec policy lint content/mondoo-gcp-security.mql.yaml`
- [ ] Test terraform-hcl variant against sample HCL files
- [ ] Verify MQL syntax matches existing variant patterns in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)