### PR TITLE
fix: disambiguate k8s imagepull check titles by resource type

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -5395,7 +5395,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/
         title: Kubernetes Pod Security Standards
   - uid: mondoo-kubernetes-security-pod-imagepull
-    title: Container image pull should be consistent
+    title: Pod container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5447,7 +5447,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-cronjob-imagepull
-    title: Container image pull should be consistent
+    title: CronJob container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5496,7 +5496,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-statefulset-imagepull
-    title: Container image pull should be consistent
+    title: StatefulSet container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5545,7 +5545,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-deployment-imagepull
-    title: Container image pull should be consistent
+    title: Deployment container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5604,7 +5604,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-job-imagepull
-    title: Container image pull should be consistent
+    title: Job container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5663,7 +5663,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-replicaset-imagepull
-    title: Container image pull should be consistent
+    title: ReplicaSet container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages
@@ -5722,7 +5722,7 @@ queries:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
         title: Image pull policy
   - uid: mondoo-kubernetes-security-daemonset-imagepull
-    title: Container image pull should be consistent
+    title: DaemonSet container image pull should be consistent
     impact: 60
     props:
       - uid: mondooKubernetesSecurityExcludedByFixedImages


### PR DESCRIPTION
All 7 "Container image pull should be consistent" checks in `mondoo-kubernetes-security` now include the workload type so users can immediately identify which resource a finding applies to.

### Changes

| UID | Old Title | New Title |
|-----|-----------|-----------|
| `mondoo-kubernetes-security-pod-imagepull` | Container image pull should be consistent | **Pod** container image pull should be consistent |
| `mondoo-kubernetes-security-cronjob-imagepull` | Container image pull should be consistent | **CronJob** container image pull should be consistent |
| `mondoo-kubernetes-security-statefulset-imagepull` | Container image pull should be consistent | **StatefulSet** container image pull should be consistent |
| `mondoo-kubernetes-security-deployment-imagepull` | Container image pull should be consistent | **Deployment** container image pull should be consistent |
| `mondoo-kubernetes-security-job-imagepull` | Container image pull should be consistent | **Job** container image pull should be consistent |
| `mondoo-kubernetes-security-replicaset-imagepull` | Container image pull should be consistent | **ReplicaSet** container image pull should be consistent |
| `mondoo-kubernetes-security-daemonset-imagepull` | Container image pull should be consistent | **DaemonSet** container image pull should be consistent |

### Context

When these checks fire, users see the same title 7 times with no way to distinguish which workload type triggered the finding. Prefixing the resource type makes each finding self-describing.