### PR TITLE
feat: add 15 new AWS security checks to close coverage gaps

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -33604,7 +33604,7 @@ queries:
             2. Select **Task definitions** in the left panel.
             3. Select the task definition to review.
             4. For each container definition, review the **Environment variables** section.
-            5. Remove any environment variables with names suggesting secrets (e.g., `PASSWORD`, `SECRET_KEY`, `API_KEY`, `ACCESS_KEY`).
+            5. Remove any environment variables with names that store secrets (e.g., `DB_PASSWORD`, `API_KEY`, `SECRET_KEY`, `AWS_SECRET_ACCESS_KEY`).
             6. Instead, use the **Secrets** section to reference values from AWS Secrets Manager or SSM Parameter Store.
             7. Create a new revision of the task definition with the changes.
         - id: cli
@@ -33649,7 +33649,7 @@ queries:
     mql: |
       aws.ecs.taskDefinitions.all(
         containerDefinitions.all(
-          environment.none( name == /(?i)^(password|secret|.*_password|.*_secret|.*_secret_key|api_key|apikey|access_key|aws_secret_access_key|auth_token|private_key|db_password|database_password)$/ ) &&
+          environment.none( name == /(?i)^(aws_secret_access_key|aws_access_key_id|db_password|database_password|master_password|admin_password|api_key|api_secret|private_key|secret_key|auth_token|access_token)$/ ) &&
           environment.none( value == /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ ) &&
           environment.none( value == /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ )
         )


### PR DESCRIPTION
## Summary

- Adds 15 new security checks across key AWS services to close identified coverage gaps
- 9 checks include full Terraform HCL/Plan/State and CloudFormation variants
- 3 checks are AWS-only (secret scanning and policy analysis don't translate to IaC)
- 3 checks are AWS-only because they validate runtime-only state (default VPC, EMR encryption config, ECS env vars)
- All checks include console and CLI remediation steps; IaC checks also include Terraform and CloudFormation remediation examples

### New checks

| Check | Impact | Service | IaC Variants |
|-------|--------|---------|-------------|
| ECS task definitions no plaintext secrets | 100 | ECS | AWS only |
| ECR repositories no public access | 90 | ECR | AWS only |
| EC2 launch templates no secrets | 90 | EC2 | AWS only |
| No default VPC in use | 80 | VPC | AWS only |
| EMR local disk encryption enabled | 80 | EMR | AWS only |
| Config aggregator configured | 80 | Config | AWS + TF + CFN |
| CloudTrail CloudWatch integration | 60 | CloudTrail | AWS + TF + CFN |
| ElastiCache backup retention | 60 | ElastiCache | AWS + TF + CFN |
| RDS backup retention | 60 | RDS | AWS + TF + CFN |
| RDS deletion protection | 60 | RDS | AWS + TF + CFN |
| RDS cluster deletion protection | 60 | RDS | AWS + TF + CFN |
| ECR KMS encryption | 60 | ECR | AWS + TF + CFN |
| Neptune audit log export | 60 | Neptune | AWS + TF + CFN |
| DocumentDB audit log export | 60 | DocumentDB | AWS + TF + CFN |
| RDS Performance Insights enabled | 50 | RDS | AWS + TF + CFN |

### Dependencies

The last 3 checks (Config aggregator, ECR public access, launch template secrets) require new MQL resources being added in mondoohq/mql#7052:
- `aws.config.aggregators` — Config aggregation verification
- `aws.ecr.repository.policy` — ECR repository policy analysis
- `aws.ec2.launchTemplates` with `userData` — Launch template secret scanning

## Test plan
- [x] `make test/lint/content` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)