### PR TITLE
:star: add 15 new AWS security checks to close coverage gaps

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -33590,6 +33590,8 @@ queries:
         - **Rotation difficulty:** Hardcoded secrets require redeployment of task definitions to rotate, making it difficult to respond to compromises.
         - **Blast radius:** A single compromised task definition can expose multiple secrets simultaneously.
 
+        **Scope:** This check detects common secret patterns in environment variable names (e.g., `DB_PASSWORD`, `API_KEY`, `AWS_SECRET_ACCESS_KEY`) and values (AWS access key IDs, private key headers). Secrets stored under non-standard variable names without recognizable value patterns will not be detected.
+
         **Risk mitigation:**
 
         - Use AWS Secrets Manager or AWS Systems Manager Parameter Store to manage secrets securely.


### PR DESCRIPTION
## Summary

- Adds 15 new security checks across key AWS services to close identified coverage gaps
- 9 checks include full Terraform HCL/Plan/State and CloudFormation variants
- 3 checks are AWS-only (secret scanning and policy analysis don't translate to IaC)
- 3 checks are AWS-only because they validate runtime-only state (default VPC, EMR encryption config, ECS env vars)
- All checks include console and CLI remediation steps; IaC checks also include Terraform and CloudFormation remediation examples

### New checks

| Check | Impact | Service | IaC Variants |
|-------|--------|---------|-------------|
| ECS task definitions no plaintext secrets | 90 | ECS | AWS only |
| ECR repositories no public access | 90 | ECR | AWS only |
| EC2 launch templates no secrets | 90 | EC2 | AWS only |
| No default VPC in use | 80 | VPC | AWS only |
| EMR local disk encryption enabled | 80 | EMR | AWS only |
| Config aggregator configured | 80 | Config | AWS + TF + CFN |
| CloudTrail CloudWatch integration | 60 | CloudTrail | AWS + TF + CFN |
| ElastiCache backup retention | 60 | ElastiCache | AWS + TF + CFN |
| RDS backup retention | 60 | RDS | AWS + TF + CFN |
| RDS deletion protection | 60 | RDS | AWS + TF + CFN |
| RDS cluster deletion protection | 60 | RDS | AWS + TF + CFN |
| ECR KMS encryption | 60 | ECR | AWS + TF + CFN |
| Neptune audit log export | 60 | Neptune | AWS + TF + CFN |
| DocumentDB audit log export | 60 | DocumentDB | AWS + TF + CFN |
| RDS Performance Insights enabled | 50 | RDS | AWS + TF + CFN |

### Dependencies

The last 3 checks (Config aggregator, ECR public access, launch template secrets) require new MQL resources being added in mondoohq/mql#7052:
- `aws.config.aggregators` — Config aggregation verification
- `aws.ecr.repository.policy` — ECR repository policy analysis
- `aws.ec2.launchTemplates` with `userData` — Launch template secret scanning

## Test plan
- [x] `make test/lint/content` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)