### PR TITLE
fix: remove trailing colons from Risk mitigation headers

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -326,7 +326,7 @@ queries:
           - Increased blast radius if the service account credentials are leaked or the instance is compromised.
           - Non-compliance with security benchmarks such as CIS Google Cloud Platform Foundations Benchmark and NIST 800-53.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Replace default service accounts with custom service accounts that have narrowly scoped IAM roles tailored to the workload.
           - Regularly review and audit service account usage to ensure they are aligned with current access needs.
           - Disable or delete the default service account only after ensuring that no dependent applications or services will be disrupted.
@@ -483,7 +483,7 @@ queries:
           - Violations of least privilege and non-compliance with security frameworks such as CIS GCP Foundations Benchmark, NIST 800-53, and ISO 27001.
           - Obscured audit trails, since full access allows interactions with multiple services without role-based segmentation.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Assign custom service accounts to instances with only the specific roles required for their function.
           - Avoid using the “Allow full access to all Cloud APIs” option during instance creation.
           - Enforce IAM policies and organizational constraints to block the use of overly permissive API scopes.
@@ -658,7 +658,7 @@ queries:
           - Non-compliance with security best practices and frameworks like CIS GCP Foundations Benchmark, NIST 800-53, and ISO 27001.
           - Operational complexity, as access changes require manual updates to metadata.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable OS Login by setting the enable-oslogin metadata key to TRUE at the project or instance level.
           - Use IAM roles to define which users can access which instances, and whether they have standard or administrative privileges.
           - Leverage OS Login with 2-Step Verification (OS Login 2SV) for enhanced access protection.
@@ -799,7 +799,7 @@ queries:
           - Non-compliance with regulatory frameworks like GDPR, HIPAA, PCI DSS, ISO 27001, and the CIS GCP Foundations Benchmark.
           - Audit and incident response challenges, since access by allUsers or allAuthenticatedUsers is not attributable to a specific identity.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Audit IAM policies and bucket ACLs to detect any bindings involving allUsers or allAuthenticatedUsers.
           - Remove these principals from bucket policies and replace them with specific identities (e.g., service accounts, groups, or individual users) that require access.
           - Enable Public Access Prevention to proactively block public access configuration.
@@ -5364,7 +5364,7 @@ queries:
           - Compliance violations, as many regulatory frameworks require data retention capabilities that depend on encryption key availability.
           - Operational disruptions if applications lose access to required encryption keys.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Set the destroy scheduled duration to at least 24 hours (86400 seconds) for all crypto keys.
           - Consider longer durations (e.g., 30 days) for keys protecting critical or regulated data.
           - Implement alerting on key destruction events to ensure timely review.
@@ -5492,7 +5492,7 @@ queries:
           - Reduced visibility into where cryptographic operations are performed.
           - Challenges during compliance audits when demonstrating geographic controls.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create KMS keyrings in specific regional locations that align with your data residency requirements.
           - Use organization policies to restrict the allowed locations for KMS resources.
           - Document and enforce a key management policy that specifies approved locations.
@@ -5621,7 +5621,7 @@ queries:
           - Non-compliance with security frameworks such as CIS Google Cloud Platform Foundations Benchmark, NIST 800-57, and PCI DSS which require regular key rotation.
           - Operational overhead from manual key rotation processes.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable automatic rotation for all ENCRYPT_DECRYPT crypto keys with a rotation period of 90 days or less.
           - Monitor key rotation events to ensure rotations occur as scheduled.
           - Review keys that are marked as import-only, as these cannot be automatically rotated and require manual processes.
@@ -6350,7 +6350,7 @@ queries:
           - Increased blast radius in the event of a credential compromise.
           - Non-compliance with security benchmarks such as CIS Google Cloud Platform Foundations Benchmark (Control 3.6), NIST 800-53, and PCI DSS.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Restrict source ranges in firewall rules to only known and trusted CIDR blocks (e.g., corporate VPN ranges, bastion host IPs).
           - Use Identity-Aware Proxy (IAP) for SSH access instead of exposing port 22 directly.
           - Implement OS Login with two-factor authentication for an additional layer of access control.
@@ -6511,7 +6511,7 @@ queries:
           - Exploitation of known RDP vulnerabilities, particularly on unpatched systems.
           - Non-compliance with security benchmarks such as CIS Google Cloud Platform Foundations Benchmark (Control 3.7), NIST 800-53, and PCI DSS.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Restrict source ranges in firewall rules to only known and trusted CIDR blocks (e.g., corporate VPN ranges, bastion host IPs).
           - Use Identity-Aware Proxy (IAP) for remote access instead of exposing port 3389 directly.
           - Deploy a VPN or bastion host architecture to provide a controlled entry point for RDP connections.
@@ -6656,7 +6656,7 @@ queries:
           - Non-compliance with virtually all security frameworks including CIS Google Cloud Platform Foundations Benchmark, NIST 800-53, PCI DSS, and SOC 2.
           - Rapid compromise in the event of any service-level vulnerability.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Follow the principle of least privilege: only allow the specific protocols and ports required for each workload.
           - Restrict source ranges to known and trusted CIDR blocks.
           - Use separate firewall rules for each service with specific port allowances.
@@ -6813,7 +6813,7 @@ queries:
           - Non-compliance with data protection regulations including GDPR, HIPAA, PCI DSS, and SOC 2.
           - Complete loss of data confidentiality, integrity, and availability.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Restrict database firewall rules to only allow access from application server IP ranges or VPC-internal CIDR blocks.
           - Use Cloud SQL Auth Proxy or Private Service Connect for secure database connectivity.
           - Place databases in private subnets without public IP addresses.
@@ -6960,7 +6960,7 @@ queries:
           - Difficulty in maintaining a clear understanding of what is actually exposed.
           - Non-compliance with security best practices and frameworks that require least-privilege network access.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Always specify explicit port numbers in firewall allow rules.
           - Create separate firewall rules for each service with the minimum required ports.
           - Use network tags or service accounts to target rules to specific instances.
@@ -7655,7 +7655,7 @@ queries:
           -  Elimination of service account key management.
           -  Protection of the node metadata server from unauthorized pod access.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           -  Enable Workload Identity at the cluster level and configure Kubernetes service accounts to use Google Cloud IAM service accounts.
           -  Remove any exported service account keys that are no longer needed.
           -  Regularly audit the IAM bindings between Kubernetes and Google Cloud service accounts.
@@ -7768,7 +7768,7 @@ queries:
           -  Controlled egress through Cloud NAT or other managed gateways.
           -  Better compliance with network segmentation requirements.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           -  Enable private nodes when creating or updating GKE clusters.
           -  Use Cloud NAT for outbound internet access when needed.
           -  Configure master authorized networks to restrict access to the control plane.
@@ -7885,7 +7885,7 @@ queries:
           -  Virtual Trusted Platform Module (vTPM) for measured boot and node integrity verification.
           -  Integrity monitoring to detect unauthorized changes to the node's boot sequence.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           -  Enable Shielded Nodes on all GKE clusters.
           -  Monitor integrity validation failures through Cloud Logging.
           -  Use Shielded Nodes in combination with Binary Authorization for defense-in-depth.
@@ -8008,7 +8008,7 @@ queries:
           -  Timely application of security patches and bug fixes.
           -  Predictable upgrade cadence based on the chosen channel (Rapid, Regular, or Stable).
 
-        **Risk mitigation:**
+        **Risk mitigation**
           -  Enroll all GKE clusters in an appropriate release channel based on workload requirements.
           -  Use the Regular channel for production workloads that need a balance between new features and stability.
           -  Use maintenance windows to control when upgrades are applied.
@@ -8457,7 +8457,7 @@ queries:
           •  Protection against unauthorized data access from compromised workloads within the same network.
           •  Better alignment with defense-in-depth security principles.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           •  Enable AUTH on all Cloud Redis instances.
           •  Store the AUTH string securely using Secret Manager.
           •  Rotate AUTH strings regularly.
@@ -8573,7 +8573,7 @@ queries:
           -  Cloud Audit Logs for all key usage, enabling monitoring and compliance reporting.
           -  Separation of duties between data administrators and key administrators.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           -  Configure CMEK for all Cloud Redis instances that store sensitive data.
           -  Use Cloud KMS to manage encryption keys with appropriate IAM policies.
           -  Enable automatic key rotation on a schedule that meets compliance requirements.
@@ -8715,7 +8715,7 @@ queries:
           - Non-compliance with security frameworks such as CIS GCP Foundations Benchmark, NIST 800-53, and ISO 27001.
           - Difficult-to-audit access patterns, as key usage is harder to trace than federated identity.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Use Workload Identity Federation for external workloads instead of service account keys.
           - Use attached service accounts (Google-managed keys) for GCP workloads.
           - If user-managed keys are absolutely necessary, implement strict key rotation policies and audit procedures.
@@ -8837,7 +8837,7 @@ queries:
           - Violation of least privilege principles required by CIS GCP Foundations Benchmark and NIST 800-53.
           - Difficult-to-audit access, as many services may share the same overly privileged identity.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create custom service accounts with narrowly scoped IAM roles for each workload.
           - Disable default service accounts after migrating all workloads to custom accounts.
           - Use organization policies to prevent the use of default service accounts.
@@ -8943,7 +8943,7 @@ queries:
           - Difficulty identifying which keys are still actively used versus those that should be decommissioned.
           - Increased risk of key reuse across environments or teams.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Implement automated key rotation processes that generate new keys and retire old ones within 90 days.
           - Use Cloud Monitoring alerts to detect keys approaching the rotation deadline.
           - Prefer Workload Identity Federation or Google-managed keys over user-managed keys to avoid rotation requirements entirely.
@@ -9045,7 +9045,7 @@ queries:
           - Cluttered key management that obscures the active credential inventory.
           - Increased audit complexity when reviewing service account access.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Delete disabled keys promptly after confirming no active workloads depend on them.
           - Implement automation to identify and remove disabled keys as part of periodic credential hygiene.
           - Monitor key status changes using Cloud Audit Logs.
@@ -9149,7 +9149,7 @@ queries:
           - Gaps in security monitoring and threat detection capabilities.
           - Reduced ability to perform root cause analysis after incidents.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Set log bucket retention to at least 30 days for operational logs and longer for compliance-sensitive logs.
           - Configure log sinks to export logs to long-term storage (Cloud Storage, BigQuery) for extended retention.
           - Review retention policies regularly to ensure they meet organizational and regulatory requirements.
@@ -9262,7 +9262,7 @@ queries:
           - Non-compliance with regulatory requirements for immutable audit trails.
           - Loss of forensic evidence during incident investigations.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Lock custom log buckets that store security-critical or compliance-relevant logs.
           - Ensure adequate retention is configured before locking, as the retention period cannot be reduced after locking.
           - Use the _Required bucket for admin activity and system event logs which are automatically protected.
@@ -9382,7 +9382,7 @@ queries:
           - Non-compliance with data protection requirements mandating customer-managed encryption.
           - Limited auditability of encryption key operations on sensitive log data.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK for all log buckets that store sensitive or compliance-relevant logs.
           - Use Cloud KMS to manage encryption keys with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -9499,7 +9499,7 @@ queries:
           - Gaps in security monitoring when logs are not forwarded to SIEM or monitoring tools.
           - Non-compliance with regulatory requirements for centralized audit log management.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure at least one log sink to export security-critical logs to long-term storage.
           - Use organization-level sinks for consistent log export across all projects.
           - Consider multiple sinks for different log types (e.g., audit logs to BigQuery, security logs to SIEM).
@@ -9605,7 +9605,7 @@ queries:
           - Non-compliance with data protection requirements mandating customer-managed encryption.
           - Limited auditability of encryption key operations.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK for all Pub/Sub topics that handle sensitive data.
           - Use Cloud KMS to manage encryption keys with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -9706,7 +9706,7 @@ queries:
           - Accumulated orphaned subscriptions increase the attack surface and complicate access auditing.
           - Without expiration, manual cleanup is required to identify and remove stale subscriptions.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure expiration policies on all subscriptions to automatically clean up inactive ones.
           - The default expiration is 31 days of inactivity; adjust based on operational requirements.
           - Regularly audit subscription usage to identify and remove unused subscriptions.
@@ -9812,7 +9812,7 @@ queries:
           - Increased costs from unauthorized message publishing.
           - Non-compliance with data protection regulations that require access controls on data in transit.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Remove `allUsers` and `allAuthenticatedUsers` from all topic IAM bindings.
           - Use specific service accounts, groups, or users for topic access.
           - Apply the principle of least privilege by granting only the minimum required roles (e.g., `roles/pubsub.publisher` or `roles/pubsub.subscriber`).
@@ -9933,7 +9933,7 @@ queries:
           - Disruption of message processing when unauthorized consumers acknowledge messages.
           - Non-compliance with data protection regulations that require access controls on data in transit.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Remove `allUsers` and `allAuthenticatedUsers` from all subscription IAM bindings.
           - Use specific service accounts, groups, or users for subscription access.
           - Apply the principle of least privilege by granting only `roles/pubsub.subscriber` to authorized consumers.
@@ -10058,7 +10058,7 @@ queries:
           - Data exfiltration through functions that access internal resources.
           - Unexpected cost increases from malicious or abusive traffic.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Set ingress settings to ALLOW_INTERNAL_ONLY or ALLOW_INTERNAL_AND_GCLB.
           - Use Cloud Load Balancing with Cloud Armor for functions that need external access with protection.
           - Implement authentication requirements on all function endpoints.
@@ -10172,7 +10172,7 @@ queries:
           - Lateral movement across project resources.
           - Violation of least privilege requirements in CIS GCP Foundations Benchmark and NIST 800-53.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create dedicated service accounts with only the IAM roles needed for each function's operation.
           - Assign the custom service account when deploying the function.
           - Regularly review and audit function service account permissions.
@@ -10289,7 +10289,7 @@ queries:
           - VPC connectors enable network-level access controls through firewall rules and VPC Service Controls.
           - Private connectivity is essential for compliance with data protection requirements that mandate encrypted internal communication paths.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure a Serverless VPC Access connector for each function that accesses VPC resources.
           - Use VPC connector egress settings to control which traffic routes through the connector.
           - Monitor connector throughput and scale as needed.
@@ -10409,7 +10409,7 @@ queries:
           - Non-compliance with data protection requirements mandating customer-managed encryption.
           - Limited auditability of encryption key operations.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK for all Cloud Functions that handle sensitive data.
           - Use Cloud KMS to manage encryption keys with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -10525,7 +10525,7 @@ queries:
           - Increased attack surface for application-level exploits.
           - Unexpected costs from malicious or abusive traffic.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Set ingress to INGRESS_TRAFFIC_INTERNAL_ONLY or INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER.
           - Use Cloud Load Balancing with Cloud Armor for services requiring external access.
           - Implement IAM-based authentication for all Cloud Run services.
@@ -10634,7 +10634,7 @@ queries:
           - Cloud Audit Logs provide visibility into all key usage operations.
           - Compliance frameworks may require customer-managed encryption for workloads handling sensitive data.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK for Cloud Run services handling sensitive or regulated data.
           - Use Cloud KMS to manage keys with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -10752,7 +10752,7 @@ queries:
           - Lateral movement across project resources.
           - Violation of least privilege requirements in security frameworks.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create dedicated service accounts with only the IAM roles needed for each service.
           - Specify the custom service account in the service's revision template.
           - Regularly audit service account permissions and usage.
@@ -10882,7 +10882,7 @@ queries:
           - VPC access enables network-level access controls through firewall rules and VPC Service Controls.
           - Private connectivity is essential for compliance with data protection requirements that mandate encrypted internal communication paths.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure VPC access for Cloud Run services that communicate with internal resources.
           - Use Direct VPC egress or a Serverless VPC Access connector.
           - Configure egress settings to control which traffic routes through the VPC.
@@ -11004,7 +11004,7 @@ queries:
           - Lateral movement across project resources.
           - Violation of least privilege requirements in security frameworks.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create dedicated service accounts with only the IAM roles needed for each job.
           - Specify the custom service account in the job's task template.
           - Regularly audit service account permissions and usage.
@@ -11144,7 +11144,7 @@ queries:
           - Cloud Audit Logs provide visibility into all key usage operations.
           - Compliance frameworks may require customer-managed encryption for workloads handling sensitive data.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK for Cloud Run jobs handling sensitive or regulated data.
           - Use Cloud KMS to manage keys with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -11261,7 +11261,7 @@ queries:
           - Compliance frameworks may require customer-managed encryption for data processing environments.
           - Audit trails for key usage support security monitoring and compliance reporting.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure CMEK when creating Dataproc clusters by specifying a KMS key for GCE PD encryption.
           - Use Cloud KMS to manage encryption keys with appropriate IAM policies.
           - Enable automatic key rotation on encryption keys used by Dataproc clusters.
@@ -11378,7 +11378,7 @@ queries:
           - Data exfiltration through network-level access to cluster endpoints.
           - Increased exposure to brute-force and scanning attacks.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable internal IP only mode when creating clusters.
           - Ensure Private Google Access is enabled on the subnet for accessing Google APIs.
           - Use Cloud NAT for outbound internet access if needed.
@@ -11492,7 +11492,7 @@ queries:
           - Integrity monitoring detects changes to the boot sequence and raises alerts for unauthorized modifications.
           - Without these protections, attackers who gain node access could install persistent rootkits that survive reboots.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable all three Shielded VM features (Secure Boot, vTPM, integrity monitoring) when creating clusters.
           - Monitor integrity validation reports for signs of boot-level tampering.
           - Use Shielded VM images for cluster nodes.
@@ -11642,7 +11642,7 @@ queries:
           - Lateral movement across project resources.
           - Violation of least privilege requirements in CIS GCP Foundations Benchmark and NIST 800-53.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create dedicated service accounts with only the IAM roles needed for each cluster's workload.
           - Assign the custom service account when creating the cluster.
           - Regularly review and audit cluster service account permissions.
@@ -11775,7 +11775,7 @@ queries:
           - Non-compliance with container security policies and regulatory requirements.
           - Complete bypass of image integrity verification.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Set the default admission rule to ALWAYS_DENY or REQUIRE_ATTESTATION.
           - Create attestors for your CI/CD pipeline to sign verified images.
           - Use per-cluster admission rules for environments with different security requirements.
@@ -11893,7 +11893,7 @@ queries:
           - Without global evaluation, organizations must manually allowlist every system image, which is error-prone and can lead to overly broad allowlist patterns.
           - Disabling global evaluation may cause operational issues if system images are not explicitly allowlisted.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable global policy evaluation mode to benefit from Google-maintained system image verification.
           - Combine global evaluation with project-specific attestation policies for application images.
           - Monitor policy evaluation logs for unexpected denials or allowances.
@@ -12012,7 +12012,7 @@ queries:
           - Data access through APIs that the key was never intended to call.
           - Non-compliance with CIS GCP Foundations Benchmark requirements.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure API target restrictions on all API keys to limit them to only required APIs.
           - Regularly review API key usage to ensure restrictions are appropriate.
           - Consider using service accounts with OAuth 2.0 instead of API keys where possible.
@@ -12130,7 +12130,7 @@ queries:
           - API quota exhaustion from abusive callers.
           - Cost overruns from unauthorized API usage.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure appropriate application restrictions based on key usage context.
           - Use IP restrictions for server-side keys.
           - Use HTTP referrer restrictions for browser-side keys.
@@ -12258,7 +12258,7 @@ queries:
           - Rotation ensures that decommissioned applications and former team members lose access through old keys.
           - Key rotation is a standard security practice required by many compliance frameworks.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Implement a key rotation schedule of 90 days or less.
           - Automate key rotation as part of your CI/CD or operations pipeline.
           - Monitor key age using Cloud Monitoring and alert when keys approach the rotation deadline.
@@ -12361,7 +12361,7 @@ queries:
           - Reduced network segmentation and isolation between workloads.
           - Non-compliance with CIS GCP Foundations Benchmark and organizational network security policies.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Delete the default network and all its associated firewall rules.
           - Create custom VPC networks with explicitly defined subnets and firewall rules.
           - Use organization policies to prevent automatic creation of default networks in new projects.
@@ -12475,7 +12475,7 @@ queries:
           - Gaps in forensic investigation during incident response.
           - Reduced effectiveness of DNS-based threat intelligence integration.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create a Cloud DNS policy with logging enabled and apply it to all VPC networks.
           - Forward DNS logs to your SIEM or security monitoring platform.
           - Configure alerts for queries to known malicious domains or unusual DNS patterns.
@@ -12582,7 +12582,7 @@ queries:
           - Firewall rules based on subnet ranges become less effective when subnets are too large.
           - Smaller, purpose-built subnets improve security isolation and reduce blast radius.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Design subnets with the smallest CIDR range that meets operational requirements.
           - Use separate subnets for different workload types, environments, and security zones.
           - Implement secondary IP ranges for pods and services in GKE clusters.
@@ -12709,7 +12709,7 @@ queries:
           - Compliance with security standards that mandate encryption of data in transit.
           - Defense-in-depth when combined with AUTH and VPC network isolation.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable in-transit encryption on all Cloud Memorystore for Redis instances and clusters.
           - Ensure client applications are configured to use TLS when connecting to Redis.
           - Combine in-transit encryption with AUTH and network-level access controls.
@@ -12834,7 +12834,7 @@ queries:
           - Applications relying on Redis for caching, session management, or data storage need reliable availability.
           - Data loss from a Basic tier failure can impact application state, user sessions, and business operations.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Use Standard HA tier for all production Redis instances.
           - Reserve Basic tier only for development or testing environments where data loss is acceptable.
           - Monitor Redis instance health and configure alerts for failover events.
@@ -12946,7 +12946,7 @@ queries:
           - Fine-grained access management through IAM, allowing different permissions for different service accounts.
           - Alignment with the principle of least privilege by granting access only to authorized identities.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable IAM authentication on all Cloud Memorystore for Redis Cluster instances.
           - Assign the appropriate IAM roles to service accounts that need Redis access.
           - Monitor IAM authentication logs through Cloud Audit Logs.
@@ -13058,7 +13058,7 @@ queries:
           - Protection for production workloads that depend on the cluster for caching or session management.
           - Alignment with operational best practices for critical infrastructure protection.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable deletion protection on all production Cloud Memorystore for Redis Cluster instances.
           - Use IAM policies to restrict who can disable deletion protection.
           - Implement change management processes for any modifications to deletion protection settings.
@@ -13168,7 +13168,7 @@ queries:
           - No separation of duties between the cloud provider managing encryption and the customer controlling keys.
           - Limited auditability of encryption key operations for sensitive credential data.
 
-        **Risk mitigation:**
+        **Risk mitigation**
 
           - **Key control:** Full control over key lifecycle including rotation and deletion.
           - **Access management:** Fine-grained access control through Cloud KMS key policies.
@@ -13325,7 +13325,7 @@ queries:
           - Accumulation of stale credentials that are difficult to track and manage.
           - Increased difficulty in incident response, as there is no established rotation workflow to invoke during a breach.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Configure rotation policies on all Secret Manager secrets with a rotation period appropriate for the sensitivity of the data.
           - Use Cloud Functions or Pub/Sub topic triggers to automate the rotation process.
           - Monitor rotation events through Cloud Audit Logs to ensure rotation is occurring as scheduled.
@@ -13464,7 +13464,7 @@ queries:
           - Data breaches across connected services that rely on the exposed credentials.
           - Non-compliance with virtually all security frameworks including PCI DSS, HIPAA, SOC 2, and NIST 800-53.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Audit IAM policies on all secrets to detect bindings involving `allUsers` or `allAuthenticatedUsers`.
           - Remove public access principals and replace them with specific service accounts, groups, or individual users.
           - Use organization policies to restrict the use of `allUsers` and `allAuthenticatedUsers` across your projects.
@@ -14524,7 +14524,7 @@ queries:
           - If the etcd storage layer is compromised, Secrets remain protected by the additional Cloud KMS encryption.
           - Compliance frameworks may require customer-managed encryption for sensitive data stores, including Kubernetes Secrets.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable application-layer secrets encryption on all GKE clusters that handle sensitive workloads.
           - Use Cloud KMS to manage the encryption key with appropriate IAM policies and automatic rotation.
           - Monitor key usage through Cloud Audit Logs.
@@ -14635,7 +14635,7 @@ queries:
           - Boot-level attacks can persist across node restarts and are difficult to detect with runtime security tools.
           - Each node pool can have independent shielded instance settings, so it is important to verify Secure Boot is enabled on every node pool, not just the cluster default.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Enable Secure Boot on all node pools, including newly created ones.
           - Use the `constraints/compute.requireShieldedVm` Organization Policy to enforce Shielded VM features.
           - Monitor integrity validation failures through Cloud Logging.
@@ -18055,7 +18055,7 @@ queries:
           - ML pipelines often access sensitive data stores, model registries, and storage buckets that should be scoped precisely.
           - Custom service accounts with narrowly scoped roles limit the blast radius of security incidents.
 
-        **Risk mitigation:**
+        **Risk mitigation**
           - Create a dedicated service account with only the IAM roles needed for the pipeline.
           - Specify the custom service account when submitting pipeline jobs.
           - Regularly audit service account permissions and usage.

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -416,7 +416,7 @@ queries:
           - Required approvals create an audit trail of who reviewed and approved each change.
           - Many compliance frameworks (SOC 2, ISO 27001) require separation of duties for code changes.
 
-        Risk mitigation:
+        Risk mitigation
           - Require at least one approval on all projects.
           - For critical projects, consider requiring two or more approvals.
           - Combine with protected branches to enforce approval requirements.
@@ -489,7 +489,7 @@ queries:
           - Regulatory and compliance frameworks require separation of duties between code authors and reviewers.
           - Supply chain attacks often exploit the ability to self-approve changes.
 
-        Risk mitigation:
+        Risk mitigation
           - Disable author approval for all projects.
           - Combine with required approvals to ensure independent review.
           - Monitor merge request activity for unusual approval patterns.
@@ -557,7 +557,7 @@ queries:
           - This bypasses the intent of code review by allowing unapproved code to be merged.
           - Compliance requirements for code review are not met if approved code is modified post-approval.
 
-        Risk mitigation:
+        Risk mitigation
           - Enable reset approvals on push for all projects.
           - Combine with required approvals and branch protection rules.
           - Educate developers to re-review merge requests after new commits are pushed.
@@ -625,7 +625,7 @@ queries:
           - This setting closes a gap where multiple contributors to a branch could approve each other's changes without independent review.
           - Strengthens the audit trail by ensuring approvals come from independent reviewers.
 
-        Risk mitigation:
+        Risk mitigation
           - Disable committer approval for all projects.
           - Combine with author approval restrictions for comprehensive separation of duties.
           - Use code owner approvals for additional review requirements on critical paths.
@@ -692,7 +692,7 @@ queries:
           - History rewriting makes incident investigation and forensic analysis extremely difficult.
           - Accidental force pushes can cause data loss and disrupt development workflows.
 
-        Risk mitigation:
+        Risk mitigation
           - Disable force push on all protected branches, especially the default branch.
           - Use branch protection rules to enforce this at the project level.
           - Monitor for any changes to branch protection settings.
@@ -763,7 +763,7 @@ queries:
           - Compliance checks and policy validations in the pipeline are skipped.
           - Attackers can merge malicious code that would otherwise be caught by automated checks.
 
-        Risk mitigation:
+        Risk mitigation
           - Require pipeline success on all projects with CI/CD pipelines.
           - Include security scanning jobs in your pipeline configuration.
           - Combine with the "don't allow merge on skipped pipeline" setting.

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -81,7 +81,7 @@ queries:
           •  Privilege escalation if an administrator account is compromised.
           •  Non-compliance with CIS OCI Foundations Benchmark, NIST 800-53, and PCI DSS.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable MFA for all active IAM users, especially those with administrative privileges.
           •  Use TOTP-based authenticator apps for the second factor.
           •  Regularly audit MFA enrollment status.
@@ -132,7 +132,7 @@ queries:
           •  Security alerts about suspicious account activity cannot be delivered.
           •  Unverified accounts may indicate orphaned or misconfigured user identities.
 
-        Risk mitigation:
+        Risk mitigation
           •  Require email verification for all IAM users during account creation.
           •  Periodically audit user accounts for unverified email addresses.
           •  Disable accounts with unverified emails that have not been resolved within a set time frame.
@@ -198,7 +198,7 @@ queries:
           •  A compromised user in such a group has unlimited blast radius across the entire tenancy.
           •  This violates the principle of least privilege and makes access auditing difficult.
 
-        Risk mitigation:
+        Risk mitigation
           •  Replace broad tenancy-level policies with compartment-scoped policies.
           •  Use specific resource types instead of `all-resources`.
           •  Grant only the minimum permissions required for each group's function.
@@ -317,7 +317,7 @@ queries:
           •  Compromised API keys provide programmatic access to OCI resources.
           •  Orphaned credentials are a common vector in cloud security breaches.
 
-        Risk mitigation:
+        Risk mitigation
           •  Delete or deactivate API keys when user accounts are deactivated.
           •  Implement automated credential cleanup as part of user offboarding.
           •  Regularly audit API keys across all users for stale or unnecessary credentials.
@@ -375,7 +375,7 @@ queries:
           •  Orphaned tokens may go unnoticed during security audits if not linked to active user reviews.
           •  Compromised tokens allow unauthorized API access to OCI resources.
 
-        Risk mitigation:
+        Risk mitigation
           •  Delete auth tokens when user accounts are deactivated.
           •  Implement automated credential cleanup during user offboarding.
           •  Regularly audit auth tokens across all users.
@@ -450,7 +450,7 @@ queries:
           •  Exposure of internal application data, configuration files, or database backups.
           •  Non-compliance with CIS OCI Foundations Benchmark.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set all buckets to `NoPublicAccess` unless there is an explicit, documented business requirement.
           •  Use IAM policies and pre-authenticated requests for controlled access.
           •  Regularly audit bucket access types.
@@ -554,7 +554,7 @@ queries:
           •  An audit trail of all object changes.
           •  Protection against ransomware that attempts to encrypt or destroy data.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable versioning on all buckets containing important data.
           •  Configure lifecycle policies to manage version retention and storage costs.
           •  Regularly test recovery from versioned objects.
@@ -658,7 +658,7 @@ queries:
           •  Integration with OCI Events and Notifications for automated alerting.
           •  Audit trail for compliance requirements.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable object events on all buckets.
           •  Configure event rules to alert on suspicious activity.
           •  Integrate events with SIEM or logging platforms.
@@ -758,7 +758,7 @@ queries:
           •  Compliance with regulations that require customer-controlled encryption (HIPAA, PCI DSS, FedRAMP).
           •  Separation of duties between data management and key management.
 
-        Risk mitigation:
+        Risk mitigation
           •  Create encryption keys in OCI Vault.
           •  Assign customer-managed keys to all Object Storage buckets.
           •  Configure key rotation policies.
@@ -881,7 +881,7 @@ queries:
           •  Unauthorized access to databases, management interfaces, and internal services.
           •  Non-compliance with CIS OCI Foundations Benchmark, PCI DSS, and NIST 800-53.
 
-        Risk mitigation:
+        Risk mitigation
           •  Remove or restrict overly permissive ingress rules.
           •  Use specific protocol and port ranges in security list rules.
           •  Restrict source CIDR blocks to known trusted IP ranges.
@@ -1000,7 +1000,7 @@ queries:
           •  Data exfiltration through exposed database or application ports.
           •  Non-compliance with CIS OCI Foundations Benchmark.
 
-        Risk mitigation:
+        Risk mitigation
           •  Always specify destination port ranges in TCP ingress rules.
           •  Restrict source CIDR blocks to known trusted IP ranges.
           •  Use the minimum set of ports required for each workload.
@@ -1127,7 +1127,7 @@ queries:
           •  Download additional malware or tools.
           •  Participate in DDoS attacks or cryptocurrency mining.
 
-        Risk mitigation:
+        Risk mitigation
           •  Restrict egress rules to specific destination CIDR blocks and protocols.
           •  Use a NAT gateway or proxy for controlled internet access.
           •  Monitor outbound traffic for anomalies.

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -89,7 +89,7 @@ queries:
 
         Snowflake has been the target of high-profile attacks where stolen credentials were used to access customer data. MFA would have prevented many of these breaches.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable Duo MFA for all active users.
           •  Prioritize MFA for users with ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN roles.
           •  Consider using key-pair authentication for service accounts.
@@ -141,7 +141,7 @@ queries:
           •  Excessive ACCOUNTADMIN assignments increase the risk of accidental or malicious misuse.
           •  Audit and accountability are harder to maintain with many privileged users.
 
-        Risk mitigation:
+        Risk mitigation
           •  Limit ACCOUNTADMIN to 2-3 trusted administrators.
           •  Use SECURITYADMIN and SYSADMIN for day-to-day administration.
           •  Ensure all ACCOUNTADMIN users have MFA enabled.
@@ -189,7 +189,7 @@ queries:
           •  Users who have not completed their password change may be inactive or orphaned accounts.
           •  Attackers who intercept temporary passwords have access until the password is changed.
 
-        Risk mitigation:
+        Risk mitigation
           •  Follow up with users who have not changed their initial passwords.
           •  Set expiration policies for temporary passwords.
           •  Disable accounts that have not completed initial setup within a reasonable time frame.
@@ -238,7 +238,7 @@ queries:
           •  NIST SP 800-63B recommends a minimum of 8 characters, but longer passwords (14+) provide substantially better protection.
           •  Snowflake accounts with weak passwords are prime targets for data exfiltration.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set minimum password length to 14 or more characters in all password policies.
           •  Encourage use of passphrases for easier memorization of long passwords.
           •  Combine password length requirements with MFA for defense-in-depth.
@@ -288,7 +288,7 @@ queries:
           •  Detection of unauthorized access attempts through lockout events.
           •  A forced pause that limits the speed of automated attacks.
 
-        Risk mitigation:
+        Risk mitigation
           •  Configure password lockout retry limits between 3 and 5 attempts.
           •  Set reasonable lockout duration (e.g., 15-30 minutes).
           •  Monitor lockout events for signs of attack.
@@ -340,7 +340,7 @@ queries:
           •  Blocklisting of known malicious IP ranges.
           •  An additional layer of defense beyond authentication.
 
-        Risk mitigation:
+        Risk mitigation
           •  Create network policies that restrict access to corporate networks and VPNs.
           •  Apply network policies at the account level for broad protection.
           •  Use network rules for more granular control.
@@ -387,7 +387,7 @@ queries:
           •  All the risks of having no network policy apply equally.
           •  Audit and compliance checks may incorrectly pass because a network policy exists.
 
-        Risk mitigation:
+        Risk mitigation
           •  Replace 0.0.0.0/0 entries with specific trusted IP ranges.
           •  Audit network policies regularly for overly permissive entries.
           •  Use the smallest CIDR blocks that cover your organization's legitimate access points.
@@ -429,7 +429,7 @@ queries:
           •  If the user's session is compromised, the attacker immediately has the highest privileges.
           •  Proper privilege separation requires using lower-privilege roles for routine work.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set default roles to the minimum privilege level needed for daily tasks.
           •  Use ACCOUNTADMIN only when explicitly required by switching roles.
           •  Assign SYSADMIN, SECURITYADMIN, or custom roles as defaults.
@@ -476,7 +476,7 @@ queries:
           •  Dictionary attacks are effective against passwords that don't mix character types.
           •  Complexity requirements force passwords into a larger search space, making brute-force attacks less feasible.
 
-        Risk mitigation:
+        Risk mitigation
           •  Require at least one character from each category (uppercase, lowercase, numeric, special).
           •  Combine complexity requirements with minimum length requirements for maximum protection.
           •  Use MFA as an additional layer of protection.
@@ -524,7 +524,7 @@ queries:
           •  Stale passwords are more likely to appear in credential dumps and breach databases.
           •  Regular rotation ensures that even if a password is compromised, it has a limited useful lifetime.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set maximum password age to 90 days or less.
           •  Combine password rotation with MFA for defense-in-depth.
           •  Notify users in advance of upcoming password expiration.
@@ -570,7 +570,7 @@ queries:
           •  Previously compromised passwords can be reused, negating the benefit of password rotation.
           •  Password history enforcement ensures each rotation uses a genuinely new password.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set password history to at least 5 previous passwords.
           •  Combine password history with maximum age and complexity requirements.
           •  Educate users about the importance of using unique passwords.
@@ -621,7 +621,7 @@ queries:
           •  Forensic investigation of data changes for security incidents.
           •  Point-in-time cloning for testing and analysis.
 
-        Risk mitigation:
+        Risk mitigation
           •  Set retention time to at least 1 day for all databases.
           •  Use longer retention periods (up to 90 days with Enterprise edition) for critical data.
           •  Monitor databases with zero retention time and remediate promptly.

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -83,7 +83,7 @@ queries:
           •  Without device authorization enforcement, any user with access can add devices without admin review.
           •  Unauthorized devices can access internal services and resources on the tailnet.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable device authorization in the Tailscale admin console.
           •  Regularly review the device list and remove unauthorized or unknown devices.
           •  Use device tags and ACLs to restrict access even after authorization.
@@ -146,7 +146,7 @@ queries:
           •  Forced re-authentication that verifies the user still has valid credentials.
           •  Reduced blast radius for compromised device keys.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable key expiry on all devices.
           •  Set appropriate expiry periods based on device risk (e.g., shorter for mobile devices).
           •  Monitor for devices with disabled key expiry and re-enable as needed.
@@ -212,7 +212,7 @@ queries:
           •  Access to the latest security features and bug fixes.
           •  Compatibility with the latest tailnet security settings.
 
-        Risk mitigation:
+        Risk mitigation
           •  Enable automatic updates where possible.
           •  Monitor for devices with available updates and ensure they are applied promptly.
           •  Include Tailscale client updates in your organization's patch management process.
@@ -275,7 +275,7 @@ queries:
           •  Unresolved lock errors can prevent devices from communicating properly in the tailnet.
           •  In a locked tailnet, only devices with properly signed keys should be trusted.
 
-        Risk mitigation:
+        Risk mitigation
           •  Review and resolve all tailnet lock errors promptly.
           •  Sign legitimate devices using a trusted signing node.
           •  Remove devices that cannot be properly verified.
@@ -333,7 +333,7 @@ queries:
           •  Unauthorized access requests are identified and denied.
           •  The organization maintains an active access governance process.
 
-        Risk mitigation:
+        Risk mitigation
           •  Review pending user approvals regularly.
           •  Approve legitimate users and deny unknown access requests.
           •  Configure notifications for new approval requests.
@@ -373,7 +373,7 @@ queries:
           •  Too many administrators makes it harder to maintain accountability and audit trails.
           •  The principle of least privilege requires minimizing the number of highly privileged users.
 
-        Risk mitigation:
+        Risk mitigation
           •  Limit owner roles to 1-2 primary tailnet owners.
           •  Limit admin roles to 2-3 trusted administrators.
           •  Use member roles for most users who only need device connectivity.
@@ -413,7 +413,7 @@ queries:
           •  Unused accounts still have network access and may have overly permissive configurations.
           •  Maintaining unused accounts violates the principle of least privilege.
 
-        Risk mitigation:
+        Risk mitigation
           •  Regularly review idle users and determine if they still need access.
           •  Suspend or remove users who no longer need tailnet access.
           •  Implement an offboarding process that includes removing tailnet access.


### PR DESCRIPTION
## Summary
- Standardize "Risk mitigation" section headers by removing inconsistent trailing colons across 5 security policy files
- Affected policies: GCP, GitLab, OCI, Snowflake, and Tailscale
- No content changes — formatting only

## Test plan
- [x] `cnspec policy lint` passes on all modified files
- [ ] Verify Markdown rendering of descriptions is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)