### PR TITLE
:broom: improve remediation step intro sentences

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -551,7 +551,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EKS clusters use KMS for Kubernetes secrets encryption using the AWS Console:
 
             1. Navigate to the Amazon EKS Console.
             2. Select the EKS cluster you want to configure.
@@ -561,9 +561,7 @@ queries:
             6. Save the changes to apply the new configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            To check if your EKS cluster is using a custom KMS key:
+            To ensure EKS clusters use KMS for Kubernetes secrets encryption using the AWS CLI, check if your EKS cluster is using a custom KMS key:
 
             ```bash
             aws eks describe-cluster --name <cluster_name> --query "cluster.encryptionConfig"
@@ -576,9 +574,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define an EKS cluster with a custom KMS key in your Terraform configuration:
+            To ensure EKS clusters use KMS for Kubernetes secrets encryption in Terraform, define an EKS cluster with a custom KMS key in your Terraform configuration:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -599,9 +595,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create an EKS cluster with a custom KMS key in your CloudFormation template:
+            To ensure EKS clusters use KMS for Kubernetes secrets encryption in CloudFormation, create an EKS cluster with a custom KMS key in your CloudFormation template:
 
             ```yaml
             Resources:
@@ -719,7 +713,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To configure EKS cluster networking to use a private VPC endpoint using the AWS Console:
 
             1. Navigate to the Amazon EKS Console.
             2. Select the EKS cluster you want to configure.
@@ -728,9 +722,7 @@ queries:
             5. Save the changes to apply the new configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            To check if your EKS cluster is using private endpoint access and not public endpoint access:
+            To configure EKS cluster networking to use a private VPC endpoint using the AWS CLI, check if your cluster is using private endpoint access:
 
             ```bash
             aws eks describe-cluster --name <cluster_name> --query "cluster.resourcesVpcConfig.{Private:endpointPrivateAccess, Public:endpointPublicAccess}"
@@ -745,9 +737,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define an EKS cluster with private endpoint access and public endpoint access disabled in your Terraform configuration:
+            To configure EKS cluster networking to use a private VPC endpoint in Terraform, define a cluster with private endpoint access enabled and public access disabled:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -763,9 +753,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create an EKS cluster with private endpoint access in your CloudFormation template:
+            To configure EKS cluster networking to use a private VPC endpoint in CloudFormation, create a cluster with private endpoint access enabled:
 
             ```yaml
             Resources:
@@ -860,7 +848,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure no root user account access key exists using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users → Root User.
@@ -871,9 +859,7 @@ queries:
             5.  Ensure that MFA is enabled for the root user for additional security.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if the root user has an access key:
+            To ensure no root user account access key exists using the AWS CLI, check if the root user has an access key:
 
             ```bash
             aws iam get-account-summary --query "SummaryMap.RootAccessKeysPresent"
@@ -888,9 +874,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            AWS does not allow direct management of the root user's access key via Terraform. However, you should enforce IAM policies that prevent the creation of root access keys:
+            To ensure no root user account access key exists in Terraform, AWS does not allow direct management of the root user's access key via Terraform. However, you should enforce IAM policies that prevent the creation of root access keys:
 
             ```hcl
             resource "aws_iam_policy" "deny_root_access_keys" {
@@ -911,9 +895,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            AWS does not allow direct management of the root user's access keys via CloudFormation. However, you can create a stack that implements preventative controls:
+            To ensure no root user account access key exists in CloudFormation, AWS does not allow direct management of the root user's access keys via CloudFormation. However, you can create a stack that implements preventative controls:
 
             ```yaml
             Resources:
@@ -1006,7 +988,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure MFA is enabled for the "root user" account using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users → Root User.
@@ -1018,9 +1000,7 @@ queries:
             6.  Enter the two consecutive MFA codes generated by the device and select Enable MFA.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if MFA is enabled for the root user:
+            To ensure MFA is enabled for the "root user" account using the AWS CLI, check if MFA is enabled for the root user:
 
             ```bash
             aws iam get-account-summary --query "SummaryMap.AccountMFAEnabled"
@@ -1041,9 +1021,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            AWS does not allow managing root MFA directly through Terraform. However, you can enforce a security policy that blocks root logins unless MFA is enabled:
+            To ensure MFA is enabled for the "root user" account in Terraform, AWS does not allow managing root MFA directly through Terraform. However, you can enforce a security policy that blocks root logins unless MFA is enabled:
 
             ```hcl
             resource "aws_iam_policy" "require_root_mfa" {
@@ -1069,7 +1047,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure MFA is enabled for the "root user" account in CloudFormation:
 
             ```yaml
             Resources:
@@ -1201,7 +1179,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To require uppercase characters in IAM passwords using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Account settings in the left panel.
@@ -1216,9 +1194,7 @@ queries:
             4.  Select Apply Password Policy to enforce these settings.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current password policy settings:
+            To require uppercase characters in IAM passwords using the AWS CLI, check the current password policy settings:
 
             ```bash
             aws iam get-account-password-policy
@@ -1239,9 +1215,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define a strict password policy using Terraform:
+            To require uppercase characters in IAM passwords in Terraform, define a strict password policy using Terraform:
 
             ```hcl
             resource "aws_iam_account_password_policy" "strong_policy" {
@@ -1257,9 +1231,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not support managing the IAM account password policy. There is no `AWS::IAM::AccountPasswordPolicy` resource type.
+            To require uppercase characters in IAM passwords in CloudFormation, note that CloudFormation does not support managing the IAM account password policy. There is no `AWS::IAM::AccountPasswordPolicy` resource type.
 
             Use the AWS CLI to configure the account password policy:
 
@@ -1379,7 +1351,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To define the maximum number of days an IAM key is allowed to exist before rotation using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users in the left panel.
@@ -1392,9 +1364,7 @@ queries:
             6.  Repeat this process for all IAM users with access keys.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all IAM users with active access keys:
+            To define the maximum number of days an IAM key is allowed to exist before rotation using the AWS CLI, list all IAM users with active access keys:
 
             ```bash
             aws iam list-users --query "Users[*].UserName"
@@ -1414,9 +1384,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            AWS does not support automatic access key rotation in Terraform, but you can enforce IAM policies to require regular key rotation:
+            To define the maximum number of days an IAM key is allowed to exist before rotation in Terraform, AWS does not support automatic access key rotation in Terraform, but you can enforce IAM policies to require regular key rotation:
 
             ```hcl
             resource "aws_iam_policy" "enforce_key_rotation" {
@@ -1442,7 +1410,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To define the maximum number of days an IAM key is allowed to exist before rotation in CloudFormation:
 
             ```yaml
             Resources:
@@ -1521,7 +1489,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure MFA is enabled for all IAM users with console access using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users in the left panel.
@@ -1535,9 +1503,7 @@ queries:
             7.  Repeat this process for all IAM users with console access.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List IAM users with console access and check their MFA status:
+            To ensure MFA is enabled for all IAM users with console access using the AWS CLI, list IAM users with console access and check their MFA status:
 
             ```bash
             aws iam list-users --query "Users[*].UserName"
@@ -1556,9 +1522,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            AWS does not allow enforcing MFA directly via Terraform, but you can create an IAM policy that denies access unless MFA is enabled:
+            To ensure MFA is enabled for all IAM users with console access in Terraform, AWS does not allow enforcing MFA directly via Terraform, but you can create an IAM policy that denies access unless MFA is enabled:
 
             ```hcl
             resource "aws_iam_policy" "enforce_mfa" {
@@ -1589,7 +1553,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure MFA is enabled for all IAM users with console access in CloudFormation:
 
             ```yaml
             Resources:
@@ -1702,7 +1666,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure IAM groups are utilized by assigning at least one user using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Groups in the left panel.
@@ -1714,9 +1678,7 @@ queries:
             5.  If an IAM group is not needed, consider deleting it to reduce clutter.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all IAM groups:
+            To ensure IAM groups are utilized by assigning at least one user using the AWS CLI, list all IAM groups:
 
             ```bash
             aws iam list-groups --query "Groups[*].GroupName"
@@ -1741,9 +1703,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure IAM users are assigned to groups in Terraform:
+            To ensure IAM groups are utilized by assigning at least one user in Terraform, ensure IAM users are assigned to groups in Terraform:
 
             ```hcl
             resource "aws_iam_group" "admins" {
@@ -1762,9 +1722,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation can manage IAM groups and group memberships. To ensure IAM groups have at least one user:
+            To ensure IAM groups are utilized by assigning at least one user in CloudFormation, CloudFormation can manage IAM groups and group memberships. To ensure IAM groups have at least one user:
 
             ```yaml
             Resources:
@@ -1866,7 +1824,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure IAM users have only one active access key using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users in the left panel.
@@ -1879,9 +1837,7 @@ queries:
               - If a key is needed for rotation, create a new key before deleting the old one.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all IAM users:
+            To ensure IAM users have only one active access key using the AWS CLI, list all IAM users:
 
             ```bash
             aws iam list-users --query "Users[*].UserName"
@@ -1901,9 +1857,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            AWS does not support direct enforcement of single active access keys in Terraform, but you can enforce a security policy to limit IAM users to one active key:
+            To ensure IAM users have only one active access key in Terraform, AWS does not support direct enforcement of single active access keys in Terraform, but you can enforce a security policy to limit IAM users to one active key:
 
             ```hcl
             resource "aws_iam_policy" "limit_access_keys" {
@@ -1929,7 +1883,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure IAM users have only one active access key in CloudFormation:
 
             ```yaml
             Resources:
@@ -2038,7 +1992,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure IAM users receive permissions only through groups using the AWS Console:
 
             1.  Navigate to the AWS IAM Console.
             2.  Select Users in the left panel.
@@ -2050,9 +2004,7 @@ queries:
               - Assign the user to an IAM group that grants the necessary permissions.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all IAM users and check if they have directly attached policies:
+            To ensure IAM users receive permissions only through groups using the AWS CLI, list all IAM users and check if they have directly attached policies:
 
             ```bash
             aws iam list-users --query "Users[*].UserName"
@@ -2089,9 +2041,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enforce group-based permissions and prevent direct policy assignments:
+            To ensure IAM users receive permissions only through groups in Terraform, enforce group-based permissions and prevent direct policy assignments:
 
             ```hcl
             resource "aws_iam_group" "developers" {
@@ -2110,9 +2060,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation can enforce that IAM users receive permissions through groups only:
+            To ensure IAM users receive permissions only through groups in CloudFormation, CloudFormation can enforce that IAM users receive permissions through groups only:
 
             ```yaml
             Resources:
@@ -2235,7 +2183,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure the default security group of every VPC restricts all traffic using the AWS Console:
 
             1.  Navigate to the AWS VPC Console.
             2.  Select Security Groups from the left panel.
@@ -2246,9 +2194,7 @@ queries:
             5.  Save the changes to ensure that the default security group does not allow any traffic.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all default security groups:
+            To ensure the default security group of every VPC restricts all traffic using the AWS CLI, list all default security groups:
 
             ```bash
             aws ec2 describe-security-groups --filters Name=group-name,Values=default --query "SecurityGroups[*].GroupId"
@@ -2267,9 +2213,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the default security group restricts all traffic:
+            To ensure the default security group of every VPC restricts all traffic in Terraform, ensure the default security group restricts all traffic:
 
             ```hcl
             resource "aws_default_security_group" "default_sg" {
@@ -2285,9 +2229,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation cannot directly manage or remove rules from a VPC's default security group. The default security group is automatically created with each VPC and cannot be deleted or have its rules managed through native CloudFormation resources.
+            To ensure the default security group of every VPC restricts all traffic in CloudFormation, note that CloudFormation cannot directly manage or remove rules from a VPC's default security group. The default security group is automatically created with each VPC and cannot be deleted or have its rules managed through native CloudFormation resources.
 
             To restrict the default security group, use one of these approaches:
 
@@ -2386,7 +2328,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS volume encryption is enabled by default using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select EC2 Dashboard > EBS > Settings.
@@ -2396,9 +2338,7 @@ queries:
             6.  Select Save changes to enforce encryption by default.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if EBS encryption is enabled by default:
+            To ensure EBS volume encryption is enabled by default using the AWS CLI, check if EBS encryption is enabled by default:
 
             ```bash
             aws ec2 get-ebs-encryption-by-default
@@ -2417,9 +2357,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure EBS encryption is enabled by default:
+            To ensure EBS volume encryption is enabled by default in Terraform, ensure EBS encryption is enabled by default:
 
             ```hcl
             resource "aws_ebs_encryption_by_default" "default_encryption" {}
@@ -2434,9 +2372,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not support enabling EBS encryption by default. There are no `AWS::EC2::EBSEncryptionByDefault` or `AWS::EC2::EBSDefaultKMSKey` resource types. This is an account-level setting that must be configured outside of CloudFormation.
+            To ensure EBS volume encryption is enabled by default in CloudFormation, note that CloudFormation does not support enabling EBS encryption by default. There are no `AWS::EC2::EBSEncryptionByDefault` or `AWS::EC2::EBSDefaultKMSKey` resource types. This is an account-level setting that must be configured outside of CloudFormation.
 
             Use the AWS CLI to enable EBS encryption by default:
 
@@ -2518,7 +2454,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure public access to S3 buckets is blocked at the account level using the AWS Console:
 
             1.  Navigate to the AWS S3 Console.
             2.  Select Block Public Access Settings for this Account.
@@ -2530,9 +2466,7 @@ queries:
             4.  Select Save Changes to enforce these settings at the account level.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if public access is blocked at the account level:
+            To ensure public access to S3 buckets is blocked at the account level using the AWS CLI, check if public access is blocked at the account level:
 
             ```bash
             aws s3control get-public-access-block --account-id <account-id>
@@ -2552,9 +2486,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure account-level S3 public access block settings are enforced:
+            To ensure public access to S3 buckets is blocked at the account level in Terraform, ensure account-level S3 public access block settings are enforced:
 
             ```hcl
             resource "aws_s3_account_public_access_block" "account_block" {
@@ -2566,9 +2498,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not support managing S3 Block Public Access at the account level. There is no `AWS::S3::AccountPublicAccessBlock` resource type. This is an account-level setting that must be configured outside of CloudFormation.
+            To ensure public access to S3 buckets is blocked at the account level in CloudFormation, note that CloudFormation does not support managing S3 Block Public Access at the account level. There is no `AWS::S3::AccountPublicAccessBlock` resource type. This is an account-level setting that must be configured outside of CloudFormation.
 
             Use the AWS CLI to enable account-level S3 Block Public Access:
 
@@ -2675,7 +2605,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon S3 buckets have public access restrictions enforced using the AWS Console:
 
             1.  Navigate to the AWS S3 Console.
             2.  Select a bucket and go to the Permissions tab.
@@ -2689,9 +2619,7 @@ queries:
             6.  Save changes and confirm that public access is fully restricted.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the public access block settings for a specific bucket:
+            To ensure Amazon S3 buckets have public access restrictions enforced using the AWS CLI, check the public access block settings for a specific bucket:
 
             ```bash
             aws s3api get-public-access-block --bucket <bucket-name>
@@ -2733,9 +2661,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure S3 public access block settings are enforced at the bucket level:
+            To ensure Amazon S3 buckets have public access restrictions enforced in Terraform, ensure S3 public access block settings are enforced at the bucket level:
 
             ```hcl
             resource "aws_s3_bucket_public_access_block" "secure_bucket" {
@@ -2776,9 +2702,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Use the `PublicAccessBlockConfiguration` property within the `AWS::S3::Bucket` resource to enable public access blocking at the bucket level:
+            To ensure Amazon S3 buckets have public access restrictions enforced in CloudFormation, use the `PublicAccessBlockConfiguration` property within the `AWS::S3::Bucket` resource to enable public access blocking at the bucket level:
 
             ```yaml
             Resources:
@@ -2916,7 +2840,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure no public IPs are associated with EC2 instances using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select Instances in the left panel.
@@ -2928,9 +2852,7 @@ queries:
             5.  If public access is necessary, use a bastion host, VPN, or AWS Systems Manager Session Manager instead of directly exposing the instance.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List EC2 instances with public IP addresses:
+            To ensure no public IPs are associated with EC2 instances using the AWS CLI, list EC2 instances with public IP addresses:
 
             ```bash
             aws ec2 describe-instances --query "Reservations[*].Instances[*].[InstanceId, PublicIpAddress]" --output table
@@ -2949,9 +2871,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure that EC2 instances are launched without public IPs:
+            To ensure no public IPs are associated with EC2 instances in Terraform, ensure that EC2 instances are launched without public IPs:
 
             ```hcl
             resource "aws_instance" "secure_instance" {
@@ -2977,9 +2897,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure that EC2 instances do not receive public IPs in CloudFormation templates:
+            To ensure no public IPs are associated with EC2 instances in CloudFormation, ensure that EC2 instances do not receive public IPs in CloudFormation templates:
 
             ```yaml
             Resources:
@@ -3077,7 +2995,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instances use IMDSv2 for metadata access using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select Instances in the left panel.
@@ -3091,9 +3009,7 @@ queries:
               - Select Save to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the IMDS version for all EC2 instances:
+            To ensure EC2 instances use IMDSv2 for metadata access using the AWS CLI, check the IMDS version for all EC2 instances:
 
             ```bash
             aws ec2 describe-instances --query "Reservations[*].Instances[*].{Instance:InstanceId, MetadataOptions:MetadataOptions}" --output table
@@ -3106,9 +3022,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure IMDSv2-only is enforced in Terraform:
+            To ensure EC2 instances use IMDSv2 for metadata access in Terraform, ensure IMDSv2-only is enforced in Terraform:
 
             ```hcl
             resource "aws_instance" "secure_instance" {
@@ -3128,9 +3042,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure IMDSv2-only in a CloudFormation template:
+            To ensure EC2 instances use IMDSv2 for metadata access in CloudFormation, configure IMDSv2-only in a CloudFormation template:
 
             ```yaml
             Resources:
@@ -3237,7 +3149,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure VPC Block Public Access (BPA) is enabled using the AWS Console:
 
             1. Navigate to the AWS VPC Console.
             2. Select Your VPCs from the left panel.
@@ -3248,9 +3160,7 @@ queries:
             7. Select Save changes to apply the settings.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable VPC Block Public Access for a specific VPC:
+            To ensure VPC Block Public Access (BPA) is enabled using the AWS CLI, enable VPC Block Public Access for a specific VPC:
 
             ```bash
             aws ec2 enable-vpc-block-public-access-v2 --vpc-ids vpc-12345678
@@ -3269,7 +3179,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure VPC Block Public Access (BPA) is enabled in Terraform:
 
             ```hcl
             resource "aws_vpc" "main" {
@@ -3292,9 +3202,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not support managing VPC Block Public Access. There are no `AWS::EC2::VPCBlockPublicAccess` or `AWS::EC2::VPCBlockPublicAccessExclusion` resource types.
+            To ensure VPC Block Public Access (BPA) is enabled in CloudFormation, note that CloudFormation does not support managing VPC Block Public Access. There are no `AWS::EC2::VPCBlockPublicAccess` or `AWS::EC2::VPCBlockPublicAccessExclusion` resource types.
 
             Use the AWS CLI to enable VPC Block Public Access:
 
@@ -3381,7 +3289,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure VPC flow logging is enabled in all VPCs using the AWS Console:
 
             1.  Navigate to the AWS VPC Console.
             2.  Select Your VPCs from the left panel.
@@ -3396,9 +3304,7 @@ queries:
               - Select Create to enable flow logging.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if VPC Flow Logs are enabled for all VPCs:
+            To ensure VPC flow logging is enabled in all VPCs using the AWS CLI, check if VPC Flow Logs are enabled for all VPCs:
 
             ```bash
             aws ec2 describe-flow-logs --query "FlowLogs[*].{VPC:ResourceId,LogGroup:LogGroupName}"
@@ -3417,9 +3323,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure that VPC Flow Logs are enabled in Terraform:
+            To ensure VPC flow logging is enabled in all VPCs in Terraform, ensure that VPC Flow Logs are enabled in Terraform:
 
             ```hcl
             resource "aws_flow_log" "vpc_flow_log" {
@@ -3434,9 +3338,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable VPC Flow Logs in CloudFormation:
+            To ensure VPC flow logging is enabled in all VPCs in CloudFormation, enable VPC Flow Logs in CloudFormation:
 
             ```yaml
             Resources:
@@ -3554,7 +3456,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS) using the AWS Console:
 
             1.  Navigate to the AWS DynamoDB Console.
             2.  Select Tables from the left panel.
@@ -3568,9 +3470,7 @@ queries:
               - Migrate data from the old table and delete the unencrypted table.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a DynamoDB table is encrypted with AWS KMS CMKs:
+            To ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS) using the AWS CLI, check if a DynamoDB table is encrypted with AWS KMS CMKs:
 
             ```bash
             aws dynamodb describe-table --table-name <table-name> --query "Table.SSEDescription"
@@ -3594,9 +3494,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure DynamoDB tables use KMS CMKs for encryption:
+            To ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS) in Terraform, ensure DynamoDB tables use KMS CMKs for encryption:
 
             ```hcl
             resource "aws_kms_key" "dynamodb_encryption" {
@@ -3621,9 +3519,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable KMS encryption for DynamoDB tables in CloudFormation:
+            To ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS) in CloudFormation, enable KMS encryption for DynamoDB tables in CloudFormation:
 
             ```yaml
             Resources:
@@ -3755,7 +3651,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda functions have concurrent execution limits using the AWS Console:
 
             1.  Navigate to the AWS Lambda Console.
             2.  Select Functions from the left panel.
@@ -3765,9 +3661,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current concurrency setting for a Lambda function:
+            To ensure Lambda functions have concurrent execution limits using the AWS CLI, check the current concurrency setting for a Lambda function:
 
             ```bash
             aws lambda get-function-concurrency --function-name <function-name>
@@ -3786,9 +3680,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure Lambda functions have a reserved concurrency limit:
+            To ensure Lambda functions have concurrent execution limits in Terraform, ensure Lambda functions have a reserved concurrency limit:
 
             ```hcl
             resource "aws_lambda_function" "secure_lambda" {
@@ -3803,9 +3695,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Define reserved concurrency settings for a Lambda function in CloudFormation:
+            To ensure Lambda functions have concurrent execution limits in CloudFormation, define reserved concurrency settings for a Lambda function in CloudFormation:
 
             ```yaml
             Resources:
@@ -3910,7 +3800,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure the policy attached to the lambda function prohibits public access using the AWS Console:
 
             1. Navigate to the AWS Lambda Console.
             2. Select Functions in the left panel.
@@ -3922,9 +3812,7 @@ queries:
             8. Select Save to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Get the current policy for a Lambda function:
+            To ensure the policy attached to the lambda function prohibits public access using the AWS CLI, get the current policy for a Lambda function:
 
             ```bash
             aws lambda get-policy --function-name <function-name>
@@ -3948,7 +3836,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure the policy attached to the lambda function prohibits public access in Terraform:
 
             ```hcl
             resource "aws_lambda_function" "secure_function" {
@@ -3973,7 +3861,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure the policy attached to the lambda function prohibits public access in CloudFormation:
 
             ```yaml
             Resources:
@@ -4060,7 +3948,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure no pending OS upgrades are available for RDS instances using the AWS Console:
 
             1. Navigate to the AWS RDS Console.
             2. Select Databases in the left panel.
@@ -4071,9 +3959,7 @@ queries:
             7. Select Upgrade operating system to apply the pending patches.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for RDS instances with pending OS upgrades:
+            To ensure no pending OS upgrades are available for RDS instances using the AWS CLI, check for RDS instances with pending OS upgrades:
 
             ```bash
             aws rds describe-pending-maintenance-actions
@@ -4098,7 +3984,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure no pending OS upgrades are available for RDS instances in Terraform:
 
             ```hcl
             # You can use auto minor version upgrades to reduce manual management
@@ -4120,7 +4006,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure no pending OS upgrades are available for RDS instances in CloudFormation:
 
             ```yaml
             Resources:
@@ -4186,7 +4072,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure all RDS instances are enabled for encryption-at-rest using the AWS Console:
 
             1. Navigate to the AWS RDS Console.
             2. Select Databases in the left panel.
@@ -4204,9 +4090,7 @@ queries:
             5. Once migration is complete, decommission the unencrypted instance.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a snapshot of the unencrypted instance:
+            To ensure all RDS instances are enabled for encryption-at-rest using the AWS CLI, create a snapshot of the unencrypted instance:
 
             ```bash
             aws rds create-db-snapshot \
@@ -4240,7 +4124,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure all RDS instances are enabled for encryption-at-rest in Terraform:
 
             ```hcl
             # Create a KMS key for RDS encryption
@@ -4271,7 +4155,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure all RDS instances are enabled for encryption-at-rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -4384,7 +4268,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS cluster parameter groups enforce encryption in transit using the AWS Console:
 
             1. Navigate to the AWS RDS Console.
             2. In the left navigation panel, select Parameter groups.
@@ -4403,9 +4287,7 @@ queries:
             10. Note that the cluster may require a reboot to apply the parameter change.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            First, check if the cluster parameter group has SSL enabled:
+            To ensure RDS cluster parameter groups enforce encryption in transit using the AWS CLI, first, check if the cluster parameter group has SSL enabled:
 
             ```bash
             aws rds describe-db-cluster-parameters \
@@ -4450,7 +4332,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS cluster parameter groups enforce encryption in transit in Terraform:
 
             ```hcl
             # Create a MySQL cluster parameter group with SSL enabled
@@ -4479,7 +4361,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS cluster parameter groups enforce encryption in transit in CloudFormation:
 
             ```yaml
             Resources:
@@ -4592,7 +4474,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure no pending OS upgrades are available for RDS clusters using the AWS Console:
 
             1. Navigate to the AWS RDS Console.
             2. Select Databases in the left panel.
@@ -4604,9 +4486,7 @@ queries:
             8. Select Upgrade operating system to apply the pending patches.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for pending maintenance actions on RDS clusters:
+            To ensure no pending OS upgrades are available for RDS clusters using the AWS CLI, check for pending maintenance actions on RDS clusters:
 
             ```bash
             aws rds describe-pending-maintenance-actions
@@ -4631,7 +4511,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure no pending OS upgrades are available for RDS clusters in Terraform:
 
             ```hcl
             # Ensure auto minor version upgrades are enabled to reduce manual management of OS patches
@@ -4660,7 +4540,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure no pending OS upgrades are available for RDS clusters in CloudFormation:
 
             ```yaml
             Resources:
@@ -4744,7 +4624,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure all RDS clusters are set to be encrypted-at-rest using the AWS Console:
 
             1. Navigate to the AWS RDS Console.
             2. Select Databases in the left panel.
@@ -4761,9 +4641,7 @@ queries:
             5. Once migration is complete, decommission the unencrypted cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Export data from unencrypted cluster (for MySQL):
+            To ensure all RDS clusters are set to be encrypted-at-rest using the AWS CLI, export data from unencrypted cluster (for MySQL):
 
             ```bash
             # Use the RDS export feature to S3
@@ -4807,7 +4685,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure all RDS clusters are set to be encrypted-at-rest in Terraform:
 
             ```hcl
             # Create a KMS key for RDS cluster encryption
@@ -4847,7 +4725,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure all RDS clusters are set to be encrypted-at-rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -4967,7 +4845,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure all RDS clusters are not publicly accessible using the AWS Console:
 
             1.  Navigate to the AWS RDS Console.
             2.  In the left panel, select Databases.
@@ -4989,9 +4867,7 @@ queries:
             7.  Confirm the security group allows access only from trusted sources—e.g., your app servers, bastion hosts, or VPN.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an RDS Cluster is publicly accessible:
+            To ensure all RDS clusters are not publicly accessible using the AWS CLI, check if an RDS Cluster is publicly accessible:
 
             ```bash
             aws rds describe-db-clusters --query "DBClusters[*].{DBClusterIdentifier:DBClusterIdentifier, PubliclyAccessible:PubliclyAccessible}"
@@ -5022,9 +4898,7 @@ queries:
             If any subnet used by the DB subnet group has MapPublicIpOnLaunch: true, consider moving the cluster to a private subnet group.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure RDS clusters are not publicly accessible:
+            To ensure all RDS clusters are not publicly accessible in Terraform, ensure RDS clusters are not publicly accessible:
 
             ```hcl
               resource "aws_rds_cluster" "secure_cluster" {
@@ -5053,9 +4927,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure RDS clusters are not publicly accessible:
+            To ensure all RDS clusters are not publicly accessible in CloudFormation, ensure RDS clusters are not publicly accessible:
 
             ```yaml
               Resources:
@@ -5162,7 +5034,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure all RDS instances are not publicly accessible using the AWS Console:
 
               1.  Navigate to the AWS RDS Console.
               2.  Select Databases in the left panel.
@@ -5175,9 +5047,7 @@ queries:
               6.  Ensure the instance is placed in a private subnet with security group rules allowing access only from authorized sources.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an RDS instance is publicly accessible:
+            To ensure all RDS instances are not publicly accessible using the AWS CLI, check if an RDS instance is publicly accessible:
 
             ```bash
             aws rds describe-db-instances --query "DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier, PubliclyAccessible:PubliclyAccessible}"
@@ -5198,9 +5068,7 @@ queries:
             If `MapPublicIpOnLaunch` is `true`, move the RDS instance to a private subnet.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure RDS instances are not publicly accessible:
+            To ensure all RDS instances are not publicly accessible in Terraform, ensure RDS instances are not publicly accessible:
 
             ```hcl
             resource "aws_db_instance" "secure_rds" {
@@ -5220,9 +5088,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure RDS instances are not publicly accessible:
+            To ensure all RDS instances are not publicly accessible in CloudFormation, ensure RDS instances are not publicly accessible:
 
             ```yaml
             Resources:
@@ -5330,7 +5196,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters are not publicly accessible using the AWS Console:
 
             1.  Navigate to the AWS Redshift Console.
             2.  Select Clusters in the left panel.
@@ -5343,9 +5209,7 @@ queries:
             6.  Ensure that the cluster is placed in a private subnet and that security groups restrict access to trusted sources only.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a Redshift cluster is publicly accessible:
+            To ensure Redshift clusters are not publicly accessible using the AWS CLI, check if a Redshift cluster is publicly accessible:
 
             ```bash
             aws redshift describe-clusters --query "Clusters[*].{Cluster:ClusterIdentifier, PubliclyAccessible:PubliclyAccessible}"
@@ -5366,9 +5230,7 @@ queries:
             If `MapPublicIpOnLaunch` is `true`, move the Redshift cluster to a private subnet.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure Redshift clusters are not publicly accessible:
+            To ensure Redshift clusters are not publicly accessible in Terraform, ensure Redshift clusters are not publicly accessible:
 
             ```hcl
             resource "aws_redshift_cluster" "secure_redshift" {
@@ -5387,9 +5249,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure Redshift clusters are not publicly accessible:
+            To ensure Redshift clusters are not publicly accessible in CloudFormation, ensure Redshift clusters are not publicly accessible:
 
             ```yaml
             Resources:
@@ -5488,7 +5348,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To configure instances to delete EBS volumes on termination using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select Instances in the left panel.
@@ -5499,9 +5359,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an EBS volume is set to delete on termination:
+            To configure instances to delete EBS volumes on termination using the AWS CLI, check if an EBS volume is set to delete on termination:
 
             ```bash
             aws ec2 describe-instances --query "Reservations[].Instances[].BlockDeviceMappings[?Ebs.DeleteOnTermination==`false`]" --output table
@@ -5514,9 +5372,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure EBS volumes delete on termination:
+            To configure instances to delete EBS volumes on termination in Terraform, ensure EBS volumes delete on termination:
 
             ```hcl
             resource "aws_instance" "secure_instance" {
@@ -5536,9 +5392,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure EBS volumes are deleted on termination:
+            To configure instances to delete EBS volumes on termination in CloudFormation, ensure EBS volumes are deleted on termination:
 
             ```yaml
             Resources:
@@ -5638,7 +5492,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS snapshots are not publicly restorable using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select Snapshots in the left panel.
@@ -5651,9 +5505,7 @@ queries:
               - Select Save Changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if any snapshots are publicly accessible:
+            To ensure EBS snapshots are not publicly restorable using the AWS CLI, check if any snapshots are publicly accessible:
 
             ```bash
             aws ec2 describe-snapshots --owner-id <account-id> --query "Snapshots[?Public].SnapshotId"
@@ -5666,9 +5518,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Note: It's not possible to set this on snapshot level via terraform, but you can use a global setting:
+            To ensure EBS snapshots are not publicly restorable in Terraform, note: It's not possible to set this on snapshot level via terraform, but you can use a global setting:
 
             ```hcl
             resource "aws_ebs_snapshot_block_public_access" "secure_snapshot" {
@@ -5677,9 +5527,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not support managing EBS snapshot block public access. There is no `AWS::EC2::SnapshotBlockPublicAccess` resource type. This is an account-level setting that must be configured outside of CloudFormation.
+            To ensure EBS snapshots are not publicly restorable in CloudFormation, note that CloudFormation does not support managing EBS snapshot block public access. There is no `AWS::EC2::SnapshotBlockPublicAccess` resource type. This is an account-level setting that must be configured outside of CloudFormation.
 
             Use the AWS CLI to block public access for EBS snapshots:
 
@@ -5759,7 +5607,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS Snapshots are configured to be encrypted at-rest using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Snapshots under the Elastic Block Store section.
@@ -5776,9 +5624,7 @@ queries:
             2. Enable EBS encryption by default.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for unencrypted snapshots:
+            To ensure EBS Snapshots are configured to be encrypted at-rest using the AWS CLI, check for unencrypted snapshots:
 
             ```bash
             aws ec2 describe-snapshots --owner-ids self --query "Snapshots[?Encrypted==`false`].SnapshotId"
@@ -5802,7 +5648,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EBS Snapshots are configured to be encrypted at-rest in Terraform:
 
             ```hcl
             # Enable default EBS encryption for the account
@@ -5841,9 +5687,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure that EBS snapshots are encrypted in CloudFormation:
+            To ensure EBS Snapshots are configured to be encrypted at-rest in CloudFormation, ensure that EBS snapshots are encrypted in CloudFormation:
 
             ```yaml
             Resources:
@@ -5959,7 +5803,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure attached EBS volumes are configured to be encrypted at-rest using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Volumes under the Elastic Block Store section.
@@ -5993,9 +5837,7 @@ queries:
                - Click Update.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for unencrypted volumes:
+            To ensure attached EBS volumes are configured to be encrypted at-rest using the AWS CLI, check for unencrypted volumes:
 
             ```bash
             aws ec2 describe-volumes --query "Volumes[?Encrypted==`false`].VolumeId"
@@ -6051,7 +5893,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure attached EBS volumes are configured to be encrypted at-rest in Terraform:
 
             ```hcl
             # Enable default EBS encryption for the account
@@ -6106,9 +5948,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure EBS volumes are encrypted:
+            To ensure attached EBS volumes are configured to be encrypted at-rest in CloudFormation, ensure EBS volumes are encrypted:
 
             ```yaml
             Resources:
@@ -6217,9 +6057,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            EBS encryption type cannot be changed in place. To migrate a volume from sse-ebs to sse-kms:
+            To ensure EBS volumes use KMS encryption instead of default using the AWS Console, EBS encryption type cannot be changed in place. To migrate a volume from sse-ebs to sse-kms:
 
             1. Navigate to the AWS EC2 Console and select **Volumes**.
             2. Create a snapshot of the existing volume:
@@ -6245,9 +6083,7 @@ queries:
             4. Select **Update**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the encryption type of existing volumes:
+            To ensure EBS volumes use KMS encryption instead of default using the AWS CLI, check the encryption type of existing volumes:
 
             ```bash
             aws ec2 describe-volumes --query "Volumes[*].{VolumeId:VolumeId,Encrypted:Encrypted,KmsKeyId:KmsKeyId}" --output table
@@ -6269,7 +6105,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EBS volumes use KMS encryption instead of default in Terraform:
 
             ```hcl
             resource "aws_kms_key" "ebs_encryption" {
@@ -6299,7 +6135,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EBS volumes use KMS encryption instead of default in CloudFormation:
 
             ```yaml
             Resources:
@@ -6401,7 +6237,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EFS is configured to encrypt file data using KMS using the AWS Console:
 
             1.  Navigate to the AWS EFS Console.
             2.  Select File Systems from the left panel.
@@ -6416,9 +6252,7 @@ queries:
             6.  Once data migration is complete, delete the old unencrypted file system.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an EFS file system is encrypted:
+            To ensure EFS is configured to encrypt file data using KMS using the AWS CLI, check if an EFS file system is encrypted:
 
             ```bash
             aws efs describe-file-systems --query "FileSystems[*].{FileSystemId:FileSystemId, Encrypted:Encrypted}"
@@ -6431,9 +6265,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure EFS encryption is enabled with an AWS KMS key:
+            To ensure EFS is configured to encrypt file data using KMS in Terraform, ensure EFS encryption is enabled with an AWS KMS key:
 
             ```hcl
             resource "aws_kms_key" "efs_encryption_key" {
@@ -6448,9 +6280,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure EFS file systems are encrypted using AWS KMS:
+            To ensure EFS is configured to encrypt file data using KMS in CloudFormation, ensure EFS file systems are encrypted using AWS KMS:
 
             ```yaml
             Resources:
@@ -6562,7 +6392,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudWatch Logs are encrypted at rest using KMS CMKs using the AWS Console:
 
             1.  Navigate to the AWS CloudWatch Console.
             2.  Select Log Groups from the left panel.
@@ -6574,9 +6404,7 @@ queries:
               - Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a CloudWatch log group is encrypted with a KMS CMK:
+            To ensure CloudWatch Logs are encrypted at rest using KMS CMKs using the AWS CLI, check if a CloudWatch log group is encrypted with a KMS CMK:
 
             ```bash
             aws logs describe-log-groups --query "logGroups[*].{LogGroupName:logGroupName, KmsKeyId:kmsKeyId}"
@@ -6589,9 +6417,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure CloudWatch Logs use KMS encryption:
+            To ensure CloudWatch Logs are encrypted at rest using KMS CMKs in Terraform, ensure CloudWatch Logs use KMS encryption:
 
             ```hcl
             resource "aws_kms_key" "cloudwatch_kms_key" {
@@ -6606,9 +6432,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure CloudWatch Logs are encrypted using AWS KMS:
+            To ensure CloudWatch Logs are encrypted at rest using KMS CMKs in CloudFormation, ensure CloudWatch Logs are encrypted using AWS KMS:
 
             ```yaml
             Resources:
@@ -6721,7 +6545,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To enforce allowed TLS policies on ALBs using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Load Balancers under the Load Balancing section.
@@ -6735,9 +6559,7 @@ queries:
             7. Select Save changes to apply the updated security policy.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Identify listeners for your load balancer:
+            To enforce allowed TLS policies on ALBs using the AWS CLI, identify listeners for your load balancer:
 
             ```bash
             aws elbv2 describe-listeners --load-balancer-arn arn:aws:elasticloadbalancing:region:account-id:loadbalancer/app/my-load-balancer/1234567890abcdef
@@ -6760,7 +6582,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To enforce allowed TLS policies on ALBs in Terraform:
 
             ```hcl
             resource "aws_lb" "secure_alb" {
@@ -6786,7 +6608,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To enforce allowed TLS policies on ALBs in CloudFormation:
 
             ```yaml
             Resources:
@@ -6909,7 +6731,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Application Load Balancers are configured with HTTPS listeners using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Load Balancers under the Load Balancing section.
@@ -6933,9 +6755,7 @@ queries:
             8. Select Save changes to apply the updated configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an HTTPS listener:
+            To ensure Application Load Balancers are configured with HTTPS listeners using the AWS CLI, create an HTTPS listener:
 
             ```bash
             aws elbv2 create-listener \
@@ -6958,7 +6778,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Load Balancers are configured with HTTPS listeners in Terraform:
 
             ```hcl
             resource "aws_lb" "secure_alb" {
@@ -7002,7 +6822,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Application Load Balancers are configured with HTTPS listeners in CloudFormation:
 
             ```yaml
             Resources:
@@ -7131,7 +6951,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Application Load Balancers have logging enabled using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Load Balancers under the Load Balancing section.
@@ -7146,9 +6966,7 @@ queries:
             Note: Ensure the S3 bucket has the appropriate permissions to allow the ELB to write logs.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable access logs for a load balancer:
+            To ensure Application Load Balancers have logging enabled using the AWS CLI, enable access logs for a load balancer:
 
             ```bash
             aws elbv2 modify-load-balancer-attributes \
@@ -7185,7 +7003,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Load Balancers have logging enabled in Terraform:
 
             ```hcl
             # S3 bucket for ALB access logs
@@ -7236,7 +7054,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Application Load Balancers have logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -7367,7 +7185,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Application Load Balancers have deletion protection using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Load Balancers under the Load Balancing section.
@@ -7380,9 +7198,7 @@ queries:
               - Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an ALB has deletion protection enabled:
+            To ensure Application Load Balancers have deletion protection using the AWS CLI, check if an ALB has deletion protection enabled:
 
             ```bash
             aws elbv2 describe-load-balancers --query "LoadBalancers[*].{Name:LoadBalancerName, DeletionProtectionEnabled:Attributes[?Key=='deletion_protection.enabled'].Value | [0]}"
@@ -7397,9 +7213,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure ALBs have deletion protection enabled:
+            To ensure Application Load Balancers have deletion protection in Terraform, ensure ALBs have deletion protection enabled:
 
             ```hcl
             resource "aws_lb" "secure_alb" {
@@ -7414,9 +7228,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable deletion protection for ALBs:
+            To ensure Application Load Balancers have deletion protection in CloudFormation, enable deletion protection for ALBs:
 
             ```yaml
             Resources:
@@ -7521,7 +7333,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Elasticsearch Service domains have encryption at rest using the AWS Console:
 
             1.  Navigate to the Amazon Elasticsearch Service Console.
             2.  Select Domains in the left panel.
@@ -7535,9 +7347,7 @@ queries:
             6.  Migrate data from the unencrypted domain to the new encrypted domain, then delete the unencrypted domain.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an Elasticsearch domain is encrypted:
+            To ensure Elasticsearch Service domains have encryption at rest using the AWS CLI, check if an Elasticsearch domain is encrypted:
 
             ```bash
             aws es describe-elasticsearch-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
@@ -7552,9 +7362,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure Elasticsearch Service encryption is enabled using AWS KMS:
+            To ensure Elasticsearch Service domains have encryption at rest in Terraform, ensure Elasticsearch Service encryption is enabled using AWS KMS:
 
             ```hcl
             resource "aws_kms_key" "es_kms_key" {
@@ -7574,9 +7382,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable encryption at rest for Elasticsearch domains:
+            To ensure Elasticsearch Service domains have encryption at rest in CloudFormation, enable encryption at rest for Elasticsearch domains:
 
             ```yaml
             Resources:
@@ -7681,7 +7487,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon Elasticsearch Service domains use node-to-node encryption using the AWS Console:
 
             1. Navigate to the Amazon Elasticsearch Service Console.
             2. Select the domain you want to update.
@@ -7692,9 +7498,7 @@ queries:
             Note: Enabling node-to-node encryption on an existing domain requires a blue/green deployment. Plan for potential downtime.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if node-to-node encryption is enabled:
+            To ensure Amazon Elasticsearch Service domains use node-to-node encryption using the AWS CLI, check if node-to-node encryption is enabled:
 
             ```bash
             aws es describe-elasticsearch-domain --domain-name <domain-name> \
@@ -7709,7 +7513,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon Elasticsearch Service domains use node-to-node encryption in Terraform:
 
             ```hcl
             resource "aws_elasticsearch_domain" "example" {
@@ -7723,7 +7527,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon Elasticsearch Service domains use node-to-node encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -7825,7 +7629,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure rotation for customer-managed keys (CMKs) is enabled using the AWS Console:
 
             1.  Navigate to the AWS KMS Console.
             2.  Select Customer managed keys in the left panel.
@@ -7836,9 +7640,7 @@ queries:
               - Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if key rotation is enabled for all customer-managed CMKs:
+            To ensure rotation for customer-managed keys (CMKs) is enabled using the AWS CLI, check if key rotation is enabled for all customer-managed CMKs:
 
             ```bash
             aws kms list-keys --query "Keys[*].KeyId" | while read -r key_id; do
@@ -7853,9 +7655,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure KMS key rotation is enabled:
+            To ensure rotation for customer-managed keys (CMKs) is enabled in Terraform, ensure KMS key rotation is enabled:
 
             ```hcl
             resource "aws_kms_key" "secure_kms_key" {
@@ -7865,9 +7665,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable KMS key rotation for CMKs:
+            To ensure rotation for customer-managed keys (CMKs) is enabled in CloudFormation, enable KMS key rotation for CMKs:
 
             ```yaml
             Resources:
@@ -7964,7 +7762,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker notebook instances are configured to use KMS using the AWS Console:
 
             1.  Navigate to the AWS SageMaker Console.
             2.  Select Notebook instances in the left panel.
@@ -7977,9 +7775,7 @@ queries:
             6.  Delete the unencrypted notebook instance once migration is complete.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if SageMaker notebook instances are encrypted with KMS:
+            To ensure SageMaker notebook instances are configured to use KMS using the AWS CLI, check if SageMaker notebook instances are encrypted with KMS:
 
             ```bash
             aws sagemaker list-notebook-instances --query "NotebookInstances[*].{Name:NotebookInstanceName, KmsKeyId:KmsKeyId}"
@@ -7996,9 +7792,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker notebook instances are encrypted using a KMS key:
+            To ensure SageMaker notebook instances are configured to use KMS in Terraform, ensure SageMaker notebook instances are encrypted using a KMS key:
 
             ```hcl
             resource "aws_kms_key" "sagemaker_kms_key" {
@@ -8015,7 +7809,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker notebook instances are configured to use KMS in CloudFormation:
 
             ```yaml
             Resources:
@@ -8119,7 +7913,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail log file validation is enabled using the AWS Console:
 
             1. Navigate to the AWS CloudTrail Console.
             2. Select Trails in the left panel.
@@ -8130,9 +7924,7 @@ queries:
             7. Select Save changes to update the trail.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if log file validation is enabled for a specific trail:
+            To ensure CloudTrail log file validation is enabled using the AWS CLI, check if log file validation is enabled for a specific trail:
 
             ```bash
             aws cloudtrail describe-trails \
@@ -8157,7 +7949,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudTrail log file validation is enabled in Terraform:
 
             ```hcl
             # Create a secure CloudTrail trail with log file validation enabled
@@ -8211,7 +8003,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudTrail log file validation is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -8329,7 +8121,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail trails use KMS server-side encryption using the AWS Console:
 
             1.  Navigate to the AWS CloudTrail Console.
             2.  Select Trails in the left panel.
@@ -8342,9 +8134,7 @@ queries:
               - Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a CloudTrail trail is using KMS encryption:
+            To ensure CloudTrail trails use KMS server-side encryption using the AWS CLI, check if a CloudTrail trail is using KMS encryption:
 
             ```bash
             aws cloudtrail describe-trails --query "trailList[*].{TrailName:Name, KmsKeyId:KmsKeyId}"
@@ -8357,9 +8147,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure CloudTrail is encrypted with KMS:
+            To ensure CloudTrail trails use KMS server-side encryption in Terraform, ensure CloudTrail is encrypted with KMS:
 
             ```hcl
             resource "aws_kms_key" "cloudtrail_kms_key" {
@@ -8376,9 +8164,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable CloudTrail encryption using KMS:
+            To ensure CloudTrail trails use KMS server-side encryption in CloudFormation, enable CloudTrail encryption using KMS:
 
             ```yaml
             Resources:
@@ -8484,7 +8270,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure security groups restrict incoming SSH traffic using the AWS Console:
 
             1.  Navigate to the Amazon EC2 Console.
             2.  Select Security Groups from the left navigation panel.
@@ -8493,9 +8279,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check security groups with unrestricted SSH access:
+            To ensure security groups restrict incoming SSH traffic using the AWS CLI, check security groups with unrestricted SSH access:
 
             ```bash
             aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?FromPort==`22` && (IpRanges[].CidrIp=='0.0.0.0/0' || Ipv6Ranges[].CidrIpv6=='::/0')]].GroupId"
@@ -8514,9 +8298,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SSH access is restricted to a specific IP range:
+            To ensure security groups restrict incoming SSH traffic in Terraform, ensure SSH access is restricted to a specific IP range:
 
             ```hcl
             resource "aws_security_group" "secure_sg" {
@@ -8539,9 +8321,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            This template ensures that SSH access (port 22) is only allowed from a specific IP range (e.g., a corporate VPN or a bastion host):
+            To ensure security groups restrict incoming SSH traffic in CloudFormation, this template ensures that SSH access (port 22) is only allowed from a specific IP range (e.g., a corporate VPN or a bastion host):
 
             ```yaml
             Resources:
@@ -8658,7 +8438,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure security groups restrict incoming VNC traffic using the AWS Console:
 
             1.  Navigate to the Amazon EC2 Console.
             2.  Select Security Groups from the left navigation panel.
@@ -8668,9 +8448,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check security groups with unrestricted VNC access:
+            To ensure security groups restrict incoming VNC traffic using the AWS CLI, check security groups with unrestricted VNC access:
 
             ```bash
             aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?((FromPort==`5900` || FromPort==`5901` || FromPort==`5902` || FromPort==`5903`) && (IpRanges[].CidrIp=='0.0.0.0/0' || Ipv6Ranges[].CidrIpv6=='::/0'))]].GroupId"
@@ -8713,9 +8491,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure security groups restrict VNC access to a specific IP range:
+            To ensure security groups restrict incoming VNC traffic in CloudFormation, ensure security groups restrict VNC access to a specific IP range:
 
             ```yaml
             Resources:
@@ -8839,7 +8615,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure security groups restrict incoming RDP traffic using the AWS Console:
 
             1.  Navigate to the Amazon EC2 Console.
             2.  Select Security Groups from the left navigation panel.
@@ -8849,9 +8625,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for security groups with unrestricted RDP access:
+            To ensure security groups restrict incoming RDP traffic using the AWS CLI, check for security groups with unrestricted RDP access:
 
             ```bash
             aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?FromPort==`3389` && (IpRanges[].CidrIp=='0.0.0.0/0' || Ipv6Ranges[].CidrIpv6=='::/0')]].GroupId"
@@ -8870,9 +8644,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure security groups restrict RDP access to a specific IP range:
+            To ensure security groups restrict incoming RDP traffic in Terraform, ensure security groups restrict RDP access to a specific IP range:
 
             ```hcl
             resource "aws_security_group" "restricted_rdp" {
@@ -8896,9 +8668,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure security groups do not allow unrestricted RDP access:
+            To ensure security groups restrict incoming RDP traffic in CloudFormation, ensure security groups do not allow unrestricted RDP access:
 
             ```yaml
             Resources:
@@ -9013,7 +8783,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure security groups restrict access to specific IPs and ports using the AWS Console:
 
             1.  Navigate to the AWS EC2 Console.
             2.  Select Security Groups in the left panel.
@@ -9025,9 +8795,7 @@ queries:
             5.  Repeat for outbound rules, ensuring traffic is limited to necessary destinations.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check security groups for unrestricted inbound rules:
+            To ensure security groups restrict access to specific IPs and ports using the AWS CLI, check security groups for unrestricted inbound rules:
 
             ```bash
             aws ec2 describe-security-groups --query "SecurityGroups[*].{ID:GroupId, Name:GroupName, Ingress:IpPermissions[*]}"
@@ -9054,9 +8822,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure security groups do not allow open access:
+            To ensure security groups restrict access to specific IPs and ports in Terraform, ensure security groups do not allow open access:
 
             ```hcl
             resource "aws_security_group" "restricted_sg" {
@@ -9082,9 +8848,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure security groups do not allow unrestricted access:
+            To ensure security groups restrict access to specific IPs and ports in CloudFormation, ensure security groups do not allow unrestricted access:
 
             ```yaml
             Resources:
@@ -9189,16 +8953,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Terraform AWS providers do not contain hard-coded credentials using the AWS Console:
 
             1. This check applies to Terraform configuration files, not the AWS Console.
             2. Review your Terraform provider blocks and remove any hard-coded `access_key` or `secret_key` values.
             3. Use environment variables, IAM roles, or AWS credential files instead.
         - id: terraform
           desc: |
-            **Using Environment Variables**
-
-            Configure AWS credentials using environment variables instead of hard-coding them:
+            To ensure Terraform AWS providers do not contain hard-coded credentials using environment variables, configure AWS credentials using environment variables instead of hard-coding them:
 
             ```bash
             export AWS_ACCESS_KEY_ID="your-access-key"
@@ -9211,9 +8973,7 @@ queries:
             provider "aws" {}
             ```
 
-            **Using Assumed Role**
-
-            Use IAM roles for authentication:
+            To ensure Terraform AWS providers do not contain hard-coded credentials using an assumed role, use IAM roles for authentication:
 
             ```hcl
             provider "aws" {
@@ -9225,9 +8985,7 @@ queries:
             }
             ```
 
-            **Using AWS Profiles**
-
-            Configure AWS CLI profiles and reference them in Terraform:
+            To ensure Terraform AWS providers do not contain hard-coded credentials using AWS profiles, configure AWS CLI profiles and reference them in Terraform:
 
             ```hcl
             provider "aws" {
@@ -9237,9 +8995,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            This check is specific to Terraform provider configurations and is not applicable to CloudFormation templates. CloudFormation uses IAM roles and AWS STS for authentication rather than static credentials in templates.
+            To ensure Terraform AWS providers do not contain hard-coded credentials in CloudFormation, this check is specific to Terraform provider configurations and is not applicable to CloudFormation templates. CloudFormation uses IAM roles and AWS STS for authentication rather than static credentials in templates.
     refs:
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration
         title: Terraform AWS Provider - Authentication and Configuration
@@ -9316,7 +9072,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure API Gateway cache is enabled and encrypted using the AWS Console:
 
             1.  Navigate to the Amazon API Gateway Console.
             2.  Select the desired API and stage.
@@ -9325,8 +9081,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-            Enable cache encryption for a specific method:
+            To ensure API Gateway cache is enabled and encrypted using the AWS CLI, enable cache encryption for a specific method:
 
             ```bash
             aws apigateway update-method-settings \
@@ -9336,9 +9091,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable cache encryption in API Gateway method settings:
+            To ensure API Gateway cache is enabled and encrypted in Terraform, enable cache encryption in API Gateway method settings:
 
             ```hcl
             resource "aws_api_gateway_method_settings" "example" {
@@ -9356,7 +9109,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure API Gateway cache is enabled and encrypted in CloudFormation:
 
             ```yaml
             Resources:
@@ -9457,7 +9210,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure API Gateway stages have execution logging enabled using the AWS Console:
 
             1.  Navigate to the Amazon API Gateway Console.
             2.  Select the desired API and stage.
@@ -9467,9 +9220,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable access logging for an API Gateway stage:
+            To ensure API Gateway stages have execution logging enabled using the AWS CLI, enable access logging for an API Gateway stage:
 
             ```bash
             aws apigateway update-stage \
@@ -9480,9 +9231,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable access logging for API Gateway stages:
+            To ensure API Gateway stages have execution logging enabled in Terraform, enable access logging for API Gateway stages:
 
             ```hcl
             resource "aws_api_gateway_stage" "example" {
@@ -9509,7 +9258,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure API Gateway stages have execution logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -9610,7 +9359,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure API Gateway methods require authentication using the AWS Console:
 
             1.  Navigate to the Amazon API Gateway Console.
             2.  Select the desired API and resource/method.
@@ -9620,9 +9369,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update method authorization for an API Gateway method:
+            To ensure API Gateway methods require authentication using the AWS CLI, update method authorization for an API Gateway method:
 
             ```bash
             aws apigateway update-method \
@@ -9633,9 +9380,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure authentication for API Gateway methods:
+            To ensure API Gateway methods require authentication in Terraform, configure authentication for API Gateway methods:
 
             ```hcl
             resource "aws_api_gateway_method" "example" {
@@ -9659,7 +9404,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure API Gateway methods require authentication in CloudFormation:
 
             ```yaml
             Resources:
@@ -9753,7 +9498,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure API Gateway uses TLS 1.2 or higher using the AWS Console:
 
             1.  Navigate to the Amazon API Gateway Console.
             2.  Select "Custom Domain Names" from the left panel.
@@ -9762,9 +9507,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the security policy for an API Gateway custom domain name:
+            To ensure API Gateway uses TLS 1.2 or higher using the AWS CLI, update the security policy for an API Gateway custom domain name:
 
             ```bash
             aws apigateway update-domain-name \
@@ -9773,9 +9516,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure TLS 1.2 for API Gateway custom domain names:
+            To ensure API Gateway uses TLS 1.2 or higher in Terraform, configure TLS 1.2 for API Gateway custom domain names:
 
             ```hcl
             resource "aws_api_gateway_domain_name" "example" {
@@ -9790,7 +9531,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure API Gateway uses TLS 1.2 or higher in CloudFormation:
 
             ```yaml
             Resources:
@@ -9891,7 +9632,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure API Gateway X-Ray tracing is enabled using the AWS Console:
 
             1.  Navigate to the Amazon API Gateway Console.
             2.  Select the desired API and stage.
@@ -9900,9 +9641,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable X-Ray tracing for an API Gateway stage:
+            To ensure API Gateway X-Ray tracing is enabled using the AWS CLI, enable X-Ray tracing for an API Gateway stage:
 
             ```bash
             aws apigateway update-stage \
@@ -9912,9 +9651,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable X-Ray tracing for API Gateway stages:
+            To ensure API Gateway X-Ray tracing is enabled in Terraform, enable X-Ray tracing for API Gateway stages:
 
             ```hcl
             resource "aws_api_gateway_stage" "example" {
@@ -9926,7 +9663,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure API Gateway X-Ray tracing is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -10019,7 +9756,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instance user data does not contain secrets using the AWS Console:
 
             1.  Navigate to the EC2 Console.
             2.  Select the instance and go to the "Actions" menu.
@@ -10028,9 +9765,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the user data for an EC2 instance to remove hard-coded secrets:
+            To ensure EC2 instance user data does not contain secrets using the AWS CLI, update the user data for an EC2 instance to remove hard-coded secrets:
 
             ```bash
             aws ec2 modify-instance-attribute \
@@ -10039,9 +9774,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Instead of embedding secrets in user data, use IAM roles or AWS Secrets Manager:
+            To ensure EC2 instance user data does not contain secrets in Terraform, instead of embedding secrets in user data, use IAM roles or AWS Secrets Manager:
 
             ```hcl
             resource "aws_instance" "example" {
@@ -10161,7 +9894,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure IAM policies do not use wildcards and apply least privilege using the AWS Console:
 
             1.  Navigate to the IAM Console.
             2.  Select "Policies" from the left panel.
@@ -10170,9 +9903,7 @@ queries:
             5.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update an IAM policy to replace wildcard resources:
+            To ensure IAM policies do not use wildcards and apply least privilege using the AWS CLI, update an IAM policy to replace wildcard resources:
 
             ```bash
             aws iam create-policy-version \
@@ -10182,9 +9913,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Replace wildcard resources with specific ARNs:
+            To ensure IAM policies do not use wildcards and apply least privilege in Terraform, replace wildcard resources with specific ARNs:
 
             ```hcl
             resource "aws_iam_policy" "example" {
@@ -10215,9 +9944,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Replace wildcard resources with specific ARNs in IAM policy documents:
+            To ensure IAM policies do not use wildcards and apply least privilege in CloudFormation, replace wildcard resources with specific ARNs in IAM policy documents:
 
             ```yaml
             Resources:
@@ -10384,7 +10111,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 bucket versioning is enabled using the AWS Console:
 
             1.  Navigate to the Amazon S3 Console.
             2.  Select the desired bucket.
@@ -10393,9 +10120,7 @@ queries:
             5.  Enable versioning and save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable versioning for an S3 bucket:
+            To ensure S3 bucket versioning is enabled using the AWS CLI, enable versioning for an S3 bucket:
 
             ```bash
             aws s3api put-bucket-versioning \
@@ -10404,9 +10129,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform (AWS Provider 4.x)**
-
-            Enable versioning for S3 buckets:
+            To ensure S3 bucket versioning is enabled in Terraform (AWS Provider 4.x), enable versioning for S3 buckets:
 
             ```hcl
             resource "aws_s3_bucket" "example" {
@@ -10422,7 +10145,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure S3 bucket versioning is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -10521,7 +10244,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 bucket logging is enabled using the AWS Console:
 
             1.  Navigate to the Amazon S3 Console.
             2.  Select the desired bucket.
@@ -10530,9 +10253,7 @@ queries:
             5.  Enable logging, specify a target bucket and prefix, and save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable logging for an S3 bucket:
+            To ensure S3 bucket logging is enabled using the AWS CLI, enable logging for an S3 bucket:
 
             ```bash
             aws s3api put-bucket-logging \
@@ -10546,9 +10267,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable logging for S3 buckets:
+            To ensure S3 bucket logging is enabled in Terraform, enable logging for S3 buckets:
 
             ```hcl
             resource "aws_s3_bucket" "example" {
@@ -10564,7 +10283,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure S3 bucket logging is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -10664,7 +10383,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 bucket server-side encryption is enabled using the AWS Console:
 
             1.  Navigate to the Amazon S3 Console.
             2.  Select the desired bucket.
@@ -10673,9 +10392,7 @@ queries:
             5.  Enable default encryption using SSE-S3 or SSE-KMS and save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable default server-side encryption for an S3 bucket using SSE-KMS:
+            To ensure S3 bucket server-side encryption is enabled using the AWS CLI, enable default server-side encryption for an S3 bucket using SSE-KMS:
 
             ```bash
             aws s3api put-bucket-encryption \
@@ -10693,9 +10410,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable server-side encryption for S3 buckets:
+            To ensure S3 bucket server-side encryption is enabled in Terraform, enable server-side encryption for S3 buckets:
 
             ```hcl
             resource "aws_s3_bucket" "example" {
@@ -10715,7 +10430,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure S3 bucket server-side encryption is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -10815,7 +10530,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 buckets do not allow public read access via ACLs using the AWS Console:
 
             1.  Navigate to the Amazon S3 Console.
             2.  Select the desired bucket.
@@ -10825,9 +10540,7 @@ queries:
             6.  Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Set the ACL of an S3 bucket to private:
+            To ensure S3 buckets do not allow public read access via ACLs using the AWS CLI, set the ACL of an S3 bucket to private:
 
             ```bash
             aws s3api put-bucket-acl \
@@ -10836,9 +10549,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use bucket public access blocks to prevent public access:
+            To ensure S3 buckets do not allow public read access via ACLs in Terraform, use bucket public access blocks to prevent public access:
 
             ```hcl
             resource "aws_s3_bucket_public_access_block" "example" {
@@ -10852,7 +10563,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure S3 buckets do not allow public read access via ACLs in CloudFormation:
 
             ```yaml
             Resources:
@@ -10952,7 +10663,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 bucket static website hosting is disabled using the AWS Console:
 
             1. Navigate to the Amazon S3 Console.
             2. Select the desired bucket.
@@ -10961,16 +10672,14 @@ queries:
             5. Select "Disable" and save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure S3 bucket static website hosting is disabled using the AWS CLI:
 
             ```bash
             aws s3api delete-bucket-website --bucket <bucket-name>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Remove any `aws_s3_bucket_website_configuration` resources associated with the bucket:
+            To ensure S3 bucket static website hosting is disabled in Terraform, remove any `aws_s3_bucket_website_configuration` resources associated with the bucket:
 
             ```hcl
             # Remove or comment out website configuration resources
@@ -11063,7 +10772,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail is enabled in all regions with a multi-region trail using the AWS Console:
 
             1. Navigate to the AWS CloudTrail Console.
             2. Select Trails in the left panel.
@@ -11073,9 +10782,7 @@ queries:
             6. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if any trail is configured as a multi-region trail:
+            To ensure CloudTrail is enabled in all regions with a multi-region trail using the AWS CLI, check if any trail is configured as a multi-region trail:
 
             ```bash
             aws cloudtrail describe-trails \
@@ -11099,7 +10806,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudTrail is enabled in all regions with a multi-region trail in Terraform:
 
             ```hcl
             resource "aws_cloudtrail" "multi_region_trail" {
@@ -11113,7 +10820,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudTrail is enabled in all regions with a multi-region trail in CloudFormation:
 
             ```yaml
             Resources:
@@ -11205,7 +10912,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudFront distributions require HTTPS for viewer connections using the AWS Console:
 
             1. Navigate to the Amazon CloudFront Console.
             2. Select the distribution you want to update.
@@ -11216,9 +10923,7 @@ queries:
             7. Repeat for any additional cache behaviors.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the viewer protocol policy for a distribution:
+            To ensure CloudFront distributions require HTTPS for viewer connections using the AWS CLI, check the viewer protocol policy for a distribution:
 
             ```bash
             aws cloudfront get-distribution-config --id <distribution-id> \
@@ -11236,7 +10941,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudFront distributions require HTTPS for viewer connections in Terraform:
 
             ```hcl
             resource "aws_cloudfront_distribution" "secure_distribution" {
@@ -11275,7 +10980,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudFront distributions require HTTPS for viewer connections in CloudFormation:
 
             ```yaml
             Resources:
@@ -11387,7 +11092,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon EKS control plane logging is enabled using the AWS Console:
 
             1. Navigate to the Amazon EKS Console.
             2. Select the EKS cluster you want to configure.
@@ -11396,9 +11101,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current logging configuration for an EKS cluster:
+            To ensure Amazon EKS control plane logging is enabled using the AWS CLI, check the current logging configuration for an EKS cluster:
 
             ```bash
             aws eks describe-cluster --name <cluster_name> \
@@ -11413,7 +11116,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon EKS control plane logging is enabled in Terraform:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -11435,7 +11138,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon EKS control plane logging is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -11544,7 +11247,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure OpenSearch Service domains have encryption at rest using the AWS Console:
 
             1.  Navigate to the Amazon OpenSearch Service Console.
             2.  Select Domains in the left panel.
@@ -11558,9 +11261,7 @@ queries:
             6.  Migrate data from the unencrypted domain to the new encrypted domain, then delete the unencrypted domain.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an OpenSearch domain is encrypted:
+            To ensure OpenSearch Service domains have encryption at rest using the AWS CLI, check if an OpenSearch domain is encrypted:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
@@ -11575,9 +11276,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure OpenSearch Service encryption is enabled using AWS KMS:
+            To ensure OpenSearch Service domains have encryption at rest in Terraform, ensure OpenSearch Service encryption is enabled using AWS KMS:
 
             ```hcl
             resource "aws_kms_key" "opensearch_kms_key" {
@@ -11597,9 +11296,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable encryption at rest for OpenSearch domains:
+            To ensure OpenSearch Service domains have encryption at rest in CloudFormation, enable encryption at rest for OpenSearch domains:
 
             ```yaml
             Resources:
@@ -11705,7 +11402,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon OpenSearch Service domains enforce HTTPS using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -11714,9 +11411,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if HTTPS is enforced on a domain:
+            To ensure Amazon OpenSearch Service domains enforce HTTPS using the AWS CLI, check if HTTPS is enforced on a domain:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -11731,7 +11426,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon OpenSearch Service domains enforce HTTPS in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -11746,7 +11441,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon OpenSearch Service domains enforce HTTPS in CloudFormation:
 
             ```yaml
             Resources:
@@ -11846,7 +11541,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon OpenSearch Service domains use node-to-node encryption using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -11857,9 +11552,7 @@ queries:
             Note: Enabling node-to-node encryption on an existing domain requires a blue/green deployment. Plan for potential downtime.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if node-to-node encryption is enabled:
+            To ensure Amazon OpenSearch Service domains use node-to-node encryption using the AWS CLI, check if node-to-node encryption is enabled:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -11874,7 +11567,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon OpenSearch Service domains use node-to-node encryption in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -11888,7 +11581,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon OpenSearch Service domains use node-to-node encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -11987,7 +11680,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon OpenSearch Service domains use TLS 1.2 or higher using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -11996,9 +11689,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the TLS security policy for a domain:
+            To ensure Amazon OpenSearch Service domains use TLS 1.2 or higher using the AWS CLI, check the TLS security policy for a domain:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -12013,7 +11704,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon OpenSearch Service domains use TLS 1.2 or higher in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -12028,7 +11719,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon OpenSearch Service domains use TLS 1.2 or higher in CloudFormation:
 
             ```yaml
             Resources:
@@ -12130,7 +11821,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure OpenSearch Service domains have fine-grained access control using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -12142,9 +11833,7 @@ queries:
             Note: Enabling fine-grained access control requires encryption at rest, node-to-node encryption, and HTTPS enforcement to also be enabled.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if fine-grained access control is enabled:
+            To ensure OpenSearch Service domains have fine-grained access control using the AWS CLI, check if fine-grained access control is enabled:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -12159,7 +11848,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure OpenSearch Service domains have fine-grained access control in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -12186,7 +11875,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure OpenSearch Service domains have fine-grained access control in CloudFormation:
 
             ```yaml
             Resources:
@@ -12296,7 +11985,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon OpenSearch Service domains have audit logging enabled using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -12307,9 +11996,7 @@ queries:
             Note: Audit logging requires fine-grained access control to be enabled.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if audit logging is enabled:
+            To ensure Amazon OpenSearch Service domains have audit logging enabled using the AWS CLI, check if audit logging is enabled:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -12324,7 +12011,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon OpenSearch Service domains have audit logging enabled in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -12345,7 +12032,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon OpenSearch Service domains have audit logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -12451,9 +12138,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: You cannot migrate an existing public domain into a VPC. You must create a new domain within a VPC and migrate your data.
+            To ensure Amazon OpenSearch Service domains are deployed within a VPC using the AWS Console, note: You cannot migrate an existing public domain into a VPC. You must create a new domain within a VPC and migrate your data.
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select Create domain.
@@ -12463,9 +12148,7 @@ queries:
             6. Migrate data from the old public domain to the new VPC domain using a snapshot or reindex operation.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a domain is in a VPC:
+            To ensure Amazon OpenSearch Service domains are deployed within a VPC using the AWS CLI, check if a domain is in a VPC:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -12481,7 +12164,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon OpenSearch Service domains are deployed within a VPC in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -12508,7 +12191,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon OpenSearch Service domains are deployed within a VPC in CloudFormation:
 
             ```yaml
             Resources:
@@ -12606,7 +12289,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure OpenSearch Service domains block anonymous authentication using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -12615,9 +12298,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if anonymous authentication is enabled:
+            To ensure OpenSearch Service domains block anonymous authentication using the AWS CLI, check if anonymous authentication is enabled:
 
             ```bash
             aws opensearch describe-domain --domain-name <domain-name> \
@@ -12632,7 +12313,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure OpenSearch Service domains block anonymous authentication in Terraform:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -12652,7 +12333,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure OpenSearch Service domains block anonymous authentication in CloudFormation:
 
             ```yaml
             Resources:
@@ -12753,7 +12434,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECR repositories have image scanning on push enabled using the AWS Console:
 
             1. Navigate to the Amazon ECR Console.
             2. Select the repository you want to configure.
@@ -12762,9 +12443,7 @@ queries:
             5. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if image scanning on push is enabled:
+            To ensure ECR repositories have image scanning on push enabled using the AWS CLI, check if image scanning on push is enabled:
 
             ```bash
             aws ecr describe-repositories --query "repositories[*].{Name:repositoryName, ScanOnPush:imageScanningConfiguration.scanOnPush}"
@@ -12779,7 +12458,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECR repositories have image scanning on push enabled in Terraform:
 
             ```hcl
             resource "aws_ecr_repository" "example" {
@@ -12792,7 +12471,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECR repositories have image scanning on push enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -12891,7 +12570,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECR repositories have image tag immutability enabled using the AWS Console:
 
             1. Navigate to the Amazon ECR Console.
             2. Select the repository you want to configure.
@@ -12900,9 +12579,7 @@ queries:
             5. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check tag immutability settings:
+            To ensure ECR repositories have image tag immutability enabled using the AWS CLI, check tag immutability settings:
 
             ```bash
             aws ecr describe-repositories --query "repositories[*].{Name:repositoryName, TagImmutability:imageTagMutability}"
@@ -12917,7 +12594,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECR repositories have image tag immutability enabled in Terraform:
 
             ```hcl
             resource "aws_ecr_repository" "example" {
@@ -12927,7 +12604,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECR repositories have image tag immutability enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -13021,7 +12698,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions do not allow privileged containers using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select Task definitions in the left panel.
@@ -13031,9 +12708,7 @@ queries:
             6. If a container is running as privileged, create a new revision with the setting disabled.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for privileged containers in task definitions:
+            To ensure ECS task definitions do not allow privileged containers using the AWS CLI, check for privileged containers in task definitions:
 
             ```bash
             aws ecs list-task-definitions --status ACTIVE --query "taskDefinitionArns" | \
@@ -13050,9 +12725,7 @@ queries:
             Ensure the container definition in your JSON file has `"privileged": false` or omits the field entirely.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure container definitions do not set privileged to true:
+            To ensure ECS task definitions do not allow privileged containers in Terraform, ensure container definitions do not set privileged to true:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -13070,7 +12743,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS task definitions do not allow privileged containers in CloudFormation:
 
             ```yaml
             Resources:
@@ -13173,7 +12846,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions use read-only root filesystems using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select Task definitions in the left panel.
@@ -13184,9 +12857,7 @@ queries:
             7. Create a new revision with the updated settings.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check read-only root filesystem settings:
+            To ensure ECS task definitions use read-only root filesystems using the AWS CLI, check read-only root filesystem settings:
 
             ```bash
             aws ecs list-task-definitions --status ACTIVE --query "taskDefinitionArns" | \
@@ -13203,7 +12874,7 @@ queries:
             Ensure the container definition has `"readonlyRootFilesystem": true`.
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECS task definitions use read-only root filesystems in Terraform:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -13231,7 +12902,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS task definitions use read-only root filesystems in CloudFormation:
 
             ```yaml
             Resources:
@@ -13333,7 +13004,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions have logging configured for all containers using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select Task definitions in the left panel.
@@ -13344,9 +13015,7 @@ queries:
             7. Create a new revision with the updated settings.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check logging configuration for task definitions:
+            To ensure ECS task definitions have logging configured for all containers using the AWS CLI, check logging configuration for task definitions:
 
             ```bash
             aws ecs list-task-definitions --status ACTIVE --query "taskDefinitionArns" | \
@@ -13376,7 +13045,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECS task definitions have logging configured for all containers in Terraform:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -13401,7 +13070,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS task definitions have logging configured for all containers in CloudFormation:
 
             ```yaml
             Resources:
@@ -13507,7 +13176,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EFS file systems have automatic backups enabled using the AWS Console:
 
             1. Navigate to the Amazon EFS Console.
             2. Select the file system you want to configure.
@@ -13515,9 +13184,7 @@ queries:
             4. If disabled, select Edit, enable Automatic backups, and select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if automatic backups are enabled:
+            To ensure EFS file systems have automatic backups enabled using the AWS CLI, check if automatic backups are enabled:
 
             ```bash
             aws efs describe-backup-policy --file-system-id <file-system-id>
@@ -13531,7 +13198,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EFS file systems have automatic backups enabled in Terraform:
 
             ```hcl
             resource "aws_efs_file_system" "example" {
@@ -13548,7 +13215,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EFS file systems have automatic backups enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -13644,7 +13311,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Application Load Balancers drop invalid HTTP headers using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Load Balancers under the Load Balancing section.
@@ -13655,9 +13322,7 @@ queries:
             7. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if dropping invalid headers is enabled:
+            To ensure Application Load Balancers drop invalid HTTP headers using the AWS CLI, check if dropping invalid headers is enabled:
 
             ```bash
             aws elbv2 describe-load-balancer-attributes \
@@ -13674,7 +13339,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Load Balancers drop invalid HTTP headers in Terraform:
 
             ```hcl
             resource "aws_lb" "example" {
@@ -13689,7 +13354,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Application Load Balancers drop invalid HTTP headers in CloudFormation:
 
             ```yaml
             Resources:
@@ -13794,9 +13459,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Direct internet access cannot be changed on an existing notebook instance. You must create a new instance.
+            To ensure SageMaker notebook instances do not have direct internet access using the AWS Console, note: Direct internet access cannot be changed on an existing notebook instance. You must create a new instance.
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select Notebook instances in the left panel.
@@ -13807,9 +13470,7 @@ queries:
             7. Migrate your work from the old instance and delete it.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if direct internet access is enabled:
+            To ensure SageMaker notebook instances do not have direct internet access using the AWS CLI, check if direct internet access is enabled:
 
             ```bash
             aws sagemaker describe-notebook-instance \
@@ -13830,7 +13491,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SageMaker notebook instances do not have direct internet access in Terraform:
 
             ```hcl
             resource "aws_sagemaker_notebook_instance" "example" {
@@ -13844,7 +13505,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker notebook instances do not have direct internet access in CloudFormation:
 
             ```yaml
             Resources:
@@ -13944,7 +13605,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0 using the AWS Console:
 
             1. Navigate to the Amazon EKS Console.
             2. Select the EKS cluster you want to configure.
@@ -13954,9 +13615,7 @@ queries:
             6. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current public access CIDR configuration:
+            To ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0 using the AWS CLI, check the current public access CIDR configuration:
 
             ```bash
             aws eks describe-cluster --name <cluster_name> \
@@ -13971,7 +13630,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0 in Terraform:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -13987,7 +13646,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0 in CloudFormation:
 
             ```yaml
             Resources:
@@ -14104,7 +13763,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon EKS clusters have deletion protection enabled using the AWS Console:
 
             1. Navigate to the Amazon EKS Console.
             2. Select the EKS cluster you want to configure.
@@ -14113,9 +13772,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if deletion protection is enabled:
+            To ensure Amazon EKS clusters have deletion protection enabled using the AWS CLI, check if deletion protection is enabled:
 
             ```bash
             aws eks describe-cluster --name <cluster_name> \
@@ -14130,7 +13787,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon EKS clusters have deletion protection enabled in Terraform:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -14149,7 +13806,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon EKS clusters have deletion protection enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -14245,7 +13902,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CodeBuild projects do not run in privileged mode using the AWS Console:
 
             1. Navigate to the AWS CodeBuild Console.
             2. Select Build projects in the left panel.
@@ -14255,9 +13912,7 @@ queries:
             6. Choose Update environment to save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if privileged mode is enabled on a CodeBuild project:
+            To ensure CodeBuild projects do not run in privileged mode using the AWS CLI, check if privileged mode is enabled on a CodeBuild project:
 
             ```bash
             aws codebuild batch-get-projects --names <project-name> \
@@ -14272,9 +13927,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the CodeBuild project environment does not enable privileged mode:
+            To ensure CodeBuild projects do not run in privileged mode in Terraform, ensure the CodeBuild project environment does not enable privileged mode:
 
             ```hcl
             resource "aws_codebuild_project" "example" {
@@ -14300,7 +13953,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CodeBuild projects do not run in privileged mode in CloudFormation:
 
             ```yaml
             Resources:
@@ -14404,7 +14057,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CodeBuild projects do not store plaintext credentials using the AWS Console:
 
             1. Navigate to the AWS CodeBuild Console.
             2. Select Build projects in the left panel.
@@ -14415,9 +14068,7 @@ queries:
             7. Choose Update environment to save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the image pull credentials type for a CodeBuild project:
+            To ensure CodeBuild projects do not store plaintext credentials using the AWS CLI, check the image pull credentials type for a CodeBuild project:
 
             ```bash
             aws codebuild batch-get-projects --names <project-name> \
@@ -14439,9 +14090,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the CodeBuild project uses secure credential storage:
+            To ensure CodeBuild projects do not store plaintext credentials in Terraform, ensure the CodeBuild project uses secure credential storage:
 
             ```hcl
             resource "aws_codebuild_project" "example" {
@@ -14479,7 +14128,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CodeBuild projects do not store plaintext credentials in CloudFormation:
 
             ```yaml
             Resources:
@@ -14638,7 +14287,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune DB clusters are encrypted at rest using the AWS Console:
 
             1. Navigate to the Amazon Neptune Console.
             2. Select Databases in the left panel.
@@ -14654,9 +14303,7 @@ queries:
             8. Delete the unencrypted cluster after verifying the migration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a Neptune cluster is encrypted:
+            To ensure Neptune DB clusters are encrypted at rest using the AWS CLI, check if a Neptune cluster is encrypted:
 
             ```bash
             aws neptune describe-db-clusters --db-cluster-identifier <cluster-id> \
@@ -14674,9 +14321,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure Neptune clusters are created with encryption at rest enabled:
+            To ensure Neptune DB clusters are encrypted at rest in Terraform, ensure Neptune clusters are created with encryption at rest enabled:
 
             ```hcl
             resource "aws_kms_key" "neptune_kms_key" {
@@ -14695,7 +14340,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Neptune DB clusters are encrypted at rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -14795,7 +14440,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon GuardDuty is enabled using the AWS Console:
 
             1. Navigate to the Amazon GuardDuty Console.
             2. If GuardDuty has never been enabled, choose Get Started.
@@ -14803,9 +14448,7 @@ queries:
             4. Repeat in each AWS Region where you want protection.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable GuardDuty in the current region:
+            To ensure Amazon GuardDuty is enabled using the AWS CLI, enable GuardDuty in the current region:
 
             ```bash
             aws guardduty create-detector --enable
@@ -14819,7 +14462,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon GuardDuty is enabled in Terraform:
 
             ```hcl
             resource "aws_guardduty_detector" "main" {
@@ -14829,7 +14472,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon GuardDuty is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -14922,7 +14565,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure GuardDuty findings are published at least every 15 minutes using the AWS Console:
 
             1. Navigate to the Amazon GuardDuty Console.
             2. Select Settings.
@@ -14930,7 +14573,7 @@ queries:
             4. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure GuardDuty findings are published at least every 15 minutes using the AWS CLI:
 
             ```bash
             aws guardduty update-detector \
@@ -14939,7 +14582,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure GuardDuty findings are published at least every 15 minutes in Terraform:
 
             ```hcl
             resource "aws_guardduty_detector" "main" {
@@ -14949,7 +14592,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure GuardDuty findings are published at least every 15 minutes in CloudFormation:
 
             ```yaml
             Resources:
@@ -15037,7 +14680,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Security Hub is enabled using the AWS Console:
 
             1. Navigate to the AWS Security Hub Console.
             2. Choose Go to Security Hub.
@@ -15045,21 +14688,21 @@ queries:
             4. Choose Enable Security Hub.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure AWS Security Hub is enabled using the AWS CLI:
 
             ```bash
             aws securityhub enable-security-hub
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Security Hub is enabled in Terraform:
 
             ```hcl
             resource "aws_securityhub_account" "main" {}
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Security Hub is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -15129,7 +14772,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Config recorder is enabled and recording using the AWS Console:
 
             1. Navigate to the AWS Config Console.
             2. If Config has not been set up, choose Get Started or 1-click setup.
@@ -15137,7 +14780,7 @@ queries:
             4. Repeat in each AWS Region.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure AWS Config recorder is enabled and recording using the AWS CLI:
 
             ```bash
             aws configservice start-configuration-recorder \
@@ -15145,7 +14788,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Config recorder is enabled and recording in Terraform:
 
             ```hcl
             resource "aws_config_configuration_recorder_status" "main" {
@@ -15155,7 +14798,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Config recorder is enabled and recording in CloudFormation:
 
             ```yaml
             Resources:
@@ -15242,7 +14885,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Config records all supported resource types using the AWS Console:
 
             1. Navigate to the AWS Config Console.
             2. Select Settings.
@@ -15251,7 +14894,7 @@ queries:
             5. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure AWS Config records all supported resource types using the AWS CLI:
 
             ```bash
             aws configservice put-configuration-recorder \
@@ -15260,7 +14903,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Config records all supported resource types in Terraform:
 
             ```hcl
             resource "aws_config_configuration_recorder" "main" {
@@ -15275,7 +14918,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Config records all supported resource types in CloudFormation:
 
             ```yaml
             Resources:
@@ -15378,7 +15021,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Secrets Manager secrets have automatic rotation enabled using the AWS Console:
 
             1. Navigate to the AWS Secrets Manager Console.
             2. Select the secret.
@@ -15388,7 +15031,7 @@ queries:
             6. Choose Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Secrets Manager secrets have automatic rotation enabled using the AWS CLI:
 
             ```bash
             aws secretsmanager rotate-secret \
@@ -15398,7 +15041,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Secrets Manager secrets have automatic rotation enabled in Terraform:
 
             ```hcl
             resource "aws_secretsmanager_secret_rotation" "example" {
@@ -15412,7 +15055,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Secrets Manager secrets have automatic rotation enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -15495,7 +15138,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Secrets Manager secrets use customer-managed KMS keys using the AWS Console:
 
             1. Navigate to the AWS Secrets Manager Console.
             2. Select the secret.
@@ -15504,7 +15147,7 @@ queries:
             5. Choose Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Secrets Manager secrets use customer-managed KMS keys using the AWS CLI:
 
             ```bash
             aws secretsmanager update-secret \
@@ -15513,7 +15156,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Secrets Manager secrets use customer-managed KMS keys in Terraform:
 
             ```hcl
             resource "aws_secretsmanager_secret" "example" {
@@ -15523,7 +15166,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Secrets Manager secrets use customer-managed KMS keys in CloudFormation:
 
             ```yaml
             Resources:
@@ -15613,7 +15256,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure IAM Access Analyzer is enabled using the AWS Console:
 
             1. Navigate to the IAM Console.
             2. Under Access reports, select Access Analyzer.
@@ -15622,7 +15265,7 @@ queries:
             5. Choose Create analyzer.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure IAM Access Analyzer is enabled using the AWS CLI:
 
             ```bash
             aws accessanalyzer create-analyzer \
@@ -15631,7 +15274,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure IAM Access Analyzer is enabled in Terraform:
 
             ```hcl
             resource "aws_accessanalyzer_analyzer" "account" {
@@ -15641,7 +15284,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure IAM Access Analyzer is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -15721,7 +15364,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SNS topics are encrypted with KMS using the AWS Console:
 
             1. Navigate to the Amazon SNS Console.
             2. Select the topic.
@@ -15730,7 +15373,7 @@ queries:
             5. Choose Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure SNS topics are encrypted with KMS using the AWS CLI:
 
             ```bash
             aws sns set-topic-attributes \
@@ -15740,7 +15383,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SNS topics are encrypted with KMS in Terraform:
 
             ```hcl
             resource "aws_sns_topic" "example" {
@@ -15750,7 +15393,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SNS topics are encrypted with KMS in CloudFormation:
 
             ```yaml
             Resources:
@@ -15842,7 +15485,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SNS topics use signature version 2 for message verification using the AWS Console:
 
             1. Navigate to the Amazon SNS Console.
             2. Select the topic.
@@ -15851,7 +15494,7 @@ queries:
             5. Choose Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure SNS topics use signature version 2 for message verification using the AWS CLI:
 
             ```bash
             aws sns set-topic-attributes \
@@ -15861,7 +15504,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SNS topics use signature version 2 for message verification in Terraform:
 
             ```hcl
             resource "aws_sns_topic" "example" {
@@ -15871,7 +15514,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SNS topics use signature version 2 for message verification in CloudFormation:
 
             ```yaml
             Resources:
@@ -15961,7 +15604,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SQS queues are encrypted using the AWS Console:
 
             1. Navigate to the Amazon SQS Console.
             2. Select the queue.
@@ -15970,9 +15613,7 @@ queries:
             5. Choose Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable SQS-managed encryption:
+            To ensure SQS queues are encrypted using the AWS CLI, enable SQS-managed encryption:
 
             ```bash
             aws sqs set-queue-attributes \
@@ -15981,7 +15622,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQS queues are encrypted in Terraform:
 
             ```hcl
             resource "aws_sqs_queue" "example" {
@@ -15991,7 +15632,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SQS queues are encrypted in CloudFormation:
 
             ```yaml
             Resources:
@@ -16082,7 +15723,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SQS queues have a dead letter queue configured using the AWS Console:
 
             1. Navigate to the Amazon SQS Console.
             2. Select the queue.
@@ -16092,7 +15733,7 @@ queries:
             6. Choose Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure SQS queues have a dead letter queue configured using the AWS CLI:
 
             ```bash
             aws sqs set-queue-attributes \
@@ -16101,7 +15742,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQS queues have a dead letter queue configured in Terraform:
 
             ```hcl
             resource "aws_sqs_queue" "dlq" {
@@ -16119,7 +15760,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SQS queues have a dead letter queue configured in CloudFormation:
 
             ```yaml
             Resources:
@@ -16215,7 +15856,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache clusters have encryption at rest enabled using the AWS Console:
 
             1. Navigate to the Amazon ElastiCache Console.
             2. Note: Encryption at rest can only be enabled at creation time.
@@ -16224,9 +15865,7 @@ queries:
             5. Delete the old unencrypted cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new replication group with encryption at rest:
+            To ensure ElastiCache clusters have encryption at rest enabled using the AWS CLI, create a new replication group with encryption at rest:
 
             ```bash
             aws elasticache create-replication-group \
@@ -16238,7 +15877,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ElastiCache clusters have encryption at rest enabled in Terraform:
 
             ```hcl
             resource "aws_elasticache_replication_group" "example" {
@@ -16252,7 +15891,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ElastiCache clusters have encryption at rest enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -16344,7 +15983,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache clusters have encryption in transit enabled using the AWS Console:
 
             1. Navigate to the Amazon ElastiCache Console.
             2. Note: Encryption in transit can only be enabled at creation time.
@@ -16352,7 +15991,7 @@ queries:
             4. Migrate data and update application connection strings to use TLS.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure ElastiCache clusters have encryption in transit enabled using the AWS CLI:
 
             ```bash
             aws elasticache create-replication-group \
@@ -16364,7 +16003,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ElastiCache clusters have encryption in transit enabled in Terraform:
 
             ```hcl
             resource "aws_elasticache_replication_group" "example" {
@@ -16378,7 +16017,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ElastiCache clusters have encryption in transit enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -16470,7 +16109,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache Redis clusters require authentication using the AWS Console:
 
             1. Navigate to the Amazon ElastiCache Console.
             2. Create a new replication group with Auth token enabled.
@@ -16478,7 +16117,7 @@ queries:
             4. Update application connection strings to include the AUTH token.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure ElastiCache Redis clusters require authentication using the AWS CLI:
 
             ```bash
             aws elasticache create-replication-group \
@@ -16491,7 +16130,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ElastiCache Redis clusters require authentication in Terraform:
 
             ```hcl
             resource "aws_elasticache_replication_group" "example" {
@@ -16506,7 +16145,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ElastiCache Redis clusters require authentication in CloudFormation:
 
             ```yaml
             Resources:
@@ -16599,7 +16238,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Backup vaults are encrypted using the AWS Console:
 
             1. Navigate to the AWS Backup Console.
             2. Choose Backup vaults.
@@ -16607,7 +16246,7 @@ queries:
             4. Note: Encryption cannot be changed after vault creation.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure AWS Backup vaults are encrypted using the AWS CLI:
 
             ```bash
             aws backup create-backup-vault \
@@ -16616,7 +16255,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Backup vaults are encrypted in Terraform:
 
             ```hcl
             resource "aws_backup_vault" "example" {
@@ -16626,7 +16265,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Backup vaults are encrypted in CloudFormation:
 
             ```yaml
             Resources:
@@ -16715,7 +16354,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure FSx file systems are encrypted at rest using the AWS Console:
 
             1. Navigate to the Amazon FSx Console.
             2. Note: Encryption can only be enabled at creation time.
@@ -16723,7 +16362,7 @@ queries:
             4. Migrate data from the unencrypted file system.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure FSx file systems are encrypted at rest using the AWS CLI:
 
             ```bash
             aws fsx create-file-system \
@@ -16735,7 +16374,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure FSx file systems are encrypted at rest in Terraform:
 
             ```hcl
             resource "aws_fsx_lustre_file_system" "example" {
@@ -16746,7 +16385,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure FSx file systems are encrypted at rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -16839,7 +16478,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters are encrypted at rest using the AWS Console:
 
             1. Navigate to the Amazon Redshift Console.
             2. Note: Encryption can only be enabled at creation time or by modifying the cluster.
@@ -16848,7 +16487,7 @@ queries:
             5. Choose Modify cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Redshift clusters are encrypted at rest using the AWS CLI:
 
             ```bash
             aws redshift modify-cluster \
@@ -16858,7 +16497,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Redshift clusters are encrypted at rest in Terraform:
 
             ```hcl
             resource "aws_redshift_cluster" "example" {
@@ -16870,7 +16509,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters are encrypted at rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -16962,7 +16601,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters have audit logging enabled using the AWS Console:
 
             1. Navigate to the Amazon Redshift Console.
             2. Select the cluster.
@@ -16971,7 +16610,7 @@ queries:
             5. Choose Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Redshift clusters have audit logging enabled using the AWS CLI:
 
             ```bash
             aws redshift enable-logging \
@@ -16981,7 +16620,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Redshift clusters have audit logging enabled in Terraform:
 
             ```hcl
             resource "aws_redshift_cluster" "example" {
@@ -16997,7 +16636,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters have audit logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -17092,7 +16731,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters use enhanced VPC routing using the AWS Console:
 
             1. Navigate to the Amazon Redshift Console.
             2. Select the cluster.
@@ -17101,7 +16740,7 @@ queries:
             5. Choose Modify cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Redshift clusters use enhanced VPC routing using the AWS CLI:
 
             ```bash
             aws redshift modify-cluster \
@@ -17110,7 +16749,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Redshift clusters use enhanced VPC routing in Terraform:
 
             ```hcl
             resource "aws_redshift_cluster" "example" {
@@ -17121,7 +16760,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters use enhanced VPC routing in CloudFormation:
 
             ```yaml
             Resources:
@@ -17212,7 +16851,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudFront distributions use TLS 1.2 or higher using the AWS Console:
 
             1. Navigate to the Amazon CloudFront Console.
             2. Select the distribution.
@@ -17221,7 +16860,7 @@ queries:
             5. Choose Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure CloudFront distributions use TLS 1.2 or higher using the AWS CLI:
 
             ```bash
             aws cloudfront get-distribution-config --id <distribution-id> > dist-config.json
@@ -17231,7 +16870,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudFront distributions use TLS 1.2 or higher in Terraform:
 
             ```hcl
             resource "aws_cloudfront_distribution" "example" {
@@ -17243,7 +16882,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudFront distributions use TLS 1.2 or higher in CloudFormation:
 
             ```yaml
             Resources:
@@ -17339,7 +16978,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudFront distributions have WAF web ACL associated using the AWS Console:
 
             1. Navigate to the Amazon CloudFront Console.
             2. Select the distribution.
@@ -17348,7 +16987,7 @@ queries:
             5. Choose Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure CloudFront distributions have WAF web ACL associated using the AWS CLI:
 
             ```bash
             aws cloudfront get-distribution-config --id <distribution-id> > dist-config.json
@@ -17358,7 +16997,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudFront distributions have WAF web ACL associated in Terraform:
 
             ```hcl
             resource "aws_cloudfront_distribution" "example" {
@@ -17367,7 +17006,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudFront distributions have WAF web ACL associated in CloudFormation:
 
             ```yaml
             Resources:
@@ -17455,7 +17094,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS snapshots are encrypted at rest using the AWS Console:
 
             1. Navigate to the Amazon RDS Console.
             2. Select Snapshots in the left panel.
@@ -17468,9 +17107,7 @@ queries:
             To prevent future unencrypted snapshots, ensure all RDS instances use encryption at rest.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for unencrypted snapshots:
+            To ensure RDS snapshots are encrypted at rest using the AWS CLI, check for unencrypted snapshots:
 
             ```bash
             aws rds describe-db-snapshots --query "DBSnapshots[?Encrypted==\`false\`].DBSnapshotIdentifier"
@@ -17486,9 +17123,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure RDS instances are encrypted so snapshots inherit encryption:
+            To ensure RDS snapshots are encrypted at rest in Terraform, ensure RDS instances are encrypted so snapshots inherit encryption:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -17501,7 +17136,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS snapshots are encrypted at rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -17588,7 +17223,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AMIs owned by the account are not publicly shared using the AWS Console:
 
             1. Navigate to the Amazon EC2 Console.
             2. Select AMIs under Images in the left panel.
@@ -17599,9 +17234,7 @@ queries:
             7. Optionally add specific AWS account IDs that should have access.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List public AMIs owned by your account:
+            To ensure AMIs owned by the account are not publicly shared using the AWS CLI, list public AMIs owned by your account:
 
             ```bash
             aws ec2 describe-images --owners self --query "Images[?Public==\`true\`].ImageId"
@@ -17622,9 +17255,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure AMIs are not publicly shared:
+            To ensure AMIs owned by the account are not publicly shared in Terraform, ensure AMIs are not publicly shared:
 
             ```hcl
             resource "aws_ami" "example" {
@@ -17646,9 +17277,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            AMI sharing is managed through the EC2 API rather than CloudFormation. Use the AWS CLI or Console to manage AMI permissions, or enable AMI Block Public Access at the account level.
+            To ensure AMIs owned by the account are not publicly shared in CloudFormation, AMI sharing is managed through the EC2 API rather than CloudFormation. Use the AWS CLI or Console to manage AMI permissions, or enable AMI Block Public Access at the account level.
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharing-amis.html
         title: AWS Documentation - Share an AMI with specific organizations or accounts
@@ -17730,7 +17359,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions specify a non-root user for containers using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select Task definitions in the left panel.
@@ -17740,9 +17369,7 @@ queries:
             6. Create a new revision with the updated setting.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for containers running as root in task definitions:
+            To ensure ECS task definitions specify a non-root user for containers using the AWS CLI, check for containers running as root in task definitions:
 
             ```bash
             aws ecs list-task-definitions --status ACTIVE --query "taskDefinitionArns" | \
@@ -17759,9 +17386,7 @@ queries:
             Ensure the container definition in your JSON file has `"user": "1000"` or a named non-root user.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure container definitions specify a non-root user:
+            To ensure ECS task definitions specify a non-root user for containers in Terraform, ensure container definitions specify a non-root user:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -17779,7 +17404,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS task definitions specify a non-root user for containers in CloudFormation:
 
             ```yaml
             Resources:
@@ -17888,7 +17513,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions enforce transit encryption for EFS volumes using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select Task definitions in the left panel.
@@ -17898,9 +17523,7 @@ queries:
             6. Create a new revision with the updated setting.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for EFS volumes without transit encryption:
+            To ensure ECS task definitions enforce transit encryption for EFS volumes using the AWS CLI, check for EFS volumes without transit encryption:
 
             ```bash
             aws ecs list-task-definitions --status ACTIVE --query "taskDefinitionArns" | \
@@ -17917,9 +17540,7 @@ queries:
             Ensure the volume configuration includes `"transitEncryption": "ENABLED"`.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure EFS volumes in ECS task definitions have transit encryption enabled:
+            To ensure ECS task definitions enforce transit encryption for EFS volumes in Terraform, ensure EFS volumes in ECS task definitions have transit encryption enabled:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -17952,7 +17573,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS task definitions enforce transit encryption for EFS volumes in CloudFormation:
 
             ```yaml
             Resources:
@@ -18067,7 +17688,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudWatch log groups have a retention period configured using the AWS Console:
 
             1. Navigate to the Amazon CloudWatch Console.
             2. Select Log Groups from the left panel.
@@ -18077,9 +17698,7 @@ queries:
             6. Choose Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check log groups without retention periods:
+            To ensure CloudWatch log groups have a retention period configured using the AWS CLI, check log groups without retention periods:
 
             ```bash
             aws logs describe-log-groups --query "logGroups[?!retentionInDays].logGroupName"
@@ -18094,9 +17713,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure CloudWatch log groups have a retention period:
+            To ensure CloudWatch log groups have a retention period configured in Terraform, ensure CloudWatch log groups have a retention period:
 
             ```hcl
             resource "aws_cloudwatch_log_group" "example" {
@@ -18106,7 +17723,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudWatch log groups have a retention period configured in CloudFormation:
 
             ```yaml
             Resources:
@@ -18200,7 +17817,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters require SSL for connections using the AWS Console:
 
             1. Navigate to the Amazon Redshift Console.
             2. Select Configurations > Workload management in the left panel.
@@ -18211,9 +17828,7 @@ queries:
             7. Reboot the cluster for changes to take effect.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current require_ssl setting:
+            To ensure Redshift clusters require SSL for connections using the AWS CLI, check the current require_ssl setting:
 
             ```bash
             aws redshift describe-cluster-parameters \
@@ -18236,9 +17851,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the Redshift parameter group requires SSL:
+            To ensure Redshift clusters require SSL for connections in Terraform, ensure the Redshift parameter group requires SSL:
 
             ```hcl
             resource "aws_redshift_parameter_group" "example" {
@@ -18259,7 +17872,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters require SSL for connections in CloudFormation:
 
             ```yaml
             Resources:
@@ -18368,7 +17981,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure VPC subnets do not automatically assign public IP addresses using the AWS Console:
 
             1. Navigate to the AWS VPC Console.
             2. Select Subnets from the left panel.
@@ -18378,9 +17991,7 @@ queries:
             6. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Disable auto-assign public IP for a subnet:
+            To ensure VPC subnets do not automatically assign public IP addresses using the AWS CLI, disable auto-assign public IP for a subnet:
 
             ```bash
             aws ec2 modify-subnet-attribute \
@@ -18396,9 +18007,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `map_public_ip_on_launch` is set to `false` (or omitted, as `false` is the default):
+            To ensure VPC subnets do not automatically assign public IP addresses in Terraform, ensure `map_public_ip_on_launch` is set to `false` (or omitted, as `false` is the default):
 
             ```hcl
             resource "aws_subnet" "private" {
@@ -18413,7 +18022,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure VPC subnets do not automatically assign public IP addresses in CloudFormation:
 
             ```yaml
             Resources:
@@ -18510,7 +18119,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instances have IMDS hop limit set to 1 using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Instances in the left panel.
@@ -18520,9 +18129,7 @@ queries:
             6. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Set the IMDS hop limit to 1:
+            To ensure EC2 instances have IMDS hop limit set to 1 using the AWS CLI, set the IMDS hop limit to 1:
 
             ```bash
             aws ec2 modify-instance-metadata-options \
@@ -18538,9 +18145,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set `http_put_response_hop_limit` to 1 in the `metadata_options` block:
+            To ensure EC2 instances have IMDS hop limit set to 1 in Terraform, set `http_put_response_hop_limit` to 1 in the `metadata_options` block:
 
             ```hcl
             resource "aws_instance" "secure_instance" {
@@ -18556,7 +18161,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EC2 instances have IMDS hop limit set to 1 in CloudFormation:
 
             ```yaml
             Resources:
@@ -18661,7 +18266,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure GuardDuty protection features are enabled using the AWS Console:
 
             1. Navigate to the Amazon GuardDuty Console.
             2. Select Settings in the left panel.
@@ -18676,9 +18281,7 @@ queries:
             6. Repeat in each AWS Region where GuardDuty is active.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable all GuardDuty protection features:
+            To ensure GuardDuty protection features are enabled using the AWS CLI, enable all GuardDuty protection features:
 
             ```bash
             aws guardduty update-detector \
@@ -18701,9 +18304,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable all GuardDuty features using `aws_guardduty_detector_feature` resources:
+            To ensure GuardDuty protection features are enabled in Terraform, enable all GuardDuty features using `aws_guardduty_detector_feature` resources:
 
             ```hcl
             resource "aws_guardduty_detector" "main" {
@@ -18749,7 +18350,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure GuardDuty protection features are enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -18858,7 +18459,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune DB clusters have IAM database authentication enabled using the AWS Console:
 
             1. Navigate to the Amazon Neptune Console.
             2. Select Databases in the left panel.
@@ -18868,9 +18469,7 @@ queries:
             6. Select Continue and apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable IAM authentication on an existing cluster:
+            To ensure Neptune DB clusters have IAM database authentication enabled using the AWS CLI, enable IAM authentication on an existing cluster:
 
             ```bash
             aws neptune modify-db-cluster \
@@ -18886,7 +18485,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Neptune DB clusters have IAM database authentication enabled in Terraform:
 
             ```hcl
             resource "aws_neptune_cluster" "example" {
@@ -18897,7 +18496,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Neptune DB clusters have IAM database authentication enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -18991,7 +18590,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure KMS key grants do not include the CreateGrant permission using the AWS Console:
 
             1. Navigate to the AWS KMS Console.
             2. Select Customer managed keys.
@@ -19001,9 +18600,7 @@ queries:
             6. For user-created grants, retire or revoke the grant and recreate it without the `CreateGrant` operation.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all grants for a KMS key and check for `CreateGrant`:
+            To ensure KMS key grants do not include the CreateGrant permission using the AWS CLI, list all grants for a KMS key and check for `CreateGrant`:
 
             ```bash
             aws kms list-grants --key-id <key-id> \
@@ -19026,9 +18623,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `aws_kms_grant` resources do not include `CreateGrant` in the operations list:
+            To ensure KMS key grants do not include the CreateGrant permission in Terraform, ensure `aws_kms_grant` resources do not include `CreateGrant` in the operations list:
 
             ```hcl
             resource "aws_kms_grant" "example" {
@@ -19039,9 +18634,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support managing KMS grants. Use the AWS CLI, SDK, or a CloudFormation custom resource to manage KMS grants and ensure `CreateGrant` is not included in the operations list.
+            To ensure KMS key grants do not include the CreateGrant permission in CloudFormation, note that CloudFormation does not natively support managing KMS grants. Use the AWS CLI, SDK, or a CloudFormation custom resource to manage KMS grants and ensure `CreateGrant` is not included in the operations list.
     refs:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
@@ -19103,7 +18696,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure KMS key grants do not use wildcard principals using the AWS Console:
 
             1. Navigate to the AWS KMS Console.
             2. Select Customer managed keys.
@@ -19112,9 +18705,7 @@ queries:
             5. Revoke the wildcard grant and recreate it with a specific principal ARN.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all grants for a KMS key and check for wildcard principals:
+            To ensure KMS key grants do not use wildcard principals using the AWS CLI, list all grants for a KMS key and check for wildcard principals:
 
             ```bash
             aws kms list-grants --key-id <key-id> \
@@ -19137,9 +18728,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `aws_kms_grant` resources specify a specific principal ARN rather than a wildcard:
+            To ensure KMS key grants do not use wildcard principals in Terraform, ensure `aws_kms_grant` resources specify a specific principal ARN rather than a wildcard:
 
             ```hcl
             resource "aws_kms_grant" "example" {
@@ -19150,9 +18739,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support managing KMS grants. Use the AWS CLI, SDK, or a CloudFormation custom resource to manage KMS grants and ensure specific principal ARNs are used instead of wildcards.
+            To ensure KMS key grants do not use wildcard principals in CloudFormation, note that CloudFormation does not natively support managing KMS grants. Use the AWS CLI, SDK, or a CloudFormation custom resource to manage KMS grants and ensure specific principal ARNs are used instead of wildcards.
     refs:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
@@ -19218,9 +18805,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            KMS key origin cannot be changed after creation. To migrate to an `AWS_KMS` origin key:
+            To ensure customer-managed KMS keys use AWS_KMS origin using the AWS Console, KMS key origin cannot be changed after creation. To migrate to an `AWS_KMS` origin key:
 
             1. Navigate to the AWS KMS Console.
             2. Create a new customer-managed key with Origin set to KMS (the default).
@@ -19229,9 +18814,7 @@ queries:
             5. Schedule deletion of the old key after confirming all references have been updated.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the origin of a KMS key:
+            To ensure customer-managed KMS keys use AWS_KMS origin using the AWS CLI, check the origin of a KMS key:
 
             ```bash
             aws kms describe-key --key-id <key-id> \
@@ -19254,9 +18837,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `aws_kms_key` resources do not specify an external origin:
+            To ensure customer-managed KMS keys use AWS_KMS origin in Terraform, ensure `aws_kms_key` resources do not specify an external origin:
 
             ```hcl
             resource "aws_kms_key" "example" {
@@ -19267,7 +18848,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure customer-managed KMS keys use AWS_KMS origin in CloudFormation:
 
             ```yaml
             Resources:
@@ -19369,7 +18950,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CodeBuild projects have SSL verification enabled for source fetches using the AWS Console:
 
             1. Navigate to the AWS CodeBuild Console.
             2. Select the build project to modify.
@@ -19379,9 +18960,7 @@ queries:
             6. Select Update source to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current setting:
+            To ensure CodeBuild projects have SSL verification enabled for source fetches using the AWS CLI, check the current setting:
 
             ```bash
             aws codebuild batch-get-projects --names <project-name> \
@@ -19397,9 +18976,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `insecure_ssl` is set to `false` (or omitted, as `false` is the default):
+            To ensure CodeBuild projects have SSL verification enabled for source fetches in Terraform, ensure `insecure_ssl` is set to `false` (or omitted, as `false` is the default):
 
             ```hcl
             resource "aws_codebuild_project" "example" {
@@ -19421,7 +18998,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CodeBuild projects have SSL verification enabled for source fetches in CloudFormation:
 
             ```yaml
             Resources:
@@ -19519,7 +19096,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache serverless caches use CMK encryption using the AWS Console:
 
             1. Navigate to the Amazon ElastiCache Console.
             2. Select Serverless caches from the left panel.
@@ -19530,9 +19107,7 @@ queries:
             Note: Encryption settings cannot be changed after creation. To switch to CMK encryption, create a new serverless cache with the desired KMS key and migrate data.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a serverless cache with CMK encryption:
+            To ensure ElastiCache serverless caches use CMK encryption using the AWS CLI, create a serverless cache with CMK encryption:
 
             ```bash
             aws elasticache create-serverless-cache \
@@ -19549,7 +19124,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ElastiCache serverless caches use CMK encryption in Terraform:
 
             ```hcl
             resource "aws_kms_key" "elasticache" {
@@ -19566,7 +19141,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ElastiCache serverless caches use CMK encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -19656,7 +19231,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon Inspector is enabled for EC2 instance scanning using the AWS Console:
 
             1. Navigate to the Amazon Inspector console.
             2. Choose **Get Started** or go to **Account management**.
@@ -19664,14 +19239,14 @@ queries:
             4. Inspector will automatically begin discovering and scanning EC2 instances.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Amazon Inspector is enabled for EC2 instance scanning using the AWS CLI:
 
             ```bash
             aws inspector2 enable --resource-types EC2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon Inspector is enabled for EC2 instance scanning in Terraform:
 
             ```hcl
             resource "aws_inspector2_enabler" "example" {
@@ -19681,9 +19256,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector EC2 scanning.
+            To ensure Amazon Inspector is enabled for EC2 instance scanning in CloudFormation, note that CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector EC2 scanning.
     refs:
       - url: https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html
         title: Getting started with Amazon Inspector
@@ -19750,21 +19323,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon Inspector is enabled for ECR container image scanning using the AWS Console:
 
             1. Navigate to the Amazon Inspector console.
             2. Choose **Account management**.
             3. Enable scanning for **Amazon ECR** container images.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Amazon Inspector is enabled for ECR container image scanning using the AWS CLI:
 
             ```bash
             aws inspector2 enable --resource-types ECR
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon Inspector is enabled for ECR container image scanning in Terraform:
 
             ```hcl
             resource "aws_inspector2_enabler" "example" {
@@ -19774,9 +19347,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector ECR scanning.
+            To ensure Amazon Inspector is enabled for ECR container image scanning in CloudFormation, note that CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector ECR scanning.
     refs:
       - url: https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html
         title: Scanning Amazon ECR container images with Amazon Inspector
@@ -19843,21 +19414,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon Inspector is enabled for Lambda function scanning using the AWS Console:
 
             1. Navigate to the Amazon Inspector console.
             2. Choose **Account management**.
             3. Enable scanning for **AWS Lambda** functions.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Amazon Inspector is enabled for Lambda function scanning using the AWS CLI:
 
             ```bash
             aws inspector2 enable --resource-types LAMBDA LAMBDA_CODE
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon Inspector is enabled for Lambda function scanning in Terraform:
 
             ```hcl
             resource "aws_inspector2_enabler" "example" {
@@ -19867,9 +19438,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector Lambda scanning.
+            To ensure Amazon Inspector is enabled for Lambda function scanning in CloudFormation, note that CloudFormation does not natively support enabling Amazon Inspector scanning. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable Inspector Lambda scanning.
     refs:
       - url: https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html
         title: Scanning AWS Lambda functions with Amazon Inspector
@@ -19940,21 +19509,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SSM SecureString parameters use KMS encryption using the AWS Console:
 
             1. Navigate to **AWS Systems Manager** > **Parameter Store**.
             2. Select a SecureString parameter.
             3. Create a new version of the parameter with a customer-managed KMS key.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure SSM SecureString parameters use KMS encryption using the AWS CLI:
 
             ```bash
             aws ssm put-parameter --name <parameter-name> --value <value> --type SecureString --key-id <kms-key-id> --overwrite
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SSM SecureString parameters use KMS encryption in Terraform:
 
             ```hcl
             resource "aws_ssm_parameter" "example" {
@@ -19966,7 +19535,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SSM SecureString parameters use KMS encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -20053,7 +19622,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DMS replication instances are not publicly accessible using the AWS Console:
 
             1. Navigate to the **AWS DMS** console.
             2. Select **Replication instances**.
@@ -20062,14 +19631,14 @@ queries:
             5. Apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure DMS replication instances are not publicly accessible using the AWS CLI:
 
             ```bash
             aws dms modify-replication-instance --replication-instance-arn <arn> --no-publicly-accessible
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DMS replication instances are not publicly accessible in Terraform:
 
             ```hcl
             resource "aws_dms_replication_instance" "example" {
@@ -20080,7 +19649,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DMS replication instances are not publicly accessible in CloudFormation:
 
             ```yaml
             Resources:
@@ -20165,7 +19734,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DMS replication instances use encryption using the AWS Console:
 
             1. Navigate to the **AWS DMS** console.
             2. Create a new replication instance with **KMS key** specified under encryption settings.
@@ -20173,14 +19742,14 @@ queries:
             Note: Encryption cannot be enabled on existing replication instances. You must create a new encrypted instance and migrate tasks to it.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure DMS replication instances use encryption using the AWS CLI:
 
             ```bash
             aws dms create-replication-instance --replication-instance-identifier <id> --replication-instance-class <class> --kms-key-id <kms-key-arn>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DMS replication instances use encryption in Terraform:
 
             ```hcl
             resource "aws_dms_replication_instance" "example" {
@@ -20191,7 +19760,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DMS replication instances use encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -20261,7 +19830,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DRS replication configurations use EBS encryption using the AWS Console:
 
             1. Navigate to the **AWS Elastic Disaster Recovery** console.
             2. Select **Source servers**.
@@ -20270,21 +19839,17 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure DRS replication configurations use EBS encryption using the AWS CLI:
 
             ```bash
             aws drs update-replication-configuration --source-server-id <id> --ebs-encryption DEFAULT
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Terraform does not have a native resource for managing AWS DRS replication configurations. Use the AWS CLI, SDK, or a `null_resource` with a local-exec provisioner to configure EBS encryption for DRS source servers.
+            To ensure DRS replication configurations use EBS encryption in Terraform, terraform does not have a native resource for managing AWS DRS replication configurations. Use the AWS CLI, SDK, or a `null_resource` with a local-exec provisioner to configure EBS encryption for DRS source servers.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support configuring AWS DRS replication settings. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable EBS encryption for DRS source server replication configurations.
+            To ensure DRS replication configurations use EBS encryption in CloudFormation, note that CloudFormation does not natively support configuring AWS DRS replication settings. Use the AWS CLI, SDK, or a CloudFormation custom resource to enable EBS encryption for DRS source server replication configurations.
     refs:
       - url: https://docs.aws.amazon.com/drs/latest/userguide/replication-settings.html
         title: AWS DRS Replication Settings
@@ -20339,7 +19904,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon Timestream databases use KMS encryption using the AWS Console:
 
             1. Navigate to the **Amazon Timestream** console.
             2. When creating a database, select a **Customer managed key** under encryption settings.
@@ -20347,14 +19912,14 @@ queries:
             Note: The KMS key must be specified at database creation time and cannot be changed afterward.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure Amazon Timestream databases use KMS encryption using the AWS CLI:
 
             ```bash
             aws timestream-write create-database --database-name <name> --kms-key-id <kms-key-arn>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Amazon Timestream databases use KMS encryption in Terraform:
 
             ```hcl
             resource "aws_timestreamwrite_database" "example" {
@@ -20364,7 +19929,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Amazon Timestream databases use KMS encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -20450,7 +20015,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Timestream InfluxDB instances are not publicly accessible using the AWS Console:
 
             1. Navigate to the **Amazon Timestream** console and select **InfluxDB instances** or **InfluxDB clusters**.
             2. Select the resource to review its connectivity configuration.
@@ -20463,9 +20028,7 @@ queries:
             Note: Public accessibility is set at creation time and cannot be modified after creation.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            When creating an InfluxDB instance, ensure it is placed in private subnets:
+            To ensure Timestream InfluxDB instances are not publicly accessible using the AWS CLI, when creating an InfluxDB instance, ensure it is placed in private subnets:
 
             ```bash
             aws timestream-influxdb create-db-instance \
@@ -20477,7 +20040,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Timestream InfluxDB instances are not publicly accessible in Terraform:
 
             ```hcl
             resource "aws_timestreaminfluxdb_db_instance" "example" {
@@ -20490,7 +20053,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Timestream InfluxDB instances are not publicly accessible in CloudFormation:
 
             ```yaml
             Resources:
@@ -20581,7 +20144,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Timestream InfluxDB instances have log delivery enabled using the AWS Console:
 
             1. Navigate to the **Amazon Timestream** console and select **InfluxDB instances** or **InfluxDB clusters**.
             2. Select the resource to modify.
@@ -20591,9 +20154,7 @@ queries:
             6. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            When creating an InfluxDB instance, enable log delivery:
+            To ensure Timestream InfluxDB instances have log delivery enabled using the AWS CLI, when creating an InfluxDB instance, enable log delivery:
 
             ```bash
             aws timestream-influxdb create-db-instance \
@@ -20605,7 +20166,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Timestream InfluxDB instances have log delivery enabled in Terraform:
 
             ```hcl
             resource "aws_timestreaminfluxdb_db_instance" "example" {
@@ -20624,7 +20185,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Timestream InfluxDB instances have log delivery enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -20713,23 +20274,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure network ACLs do not allow unrestricted inbound SSH or RDP access using the AWS Console:
 
             1. Navigate to the **VPC** console and select **Network ACLs**.
             2. Review inbound rules for entries allowing ports 22 or 3389 from 0.0.0.0/0.
             3. Modify the rules to restrict the source CIDR to known, trusted IP ranges.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure network ACLs do not allow unrestricted inbound SSH or RDP access using the AWS CLI:
 
             ```bash
             aws ec2 replace-network-acl-entry --network-acl-id <acl-id> --rule-number <number> --protocol tcp --port-range From=22,To=22 --cidr-block <trusted-cidr> --rule-action allow --ingress
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `aws_network_acl_rule` resources restrict SSH and RDP to trusted CIDRs:
+            To ensure network ACLs do not allow unrestricted inbound SSH or RDP access in Terraform, ensure `aws_network_acl_rule` resources restrict SSH and RDP to trusted CIDRs:
 
             ```hcl
             resource "aws_network_acl_rule" "ssh" {
@@ -20745,9 +20304,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure network ACL entries restrict SSH and RDP to trusted CIDRs:
+            To ensure network ACLs do not allow unrestricted inbound SSH or RDP access in CloudFormation, ensure network ACL entries restrict SSH and RDP to trusted CIDRs:
 
             ```yaml
             Resources:
@@ -20859,7 +20416,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure the default network ACL restricts all traffic using the AWS Console:
 
             1. Navigate to **VPC** > **Network ACLs**.
             2. Identify the default NACL (marked as "Yes" in the Default column).
@@ -20867,9 +20424,7 @@ queries:
             4. Ensure all subnets use custom NACLs with appropriate rules.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Replace permissive rules with deny-all rules:
+            To ensure the default network ACL restricts all traffic using the AWS CLI, replace permissive rules with deny-all rules:
 
             ```bash
             aws ec2 replace-network-acl-entry --network-acl-id <default-acl-id> --rule-number 100 --protocol -1 --rule-action deny --cidr-block 0.0.0.0/0 --ingress
@@ -20877,9 +20432,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use `aws_default_network_acl` with no ingress or egress rules to deny all traffic:
+            To ensure the default network ACL restricts all traffic in Terraform, use `aws_default_network_acl` with no ingress or egress rules to deny all traffic:
 
             ```hcl
             resource "aws_default_network_acl" "default" {
@@ -20888,9 +20441,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not provide a dedicated resource for modifying the default network ACL. The default NACL is automatically created with each VPC. Use custom NACLs for all subnets and modify the default NACL rules via the AWS CLI or SDK to deny all traffic.
+            To ensure the default network ACL restricts all traffic in CloudFormation, note that CloudFormation does not provide a dedicated resource for modifying the default network ACL. The default NACL is automatically created with each VPC. Use custom NACLs for all subnets and modify the default NACL rules via the AWS CLI or SDK to deny all traffic.
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
         title: Network ACLs - Amazon VPC
@@ -20963,7 +20514,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 key pairs use ED25519 or RSA key types using the AWS Console:
 
             1. Navigate to **EC2** > **Key Pairs**.
             2. Create a new key pair using **ED25519** or **RSA** type.
@@ -20971,16 +20522,14 @@ queries:
             4. Delete the old key pair.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure EC2 key pairs use ED25519 or RSA key types using the AWS CLI:
 
             ```bash
             aws ec2 create-key-pair --key-name my-key --key-type ed25519
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            The `aws_key_pair` resource imports existing public key material. Ensure the key material provided uses ED25519 or RSA:
+            To ensure EC2 key pairs use ED25519 or RSA key types in Terraform, the `aws_key_pair` resource imports existing public key material. Ensure the key material provided uses ED25519 or RSA:
 
             ```hcl
             resource "aws_key_pair" "example" {
@@ -20990,7 +20539,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EC2 key pairs use ED25519 or RSA key types in CloudFormation:
 
             ```yaml
             Resources:
@@ -21076,7 +20625,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS database instances have IAM authentication enabled using the AWS Console:
 
             1. Navigate to the **RDS** console.
             2. Select the database instance.
@@ -21085,14 +20634,14 @@ queries:
             5. Apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure RDS database instances have IAM authentication enabled using the AWS CLI:
 
             ```bash
             aws rds modify-db-instance --db-instance-identifier <instance-id> --enable-iam-database-authentication --apply-immediately
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS database instances have IAM authentication enabled in Terraform:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -21104,7 +20653,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS database instances have IAM authentication enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -21175,23 +20724,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS encryption by default is enabled for EKS node group volumes using the AWS Console:
 
             1. Navigate to **EC2** > **EBS Encryption** (under Account attributes).
             2. Enable **Always encrypt new EBS volumes** in all regions where EKS clusters are deployed.
             3. Optionally set a default KMS key for EBS encryption.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure EBS encryption by default is enabled for EKS node group volumes using the AWS CLI:
 
             ```bash
             aws ec2 enable-ebs-encryption-by-default --region <region>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use a launch template with encrypted EBS volumes for your EKS node group:
+            To ensure EBS encryption by default is enabled for EKS node group volumes in Terraform, use a launch template with encrypted EBS volumes for your EKS node group:
 
             ```hcl
             resource "aws_launch_template" "eks_nodes" {
@@ -21215,9 +20762,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Use a launch template with encrypted EBS volumes for EKS node groups:
+            To ensure EBS encryption by default is enabled for EKS node group volumes in CloudFormation, use a launch template with encrypted EBS volumes for EKS node groups:
 
             ```yaml
             Resources:
@@ -21289,21 +20834,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EKS clusters use API-based IAM authentication mode using the AWS Console:
 
             1. Navigate to the **EKS** console.
             2. Select the cluster and go to the **Access** tab.
             3. Update the authentication mode to **EKS API and ConfigMap** or **EKS API**.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure EKS clusters use API-based IAM authentication mode using the AWS CLI:
 
             ```bash
             aws eks update-cluster-config --name <cluster-name> --access-config authenticationMode=API_AND_CONFIG_MAP
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EKS clusters use API-based IAM authentication mode in Terraform:
 
             ```hcl
             resource "aws_eks_cluster" "example" {
@@ -21321,7 +20866,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EKS clusters use API-based IAM authentication mode in CloudFormation:
 
             ```yaml
             Resources:
@@ -21399,7 +20944,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EKS cluster add-ons are in a healthy state using the AWS Console:
 
             1. Navigate to the **EKS** console.
             2. Select the cluster and go to the **Add-ons** tab.
@@ -21407,9 +20952,7 @@ queries:
             4. Update or reconfigure any add-ons that are not in **Active** status.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List and update add-ons:
+            To ensure EKS cluster add-ons are in a healthy state using the AWS CLI, list and update add-ons:
 
             ```bash
             aws eks list-addons --cluster-name <cluster-name>
@@ -21417,9 +20960,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Manage EKS add-ons with Terraform and ensure they are kept up to date:
+            To ensure EKS cluster add-ons are in a healthy state in Terraform, manage EKS add-ons with Terraform and ensure they are kept up to date:
 
             ```hcl
             resource "aws_eks_addon" "coredns" {
@@ -21429,7 +20970,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EKS cluster add-ons are in a healthy state in CloudFormation:
 
             ```yaml
             Resources:
@@ -21491,21 +21032,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS clusters have Container Insights enabled using the AWS Console:
 
             1. Navigate to the **ECS** console.
             2. Select the cluster and choose **Update cluster**.
             3. Under **Monitoring**, enable **Container Insights**.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure ECS clusters have Container Insights enabled using the AWS CLI:
 
             ```bash
             aws ecs update-cluster-settings --cluster <cluster-name> --settings name=containerInsights,value=enabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECS clusters have Container Insights enabled in Terraform:
 
             ```hcl
             resource "aws_ecs_cluster" "example" {
@@ -21519,7 +21060,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS clusters have Container Insights enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -21612,21 +21153,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS clusters use KMS encryption for Fargate ephemeral storage using the AWS Console:
 
             1. Navigate to the **ECS** console.
             2. Select the cluster and choose **Update cluster**.
             3. Under **Encryption**, configure a **KMS key** for Fargate ephemeral storage encryption.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure ECS clusters use KMS encryption for Fargate ephemeral storage using the AWS CLI:
 
             ```bash
             aws ecs put-cluster-capacity-providers --cluster <cluster-name> --managed-storage-configuration fargateEphemeralStorageKmsKeyId=<kms-key-arn>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECS clusters use KMS encryption for Fargate ephemeral storage in Terraform:
 
             ```hcl
             resource "aws_ecs_cluster" "example" {
@@ -21641,7 +21182,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECS clusters use KMS encryption for Fargate ephemeral storage in CloudFormation:
 
             ```yaml
             Resources:
@@ -21730,21 +21271,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms using the AWS Console:
 
             1. Navigate to **AWS Certificate Manager**.
             2. Request a new certificate with **RSA 2048** or higher, or an **ECDSA P256/P384** key algorithm.
             3. Replace any certificates using weaker key algorithms.
         - id: cli
           desc: |
-            **Using AWS CLI**
+            To ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms using the AWS CLI:
 
             ```bash
             aws acm request-certificate --domain-name example.com --key-algorithm RSA_2048
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms in Terraform:
 
             ```hcl
             resource "aws_acm_certificate" "example" {
@@ -21755,7 +21296,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms in CloudFormation:
 
             ```yaml
             Resources:
@@ -21853,7 +21394,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda functions use KMS encryption for environment variables using the AWS Console:
 
             1. Navigate to the AWS Lambda Console.
             2. Select Functions in the left panel.
@@ -21864,9 +21405,7 @@ queries:
             7. Select Save to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a Lambda function to use a KMS key for environment variable encryption:
+            To ensure Lambda functions use KMS encryption for environment variables using the AWS CLI, update a Lambda function to use a KMS key for environment variable encryption:
 
             ```bash
             aws lambda update-function-configuration \
@@ -21875,7 +21414,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Lambda functions use KMS encryption for environment variables in Terraform:
 
             ```hcl
             resource "aws_lambda_function" "example" {
@@ -21891,7 +21430,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Lambda functions use KMS encryption for environment variables in CloudFormation:
 
             ```yaml
             Resources:
@@ -21996,7 +21535,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda functions have code signing configured using the AWS Console:
 
             1. Navigate to the AWS Lambda Console.
             2. Select Functions in the left panel.
@@ -22010,9 +21549,7 @@ queries:
             7. Select Save to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a code signing configuration:
+            To ensure Lambda functions have code signing configured using the AWS CLI, create a code signing configuration:
 
             ```bash
             aws lambda create-code-signing-config \
@@ -22029,7 +21566,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Lambda functions have code signing configured in Terraform:
 
             ```hcl
             resource "aws_lambda_code_signing_config" "example" {
@@ -22051,7 +21588,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Lambda functions have code signing configured in CloudFormation:
 
             ```yaml
             Resources:
@@ -22154,9 +21691,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: The minimum IMDS version cannot be changed on an existing notebook instance. You must create a new instance.
+            To ensure SageMaker notebook instances use IMDSv2 using the AWS Console, note: The minimum IMDS version cannot be changed on an existing notebook instance. You must create a new instance.
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select Notebook instances in the left panel.
@@ -22166,9 +21701,7 @@ queries:
             6. Migrate data from the old notebook instance and delete it.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new SageMaker notebook instance with IMDSv2 enforced:
+            To ensure SageMaker notebook instances use IMDSv2 using the AWS CLI, create a new SageMaker notebook instance with IMDSv2 enforced:
 
             ```bash
             aws sagemaker create-notebook-instance \
@@ -22179,7 +21712,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SageMaker notebook instances use IMDSv2 in Terraform:
 
             ```hcl
             resource "aws_sagemaker_notebook_instance" "example" {
@@ -22191,7 +21724,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker notebook instances use IMDSv2 in CloudFormation:
 
             ```yaml
             Resources:
@@ -22289,9 +21822,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Root access cannot be changed on an existing notebook instance. You must create a new instance.
+            To ensure SageMaker notebook instances do not allow root access using the AWS Console, note: Root access cannot be changed on an existing notebook instance. You must create a new instance.
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select Notebook instances in the left panel.
@@ -22301,9 +21832,7 @@ queries:
             6. Migrate data from the old notebook instance and delete it.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new SageMaker notebook instance with root access disabled:
+            To ensure SageMaker notebook instances do not allow root access using the AWS CLI, create a new SageMaker notebook instance with root access disabled:
 
             ```bash
             aws sagemaker create-notebook-instance \
@@ -22314,7 +21843,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SageMaker notebook instances do not allow root access in Terraform:
 
             ```hcl
             resource "aws_sagemaker_notebook_instance" "example" {
@@ -22326,7 +21855,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker notebook instances do not allow root access in CloudFormation:
 
             ```yaml
             Resources:
@@ -22423,7 +21952,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure S3 buckets use KMS customer managed keys for encryption using the AWS Console:
 
             1. Navigate to the Amazon S3 Console.
             2. Select the bucket to update.
@@ -22435,9 +21964,7 @@ queries:
             8. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the bucket encryption to use a KMS CMK:
+            To ensure S3 buckets use KMS customer managed keys for encryption using the AWS CLI, update the bucket encryption to use a KMS CMK:
 
             ```bash
             aws s3api put-bucket-encryption \
@@ -22454,7 +21981,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure S3 buckets use KMS customer managed keys for encryption in Terraform:
 
             ```hcl
             resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
@@ -22471,7 +21998,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure S3 buckets use KMS customer managed keys for encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -22582,7 +22109,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CodeBuild projects use KMS CMKs for artifact encryption using the AWS Console:
 
             1. Navigate to the AWS CodeBuild Console.
             2. Select Build projects in the left panel.
@@ -22593,9 +22120,7 @@ queries:
             7. Choose Update artifacts to save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a CodeBuild project to use a KMS CMK:
+            To ensure CodeBuild projects use KMS CMKs for artifact encryption using the AWS CLI, update a CodeBuild project to use a KMS CMK:
 
             ```bash
             aws codebuild update-project \
@@ -22604,7 +22129,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CodeBuild projects use KMS CMKs for artifact encryption in Terraform:
 
             ```hcl
             resource "aws_codebuild_project" "example" {
@@ -22628,7 +22153,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CodeBuild projects use KMS CMKs for artifact encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -22731,9 +22256,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Neptune snapshots inherit the encryption setting from the source cluster. To ensure snapshots are encrypted:
+            To ensure Neptune DB cluster snapshots are encrypted at rest using the AWS Console, neptune snapshots inherit the encryption setting from the source cluster. To ensure snapshots are encrypted:
 
             1. Navigate to the Amazon Neptune Console.
             2. Select Databases in the left panel.
@@ -22747,9 +22270,7 @@ queries:
               - Select Copy snapshot.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if Neptune cluster snapshots are encrypted:
+            To ensure Neptune DB cluster snapshots are encrypted at rest using the AWS CLI, check if Neptune cluster snapshots are encrypted:
 
             ```bash
             aws neptune describe-db-cluster-snapshots \
@@ -22766,9 +22287,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the source Neptune cluster is encrypted (snapshots inherit encryption):
+            To ensure Neptune DB cluster snapshots are encrypted at rest in Terraform, ensure the source Neptune cluster is encrypted (snapshots inherit encryption):
 
             ```hcl
             resource "aws_neptune_cluster" "example" {
@@ -22780,9 +22299,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure the source Neptune cluster is encrypted (snapshots inherit encryption):
+            To ensure Neptune DB cluster snapshots are encrypted at rest in CloudFormation, ensure the source Neptune cluster is encrypted (snapshots inherit encryption):
 
             ```yaml
             Resources:
@@ -22881,7 +22398,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instances have source/destination check enabled using the AWS Console:
 
             1. Navigate to the Amazon EC2 Console.
             2. Select Instances in the left panel.
@@ -22891,9 +22408,7 @@ queries:
             6. Select Save.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable source/destination check on an instance:
+            To ensure EC2 instances have source/destination check enabled using the AWS CLI, enable source/destination check on an instance:
 
             ```bash
             aws ec2 modify-instance-attribute \
@@ -22910,7 +22425,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EC2 instances have source/destination check enabled in Terraform:
 
             ```hcl
             resource "aws_instance" "example" {
@@ -22921,7 +22436,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EC2 instances have source/destination check enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -22997,7 +22512,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instances use UEFI boot mode using the AWS Console:
 
             1. Navigate to the **EC2 Console**.
             2. When launching new instances, select an AMI that supports UEFI boot mode.
@@ -23006,9 +22521,7 @@ queries:
             5. Note: Boot mode cannot be changed on a running instance; a new instance must be launched.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the boot mode of an instance:
+            To ensure EC2 instances use UEFI boot mode using the AWS CLI, check the boot mode of an instance:
 
             ```bash
             aws ec2 describe-instances --instance-ids <instance-id> \
@@ -23023,9 +22536,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            UEFI boot mode is determined by the AMI. Select a UEFI-compatible AMI for your instances:
+            To ensure EC2 instances use UEFI boot mode in Terraform, UEFI boot mode is determined by the AMI. Select a UEFI-compatible AMI for your instances:
 
             ```hcl
             resource "aws_instance" "example" {
@@ -23035,9 +22546,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            UEFI boot mode is determined by the AMI. Select a UEFI-compatible AMI for your instances:
+            To ensure EC2 instances use UEFI boot mode in CloudFormation, UEFI boot mode is determined by the AMI. Select a UEFI-compatible AMI for your instances:
 
             ```yaml
             Resources:
@@ -23091,7 +22600,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 instances use HVM virtualization using the AWS Console:
 
             1. Navigate to the **EC2 Console** and select **Instances**.
             2. Check the **Virtualization type** column for each instance.
@@ -23101,9 +22610,7 @@ queries:
               - Migrate workloads and terminate the PV instance.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List instances with their virtualization type:
+            To ensure EC2 instances use HVM virtualization using the AWS CLI, list instances with their virtualization type:
 
             ```bash
             aws ec2 describe-instances \
@@ -23119,9 +22626,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure instances use HVM AMIs (all modern AMIs use HVM):
+            To ensure EC2 instances use HVM virtualization in Terraform, ensure instances use HVM AMIs (all modern AMIs use HVM):
 
             ```hcl
             resource "aws_instance" "example" {
@@ -23131,9 +22636,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure instances use HVM AMIs (all modern AMIs use HVM):
+            To ensure EC2 instances use HVM virtualization in CloudFormation, ensure instances use HVM AMIs (all modern AMIs use HVM):
 
             ```yaml
             Resources:
@@ -23187,7 +22690,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS encryption by default is enabled when EC2 hibernation is in use using the AWS Console:
 
             1. Navigate to the **EC2 Console** and select **Instances**.
             2. Identify instances with hibernation enabled (check **Stop - Hibernate behavior** in instance details).
@@ -23199,9 +22702,7 @@ queries:
               - Terminate the original instance.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Find instances with hibernation enabled:
+            To ensure EBS encryption by default is enabled when EC2 hibernation is in use using the AWS CLI, find instances with hibernation enabled:
 
             ```bash
             aws ec2 describe-instances \
@@ -23217,9 +22718,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            When using hibernation, ensure the root EBS volume is encrypted:
+            To ensure EBS encryption by default is enabled when EC2 hibernation is in use in Terraform, when using hibernation, ensure the root EBS volume is encrypted:
 
             ```hcl
             resource "aws_instance" "example" {
@@ -23234,9 +22733,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            When using hibernation, ensure the root EBS volume is encrypted:
+            To ensure EBS encryption by default is enabled when EC2 hibernation is in use in CloudFormation, when using hibernation, ensure the root EBS volume is encrypted:
 
             ```yaml
             Resources:
@@ -23308,7 +22805,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 public hosted zones have DNSSEC signing enabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Hosted zones**.
             2. Select the public hosted zone to configure.
@@ -23318,9 +22815,7 @@ queries:
             6. After enabling, establish the chain of trust by adding a DS record to the parent zone through your domain registrar.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check DNSSEC status for a hosted zone:
+            To ensure Route 53 public hosted zones have DNSSEC signing enabled using the AWS CLI, check DNSSEC status for a hosted zone:
 
             ```bash
             aws route53 get-dnssec --hosted-zone-id <zone-id>
@@ -23339,9 +22834,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            DNSSEC requires both a Key Signing Key and enabling DNSSEC on the hosted zone:
+            To ensure Route 53 public hosted zones have DNSSEC signing enabled in Terraform, DNSSEC requires both a Key Signing Key and enabling DNSSEC on the hosted zone:
 
             ```hcl
             resource "aws_route53_key_signing_key" "example" {
@@ -23357,9 +22850,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support configuring DNSSEC signing for Route 53 hosted zones. Use the AWS CLI or Console to enable DNSSEC, or use a CloudFormation custom resource backed by a Lambda function.
+            To ensure Route 53 public hosted zones have DNSSEC signing enabled in CloudFormation, note that CloudFormation does not natively support configuring DNSSEC signing for Route 53 hosted zones. Use the AWS CLI or Console to enable DNSSEC, or use a CloudFormation custom resource backed by a Lambda function.
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec.html
         title: Configuring DNSSEC signing in Amazon Route 53
@@ -23428,7 +22919,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 public hosted zones have query logging enabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Hosted zones**.
             2. Select the public hosted zone.
@@ -23438,9 +22929,7 @@ queries:
             6. Configure the appropriate resource policy to allow Route 53 to write to the log group.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a CloudWatch Logs log group (must be in us-east-1):
+            To ensure Route 53 public hosted zones have query logging enabled using the AWS CLI, create a CloudWatch Logs log group (must be in us-east-1):
 
             ```bash
             aws logs create-log-group \
@@ -23457,9 +22946,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure query logging for a Route 53 hosted zone:
+            To ensure Route 53 public hosted zones have query logging enabled in Terraform, configure query logging for a Route 53 hosted zone:
 
             ```hcl
             resource "aws_route53_query_log" "example" {
@@ -23470,9 +22957,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable query logging via the `QueryLoggingConfig` property:
+            To ensure Route 53 public hosted zones have query logging enabled in CloudFormation, enable query logging via the `QueryLoggingConfig` property:
 
             ```yaml
             Resources:
@@ -23554,7 +23039,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 health checks are not disabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Health checks**.
             2. Review the list for any health checks with a **Disabled** status.
@@ -23563,9 +23048,7 @@ queries:
             5. If the health check is no longer needed, delete it rather than leaving it disabled.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all health checks and their disabled status:
+            To ensure Route 53 health checks are not disabled using the AWS CLI, list all health checks and their disabled status:
 
             ```bash
             aws route53 list-health-checks \
@@ -23581,9 +23064,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure health checks are not disabled:
+            To ensure Route 53 health checks are not disabled in Terraform, ensure health checks are not disabled:
 
             ```hcl
             resource "aws_route53_health_check" "example" {
@@ -23598,9 +23079,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure the health check is not disabled:
+            To ensure Route 53 health checks are not disabled in CloudFormation, ensure the health check is not disabled:
 
             ```yaml
             Resources:
@@ -23695,7 +23174,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 endpoint health checks use HTTPS using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Health checks**.
             2. Select the HTTP health check and choose **Edit**.
@@ -23705,9 +23184,7 @@ queries:
             6. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a health check to use HTTPS:
+            To ensure Route 53 endpoint health checks use HTTPS using the AWS CLI, update a health check to use HTTPS:
 
             ```bash
             aws route53 update-health-check \
@@ -23720,9 +23197,7 @@ queries:
             Note: You cannot change the health check type directly. To switch from HTTP to HTTPS, create a new HTTPS health check and update your DNS records to reference it.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure health checks to use HTTPS:
+            To ensure Route 53 endpoint health checks use HTTPS in Terraform, configure health checks to use HTTPS:
 
             ```hcl
             resource "aws_route53_health_check" "example" {
@@ -23736,9 +23211,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set the health check type to HTTPS:
+            To ensure Route 53 endpoint health checks use HTTPS in CloudFormation, set the health check type to HTTPS:
 
             ```yaml
             Resources:
@@ -23835,7 +23308,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AppStream 2.0 fleets do not have default internet access enabled using the AWS Console:
 
             1. Navigate to the **AppStream 2.0 Console** and select **Fleets**.
             2. Select the fleet and choose **Edit**.
@@ -23844,9 +23317,7 @@ queries:
             5. Save the changes and restart the fleet.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a fleet to disable default internet access:
+            To ensure AppStream 2.0 fleets do not have default internet access enabled using the AWS CLI, update a fleet to disable default internet access:
 
             ```bash
             aws appstream update-fleet \
@@ -23862,9 +23333,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable default internet access on AppStream fleets:
+            To ensure AppStream 2.0 fleets do not have default internet access enabled in Terraform, disable default internet access on AppStream fleets:
 
             ```hcl
             resource "aws_appstream_fleet" "example" {
@@ -23881,9 +23350,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `EnableDefaultInternetAccess` to `false`:
+            To ensure AppStream 2.0 fleets do not have default internet access enabled in CloudFormation, set `EnableDefaultInternetAccess` to `false`:
 
             ```yaml
             Resources:
@@ -23980,7 +23447,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AppStream 2.0 fleets enforce a maximum session duration using the AWS Console:
 
             1. Navigate to the **AppStream 2.0 Console** and select **Fleets**.
             2. Select the fleet and choose **Edit**.
@@ -23988,9 +23455,7 @@ queries:
             4. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the maximum session duration:
+            To ensure AppStream 2.0 fleets enforce a maximum session duration using the AWS CLI, update the maximum session duration:
 
             ```bash
             aws appstream update-fleet \
@@ -23999,9 +23464,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the maximum session duration:
+            To ensure AppStream 2.0 fleets enforce a maximum session duration in Terraform, set the maximum session duration:
 
             ```hcl
             resource "aws_appstream_fleet" "example" {
@@ -24014,9 +23477,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `MaxUserDurationInSeconds` to 36000 or less:
+            To ensure AppStream 2.0 fleets enforce a maximum session duration in CloudFormation, set `MaxUserDurationInSeconds` to 36000 or less:
 
             ```yaml
             Resources:
@@ -24109,7 +23570,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AppStream 2.0 fleets have idle disconnect timeout configured using the AWS Console:
 
             1. Navigate to the **AppStream 2.0 Console** and select **Fleets**.
             2. Select the fleet and choose **Edit**.
@@ -24117,9 +23578,7 @@ queries:
             4. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the idle disconnect timeout:
+            To ensure AppStream 2.0 fleets have idle disconnect timeout configured using the AWS CLI, update the idle disconnect timeout:
 
             ```bash
             aws appstream update-fleet \
@@ -24128,9 +23587,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure idle disconnect and disconnect timeouts:
+            To ensure AppStream 2.0 fleets have idle disconnect timeout configured in Terraform, configure idle disconnect and disconnect timeouts:
 
             ```hcl
             resource "aws_appstream_fleet" "example" {
@@ -24144,9 +23601,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `IdleDisconnectTimeoutInSeconds`:
+            To ensure AppStream 2.0 fleets have idle disconnect timeout configured in CloudFormation, set `IdleDisconnectTimeoutInSeconds`:
 
             ```yaml
             Resources:
@@ -24242,7 +23697,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AppStream 2.0 image builders disable default internet access using the AWS Console:
 
             1. Navigate to the **AppStream 2.0 Console** and select **Image builders**.
             2. When creating a new image builder, under **Network access**, do not check **Default Internet Access**.
@@ -24250,9 +23705,7 @@ queries:
             4. For existing image builders, create a new one without default internet access and delete the old one.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an image builder without default internet access:
+            To ensure AppStream 2.0 image builders disable default internet access using the AWS CLI, create an image builder without default internet access:
 
             ```bash
             aws appstream create-image-builder \
@@ -24264,9 +23717,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable default internet access on image builders:
+            To ensure AppStream 2.0 image builders disable default internet access in Terraform, disable default internet access on image builders:
 
             ```hcl
             resource "aws_appstream_image_builder" "example" {
@@ -24283,9 +23734,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `EnableDefaultInternetAccess` to `false`:
+            To ensure AppStream 2.0 image builders disable default internet access in CloudFormation, set `EnableDefaultInternetAccess` to `false`:
 
             ```yaml
             Resources:
@@ -24366,7 +23815,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Directory Service directories use SERVER_2019 or newer using the AWS Console:
 
             1. Navigate to the **Directory Service Console**.
             2. Select the directory running on SERVER_2012.
@@ -24375,9 +23824,7 @@ queries:
             5. Note: OS version upgrades may require a maintenance window and should be tested in a non-production directory first.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the OS version of your directories:
+            To ensure Directory Service directories use SERVER_2019 or newer using the AWS CLI, check the OS version of your directories:
 
             ```bash
             aws ds describe-directories \
@@ -24393,9 +23840,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the OS version when creating a Managed Microsoft AD directory:
+            To ensure Directory Service directories use SERVER_2019 or newer in Terraform, set the OS version when creating a Managed Microsoft AD directory:
 
             ```hcl
             resource "aws_directory_service_directory" "example" {
@@ -24414,9 +23859,7 @@ queries:
             Note: The `os_version` attribute may require recreation of the directory. Check the Terraform AWS provider documentation for current support.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Specify the OS version in the directory resource:
+            To ensure Directory Service directories use SERVER_2019 or newer in CloudFormation, specify the OS version in the directory resource:
 
             ```yaml
             Resources:
@@ -24478,7 +23921,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Directory Service directories have SSO enabled using the AWS Console:
 
             1. Navigate to the **Directory Service Console**.
             2. Select the directory.
@@ -24486,9 +23929,7 @@ queries:
             4. Choose **Enable** to enable SSO.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable SSO for a directory:
+            To ensure Directory Service directories have SSO enabled using the AWS CLI, enable SSO for a directory:
 
             ```bash
             aws ds enable-sso --directory-id <directory-id>
@@ -24502,14 +23943,10 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            SSO for Directory Service is not directly configurable via Terraform. Use the AWS CLI or Console to enable SSO after the directory is created, or use a `null_resource` with a local-exec provisioner.
+            To ensure Directory Service directories have SSO enabled in Terraform, SSO for Directory Service is not directly configurable via Terraform. Use the AWS CLI or Console to enable SSO after the directory is created, or use a `null_resource` with a local-exec provisioner.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SSO for Directory Service is not directly configurable via CloudFormation. Use the AWS CLI or Console to enable SSO after the directory is created, or use a CloudFormation custom resource.
+            To ensure Directory Service directories have SSO enabled in CloudFormation, SSO for Directory Service is not directly configurable via CloudFormation. Use the AWS CLI or Console to enable SSO after the directory is created, or use a CloudFormation custom resource.
     refs:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_single_sign_on.html
         title: Single sign-on for AWS Managed Microsoft AD
@@ -24555,7 +23992,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Directory Service Managed AD has RADIUS MFA enabled using the AWS Console:
 
             1. Navigate to the **Directory Service Console**.
             2. Select the Managed Microsoft AD directory.
@@ -24570,9 +24007,7 @@ queries:
             6. Choose **Enable**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable RADIUS MFA for a directory:
+            To ensure Directory Service Managed AD has RADIUS MFA enabled using the AWS CLI, enable RADIUS MFA for a directory:
 
             ```bash
             aws ds enable-radius --directory-id <directory-id> \
@@ -24596,9 +24031,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure RADIUS MFA settings for a directory:
+            To ensure Directory Service Managed AD has RADIUS MFA enabled in Terraform, configure RADIUS MFA settings for a directory:
 
             ```hcl
             resource "aws_directory_service_radius_settings" "example" {
@@ -24615,9 +24048,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support configuring RADIUS MFA for Directory Service. Use the AWS CLI or Console to enable RADIUS MFA after directory creation, or use a CloudFormation custom resource.
+            To ensure Directory Service Managed AD has RADIUS MFA enabled in CloudFormation, note that CloudFormation does not natively support configuring RADIUS MFA for Directory Service. Use the AWS CLI or Console to enable RADIUS MFA after directory creation, or use a CloudFormation custom resource.
     refs:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_mfa.html
         title: Enable multi-factor authentication for AWS Managed Microsoft AD
@@ -24678,7 +24109,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DocumentDB clusters are encrypted at rest using the AWS Console:
 
             1. Navigate to the Amazon DocumentDB Console.
             2. Select **Clusters** in the left panel.
@@ -24694,9 +24125,7 @@ queries:
             8. Delete the unencrypted cluster after verifying the migration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a DocumentDB cluster is encrypted:
+            To ensure DocumentDB clusters are encrypted at rest using the AWS CLI, check if a DocumentDB cluster is encrypted:
 
             ```bash
             aws docdb describe-db-clusters --db-cluster-identifier <cluster-id> \
@@ -24716,9 +24145,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable encryption at rest on a DocumentDB cluster:
+            To ensure DocumentDB clusters are encrypted at rest in Terraform, enable encryption at rest on a DocumentDB cluster:
 
             ```hcl
             resource "aws_docdb_cluster" "example" {
@@ -24732,9 +24159,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable `StorageEncrypted` on the cluster:
+            To ensure DocumentDB clusters are encrypted at rest in CloudFormation, enable `StorageEncrypted` on the cluster:
 
             ```yaml
             Resources:
@@ -24828,7 +24253,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DocumentDB clusters are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Navigate to the Amazon DocumentDB Console.
             2. Select **Clusters** in the left panel.
@@ -24840,9 +24265,7 @@ queries:
             5. Update applications to point to the new cluster endpoint.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a DocumentDB cluster with a customer-managed KMS key:
+            To ensure DocumentDB clusters are encrypted with a customer-managed KMS key using the AWS CLI, create a DocumentDB cluster with a customer-managed KMS key:
 
             ```bash
             aws docdb create-db-cluster \
@@ -24862,9 +24285,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Specify a customer-managed KMS key:
+            To ensure DocumentDB clusters are encrypted with a customer-managed KMS key in Terraform, specify a customer-managed KMS key:
 
             ```hcl
             resource "aws_docdb_cluster" "example" {
@@ -24878,9 +24299,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Specify a customer-managed KMS key via `KmsKeyId`:
+            To ensure DocumentDB clusters are encrypted with a customer-managed KMS key in CloudFormation, specify a customer-managed KMS key via `KmsKeyId`:
 
             ```yaml
             Resources:
@@ -24976,7 +24395,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DocumentDB instances have automatic minor version upgrades enabled using the AWS Console:
 
             1. Navigate to the Amazon DocumentDB Console.
             2. Select **Instances** in the left panel.
@@ -24987,9 +24406,7 @@ queries:
             7. Choose **Modify instance**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable automatic minor version upgrades for a DocumentDB instance:
+            To ensure DocumentDB instances have automatic minor version upgrades enabled using the AWS CLI, enable automatic minor version upgrades for a DocumentDB instance:
 
             ```bash
             aws docdb modify-db-instance \
@@ -25006,9 +24423,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable automatic minor version upgrades:
+            To ensure DocumentDB instances have automatic minor version upgrades enabled in Terraform, enable automatic minor version upgrades:
 
             ```hcl
             resource "aws_docdb_cluster_instance" "example" {
@@ -25020,9 +24435,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable `AutoMinorVersionUpgrade`:
+            To ensure DocumentDB instances have automatic minor version upgrades enabled in CloudFormation, enable `AutoMinorVersionUpgrade`:
 
             ```yaml
             Resources:
@@ -25114,7 +24527,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Cognito user pools enforce multi-factor authentication using the AWS Console:
 
             1. Navigate to the **Amazon Cognito Console** and select **User pools**.
             2. Select the user pool to modify.
@@ -25126,9 +24539,7 @@ queries:
             Note: Changing MFA from OPTIONAL to required will require all existing users to set up MFA at their next sign-in.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Set MFA to required for a user pool:
+            To ensure Cognito user pools enforce multi-factor authentication using the AWS CLI, set MFA to required for a user pool:
 
             ```bash
             aws cognito-idp set-user-pool-mfa-config \
@@ -25145,9 +24556,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enforce MFA on a Cognito user pool:
+            To ensure Cognito user pools enforce multi-factor authentication in Terraform, enforce MFA on a Cognito user pool:
 
             ```hcl
             resource "aws_cognito_user_pool" "example" {
@@ -25161,9 +24570,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `MfaConfiguration` to `ON`:
+            To ensure Cognito user pools enforce multi-factor authentication in CloudFormation, set `MfaConfiguration` to `ON`:
 
             ```yaml
             Resources:
@@ -25256,7 +24663,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Cognito user pools have advanced security features in enforced mode using the AWS Console:
 
             1. Navigate to the **Amazon Cognito Console** and select **User pools**.
             2. Select the user pool to modify.
@@ -25269,9 +24676,7 @@ queries:
             Note: Advanced security features incur additional costs per monthly active user.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable advanced security in enforced mode:
+            To ensure Cognito user pools have advanced security features in enforced mode using the AWS CLI, enable advanced security in enforced mode:
 
             ```bash
             aws cognito-idp update-user-pool \
@@ -25287,9 +24692,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable advanced security in enforced mode:
+            To ensure Cognito user pools have advanced security features in enforced mode in Terraform, enable advanced security in enforced mode:
 
             ```hcl
             resource "aws_cognito_user_pool" "example" {
@@ -25302,9 +24705,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `AdvancedSecurityMode` to `ENFORCED`:
+            To ensure Cognito user pools have advanced security features in enforced mode in CloudFormation, set `AdvancedSecurityMode` to `ENFORCED`:
 
             ```yaml
             Resources:
@@ -25397,7 +24798,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Cognito identity pools do not allow unauthenticated identities using the AWS Console:
 
             1. Navigate to the **Amazon Cognito Console** and select **Identity pools**.
             2. Select the identity pool to modify.
@@ -25407,9 +24808,7 @@ queries:
             6. Review and update any application code that relies on unauthenticated access to use authenticated flows instead.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Disable unauthenticated identities:
+            To ensure Cognito identity pools do not allow unauthenticated identities using the AWS CLI, disable unauthenticated identities:
 
             ```bash
             aws cognito-identity update-identity-pool \
@@ -25429,9 +24828,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable unauthenticated identities:
+            To ensure Cognito identity pools do not allow unauthenticated identities in Terraform, disable unauthenticated identities:
 
             ```hcl
             resource "aws_cognito_identity_pool" "example" {
@@ -25441,9 +24838,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `AllowUnauthenticatedIdentities` to `false`:
+            To ensure Cognito identity pools do not allow unauthenticated identities in CloudFormation, set `AllowUnauthenticatedIdentities` to `false`:
 
             ```yaml
             Resources:
@@ -25536,7 +24931,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Cognito identity pools disable Basic (Classic) auth flow using the AWS Console:
 
             1. Navigate to the **Amazon Cognito Console** and select **Identity pools**.
             2. Select the identity pool to modify.
@@ -25547,9 +24942,7 @@ queries:
             7. Update any application code that uses the Classic `GetOpenIdToken` and `AssumeRoleWithWebIdentity` flow to use `GetCredentialsForIdentity` instead.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Disable the Classic authentication flow:
+            To ensure Cognito identity pools disable Basic (Classic) auth flow using the AWS CLI, disable the Classic authentication flow:
 
             ```bash
             aws cognito-identity update-identity-pool \
@@ -25569,9 +24962,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable the Classic authentication flow:
+            To ensure Cognito identity pools disable Basic (Classic) auth flow in Terraform, disable the Classic authentication flow:
 
             ```hcl
             resource "aws_cognito_identity_pool" "example" {
@@ -25582,9 +24973,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `AllowClassicFlow` to `false`:
+            To ensure Cognito identity pools disable Basic (Classic) auth flow in CloudFormation, set `AllowClassicFlow` to `false`:
 
             ```yaml
             Resources:
@@ -25661,7 +25050,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 registered domains have transfer lock enabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Registered domains**.
             2. Select the domain name.
@@ -25669,9 +25058,7 @@ queries:
             4. Confirm the change.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable transfer lock for a domain:
+            To ensure Route 53 registered domains have transfer lock enabled using the AWS CLI, enable transfer lock for a domain:
 
             ```bash
             aws route53domains enable-domain-transfer-lock \
@@ -25689,14 +25076,10 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Domain transfer lock is not configurable via Terraform. Route 53 domain registration resources do not support managing transfer lock settings. Use the AWS CLI or Console to enable transfer lock.
+            To ensure Route 53 registered domains have transfer lock enabled in Terraform, domain transfer lock is not configurable via Terraform. Route 53 domain registration resources do not support managing transfer lock settings. Use the AWS CLI or Console to enable transfer lock.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Domain transfer lock is not configurable via CloudFormation. Use the AWS CLI or Console to manage transfer lock settings for registered domains.
+            To ensure Route 53 registered domains have transfer lock enabled in CloudFormation, domain transfer lock is not configurable via CloudFormation. Use the AWS CLI or Console to manage transfer lock settings for registered domains.
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-lock.html
         title: Locking a domain to prevent unauthorized transfer to another registrar
@@ -25738,7 +25121,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 registered domains have contact privacy protection enabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Registered domains**.
             2. Select the domain name.
@@ -25747,9 +25130,7 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable privacy protection for all contact types:
+            To ensure Route 53 registered domains have contact privacy protection enabled using the AWS CLI, enable privacy protection for all contact types:
 
             ```bash
             aws route53domains update-domain-contact-privacy \
@@ -25770,14 +25151,10 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Domain contact privacy is not configurable via Terraform. Route 53 domain registration resources do not support managing privacy protection settings. Use the AWS CLI or Console to enable contact privacy.
+            To ensure Route 53 registered domains have contact privacy protection enabled in Terraform, domain contact privacy is not configurable via Terraform. Route 53 domain registration resources do not support managing privacy protection settings. Use the AWS CLI or Console to enable contact privacy.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Domain contact privacy is not configurable via CloudFormation. Use the AWS CLI or Console to manage privacy protection settings for registered domains.
+            To ensure Route 53 registered domains have contact privacy protection enabled in CloudFormation, domain contact privacy is not configurable via CloudFormation. Use the AWS CLI or Console to manage privacy protection settings for registered domains.
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-privacy-protection.html
         title: Enabling or disabling privacy protection for contact information
@@ -25822,7 +25199,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Route 53 registered domains have auto-renew enabled using the AWS Console:
 
             1. Navigate to the **Route 53 Console** and select **Registered domains**.
             2. Select the domain name.
@@ -25830,9 +25207,7 @@ queries:
             4. Verify that a valid payment method is configured in your AWS account.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable auto-renew for a domain:
+            To ensure Route 53 registered domains have auto-renew enabled using the AWS CLI, enable auto-renew for a domain:
 
             ```bash
             aws route53domains enable-domain-auto-renew \
@@ -25849,14 +25224,10 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Domain auto-renew is not configurable via Terraform. Route 53 domain registration resources do not support managing auto-renewal settings. Use the AWS CLI or Console to enable auto-renew.
+            To ensure Route 53 registered domains have auto-renew enabled in Terraform, domain auto-renew is not configurable via Terraform. Route 53 domain registration resources do not support managing auto-renewal settings. Use the AWS CLI or Console to enable auto-renew.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Domain auto-renew is not configurable via CloudFormation. Use the AWS CLI or Console to manage auto-renewal settings for registered domains.
+            To ensure Route 53 registered domains have auto-renew enabled in CloudFormation, domain auto-renew is not configurable via CloudFormation. Use the AWS CLI or Console to manage auto-renewal settings for registered domains.
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-enable-disable-auto-renewal.html
         title: Enabling or disabling automatic renewal for a domain
@@ -25914,9 +25285,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            TLS cannot be enabled on an existing cluster. To remediate:
+            To ensure MemoryDB clusters have encryption in transit (TLS) enabled using the AWS Console, TLS cannot be enabled on an existing cluster. To remediate:
 
             1. Navigate to the **Amazon MemoryDB Console** and select **Clusters**.
             2. Create a new cluster with **Encryption in transit** enabled.
@@ -25925,9 +25294,7 @@ queries:
             5. Delete the old cluster after verifying the migration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new MemoryDB cluster with TLS enabled:
+            To ensure MemoryDB clusters have encryption in transit (TLS) enabled using the AWS CLI, create a new MemoryDB cluster with TLS enabled:
 
             ```bash
             aws memorydb create-cluster \
@@ -25945,9 +25312,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable TLS on a MemoryDB cluster:
+            To ensure MemoryDB clusters have encryption in transit (TLS) enabled in Terraform, enable TLS on a MemoryDB cluster:
 
             ```hcl
             resource "aws_memorydb_cluster" "example" {
@@ -25959,9 +25324,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `TLSEnabled` to `true`:
+            To ensure MemoryDB clusters have encryption in transit (TLS) enabled in CloudFormation, set `TLSEnabled` to `true`:
 
             ```yaml
             Resources:
@@ -26054,9 +25417,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            KMS key cannot be changed on an existing cluster. To remediate:
+            To ensure MemoryDB clusters are encrypted with a customer-managed KMS key using the AWS Console, KMS key cannot be changed on an existing cluster. To remediate:
 
             1. Navigate to the **Amazon MemoryDB Console** and select **Clusters**.
             2. Create a new cluster and under **Encryption at rest**, select a customer-managed KMS key.
@@ -26065,9 +25426,7 @@ queries:
             5. Delete the old cluster after verifying the migration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a MemoryDB cluster with a customer-managed KMS key:
+            To ensure MemoryDB clusters are encrypted with a customer-managed KMS key using the AWS CLI, create a MemoryDB cluster with a customer-managed KMS key:
 
             ```bash
             aws memorydb create-cluster \
@@ -26086,9 +25445,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Specify a customer-managed KMS key:
+            To ensure MemoryDB clusters are encrypted with a customer-managed KMS key in Terraform, specify a customer-managed KMS key:
 
             ```hcl
             resource "aws_memorydb_cluster" "example" {
@@ -26101,9 +25458,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Specify a KMS key via `KmsKeyId`:
+            To ensure MemoryDB clusters are encrypted with a customer-managed KMS key in CloudFormation, specify a KMS key via `KmsKeyId`:
 
             ```yaml
             Resources:
@@ -26199,7 +25554,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure MemoryDB clusters have automatic minor version upgrades enabled using the AWS Console:
 
             1. Navigate to the **Amazon MemoryDB Console** and select **Clusters**.
             2. Select the cluster to modify.
@@ -26208,9 +25563,7 @@ queries:
             5. Choose **Modify cluster**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable automatic minor version upgrades for a MemoryDB cluster:
+            To ensure MemoryDB clusters have automatic minor version upgrades enabled using the AWS CLI, enable automatic minor version upgrades for a MemoryDB cluster:
 
             ```bash
             aws memorydb update-cluster \
@@ -26226,9 +25579,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable automatic minor version upgrades:
+            To ensure MemoryDB clusters have automatic minor version upgrades enabled in Terraform, enable automatic minor version upgrades:
 
             ```hcl
             resource "aws_memorydb_cluster" "example" {
@@ -26240,9 +25591,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `AutoMinorVersionUpgrade` to `true`:
+            To ensure MemoryDB clusters have automatic minor version upgrades enabled in CloudFormation, set `AutoMinorVersionUpgrade` to `true`:
 
             ```yaml
             Resources:
@@ -26335,7 +25684,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Kinesis data streams have server-side encryption enabled using the AWS Console:
 
             1. Navigate to the **Amazon Kinesis Console** and select **Data streams**.
             2. Select the stream to modify.
@@ -26345,9 +25694,7 @@ queries:
             6. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable server-side encryption on a Kinesis data stream:
+            To ensure Kinesis data streams have server-side encryption enabled using the AWS CLI, enable server-side encryption on a Kinesis data stream:
 
             ```bash
             aws kinesis start-stream-encryption \
@@ -26364,9 +25711,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable server-side encryption on a Kinesis stream:
+            To ensure Kinesis data streams have server-side encryption enabled in Terraform, enable server-side encryption on a Kinesis stream:
 
             ```hcl
             resource "aws_kinesis_stream" "example" {
@@ -26378,9 +25723,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure `StreamEncryption`:
+            To ensure Kinesis data streams have server-side encryption enabled in CloudFormation, configure `StreamEncryption`:
 
             ```yaml
             Resources:
@@ -26474,7 +25817,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Kinesis data streams are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Navigate to the **Amazon Kinesis Console** and select **Data streams**.
             2. Select the stream to modify.
@@ -26484,9 +25827,7 @@ queries:
             6. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable encryption with a customer-managed KMS key:
+            To ensure Kinesis data streams are encrypted with a customer-managed KMS key using the AWS CLI, enable encryption with a customer-managed KMS key:
 
             ```bash
             aws kinesis start-stream-encryption \
@@ -26503,9 +25844,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use a customer-managed KMS key:
+            To ensure Kinesis data streams are encrypted with a customer-managed KMS key in Terraform, use a customer-managed KMS key:
 
             ```hcl
             resource "aws_kinesis_stream" "example" {
@@ -26517,9 +25856,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Specify a customer-managed KMS key:
+            To ensure Kinesis data streams are encrypted with a customer-managed KMS key in CloudFormation, specify a customer-managed KMS key:
 
             ```yaml
             Resources:
@@ -26618,7 +25955,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Kinesis Firehose delivery streams are encrypted using the AWS Console:
 
             1. Navigate to the **Amazon Data Firehose Console** and select the delivery stream.
             2. Under the **Configuration** tab, choose **Edit** next to **Server-side encryption**.
@@ -26627,9 +25964,7 @@ queries:
             5. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable server-side encryption on a Firehose delivery stream:
+            To ensure Kinesis Firehose delivery streams are encrypted using the AWS CLI, enable server-side encryption on a Firehose delivery stream:
 
             ```bash
             aws firehose start-delivery-stream-encryption \
@@ -26653,9 +25988,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable server-side encryption on a Firehose delivery stream:
+            To ensure Kinesis Firehose delivery streams are encrypted in Terraform, enable server-side encryption on a Firehose delivery stream:
 
             ```hcl
             resource "aws_kinesis_firehose_delivery_stream" "example" {
@@ -26674,9 +26007,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure `DeliveryStreamEncryptionConfiguration`:
+            To ensure Kinesis Firehose delivery streams are encrypted in CloudFormation, configure `DeliveryStreamEncryptionConfiguration`:
 
             ```yaml
             Resources:
@@ -26774,7 +26105,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Athena workgroups enforce workgroup configuration using the AWS Console:
 
             1. Navigate to the **Amazon Athena Console** and select **Workgroups**.
             2. Select the workgroup to modify.
@@ -26783,9 +26114,7 @@ queries:
             5. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable workgroup configuration enforcement:
+            To ensure Athena workgroups enforce workgroup configuration using the AWS CLI, enable workgroup configuration enforcement:
 
             ```bash
             aws athena update-work-group \
@@ -26801,9 +26130,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enforce workgroup configuration:
+            To ensure Athena workgroups enforce workgroup configuration in Terraform, enforce workgroup configuration:
 
             ```hcl
             resource "aws_athena_workgroup" "example" {
@@ -26816,9 +26143,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Set `EnforceWorkGroupConfiguration` to `true`:
+            To ensure Athena workgroups enforce workgroup configuration in CloudFormation, set `EnforceWorkGroupConfiguration` to `true`:
 
             ```yaml
             Resources:
@@ -26916,7 +26241,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Athena workgroups encrypt query results using the AWS Console:
 
             1. Navigate to the **Amazon Athena Console** and select **Workgroups**.
             2. Select the workgroup to modify.
@@ -26927,9 +26252,7 @@ queries:
             7. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Configure query result encryption with SSE-KMS:
+            To ensure Athena workgroups encrypt query results using the AWS CLI, configure query result encryption with SSE-KMS:
 
             ```bash
             aws athena update-work-group \
@@ -26952,9 +26275,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure query result encryption:
+            To ensure Athena workgroups encrypt query results in Terraform, configure query result encryption:
 
             ```hcl
             resource "aws_athena_workgroup" "example" {
@@ -26974,9 +26295,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure `EncryptionConfiguration` in the workgroup:
+            To ensure Athena workgroups encrypt query results in CloudFormation, configure `EncryptionConfiguration` in the workgroup:
 
             ```yaml
             Resources:
@@ -27079,9 +26398,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Volume encryption cannot be enabled on existing workspaces. To remediate:
+            To ensure WorkSpaces instances have root and user volume encryption enabled using the AWS Console, volume encryption cannot be enabled on existing workspaces. To remediate:
 
             1. Navigate to the **Amazon WorkSpaces Console** and select **WorkSpaces**.
             2. Note the configuration of the unencrypted workspace (bundle, directory, user).
@@ -27093,9 +26410,7 @@ queries:
             To ensure all future workspaces are encrypted, configure encryption in the directory default creation properties.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an encrypted workspace:
+            To ensure WorkSpaces instances have root and user volume encryption enabled using the AWS CLI, create an encrypted workspace:
 
             ```bash
             aws workspaces create-workspaces --workspaces '[{
@@ -27116,9 +26431,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable volume encryption on a workspace:
+            To ensure WorkSpaces instances have root and user volume encryption enabled in Terraform, enable volume encryption on a workspace:
 
             ```hcl
             resource "aws_workspaces_workspace" "example" {
@@ -27133,9 +26446,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable volume encryption:
+            To ensure WorkSpaces instances have root and user volume encryption enabled in CloudFormation, enable volume encryption:
 
             ```yaml
             Resources:
@@ -27229,7 +26540,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure WorkSpaces directories deny web access by default using the AWS Console:
 
             1. Navigate to the **Amazon WorkSpaces Console** and select **Directories**.
             2. Select the directory to modify.
@@ -27238,9 +26549,7 @@ queries:
             5. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Deny web access for a WorkSpaces directory:
+            To ensure WorkSpaces directories deny web access by default using the AWS CLI, deny web access for a WorkSpaces directory:
 
             ```bash
             aws workspaces modify-workspace-access-properties \
@@ -27256,9 +26565,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Deny web access in the directory configuration:
+            To ensure WorkSpaces directories deny web access by default in Terraform, deny web access in the directory configuration:
 
             ```hcl
             resource "aws_workspaces_directory" "example" {
@@ -27271,9 +26578,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support configuring WorkSpaces directory access properties. Use the AWS CLI or Terraform to manage web access settings.
+            To ensure WorkSpaces directories deny web access by default in CloudFormation, note that CloudFormation does not natively support configuring WorkSpaces directory access properties. Use the AWS CLI or Terraform to manage web access settings.
     refs:
       - url: https://docs.aws.amazon.com/workspaces/latest/adminguide/update-directory-details.html
         title: Update directory details for your WorkSpaces
@@ -27351,7 +26656,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure WorkSpaces directories have maintenance mode enabled using the AWS Console:
 
             1. Navigate to the **Amazon WorkSpaces Console** and select **Directories**.
             2. Select the directory to modify.
@@ -27360,9 +26665,7 @@ queries:
             5. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable maintenance mode for a WorkSpaces directory:
+            To ensure WorkSpaces directories have maintenance mode enabled using the AWS CLI, enable maintenance mode for a WorkSpaces directory:
 
             ```bash
             aws workspaces modify-workspace-creation-properties \
@@ -27378,9 +26681,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable maintenance mode in workspace creation properties:
+            To ensure WorkSpaces directories have maintenance mode enabled in Terraform, enable maintenance mode in workspace creation properties:
 
             ```hcl
             resource "aws_workspaces_directory" "example" {
@@ -27393,9 +26694,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support configuring WorkSpaces directory creation properties. Use the AWS CLI or Terraform to manage maintenance mode settings.
+            To ensure WorkSpaces directories have maintenance mode enabled in CloudFormation, note that CloudFormation does not natively support configuring WorkSpaces directory creation properties. Use the AWS CLI or Terraform to manage maintenance mode settings.
     refs:
       - url: https://docs.aws.amazon.com/workspaces/latest/adminguide/workspace-maintenance.html
         title: WorkSpaces maintenance
@@ -27458,7 +26757,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure WorkSpaces security groups do not allow unrestricted inbound access using the AWS Console:
 
             1. Navigate to the **Amazon WorkSpaces Console** and identify the security groups associated with your WorkSpaces.
             2. Go to the **VPC Console** > **Security Groups**.
@@ -27467,9 +26766,7 @@ queries:
             5. Replace unrestricted sources with specific CIDR ranges for your corporate network, VPN, or management IPs.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Identify security groups with unrestricted inbound rules:
+            To ensure WorkSpaces security groups do not allow unrestricted inbound access using the AWS CLI, identify security groups with unrestricted inbound rules:
 
             ```bash
             aws ec2 describe-security-groups \
@@ -27490,9 +26787,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Restrict security group inbound rules to specific CIDRs:
+            To ensure WorkSpaces security groups do not allow unrestricted inbound access in Terraform, restrict security group inbound rules to specific CIDRs:
 
             ```hcl
             resource "aws_security_group" "workspaces" {
@@ -27509,9 +26804,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Restrict inbound rules to specific CIDR ranges:
+            To ensure WorkSpaces security groups do not allow unrestricted inbound access in CloudFormation, restrict inbound rules to specific CIDR ranges:
 
             ```yaml
             Resources:
@@ -27592,7 +26885,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune DB instances are not publicly accessible using the AWS Console:
 
             1. Navigate to the Amazon Neptune Console.
             2. Select Databases in the left panel.
@@ -27602,9 +26895,7 @@ queries:
             6. Select Continue and apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Disable public accessibility on a Neptune instance:
+            To ensure Neptune DB instances are not publicly accessible using the AWS CLI, disable public accessibility on a Neptune instance:
 
             ```bash
             aws neptune modify-db-instance \
@@ -27620,7 +26911,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Neptune DB instances are not publicly accessible in Terraform:
 
             ```hcl
             resource "aws_neptune_cluster_instance" "example" {
@@ -27631,7 +26922,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Neptune DB instances are not publicly accessible in CloudFormation:
 
             ```yaml
             Resources:
@@ -27725,7 +27016,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure OpenSearch domains have automatic software updates enabled using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain you want to update.
@@ -27734,9 +27025,7 @@ queries:
             5. Select Save changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable automatic software updates:
+            To ensure OpenSearch domains have automatic software updates enabled using the AWS CLI, enable automatic software updates:
 
             ```bash
             aws opensearch update-domain-config --domain-name <domain-name> \
@@ -27751,9 +27040,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable automatic software updates on an OpenSearch domain:
+            To ensure OpenSearch domains have automatic software updates enabled in Terraform, enable automatic software updates on an OpenSearch domain:
 
             ```hcl
             resource "aws_opensearch_domain" "example" {
@@ -27767,9 +27054,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable automatic software updates on an OpenSearch domain:
+            To ensure OpenSearch domains have automatic software updates enabled in CloudFormation, enable automatic software updates on an OpenSearch domain:
 
             ```yaml
             Resources:
@@ -27865,7 +27150,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune DB clusters are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Navigate to the Amazon Neptune Console.
             2. Select **Databases** in the left panel.
@@ -27877,9 +27162,7 @@ queries:
             5. Update applications to point to the new cluster endpoint.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a Neptune cluster with a customer-managed KMS key:
+            To ensure Neptune DB clusters are encrypted with a customer-managed KMS key using the AWS CLI, create a Neptune cluster with a customer-managed KMS key:
 
             ```bash
             aws neptune create-db-cluster \
@@ -27897,7 +27180,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Neptune DB clusters are encrypted with a customer-managed KMS key in Terraform:
 
             ```hcl
             resource "aws_kms_key" "neptune" {
@@ -27914,7 +27197,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Neptune DB clusters are encrypted with a customer-managed KMS key in CloudFormation:
 
             ```yaml
             Resources:
@@ -28014,7 +27297,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Navigate to the Amazon Redshift Console.
             2. Select the cluster to modify.
@@ -28025,9 +27308,7 @@ queries:
             Note: Changing the encryption key requires a cluster migration. Redshift will create an encrypted copy with the new key.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Modify a cluster to use a customer-managed KMS key:
+            To ensure Redshift clusters are encrypted with a customer-managed KMS key using the AWS CLI, modify a cluster to use a customer-managed KMS key:
 
             ```bash
             aws redshift modify-cluster \
@@ -28044,7 +27325,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Redshift clusters are encrypted with a customer-managed KMS key in Terraform:
 
             ```hcl
             resource "aws_kms_key" "redshift" {
@@ -28061,7 +27342,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters are encrypted with a customer-managed KMS key in CloudFormation:
 
             ```yaml
             Resources:
@@ -28152,7 +27433,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift clusters are on the current maintenance track using the AWS Console:
 
             1. Navigate to the AWS Redshift Console.
             2. Select **Clusters** in the left panel.
@@ -28164,9 +27445,7 @@ queries:
                - Select **Modify cluster**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the maintenance track of Redshift clusters:
+            To ensure Redshift clusters are on the current maintenance track using the AWS CLI, check the maintenance track of Redshift clusters:
 
             ```bash
             aws redshift describe-clusters --query "Clusters[*].{Cluster:ClusterIdentifier,MaintenanceTrack:MaintenanceTrackName}"
@@ -28181,9 +27460,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure Redshift clusters use the `Current` maintenance track:
+            To ensure Redshift clusters are on the current maintenance track in Terraform, ensure Redshift clusters use the `Current` maintenance track:
 
             ```hcl
             resource "aws_redshift_cluster" "secure_redshift" {
@@ -28196,7 +27473,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift clusters are on the current maintenance track in CloudFormation:
 
             ```yaml
             Resources:
@@ -28274,7 +27551,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure FSx file systems are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Open the AWS Console and navigate to **FSx** under **Storage** (or search for "FSx" in the search bar).
             2. Note: Encryption settings can only be configured at creation time and cannot be changed for existing file systems.
@@ -28287,9 +27564,7 @@ queries:
             9. Delete the old file system after verifying the migration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an FSx file system with a customer-managed KMS key:
+            To ensure FSx file systems are encrypted with a customer-managed KMS key using the AWS CLI, create an FSx file system with a customer-managed KMS key:
 
             ```bash
             aws fsx create-file-system \
@@ -28308,7 +27583,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure FSx file systems are encrypted with a customer-managed KMS key in Terraform:
 
             ```hcl
             resource "aws_kms_key" "fsx" {
@@ -28324,7 +27599,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure FSx file systems are encrypted with a customer-managed KMS key in CloudFormation:
 
             ```yaml
             Resources:
@@ -28426,7 +27701,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure OpenSearch domains are encrypted with a customer-managed KMS key using the AWS Console:
 
             1. Navigate to the Amazon OpenSearch Service Console.
             2. Select the domain to update.
@@ -28437,9 +27712,7 @@ queries:
             Note: Changing the KMS key may require creating a new domain and migrating data, depending on the domain configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a domain to use a customer-managed KMS key:
+            To ensure OpenSearch domains are encrypted with a customer-managed KMS key using the AWS CLI, update a domain to use a customer-managed KMS key:
 
             ```bash
             aws opensearch update-domain-config --domain-name <domain-name> \
@@ -28454,7 +27727,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure OpenSearch domains are encrypted with a customer-managed KMS key in Terraform:
 
             ```hcl
             resource "aws_kms_key" "opensearch" {
@@ -28474,7 +27747,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure OpenSearch domains are encrypted with a customer-managed KMS key in CloudFormation:
 
             ```yaml
             Resources:
@@ -28576,7 +27849,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue jobs have a security configuration assigned using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Security configurations** in the left panel.
@@ -28588,9 +27861,7 @@ queries:
             8. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a security configuration:
+            To ensure AWS Glue jobs have a security configuration assigned using the AWS CLI, create a security configuration:
 
             ```bash
             aws glue create-security-configuration \
@@ -28610,7 +27881,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue jobs have a security configuration assigned in Terraform:
 
             ```hcl
             resource "aws_glue_security_configuration" "example" {
@@ -28645,7 +27916,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue jobs have a security configuration assigned in CloudFormation:
 
             ```yaml
             Resources:
@@ -28744,7 +28015,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue crawlers have a security configuration assigned using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Security configurations** in the left panel.
@@ -28756,9 +28027,7 @@ queries:
             8. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update a crawler to use a security configuration:
+            To ensure AWS Glue crawlers have a security configuration assigned using the AWS CLI, update a crawler to use a security configuration:
 
             ```bash
             aws glue update-crawler --name my-crawler \
@@ -28773,7 +28042,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue crawlers have a security configuration assigned in Terraform:
 
             ```hcl
             resource "aws_glue_crawler" "example" {
@@ -28790,7 +28059,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue crawlers have a security configuration assigned in CloudFormation:
 
             ```yaml
             Resources:
@@ -28888,7 +28157,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue Data Catalog encryption at rest is enabled using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Settings** in the left panel (under Data catalog).
@@ -28897,9 +28166,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable Data Catalog encryption:
+            To ensure AWS Glue Data Catalog encryption at rest is enabled using the AWS CLI, enable Data Catalog encryption:
 
             ```bash
             aws glue put-data-catalog-encryption-settings \
@@ -28923,7 +28190,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue Data Catalog encryption at rest is enabled in Terraform:
 
             ```hcl
             resource "aws_glue_data_catalog_encryption_settings" "example" {
@@ -28941,7 +28208,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue Data Catalog encryption at rest is enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -29058,7 +28325,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue security configurations encrypt S3 targets using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Security configurations** in the left panel.
@@ -29067,9 +28334,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create or update a security configuration with S3 encryption:
+            To ensure AWS Glue security configurations encrypt S3 targets using the AWS CLI, create or update a security configuration with S3 encryption:
 
             ```bash
             aws glue create-security-configuration \
@@ -29080,7 +28345,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue security configurations encrypt S3 targets in Terraform:
 
             ```hcl
             resource "aws_glue_security_configuration" "example" {
@@ -29096,7 +28361,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue security configurations encrypt S3 targets in CloudFormation:
 
             ```yaml
             Resources:
@@ -29206,7 +28471,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue security configurations encrypt CloudWatch logs using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Security configurations** in the left panel.
@@ -29215,9 +28480,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create or update a security configuration with CloudWatch encryption:
+            To ensure AWS Glue security configurations encrypt CloudWatch logs using the AWS CLI, create or update a security configuration with CloudWatch encryption:
 
             ```bash
             aws glue create-security-configuration \
@@ -29228,7 +28491,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue security configurations encrypt CloudWatch logs in Terraform:
 
             ```hcl
             resource "aws_glue_security_configuration" "example" {
@@ -29244,7 +28507,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue security configurations encrypt CloudWatch logs in CloudFormation:
 
             ```yaml
             Resources:
@@ -29354,7 +28617,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue security configurations encrypt job bookmarks using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Security configurations** in the left panel.
@@ -29363,9 +28626,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create or update a security configuration with job bookmark encryption:
+            To ensure AWS Glue security configurations encrypt job bookmarks using the AWS CLI, create or update a security configuration with job bookmark encryption:
 
             ```bash
             aws glue create-security-configuration \
@@ -29376,7 +28637,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue security configurations encrypt job bookmarks in Terraform:
 
             ```hcl
             resource "aws_glue_security_configuration" "example" {
@@ -29392,7 +28653,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue security configurations encrypt job bookmarks in CloudFormation:
 
             ```yaml
             Resources:
@@ -29506,7 +28767,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Glue jobs use a supported Glue version using the AWS Console:
 
             1. Navigate to the AWS Glue Console.
             2. Select **Jobs** in the left panel.
@@ -29516,9 +28777,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the Glue version for a job:
+            To ensure AWS Glue jobs use a supported Glue version using the AWS CLI, update the Glue version for a job:
 
             ```bash
             aws glue update-job --job-name my-job \
@@ -29526,7 +28785,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Glue jobs use a supported Glue version in Terraform:
 
             ```hcl
             resource "aws_glue_job" "example" {
@@ -29541,7 +28800,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Glue jobs use a supported Glue version in CloudFormation:
 
             ```yaml
             Resources:
@@ -29639,7 +28898,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Elastic Beanstalk environments use enhanced health reporting using the AWS Console:
 
             1. Navigate to the Elastic Beanstalk Console.
             2. Select the environment to update.
@@ -29649,9 +28908,7 @@ queries:
             6. Select **Apply**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable enhanced health reporting for an environment:
+            To ensure Elastic Beanstalk environments use enhanced health reporting using the AWS CLI, enable enhanced health reporting for an environment:
 
             ```bash
             aws elasticbeanstalk update-environment \
@@ -29661,7 +28918,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Elastic Beanstalk environments use enhanced health reporting in Terraform:
 
             ```hcl
             resource "aws_elastic_beanstalk_environment" "example" {
@@ -29678,7 +28935,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Elastic Beanstalk environments use enhanced health reporting in CloudFormation:
 
             ```yaml
             Resources:
@@ -29783,7 +29040,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS proxies require TLS for client connections using the AWS Console:
 
             1. Navigate to the Amazon RDS Console.
             2. Select **Proxies** in the left panel.
@@ -29793,9 +29050,7 @@ queries:
             6. Select **Modify proxy**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable TLS requirement for an RDS Proxy:
+            To ensure RDS proxies require TLS for client connections using the AWS CLI, enable TLS requirement for an RDS Proxy:
 
             ```bash
             aws rds modify-db-proxy \
@@ -29812,7 +29067,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS proxies require TLS for client connections in Terraform:
 
             ```hcl
             resource "aws_db_proxy" "example" {
@@ -29830,7 +29085,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS proxies require TLS for client connections in CloudFormation:
 
             ```yaml
             Resources:
@@ -29931,7 +29186,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS proxies do not have debug logging enabled using the AWS Console:
 
             1. Navigate to the Amazon RDS Console.
             2. Select **Proxies** in the left panel.
@@ -29941,9 +29196,7 @@ queries:
             6. Select **Modify proxy**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Disable debug logging for an RDS Proxy:
+            To ensure RDS proxies do not have debug logging enabled using the AWS CLI, disable debug logging for an RDS Proxy:
 
             ```bash
             aws rds modify-db-proxy \
@@ -29952,7 +29205,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS proxies do not have debug logging enabled in Terraform:
 
             ```hcl
             resource "aws_db_proxy" "example" {
@@ -29971,7 +29224,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS proxies do not have debug logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -30055,9 +29308,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            DocumentDB snapshot encryption is inherited from the source cluster. To ensure encrypted snapshots:
+            To ensure DocumentDB cluster snapshots are encrypted at rest using the AWS Console, documentDB snapshot encryption is inherited from the source cluster. To ensure encrypted snapshots:
 
             1. Navigate to the Amazon DocumentDB Console.
             2. Create a new cluster with **Encryption-at-rest** enabled.
@@ -30065,9 +29316,7 @@ queries:
             4. Delete the old unencrypted cluster and its snapshots.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if snapshots are encrypted:
+            To ensure DocumentDB cluster snapshots are encrypted at rest using the AWS CLI, check if snapshots are encrypted:
 
             ```bash
             aws docdb describe-db-cluster-snapshots \
@@ -30087,9 +29336,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            DocumentDB snapshot encryption is inherited from the source cluster. Ensure the cluster is created with encryption enabled:
+            To ensure DocumentDB cluster snapshots are encrypted at rest in Terraform, documentDB snapshot encryption is inherited from the source cluster. Ensure the cluster is created with encryption enabled:
 
             ```hcl
             resource "aws_docdb_cluster" "example" {
@@ -30105,9 +29352,7 @@ queries:
             Snapshots created from this cluster will automatically inherit encryption.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            DocumentDB snapshot encryption is inherited from the source cluster. Ensure the cluster is created with encryption enabled:
+            To ensure DocumentDB cluster snapshots are encrypted at rest in CloudFormation, documentDB snapshot encryption is inherited from the source cluster. Ensure the cluster is created with encryption enabled:
 
             ```yaml
             Resources:
@@ -30177,18 +29422,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            MemoryDB snapshot encryption is inherited from the source cluster. To ensure snapshots are encrypted with a CMK:
+            To ensure MemoryDB snapshots are encrypted with a customer-managed KMS key using the AWS Console, memoryDB snapshot encryption is inherited from the source cluster. To ensure snapshots are encrypted with a CMK:
 
             1. Navigate to the Amazon MemoryDB Console.
             2. Create a new cluster with a customer-managed KMS key selected for encryption.
             3. Migrate data from the existing cluster to the new cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check snapshot encryption:
+            To ensure MemoryDB snapshots are encrypted with a customer-managed KMS key using the AWS CLI, check snapshot encryption:
 
             ```bash
             aws memorydb describe-snapshots \
@@ -30206,9 +29447,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            MemoryDB snapshot encryption is inherited from the source cluster. Specify a `kms_key_arn` on the snapshot or ensure the cluster uses a CMK:
+            To ensure MemoryDB snapshots are encrypted with a customer-managed KMS key in Terraform, memoryDB snapshot encryption is inherited from the source cluster. Specify a `kms_key_arn` on the snapshot or ensure the cluster uses a CMK:
 
             ```hcl
             resource "aws_memorydb_snapshot" "example" {
@@ -30219,9 +29458,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Specify a KMS key when creating a MemoryDB snapshot:
+            To ensure MemoryDB snapshots are encrypted with a customer-managed KMS key in CloudFormation, specify a KMS key when creating a MemoryDB snapshot:
 
             ```yaml
             Resources:
@@ -30309,7 +29546,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure MemoryDB clusters do not use the default open-access ACL using the AWS Console:
 
             1. Navigate to the Amazon MemoryDB Console.
             2. Select **Access control lists** in the left panel.
@@ -30321,9 +29558,7 @@ queries:
             8. Select **Modify**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a custom user and ACL:
+            To ensure MemoryDB clusters do not use the default open-access ACL using the AWS CLI, create a custom user and ACL:
 
             ```bash
             aws memorydb create-user \
@@ -30341,9 +29576,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the MemoryDB cluster uses a custom ACL instead of the default open-access ACL:
+            To ensure MemoryDB clusters do not use the default open-access ACL in Terraform, ensure the MemoryDB cluster uses a custom ACL instead of the default open-access ACL:
 
             ```hcl
             resource "aws_memorydb_cluster" "example" {
@@ -30359,9 +29592,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure the MemoryDB cluster uses a custom ACL:
+            To ensure MemoryDB clusters do not use the default open-access ACL in CloudFormation, ensure the MemoryDB cluster uses a custom ACL:
 
             ```yaml
             Resources:
@@ -30463,7 +29694,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SNS topic subscriptions use HTTPS protocol using the AWS Console:
 
             1. Navigate to the Amazon SNS Console.
             2. Select the topic containing the HTTP subscription.
@@ -30474,9 +29705,7 @@ queries:
             **Warning:** Switching an existing subscription from HTTP to HTTPS requires deleting the old subscription and creating a new one. This may cause temporary message delivery failures during the transition. Coordinate changes during a maintenance window and ensure your endpoint is ready to accept HTTPS connections before making the switch.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Replace the HTTP subscription with an HTTPS subscription:
+            To ensure SNS topic subscriptions use HTTPS protocol using the AWS CLI, replace the HTTP subscription with an HTTPS subscription:
 
             ```bash
             # Unsubscribe the HTTP endpoint
@@ -30491,7 +29720,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SNS topic subscriptions use HTTPS protocol in Terraform:
 
             ```hcl
             resource "aws_sns_topic_subscription" "example" {
@@ -30502,7 +29731,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SNS topic subscriptions use HTTPS protocol in CloudFormation:
 
             ```yaml
             Resources:
@@ -30602,7 +29831,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker models have network isolation enabled using the AWS Console:
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select **Models** in the left panel under **Inference**.
@@ -30611,9 +29840,7 @@ queries:
             5. Note: Existing models cannot be modified. Create a new model with network isolation enabled and update your endpoints to use the new model.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new SageMaker model with network isolation enabled:
+            To ensure SageMaker models have network isolation enabled using the AWS CLI, create a new SageMaker model with network isolation enabled:
 
             ```bash
             aws sagemaker create-model \
@@ -30624,9 +29851,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker models have network isolation enabled:
+            To ensure SageMaker models have network isolation enabled in Terraform, ensure SageMaker models have network isolation enabled:
 
             ```hcl
             resource "aws_sagemaker_model" "example" {
@@ -30641,7 +29866,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker models have network isolation enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -30738,7 +29963,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker models are deployed within a VPC using the AWS Console:
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select **Models** in the left panel under **Inference**.
@@ -30747,9 +29972,7 @@ queries:
             5. Note: Existing models cannot be modified. Create a new model with VPC configuration and update your endpoints.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a SageMaker model with VPC configuration:
+            To ensure SageMaker models are deployed within a VPC using the AWS CLI, create a SageMaker model with VPC configuration:
 
             ```bash
             aws sagemaker create-model \
@@ -30760,9 +29983,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker models are deployed within a VPC:
+            To ensure SageMaker models are deployed within a VPC in Terraform, ensure SageMaker models are deployed within a VPC:
 
             ```hcl
             resource "aws_sagemaker_model" "example" {
@@ -30781,7 +30002,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker models are deployed within a VPC in CloudFormation:
 
             ```yaml
             Resources:
@@ -30868,16 +30089,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker training jobs have network isolation enabled using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a training job, under **Network**, enable **Network isolation**.
             3. This prevents the training container from making outbound network calls.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a training job with network isolation enabled:
+            To ensure SageMaker training jobs have network isolation enabled using the AWS CLI, create a training job with network isolation enabled:
 
             ```bash
             aws sagemaker create-training-job \
@@ -30892,9 +30111,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker training jobs have network isolation enabled:
+            To ensure SageMaker training jobs have network isolation enabled in Terraform, ensure SageMaker training jobs have network isolation enabled:
 
             ```hcl
             resource "aws_sagemaker_training_job" "example" {
@@ -30920,9 +30137,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure network isolation when creating training jobs.
+            To ensure SageMaker training jobs have network isolation enabled in CloudFormation, sageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure network isolation when creating training jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
@@ -30967,16 +30182,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker training jobs encrypt inter-container traffic using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a training job, under **Security**, enable **Inter-container traffic encryption**.
             3. This encrypts traffic between distributed training containers.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a training job with inter-container traffic encryption enabled:
+            To ensure SageMaker training jobs encrypt inter-container traffic using the AWS CLI, create a training job with inter-container traffic encryption enabled:
 
             ```bash
             aws sagemaker create-training-job \
@@ -30991,9 +30204,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker training jobs have inter-container traffic encryption:
+            To ensure SageMaker training jobs encrypt inter-container traffic in Terraform, ensure SageMaker training jobs have inter-container traffic encryption:
 
             ```hcl
             resource "aws_sagemaker_training_job" "example" {
@@ -31019,9 +30230,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to enable inter-container traffic encryption when creating training jobs.
+            To ensure SageMaker training jobs encrypt inter-container traffic in CloudFormation, sageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to enable inter-container traffic encryption when creating training jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
@@ -31066,16 +30275,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker training jobs are deployed within a VPC using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a training job, under **Network**, configure **VPC** settings.
             3. Select a VPC, subnets, and security groups.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a training job within a VPC:
+            To ensure SageMaker training jobs are deployed within a VPC using the AWS CLI, create a training job within a VPC:
 
             ```bash
             aws sagemaker create-training-job \
@@ -31090,9 +30297,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker training jobs are deployed within a VPC:
+            To ensure SageMaker training jobs are deployed within a VPC in Terraform, ensure SageMaker training jobs are deployed within a VPC:
 
             ```hcl
             resource "aws_sagemaker_training_job" "example" {
@@ -31122,9 +30327,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure VPC settings when creating training jobs.
+            To ensure SageMaker training jobs are deployed within a VPC in CloudFormation, sageMaker training jobs are created via the `CreateTrainingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure VPC settings when creating training jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-vpc.html
         title: Amazon SageMaker - Give SageMaker Training Jobs Access to Resources in Your VPC
@@ -31169,16 +30372,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker processing jobs have network isolation enabled using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a processing job, under **Network**, enable **Network isolation**.
             3. This prevents the processing container from making outbound network calls.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a processing job with network isolation enabled:
+            To ensure SageMaker processing jobs have network isolation enabled using the AWS CLI, create a processing job with network isolation enabled:
 
             ```bash
             aws sagemaker create-processing-job \
@@ -31190,9 +30391,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker processing jobs have network isolation enabled:
+            To ensure SageMaker processing jobs have network isolation enabled in Terraform, ensure SageMaker processing jobs have network isolation enabled:
 
             ```hcl
             resource "aws_sagemaker_processing_job" "example" {
@@ -31218,9 +30417,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure network isolation when creating processing jobs.
+            To ensure SageMaker processing jobs have network isolation enabled in CloudFormation, sageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure network isolation when creating processing jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
@@ -31265,15 +30462,13 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker processing jobs encrypt inter-container traffic using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a processing job, under **Security**, enable **Inter-container traffic encryption**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a processing job with inter-container traffic encryption:
+            To ensure SageMaker processing jobs encrypt inter-container traffic using the AWS CLI, create a processing job with inter-container traffic encryption:
 
             ```bash
             aws sagemaker create-processing-job \
@@ -31285,9 +30480,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker processing jobs have inter-container traffic encryption:
+            To ensure SageMaker processing jobs encrypt inter-container traffic in Terraform, ensure SageMaker processing jobs have inter-container traffic encryption:
 
             ```hcl
             resource "aws_sagemaker_processing_job" "example" {
@@ -31313,9 +30506,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to enable inter-container traffic encryption when creating processing jobs.
+            To ensure SageMaker processing jobs encrypt inter-container traffic in CloudFormation, sageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to enable inter-container traffic encryption when creating processing jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
@@ -31360,16 +30551,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker processing jobs are deployed within a VPC using the AWS Console:
 
             1. Navigate to the **SageMaker Console**.
             2. When creating a processing job, under **Network**, configure **VPC** settings.
             3. Select a VPC, subnets, and security groups.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a processing job within a VPC:
+            To ensure SageMaker processing jobs are deployed within a VPC using the AWS CLI, create a processing job within a VPC:
 
             ```bash
             aws sagemaker create-processing-job \
@@ -31381,9 +30570,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker processing jobs are deployed within a VPC:
+            To ensure SageMaker processing jobs are deployed within a VPC in Terraform, ensure SageMaker processing jobs are deployed within a VPC:
 
             ```hcl
             resource "aws_sagemaker_processing_job" "example" {
@@ -31412,9 +30599,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            SageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure VPC settings when creating processing jobs.
+            To ensure SageMaker processing jobs are deployed within a VPC in CloudFormation, sageMaker processing jobs are created via the `CreateProcessingJob` API and do not have a corresponding CloudFormation resource type. Use the AWS CLI or SDK to configure VPC settings when creating processing jobs.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/process-vpc.html
         title: Amazon SageMaker - Give SageMaker Processing Jobs Access to Resources in Your VPC
@@ -31477,7 +30662,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SageMaker domains are encrypted with a KMS key using the AWS Console:
 
             1. Navigate to the Amazon SageMaker Console.
             2. Select **Domains** in the left panel.
@@ -31490,9 +30675,7 @@ queries:
             5. Delete the unencrypted domain once migration is complete.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a SageMaker domain with KMS encryption:
+            To ensure SageMaker domains are encrypted with a KMS key using the AWS CLI, create a SageMaker domain with KMS encryption:
 
             ```bash
             aws sagemaker create-domain \
@@ -31505,9 +30688,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure SageMaker domains are encrypted with a KMS key:
+            To ensure SageMaker domains are encrypted with a KMS key in Terraform, ensure SageMaker domains are encrypted with a KMS key:
 
             ```hcl
             resource "aws_kms_key" "sagemaker_domain" {
@@ -31529,7 +30710,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SageMaker domains are encrypted with a KMS key in CloudFormation:
 
             ```yaml
             Resources:
@@ -31626,7 +30807,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon MQ brokers have audit logging enabled using the AWS Console:
 
             1. Navigate to the **Amazon MQ Console** and select **Brokers**.
             2. Select the broker you want to configure.
@@ -31635,9 +30816,7 @@ queries:
             5. Choose **Save** to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update an existing broker to enable audit logging:
+            To ensure Amazon MQ brokers have audit logging enabled using the AWS CLI, update an existing broker to enable audit logging:
 
             ```bash
             aws mq update-broker \
@@ -31653,9 +30832,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable audit logging on an Amazon MQ broker:
+            To ensure Amazon MQ brokers have audit logging enabled in Terraform, enable audit logging on an Amazon MQ broker:
 
             ```hcl
             resource "aws_mq_broker" "example" {
@@ -31669,9 +30846,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable audit logging on an Amazon MQ broker:
+            To ensure Amazon MQ brokers have audit logging enabled in CloudFormation, enable audit logging on an Amazon MQ broker:
 
             ```yaml
             Resources:
@@ -31767,7 +30942,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Amazon MQ brokers have general logging enabled using the AWS Console:
 
             1. Navigate to the **Amazon MQ Console** and select **Brokers**.
             2. Select the broker you want to configure.
@@ -31776,9 +30951,7 @@ queries:
             5. Choose **Save** to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update an existing broker to enable general logging:
+            To ensure Amazon MQ brokers have general logging enabled using the AWS CLI, update an existing broker to enable general logging:
 
             ```bash
             aws mq update-broker \
@@ -31794,9 +30967,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable general logging on an Amazon MQ broker:
+            To ensure Amazon MQ brokers have general logging enabled in Terraform, enable general logging on an Amazon MQ broker:
 
             ```hcl
             resource "aws_mq_broker" "example" {
@@ -31810,9 +30981,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable general logging on an Amazon MQ broker:
+            To ensure Amazon MQ brokers have general logging enabled in CloudFormation, enable general logging on an Amazon MQ broker:
 
             ```yaml
             Resources:
@@ -31908,9 +31077,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Public accessibility cannot be changed after a broker is created. You must create a new broker without public accessibility and migrate your workloads.
+            To ensure Amazon MQ brokers are not publicly accessible using the AWS Console, note: Public accessibility cannot be changed after a broker is created. You must create a new broker without public accessibility and migrate your workloads.
 
             1. Navigate to the **Amazon MQ Console** and choose **Create broker**.
             2. In the **Network & Security** section, ensure **Public accessibility** is set to **No**.
@@ -31919,9 +31086,7 @@ queries:
             5. Delete the publicly accessible broker.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a new broker without public accessibility:
+            To ensure Amazon MQ brokers are not publicly accessible using the AWS CLI, create a new broker without public accessibility:
 
             ```bash
             aws mq create-broker \
@@ -31942,9 +31107,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the Amazon MQ broker is not publicly accessible:
+            To ensure Amazon MQ brokers are not publicly accessible in Terraform, ensure the Amazon MQ broker is not publicly accessible:
 
             ```hcl
             resource "aws_mq_broker" "example" {
@@ -31956,9 +31119,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure the Amazon MQ broker is not publicly accessible:
+            To ensure Amazon MQ brokers are not publicly accessible in CloudFormation, ensure the Amazon MQ broker is not publicly accessible:
 
             ```yaml
             Resources:
@@ -32054,9 +31215,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Encryption at rest settings cannot be changed after an MSK cluster is created. A new cluster must be created with the desired KMS key.
+            To ensure MSK clusters use a customer-managed KMS key using the AWS Console, note: Encryption at rest settings cannot be changed after an MSK cluster is created. A new cluster must be created with the desired KMS key.
 
             1. Navigate to the **Amazon MSK Console** and choose **Create cluster**.
             2. Under **Security**, in the **Encryption at rest** section, select **Use a custom KMS key**.
@@ -32065,9 +31224,7 @@ queries:
             5. Migrate producers and consumers to the new cluster and decommission the old one.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an MSK cluster with a customer-managed KMS key:
+            To ensure MSK clusters use a customer-managed KMS key using the AWS CLI, create an MSK cluster with a customer-managed KMS key:
 
             ```bash
             aws kafka create-cluster \
@@ -32086,9 +31243,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a customer-managed KMS key for MSK encryption at rest:
+            To ensure MSK clusters use a customer-managed KMS key in Terraform, configure a customer-managed KMS key for MSK encryption at rest:
 
             ```hcl
             resource "aws_msk_cluster" "example" {
@@ -32103,9 +31258,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure a customer-managed KMS key for MSK encryption at rest:
+            To ensure MSK clusters use a customer-managed KMS key in CloudFormation, configure a customer-managed KMS key for MSK encryption at rest:
 
             ```yaml
             Resources:
@@ -32203,9 +31356,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Encryption in transit settings cannot be changed after cluster creation. A new cluster must be created with the desired setting.
+            To ensure MSK clusters encrypt data in transit with TLS using the AWS Console, note: Encryption in transit settings cannot be changed after cluster creation. A new cluster must be created with the desired setting.
 
             1. Navigate to the **Amazon MSK Console** and choose **Create cluster**.
             2. Under **Security**, in the **Encryption in transit** section, set **Client-broker encryption** to **TLS**.
@@ -32214,9 +31365,7 @@ queries:
             5. Decommission the old cluster once migration is complete.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an MSK cluster with TLS-only client-broker encryption:
+            To ensure MSK clusters encrypt data in transit with TLS using the AWS CLI, create an MSK cluster with TLS-only client-broker encryption:
 
             ```bash
             aws kafka create-cluster \
@@ -32235,9 +31384,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enforce TLS encryption for client-broker communication in MSK:
+            To ensure MSK clusters encrypt data in transit with TLS in Terraform, enforce TLS encryption for client-broker communication in MSK:
 
             ```hcl
             resource "aws_msk_cluster" "example" {
@@ -32255,9 +31402,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enforce TLS encryption for client-broker communication in MSK:
+            To ensure MSK clusters encrypt data in transit with TLS in CloudFormation, enforce TLS encryption for client-broker communication in MSK:
 
             ```yaml
             Resources:
@@ -32356,7 +31501,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure MSK clusters have logging enabled using the AWS Console:
 
             1. Navigate to the **Amazon MSK Console** and select your cluster.
             2. Choose **Edit cluster** (note: some logging settings require cluster recreation).
@@ -32367,9 +31512,7 @@ queries:
             4. Save the configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update broker logging to deliver logs to CloudWatch Logs:
+            To ensure MSK clusters have logging enabled using the AWS CLI, update broker logging to deliver logs to CloudWatch Logs:
 
             ```bash
             aws kafka update-monitoring \
@@ -32386,9 +31529,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable broker logging on an MSK cluster (at least one destination):
+            To ensure MSK clusters have logging enabled in Terraform, enable broker logging on an MSK cluster (at least one destination):
 
             ```hcl
             resource "aws_msk_cluster" "example" {
@@ -32408,9 +31549,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable broker logging on an MSK cluster:
+            To ensure MSK clusters have logging enabled in CloudFormation, enable broker logging on an MSK cluster:
 
             ```yaml
             Resources:
@@ -32492,7 +31631,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail S3 bucket is not publicly accessible using the AWS Console:
 
             1. Navigate to the **Amazon S3 Console** and select the bucket used by CloudTrail.
             2. Choose the **Permissions** tab.
@@ -32502,9 +31641,7 @@ queries:
             6. Also review the bucket policy and ACLs to ensure no public access is granted.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Block all public access on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket is not publicly accessible using the AWS CLI, block all public access on the CloudTrail S3 bucket:
 
             ```bash
             aws s3api put-public-access-block \
@@ -32520,9 +31657,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Block all public access on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket is not publicly accessible in Terraform, block all public access on the CloudTrail S3 bucket:
 
             ```hcl
             resource "aws_s3_bucket_public_access_block" "cloudtrail" {
@@ -32536,9 +31671,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Block all public access on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket is not publicly accessible in CloudFormation, block all public access on the CloudTrail S3 bucket:
 
             ```yaml
             Resources:
@@ -32595,7 +31728,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail S3 bucket has access logging enabled using the AWS Console:
 
             1. Navigate to the **Amazon S3 Console** and select the bucket used by CloudTrail.
             2. Choose the **Properties** tab.
@@ -32605,9 +31738,7 @@ queries:
             6. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable server access logging on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket has access logging enabled using the AWS CLI, enable server access logging on the CloudTrail S3 bucket:
 
             ```bash
             aws s3api put-bucket-logging \
@@ -32627,9 +31758,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable server access logging on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket has access logging enabled in Terraform, enable server access logging on the CloudTrail S3 bucket:
 
             ```hcl
             resource "aws_s3_bucket_logging" "cloudtrail" {
@@ -32641,9 +31770,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable server access logging on the CloudTrail S3 bucket:
+            To ensure CloudTrail S3 bucket has access logging enabled in CloudFormation, enable server access logging on the CloudTrail S3 bucket:
 
             ```yaml
             Resources:
@@ -32714,7 +31841,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DynamoDB tables have point-in-time recovery enabled using the AWS Console:
 
             1. Navigate to the **Amazon DynamoDB Console** and select **Tables**.
             2. Select the table you want to configure.
@@ -32723,9 +31850,7 @@ queries:
             5. Confirm the action.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable PITR on a DynamoDB table:
+            To ensure DynamoDB tables have point-in-time recovery enabled using the AWS CLI, enable PITR on a DynamoDB table:
 
             ```bash
             aws dynamodb update-continuous-backups \
@@ -32741,9 +31866,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable point-in-time recovery on a DynamoDB table:
+            To ensure DynamoDB tables have point-in-time recovery enabled in Terraform, enable point-in-time recovery on a DynamoDB table:
 
             ```hcl
             resource "aws_dynamodb_table" "example" {
@@ -32757,9 +31880,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable point-in-time recovery on a DynamoDB table:
+            To ensure DynamoDB tables have point-in-time recovery enabled in CloudFormation, enable point-in-time recovery on a DynamoDB table:
 
             ```yaml
             Resources:
@@ -32848,7 +31969,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for unauthorized API calls using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -32858,9 +31979,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for unauthorized API calls using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -32886,9 +32005,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for unauthorized API calls:
+            To ensure log metric filter exists for unauthorized API calls in Terraform, create a CloudWatch log metric filter and alarm for unauthorized API calls:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "unauthorizedapicalls" {
@@ -32917,9 +32034,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for unauthorized API calls:
+            To ensure log metric filter exists for unauthorized API calls in CloudFormation, create a CloudWatch log metric filter and alarm for unauthorized API calls:
 
             ```yaml
             Resources:
@@ -33024,7 +32139,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for console sign-in without MFA using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33034,9 +32149,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for console sign-in without MFA using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33062,9 +32175,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for console sign-in without MFA:
+            To ensure log metric filter exists for console sign-in without MFA in Terraform, create a CloudWatch log metric filter and alarm for console sign-in without MFA:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "consolesigninwithoutmfa" {
@@ -33093,9 +32204,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for console sign-in without MFA:
+            To ensure log metric filter exists for console sign-in without MFA in CloudFormation, create a CloudWatch log metric filter and alarm for console sign-in without MFA:
 
             ```yaml
             Resources:
@@ -33200,7 +32309,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for root account usage using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33210,9 +32319,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for root account usage using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33238,9 +32345,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for root account usage:
+            To ensure log metric filter exists for root account usage in Terraform, create a CloudWatch log metric filter and alarm for root account usage:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "rootaccountusage" {
@@ -33269,9 +32374,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for root account usage:
+            To ensure log metric filter exists for root account usage in CloudFormation, create a CloudWatch log metric filter and alarm for root account usage:
 
             ```yaml
             Resources:
@@ -33376,7 +32479,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for IAM policy changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33386,9 +32489,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for IAM policy changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33414,9 +32515,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for IAM policy changes:
+            To ensure log metric filter exists for IAM policy changes in Terraform, create a CloudWatch log metric filter and alarm for IAM policy changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "iampolicychanges" {
@@ -33445,9 +32544,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for IAM policy changes:
+            To ensure log metric filter exists for IAM policy changes in CloudFormation, create a CloudWatch log metric filter and alarm for IAM policy changes:
 
             ```yaml
             Resources:
@@ -33552,7 +32649,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for CloudTrail config changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33562,9 +32659,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for CloudTrail config changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33590,9 +32685,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for CloudTrail configuration changes:
+            To ensure log metric filter exists for CloudTrail config changes in Terraform, create a CloudWatch log metric filter and alarm for CloudTrail configuration changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "cloudtrailconfigchanges" {
@@ -33621,9 +32714,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for CloudTrail configuration changes:
+            To ensure log metric filter exists for CloudTrail config changes in CloudFormation, create a CloudWatch log metric filter and alarm for CloudTrail configuration changes:
 
             ```yaml
             Resources:
@@ -33728,7 +32819,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for console auth failures using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33738,9 +32829,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for console auth failures using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33766,9 +32855,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for console authentication failures:
+            To ensure log metric filter exists for console auth failures in Terraform, create a CloudWatch log metric filter and alarm for console authentication failures:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "consoleauthfailures" {
@@ -33797,9 +32884,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for console authentication failures:
+            To ensure log metric filter exists for console auth failures in CloudFormation, create a CloudWatch log metric filter and alarm for console authentication failures:
 
             ```yaml
             Resources:
@@ -33904,7 +32989,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for CMK disable or deletion using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -33914,9 +32999,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for CMK disable or deletion using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -33942,9 +33025,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for CMK disable or scheduled deletion:
+            To ensure log metric filter exists for CMK disable or deletion in Terraform, create a CloudWatch log metric filter and alarm for CMK disable or scheduled deletion:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "cmkdisableordelete" {
@@ -33973,9 +33054,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for CMK disable or scheduled deletion:
+            To ensure log metric filter exists for CMK disable or deletion in CloudFormation, create a CloudWatch log metric filter and alarm for CMK disable or scheduled deletion:
 
             ```yaml
             Resources:
@@ -34080,7 +33159,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for S3 bucket policy changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34090,9 +33169,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for S3 bucket policy changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34118,9 +33195,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for S3 bucket policy changes:
+            To ensure log metric filter exists for S3 bucket policy changes in Terraform, create a CloudWatch log metric filter and alarm for S3 bucket policy changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "s3bucketpolicychanges" {
@@ -34149,9 +33224,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for S3 bucket policy changes:
+            To ensure log metric filter exists for S3 bucket policy changes in CloudFormation, create a CloudWatch log metric filter and alarm for S3 bucket policy changes:
 
             ```yaml
             Resources:
@@ -34256,7 +33329,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for AWS Config changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34266,9 +33339,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for AWS Config changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34294,9 +33365,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for AWS Config configuration changes:
+            To ensure log metric filter exists for AWS Config changes in Terraform, create a CloudWatch log metric filter and alarm for AWS Config configuration changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "awsconfigchanges" {
@@ -34325,9 +33394,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for AWS Config configuration changes:
+            To ensure log metric filter exists for AWS Config changes in CloudFormation, create a CloudWatch log metric filter and alarm for AWS Config configuration changes:
 
             ```yaml
             Resources:
@@ -34432,7 +33499,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for security group changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34442,9 +33509,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for security group changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34470,9 +33535,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for security group changes:
+            To ensure log metric filter exists for security group changes in Terraform, create a CloudWatch log metric filter and alarm for security group changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "securitygroupchanges" {
@@ -34501,9 +33564,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for security group changes:
+            To ensure log metric filter exists for security group changes in CloudFormation, create a CloudWatch log metric filter and alarm for security group changes:
 
             ```yaml
             Resources:
@@ -34608,7 +33669,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for NACL changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34618,9 +33679,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for NACL changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34646,9 +33705,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for NACL changes:
+            To ensure log metric filter exists for NACL changes in Terraform, create a CloudWatch log metric filter and alarm for NACL changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "networkaclchanges" {
@@ -34677,9 +33734,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for NACL changes:
+            To ensure log metric filter exists for NACL changes in CloudFormation, create a CloudWatch log metric filter and alarm for NACL changes:
 
             ```yaml
             Resources:
@@ -34784,7 +33839,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for network gateway changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34794,9 +33849,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for network gateway changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34822,9 +33875,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for network gateway changes:
+            To ensure log metric filter exists for network gateway changes in Terraform, create a CloudWatch log metric filter and alarm for network gateway changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "networkgatewaychanges" {
@@ -34853,9 +33904,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for network gateway changes:
+            To ensure log metric filter exists for network gateway changes in CloudFormation, create a CloudWatch log metric filter and alarm for network gateway changes:
 
             ```yaml
             Resources:
@@ -34960,7 +34009,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for route table changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -34970,9 +34019,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for route table changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -34998,9 +34045,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for route table changes:
+            To ensure log metric filter exists for route table changes in Terraform, create a CloudWatch log metric filter and alarm for route table changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "routetablechanges" {
@@ -35029,9 +34074,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for route table changes:
+            To ensure log metric filter exists for route table changes in CloudFormation, create a CloudWatch log metric filter and alarm for route table changes:
 
             ```yaml
             Resources:
@@ -35136,7 +34179,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for VPC changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail.
@@ -35146,9 +34189,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for VPC changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -35174,9 +34215,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for VPC changes:
+            To ensure log metric filter exists for VPC changes in Terraform, create a CloudWatch log metric filter and alarm for VPC changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "vpcchanges" {
@@ -35205,9 +34244,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for VPC changes:
+            To ensure log metric filter exists for VPC changes in CloudFormation, create a CloudWatch log metric filter and alarm for VPC changes:
 
             ```yaml
             Resources:
@@ -35312,7 +34349,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure log metric filter exists for organization changes using the AWS Console:
 
             1. Navigate to **CloudWatch** and select **Log groups**.
             2. Select the log group associated with your CloudTrail trail in the management account.
@@ -35322,9 +34359,7 @@ queries:
             6. Navigate to **Alarms** > **Create alarm**, select the new metric, and configure SNS notification.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create the metric filter:
+            To ensure log metric filter exists for organization changes using the AWS CLI, create the metric filter:
 
             ```bash
             aws logs put-metric-filter \
@@ -35350,9 +34385,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create a CloudWatch log metric filter and alarm for AWS Organizations changes:
+            To ensure log metric filter exists for organization changes in Terraform, create a CloudWatch log metric filter and alarm for AWS Organizations changes:
 
             ```hcl
             resource "aws_cloudwatch_log_metric_filter" "awsorganizationschanges" {
@@ -35381,9 +34414,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create a CloudWatch log metric filter and alarm for AWS Organizations changes:
+            To ensure log metric filter exists for organization changes in CloudFormation, create a CloudWatch log metric filter and alarm for AWS Organizations changes:
 
             ```yaml
             Resources:
@@ -35500,7 +34531,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure security groups do not allow unrestricted egress using the AWS Console:
 
             1. Navigate to the AWS EC2 Console.
             2. Select Security Groups from the left panel under Network & Security.
@@ -35511,9 +34542,7 @@ queries:
             7. Select Save rules.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List security groups with unrestricted egress:
+            To ensure security groups do not allow unrestricted egress using the AWS CLI, list security groups with unrestricted egress:
 
             ```bash
             aws ec2 describe-security-groups \
@@ -35541,9 +34570,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Restrict egress rules to specific destinations instead of allowing all traffic:
+            To ensure security groups do not allow unrestricted egress in Terraform, restrict egress rules to specific destinations instead of allowing all traffic:
 
             ```hcl
             resource "aws_security_group" "example" {
@@ -35562,7 +34589,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure security groups do not allow unrestricted egress in CloudFormation:
 
             ```yaml
             Resources:
@@ -35654,7 +34681,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure root account has a hardware MFA device enabled using the AWS Console:
 
             1. Sign in to the AWS Management Console as the root user.
             2. Select your account name in the upper right corner and choose Security credentials.
@@ -35664,9 +34691,7 @@ queries:
             6. Store the hardware MFA device securely and restrict physical access to authorized personnel.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check whether a virtual MFA device is associated with the root account:
+            To ensure root account has a hardware MFA device enabled using the AWS CLI, check whether a virtual MFA device is associated with the root account:
 
             ```bash
             aws iam list-virtual-mfa-devices --query "VirtualMFADevices[?contains(SerialNumber, 'root-account-mfa-device')]"
@@ -35740,14 +34765,10 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            IAM server certificates cannot be managed directly through the AWS Console. Use the AWS CLI to list and delete expired certificates.
+            To ensure expired SSL/TLS certificates are removed from IAM using the AWS Console, IAM server certificates cannot be managed directly through the AWS Console. Use the AWS CLI to list and delete expired certificates.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List all server certificates stored in IAM along with their expiration dates:
+            To ensure expired SSL/TLS certificates are removed from IAM using the AWS CLI, list all server certificates stored in IAM along with their expiration dates:
 
             ```bash
             aws iam list-server-certificates \
@@ -35818,7 +34839,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure a support role has been created for AWS Support access using the AWS Console:
 
             1. Navigate to the AWS IAM Console.
             2. Select Roles from the left panel and choose Create role.
@@ -35828,9 +34849,7 @@ queries:
             6. Assign the role to the appropriate IAM users or groups that manage AWS Support interactions.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an IAM role with a trust policy for the account:
+            To ensure a support role has been created for AWS Support access using the AWS CLI, create an IAM role with a trust policy for the account:
 
             ```bash
             aws iam create-role \
@@ -35853,7 +34872,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure a support role has been created for AWS Support access in Terraform:
 
             ```hcl
             resource "aws_iam_role" "support" {
@@ -35876,7 +34895,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure a support role has been created for AWS Support access in CloudFormation:
 
             ```yaml
             Resources:
@@ -35935,7 +34954,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To define the number of days after which an unused credential is considered stale using the AWS Console:
 
             1. Navigate to the **AWS IAM Console**.
             2. Select **Credential report** and choose **Download report**.
@@ -35946,9 +34965,7 @@ queries:
             5. Confirm with the resource owner before disabling credentials to avoid disrupting active workloads.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Generate and review the credential report:
+            To define the number of days after which an unused credential is considered stale using the AWS CLI, generate and review the credential report:
 
             ```bash
             aws iam generate-credential-report
@@ -36069,7 +35086,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda functions have X-Ray tracing enabled using the AWS Console:
 
             1. Navigate to the AWS Lambda Console.
             2. Select Functions from the left panel.
@@ -36079,9 +35096,7 @@ queries:
             6. Select Save to apply the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the current tracing configuration for a Lambda function:
+            To ensure Lambda functions have X-Ray tracing enabled using the AWS CLI, check the current tracing configuration for a Lambda function:
 
             ```bash
             aws lambda get-function-configuration \
@@ -36106,7 +35121,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Lambda functions have X-Ray tracing enabled in Terraform:
 
             ```hcl
             resource "aws_lambda_function" "example" {
@@ -36123,7 +35138,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Lambda functions have X-Ray tracing enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -36226,7 +35241,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda permissions specify a source ARN using the AWS Console:
 
             1. Navigate to the AWS Lambda Console.
             2. Select the Lambda function to review.
@@ -36237,9 +35252,7 @@ queries:
             7. Save the updated policy.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Retrieve the current resource-based policy for a Lambda function:
+            To ensure Lambda permissions specify a source ARN using the AWS CLI, retrieve the current resource-based policy for a Lambda function:
 
             ```bash
             aws lambda get-policy --function-name <function-name> --query "Policy" --output text | python3 -m json.tool
@@ -36266,7 +35279,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Lambda permissions specify a source ARN in Terraform:
 
             ```hcl
             resource "aws_lambda_permission" "allow_s3" {
@@ -36280,7 +35293,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Lambda permissions specify a source ARN in CloudFormation:
 
             ```yaml
             Resources:
@@ -36385,14 +35398,10 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            MFA delete can only be enabled via the AWS CLI or SDK using root account credentials. The AWS Console does not support enabling MFA delete directly.
+            To ensure S3 buckets have MFA delete enabled using the AWS Console, MFA delete can only be enabled via the AWS CLI or SDK using root account credentials. The AWS Console does not support enabling MFA delete directly.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            MFA delete must be enabled using root account credentials. Generate an MFA token from the root account's MFA device, then run:
+            To ensure S3 buckets have MFA delete enabled using the AWS CLI, MFA delete must be enabled using root account credentials. Generate an MFA token from the root account's MFA device, then run:
 
             ```bash
             aws s3api put-bucket-versioning \
@@ -36410,7 +35419,7 @@ queries:
             The response should include `"MFADelete": "Enabled"`.
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure S3 buckets have MFA delete enabled in Terraform:
 
             ```hcl
             resource "aws_s3_bucket_versioning" "example" {
@@ -36428,9 +35437,7 @@ queries:
             Note: MFA delete requires root account credentials. The `mfa` argument must provide the root account MFA device serial number and a current token.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            CloudFormation does not natively support enabling MFA delete on S3 buckets. MFA delete must be enabled using the AWS CLI with root account credentials. You can configure versioning via CloudFormation, but the MFA delete setting requires a separate CLI step:
+            To ensure S3 buckets have MFA delete enabled in CloudFormation, note that CloudFormation does not natively support enabling MFA delete on S3 buckets. MFA delete must be enabled using the AWS CLI with root account credentials. You can configure versioning via CloudFormation, but the MFA delete setting requires a separate CLI step:
 
             ```yaml
             Resources:
@@ -36529,7 +35536,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Elasticsearch domains enforce HTTPS using the AWS Console:
 
             1. Navigate to the **Amazon Elasticsearch Service Console** and select **Domains**.
             2. Select the domain you want to configure.
@@ -36538,9 +35545,7 @@ queries:
             5. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the domain to enforce HTTPS:
+            To ensure Elasticsearch domains enforce HTTPS using the AWS CLI, update the domain to enforce HTTPS:
 
             ```bash
             aws es update-elasticsearch-domain-config \
@@ -36557,7 +35562,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Elasticsearch domains enforce HTTPS in Terraform:
 
             ```hcl
             resource "aws_elasticsearch_domain" "example" {
@@ -36571,7 +35576,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Elasticsearch domains enforce HTTPS in CloudFormation:
 
             ```yaml
             Resources:
@@ -36668,7 +35673,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Elasticsearch domains use TLS 1.2 or higher using the AWS Console:
 
             1. Navigate to the **Amazon Elasticsearch Service Console** and select **Domains**.
             2. Select the domain you want to configure.
@@ -36677,9 +35682,7 @@ queries:
             5. Choose **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the domain to enforce TLS 1.2:
+            To ensure Elasticsearch domains use TLS 1.2 or higher using the AWS CLI, update the domain to enforce TLS 1.2:
 
             ```bash
             aws es update-elasticsearch-domain-config \
@@ -36696,7 +35699,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Elasticsearch domains use TLS 1.2 or higher in Terraform:
 
             ```hcl
             resource "aws_elasticsearch_domain" "example" {
@@ -36711,7 +35714,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Elasticsearch domains use TLS 1.2 or higher in CloudFormation:
 
             ```yaml
             Resources:
@@ -36809,7 +35812,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Elasticsearch domains have audit logging enabled using the AWS Console:
 
             1. Navigate to the **Amazon Elasticsearch Service Console** and select **Domains**.
             2. Select the domain you want to configure.
@@ -36820,9 +35823,7 @@ queries:
             Note: Audit logging requires fine-grained access control to be enabled on the domain.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable audit logging by updating the log publishing options:
+            To ensure Elasticsearch domains have audit logging enabled using the AWS CLI, enable audit logging by updating the log publishing options:
 
             ```bash
             aws es update-elasticsearch-domain-config \
@@ -36839,7 +35840,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Elasticsearch domains have audit logging enabled in Terraform:
 
             ```hcl
             resource "aws_elasticsearch_domain" "example" {
@@ -36854,7 +35855,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Elasticsearch domains have audit logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -36951,9 +35952,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Encryption settings cannot be changed on a running cluster. You must create a new security configuration and launch a new cluster.
+            To ensure EMR clusters have at-rest encryption enabled using the AWS Console, note: Encryption settings cannot be changed on a running cluster. You must create a new security configuration and launch a new cluster.
 
             1. Navigate to the **Amazon EMR Console** and choose **Security configurations**.
             2. Choose **Create security configuration**.
@@ -36962,9 +35961,7 @@ queries:
             5. Save the security configuration and use it when launching new clusters.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a security configuration with at-rest encryption:
+            To ensure EMR clusters have at-rest encryption enabled using the AWS CLI, create a security configuration with at-rest encryption:
 
             ```bash
             aws emr create-security-configuration \
@@ -36999,7 +35996,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EMR clusters have at-rest encryption enabled in Terraform:
 
             ```hcl
             resource "aws_emr_security_configuration" "example" {
@@ -37025,7 +36022,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EMR clusters have at-rest encryption enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -37127,9 +36124,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Encryption settings cannot be changed on a running cluster. You must create a new security configuration and launch a new cluster.
+            To ensure EMR clusters have in-transit encryption enabled using the AWS Console, note: Encryption settings cannot be changed on a running cluster. You must create a new security configuration and launch a new cluster.
 
             1. Navigate to the **Amazon EMR Console** and choose **Security configurations**.
             2. Choose **Create security configuration**.
@@ -37138,9 +36133,7 @@ queries:
             5. Save the security configuration and use it when launching new clusters.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a security configuration with in-transit encryption:
+            To ensure EMR clusters have in-transit encryption enabled using the AWS CLI, create a security configuration with in-transit encryption:
 
             ```bash
             aws emr create-security-configuration \
@@ -37167,7 +36160,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EMR clusters have in-transit encryption enabled in Terraform:
 
             ```hcl
             resource "aws_emr_security_configuration" "example" {
@@ -37189,7 +36182,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EMR clusters have in-transit encryption enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -37288,9 +36281,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Log settings cannot be changed on a running cluster. You must configure logging when launching a new cluster.
+            To ensure EMR clusters have logging enabled using the AWS Console, note: Log settings cannot be changed on a running cluster. You must configure logging when launching a new cluster.
 
             1. Navigate to the **Amazon EMR Console** and choose **Create cluster**.
             2. Under **General Configuration**, enable **Logging**.
@@ -37298,9 +36289,7 @@ queries:
             4. Complete the cluster configuration and launch.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a cluster with logging enabled:
+            To ensure EMR clusters have logging enabled using the AWS CLI, create a cluster with logging enabled:
 
             ```bash
             aws emr create-cluster \
@@ -37319,7 +36308,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EMR clusters have logging enabled in Terraform:
 
             ```hcl
             resource "aws_emr_cluster" "example" {
@@ -37340,7 +36329,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EMR clusters have logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -37442,9 +36431,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            Note: Encryption at rest cannot be enabled on an existing DAX cluster. You must create a new cluster with encryption enabled.
+            To ensure DynamoDB DAX clusters have encryption at rest using the AWS Console, note: Encryption at rest cannot be enabled on an existing DAX cluster. You must create a new cluster with encryption enabled.
 
             1. Navigate to the **DynamoDB Console** and choose **DAX** > **Clusters**.
             2. Choose **Create cluster**.
@@ -37454,9 +36441,7 @@ queries:
             6. Delete the unencrypted cluster once migration is complete.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a DAX cluster with encryption at rest enabled:
+            To ensure DynamoDB DAX clusters have encryption at rest using the AWS CLI, create a DAX cluster with encryption at rest enabled:
 
             ```bash
             aws dax create-cluster \
@@ -37475,7 +36460,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DynamoDB DAX clusters have encryption at rest in Terraform:
 
             ```hcl
             resource "aws_dax_cluster" "example" {
@@ -37491,7 +36476,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DynamoDB DAX clusters have encryption at rest in CloudFormation:
 
             ```yaml
             Resources:
@@ -37590,7 +36575,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure SQS queues do not allow wildcard access policies using the AWS Console:
 
             1. Navigate to the **Amazon SQS Console** and select the queue.
             2. Choose the **Access policy** tab.
@@ -37600,9 +36585,7 @@ queries:
             6. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            View the current queue policy:
+            To ensure SQS queues do not allow wildcard access policies using the AWS CLI, view the current queue policy:
 
             ```bash
             aws sqs get-queue-attributes \
@@ -37621,7 +36604,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQS queues do not allow wildcard access policies in Terraform:
 
             ```hcl
             resource "aws_sqs_queue" "example" {
@@ -37644,7 +36627,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure SQS queues do not allow wildcard access policies in CloudFormation:
 
             ```yaml
             Resources:
@@ -37731,7 +36714,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS task definitions do not contain plaintext secrets using the AWS Console:
 
             1. Navigate to the Amazon ECS Console.
             2. Select **Task definitions** in the left panel.
@@ -37742,9 +36725,7 @@ queries:
             7. Create a new revision of the task definition with the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check for plaintext secrets in task definitions:
+            To ensure ECS task definitions do not contain plaintext secrets using the AWS CLI, check for plaintext secrets in task definitions:
 
             ```bash
             aws ecs describe-task-definition --task-definition <task-def-name> \
@@ -37776,9 +36757,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use the `secrets` block to reference values from Secrets Manager or SSM Parameter Store instead of embedding plaintext secrets in `environment`:
+            To ensure ECS task definitions do not contain plaintext secrets in Terraform, use the `secrets` block to reference values from Secrets Manager or SSM Parameter Store instead of embedding plaintext secrets in `environment`:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -37797,9 +36776,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Use the `Secrets` property to reference values from Secrets Manager or SSM Parameter Store instead of plaintext `Environment` entries:
+            To ensure ECS task definitions do not contain plaintext secrets in CloudFormation, use the `Secrets` property to reference values from Secrets Manager or SSM Parameter Store instead of plaintext `Environment` entries:
 
             ```yaml
             Resources:
@@ -37855,7 +36832,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure the default VPC is not used using the AWS Console:
 
             1. Navigate to the **VPC Console**.
             2. Select **Your VPCs** in the left panel.
@@ -37866,9 +36843,7 @@ queries:
             7. Repeat for each AWS region.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List default VPCs across all regions:
+            To ensure the default VPC is not used using the AWS CLI, list default VPCs across all regions:
 
             ```bash
             for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
@@ -37939,7 +36914,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EMR clusters have local disk encryption enabled using the AWS Console:
 
             1. Navigate to the **Amazon EMR Console**.
             2. Select **Security configurations** in the left panel.
@@ -37949,9 +36924,7 @@ queries:
             6. Apply the security configuration when creating new EMR clusters.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a security configuration with local disk encryption:
+            To ensure EMR clusters have local disk encryption enabled using the AWS CLI, create a security configuration with local disk encryption:
 
             ```bash
             aws emr create-security-configuration \
@@ -37981,9 +36954,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an EMR security configuration with local disk encryption:
+            To ensure EMR clusters have local disk encryption enabled in Terraform, configure an EMR security configuration with local disk encryption:
 
             ```hcl
             resource "aws_emr_security_configuration" "encryption" {
@@ -38013,7 +36984,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure EMR clusters have local disk encryption enabled in CloudFormation:
 
             ```yaml
             EMRSecurityConfiguration:
@@ -38107,7 +37078,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail trails deliver logs to CloudWatch using the AWS Console:
 
             1. Navigate to the **AWS CloudTrail Console**.
             2. Select **Trails** in the left panel.
@@ -38119,9 +37090,7 @@ queries:
             8. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Configure CloudWatch Logs delivery for a trail:
+            To ensure CloudTrail trails deliver logs to CloudWatch using the AWS CLI, configure CloudWatch Logs delivery for a trail:
 
             ```bash
             aws cloudtrail update-trail \
@@ -38139,9 +37108,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a CloudTrail trail with CloudWatch Logs integration:
+            To ensure CloudTrail trails deliver logs to CloudWatch in Terraform, configure a CloudTrail trail with CloudWatch Logs integration:
 
             ```hcl
             resource "aws_cloudwatch_log_group" "cloudtrail" {
@@ -38159,9 +37126,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure a CloudTrail trail with CloudWatch Logs integration:
+            To ensure CloudTrail trails deliver logs to CloudWatch in CloudFormation, configure a CloudTrail trail with CloudWatch Logs integration:
 
             ```yaml
             Resources:
@@ -38255,7 +37220,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache clusters have backup retention using the AWS Console:
 
             1. Navigate to the **Amazon ElastiCache Console**.
             2. Select **Redis clusters** in the left panel.
@@ -38266,9 +37231,7 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable backup retention for a Redis replication group:
+            To ensure ElastiCache clusters have backup retention using the AWS CLI, enable backup retention for a Redis replication group:
 
             ```bash
             aws elasticache modify-replication-group \
@@ -38286,9 +37249,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an ElastiCache replication group with backup retention:
+            To ensure ElastiCache clusters have backup retention in Terraform, configure an ElastiCache replication group with backup retention:
 
             ```hcl
             resource "aws_elasticache_replication_group" "example" {
@@ -38303,9 +37264,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an ElastiCache replication group with backup retention:
+            To ensure ElastiCache clusters have backup retention in CloudFormation, configure an ElastiCache replication group with backup retention:
 
             ```yaml
             Resources:
@@ -38392,7 +37351,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS DB instances have backup retention enabled using the AWS Console:
 
             1. Navigate to the **Amazon RDS Console**.
             2. Select **Databases** in the left panel.
@@ -38403,9 +37362,7 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable automated backups with a retention period:
+            To ensure RDS DB instances have backup retention enabled using the AWS CLI, enable automated backups with a retention period:
 
             ```bash
             aws rds modify-db-instance \
@@ -38423,9 +37380,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an RDS instance with backup retention:
+            To ensure RDS DB instances have backup retention enabled in Terraform, configure an RDS instance with backup retention:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -38438,9 +37393,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an RDS instance with backup retention:
+            To ensure RDS DB instances have backup retention enabled in CloudFormation, configure an RDS instance with backup retention:
 
             ```yaml
             Resources:
@@ -38527,7 +37480,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS instances have Performance Insights enabled using the AWS Console:
 
             1. Navigate to the **Amazon RDS Console**.
             2. Select **Databases** in the left panel.
@@ -38539,9 +37492,7 @@ queries:
             8. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable Performance Insights on an RDS instance:
+            To ensure RDS instances have Performance Insights enabled using the AWS CLI, enable Performance Insights on an RDS instance:
 
             ```bash
             aws rds modify-db-instance \
@@ -38560,9 +37511,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an RDS instance with Performance Insights enabled:
+            To ensure RDS instances have Performance Insights enabled in Terraform, configure an RDS instance with Performance Insights enabled:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -38576,9 +37525,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an RDS instance with Performance Insights enabled:
+            To ensure RDS instances have Performance Insights enabled in CloudFormation, configure an RDS instance with Performance Insights enabled:
 
             ```yaml
             Resources:
@@ -38666,7 +37613,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS DB instances have deletion protection using the AWS Console:
 
             1. Navigate to the **Amazon RDS Console**.
             2. Select **Databases** in the left panel.
@@ -38677,9 +37624,7 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable deletion protection on an RDS instance:
+            To ensure RDS DB instances have deletion protection using the AWS CLI, enable deletion protection on an RDS instance:
 
             ```bash
             aws rds modify-db-instance \
@@ -38697,9 +37642,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an RDS instance with deletion protection:
+            To ensure RDS DB instances have deletion protection in Terraform, configure an RDS instance with deletion protection:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -38712,9 +37655,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an RDS instance with deletion protection:
+            To ensure RDS DB instances have deletion protection in CloudFormation, configure an RDS instance with deletion protection:
 
             ```yaml
             Resources:
@@ -38801,7 +37742,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS DB clusters have deletion protection enabled using the AWS Console:
 
             1. Navigate to the **Amazon RDS Console**.
             2. Select **Databases** in the left panel.
@@ -38812,9 +37753,7 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable deletion protection on an RDS cluster:
+            To ensure RDS DB clusters have deletion protection enabled using the AWS CLI, enable deletion protection on an RDS cluster:
 
             ```bash
             aws rds modify-db-cluster \
@@ -38832,9 +37771,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an RDS cluster with deletion protection:
+            To ensure RDS DB clusters have deletion protection enabled in Terraform, configure an RDS cluster with deletion protection:
 
             ```hcl
             resource "aws_rds_cluster" "example" {
@@ -38848,9 +37785,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an RDS cluster with deletion protection:
+            To ensure RDS DB clusters have deletion protection enabled in CloudFormation, configure an RDS cluster with deletion protection:
 
             ```yaml
             Resources:
@@ -38938,7 +37873,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECR repositories use KMS encryption using the AWS Console:
 
             1. Navigate to the **Amazon ECR Console**.
             2. Select **Repositories** in the left panel.
@@ -38950,9 +37885,7 @@ queries:
             8. Migrate images from the old repository to the new KMS-encrypted repository.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create an ECR repository with KMS encryption:
+            To ensure ECR repositories use KMS encryption using the AWS CLI, create an ECR repository with KMS encryption:
 
             ```bash
             aws ecr create-repository \
@@ -38968,9 +37901,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an ECR repository with KMS encryption:
+            To ensure ECR repositories use KMS encryption in Terraform, configure an ECR repository with KMS encryption:
 
             ```hcl
             resource "aws_ecr_repository" "example" {
@@ -38984,9 +37915,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure an ECR repository with KMS encryption:
+            To ensure ECR repositories use KMS encryption in CloudFormation, configure an ECR repository with KMS encryption:
 
             ```yaml
             Resources:
@@ -39075,7 +38004,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune clusters have audit log export enabled using the AWS Console:
 
             1. Navigate to the **Amazon Neptune Console**.
             2. Select **Databases** in the left panel.
@@ -39086,9 +38015,7 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable audit log export for a Neptune cluster:
+            To ensure Neptune clusters have audit log export enabled using the AWS CLI, enable audit log export for a Neptune cluster:
 
             ```bash
             aws neptune modify-db-cluster \
@@ -39106,9 +38033,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a Neptune cluster with audit log export:
+            To ensure Neptune clusters have audit log export enabled in Terraform, configure a Neptune cluster with audit log export:
 
             ```hcl
             resource "aws_neptune_cluster" "example" {
@@ -39119,9 +38044,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure a Neptune cluster with audit log export:
+            To ensure Neptune clusters have audit log export enabled in CloudFormation, configure a Neptune cluster with audit log export:
 
             ```yaml
             Resources:
@@ -39206,7 +38129,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DocumentDB clusters have audit log export enabled using the AWS Console:
 
             1. Navigate to the **Amazon DocumentDB Console**.
             2. Select **Clusters** in the left panel.
@@ -39218,9 +38141,7 @@ queries:
             8. Save the changes.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable audit log export for a DocumentDB cluster:
+            To ensure DocumentDB clusters have audit log export enabled using the AWS CLI, enable audit log export for a DocumentDB cluster:
 
             ```bash
             aws docdb modify-db-cluster \
@@ -39246,9 +38167,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a DocumentDB cluster with audit log export:
+            To ensure DocumentDB clusters have audit log export enabled in Terraform, configure a DocumentDB cluster with audit log export:
 
             ```hcl
             resource "aws_docdb_cluster" "example" {
@@ -39261,9 +38180,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Configure a DocumentDB cluster with audit log export:
+            To ensure DocumentDB clusters have audit log export enabled in CloudFormation, configure a DocumentDB cluster with audit log export:
 
             ```yaml
             Resources:
@@ -39342,7 +38259,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Config aggregator is configured using the AWS Console:
 
             1. Navigate to the **AWS Config Console**.
             2. Select **Aggregators** in the left panel.
@@ -39354,9 +38271,7 @@ queries:
             8. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a Config aggregator for all regions:
+            To ensure AWS Config aggregator is configured using the AWS CLI, create a Config aggregator for all regions:
 
             ```bash
             aws configservice put-configuration-aggregator \
@@ -39379,7 +38294,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Config aggregator is configured in Terraform:
 
             ```hcl
             resource "aws_config_configuration_aggregator" "organization" {
@@ -39393,7 +38308,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Config aggregator is configured in CloudFormation:
 
             ```yaml
             Resources:
@@ -39463,7 +38378,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure AWS Config aggregator covers all regions using the AWS Console:
 
             1. Navigate to the **AWS Config Console**.
             2. Select **Aggregators** in the left panel.
@@ -39472,9 +38387,7 @@ queries:
             5. Choose **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Update the Config aggregator to include all regions:
+            To ensure AWS Config aggregator covers all regions using the AWS CLI, update the Config aggregator to include all regions:
 
             ```bash
             aws configservice put-configuration-aggregator \
@@ -39498,7 +38411,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AWS Config aggregator covers all regions in Terraform:
 
             ```hcl
             resource "aws_config_configuration_aggregator" "example" {
@@ -39512,7 +38425,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure AWS Config aggregator covers all regions in CloudFormation:
 
             ```yaml
             Resources:
@@ -39586,7 +38499,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECR repositories do not allow public access using the AWS Console:
 
             1. Navigate to the **Amazon ECR Console**.
             2. Select **Repositories** in the left panel.
@@ -39597,9 +38510,7 @@ queries:
             7. Save the updated policy.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            View the current repository policy:
+            To ensure ECR repositories do not allow public access using the AWS CLI, view the current repository policy:
 
             ```bash
             aws ecr get-repository-policy \
@@ -39622,7 +38533,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ECR repositories do not allow public access in Terraform:
 
             ```hcl
             resource "aws_ecr_repository" "example" {
@@ -39644,7 +38555,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ECR repositories do not allow public access in CloudFormation:
 
             ```yaml
             Resources:
@@ -39709,7 +38620,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EC2 launch templates do not contain secrets using the AWS Console:
 
             1. Navigate to the **EC2 Console**.
             2. Select **Launch templates** in the left panel.
@@ -39720,9 +38631,7 @@ queries:
             7. Create a new version of the launch template with the updated user data.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check user data in launch template versions:
+            To ensure EC2 launch templates do not contain secrets using the AWS CLI, check user data in launch template versions:
 
             ```bash
             aws ec2 describe-launch-template-versions \
@@ -39739,9 +38648,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Do not embed secrets in the `user_data` field of `aws_launch_template`. Instead, use IAM instance profiles and retrieve secrets at boot time:
+            To ensure EC2 launch templates do not contain secrets in Terraform, do not embed secrets in the `user_data` field of `aws_launch_template`. Instead, use IAM instance profiles and retrieve secrets at boot time:
 
             ```hcl
             resource "aws_launch_template" "example" {
@@ -39762,9 +38669,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Do not embed secrets in the `UserData` property of `AWS::EC2::LaunchTemplate`. Instead, use IAM instance profiles and retrieve secrets at boot time from Secrets Manager or SSM Parameter Store:
+            To ensure EC2 launch templates do not contain secrets in CloudFormation, do not embed secrets in the `UserData` property of `AWS::EC2::LaunchTemplate`. Instead, use IAM instance profiles and retrieve secrets at boot time from Secrets Manager or SSM Parameter Store:
 
             ```yaml
             Resources:
@@ -39820,7 +38725,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudTrail trails are actively logging using the AWS Console:
 
             1. Navigate to the **CloudTrail Console**.
             2. Select **Trails** in the left panel.
@@ -39829,9 +38734,7 @@ queries:
             5. Verify that multi-region logging is enabled.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the logging status of a trail:
+            To ensure CloudTrail trails are actively logging using the AWS CLI, check the logging status of a trail:
 
             ```bash
             aws cloudtrail get-trail-status \
@@ -39846,9 +38749,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            CloudTrail active logging status is a runtime property that cannot be directly verified in Terraform. However, ensure your trails are configured with `enable_logging` set to `true`:
+            To ensure CloudTrail trails are actively logging in Terraform, cloudTrail active logging status is a runtime property that cannot be directly verified in Terraform. However, ensure your trails are configured with `enable_logging` set to `true`:
 
             ```hcl
             resource "aws_cloudtrail" "example" {
@@ -39861,9 +38762,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure your CloudTrail trails are configured with logging enabled:
+            To ensure CloudTrail trails are actively logging in CloudFormation, ensure your CloudTrail trails are configured with logging enabled:
 
             ```yaml
             Resources:
@@ -39911,7 +38810,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EBS snapshots are not publicly shared using the AWS Console:
 
             1. Navigate to the **EC2 Console**.
             2. Select **Snapshots** under **Elastic Block Store** in the left panel.
@@ -39921,9 +38820,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if a snapshot is public:
+            To ensure EBS snapshots are not publicly shared using the AWS CLI, check if a snapshot is public:
 
             ```bash
             aws ec2 describe-snapshot-attribute \
@@ -39942,9 +38839,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            EBS snapshot public sharing is a runtime state that cannot be directly verified in Terraform. However, use `aws_ebs_snapshot_create_volume_permission` carefully and avoid granting public access. Consider using an AWS Config rule to detect public snapshots:
+            To ensure EBS snapshots are not publicly shared in Terraform, EBS snapshot public sharing is a runtime state that cannot be directly verified in Terraform. However, use `aws_ebs_snapshot_create_volume_permission` carefully and avoid granting public access. Consider using an AWS Config rule to detect public snapshots:
 
             ```hcl
             resource "aws_config_config_rule" "ebs_snapshot_public" {
@@ -39958,9 +38853,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            EBS snapshot public sharing is a runtime state. Use an AWS Config rule to detect public snapshots:
+            To ensure EBS snapshots are not publicly shared in CloudFormation, EBS snapshot public sharing is a runtime state. Use an AWS Config rule to detect public snapshots:
 
             ```yaml
             Resources:
@@ -40017,9 +38910,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
+            To ensure launch configuration EBS volumes are encrypted using the AWS Console, AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
 
             1. Navigate to the **EC2 Console** > **Launch Templates**.
             2. Select **Create launch template**.
@@ -40030,9 +38921,7 @@ queries:
             7. Delete the old launch configuration.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            List launch configurations and check encryption:
+            To ensure launch configuration EBS volumes are encrypted using the AWS CLI, list launch configurations and check encryption:
 
             ```bash
             aws autoscaling describe-launch-configurations \
@@ -40050,7 +38939,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure launch configuration EBS volumes are encrypted in Terraform:
 
             ```hcl
             resource "aws_launch_configuration" "example" {
@@ -40075,7 +38964,7 @@ queries:
             Note: Consider migrating to `aws_launch_template` which is the modern replacement.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure launch configuration EBS volumes are encrypted in CloudFormation:
 
             ```yaml
             Resources:
@@ -40169,9 +39058,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
+            To ensure launch configurations do not assign public IPs using the AWS Console, AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
 
             1. Navigate to the **EC2 Console** > **Launch Templates**.
             2. Select **Create launch template**.
@@ -40181,9 +39068,7 @@ queries:
             6. Navigate to **Auto Scaling Groups**, select the group, select **Edit**, and update it to use the new launch template.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check which launch configurations assign public IPs:
+            To ensure launch configurations do not assign public IPs using the AWS CLI, check which launch configurations assign public IPs:
 
             ```bash
             aws autoscaling describe-launch-configurations \
@@ -40201,7 +39086,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure launch configurations do not assign public IPs in Terraform:
 
             ```hcl
             resource "aws_launch_configuration" "example" {
@@ -40214,7 +39099,7 @@ queries:
             Note: Consider migrating to `aws_launch_template` which is the modern replacement.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure launch configurations do not assign public IPs in CloudFormation:
 
             ```yaml
             Resources:
@@ -40296,9 +39181,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
-
-            AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
+            To ensure launch configurations enforce IMDSv2 using the AWS Console, AWS has deprecated the launch configuration console UI. It is recommended to migrate to launch templates instead:
 
             1. Navigate to the **EC2 Console** > **Launch Templates**.
             2. Select **Create launch template**.
@@ -40308,9 +39191,7 @@ queries:
             6. Navigate to **Auto Scaling Groups**, select the group, select **Edit**, and update it to use the new launch template.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check metadata options for launch configurations:
+            To ensure launch configurations enforce IMDSv2 using the AWS CLI, check metadata options for launch configurations:
 
             ```bash
             aws autoscaling describe-launch-configurations \
@@ -40328,7 +39209,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure launch configurations enforce IMDSv2 in Terraform:
 
             ```hcl
             resource "aws_launch_configuration" "example" {
@@ -40345,7 +39226,7 @@ queries:
             Note: Consider migrating to `aws_launch_template` which is the modern replacement.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure launch configurations enforce IMDSv2 in CloudFormation:
 
             ```yaml
             Resources:
@@ -40439,7 +39320,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS instances use customer-managed KMS encryption using the AWS Console:
 
             1. Navigate to the **RDS Console**.
             2. Select **Databases** in the left panel.
@@ -40455,9 +39336,7 @@ queries:
                - Update your application to point to the new instance, then delete the old instance.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the encryption configuration of an RDS instance:
+            To ensure RDS instances use customer-managed KMS encryption using the AWS CLI, check the encryption configuration of an RDS instance:
 
             ```bash
             aws rds describe-db-instances \
@@ -40475,7 +39354,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS instances use customer-managed KMS encryption in Terraform:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -40490,7 +39369,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS instances use customer-managed KMS encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -40583,7 +39462,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS clusters use customer-managed KMS encryption using the AWS Console:
 
             1. Navigate to the **RDS Console**.
             2. Select **Databases** in the left panel.
@@ -40599,9 +39478,7 @@ queries:
                - Update your application to point to the new cluster, then delete the old cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the encryption configuration of an RDS cluster:
+            To ensure RDS clusters use customer-managed KMS encryption using the AWS CLI, check the encryption configuration of an RDS cluster:
 
             ```bash
             aws rds describe-db-clusters \
@@ -40620,7 +39497,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RDS clusters use customer-managed KMS encryption in Terraform:
 
             ```hcl
             resource "aws_rds_cluster" "example" {
@@ -40635,7 +39512,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure RDS clusters use customer-managed KMS encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -40712,7 +39589,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure RDS snapshots use customer-managed KMS encryption using the AWS Console:
 
             1. Navigate to the **RDS Console**.
             2. Select **Snapshots** in the left panel.
@@ -40725,9 +39602,7 @@ queries:
                - Once the copy is available, you can delete the original snapshot if it is no longer needed.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the encryption configuration of an RDS snapshot:
+            To ensure RDS snapshots use customer-managed KMS encryption using the AWS CLI, check the encryption configuration of an RDS snapshot:
 
             ```bash
             aws rds describe-db-snapshots \
@@ -40745,9 +39620,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            RDS snapshots inherit encryption from the source database. Ensure your RDS instances use CMK encryption so that snapshots are automatically encrypted with the same key:
+            To ensure RDS snapshots use customer-managed KMS encryption in Terraform, RDS snapshots inherit encryption from the source database. Ensure your RDS instances use CMK encryption so that snapshots are automatically encrypted with the same key:
 
             ```hcl
             resource "aws_db_instance" "example" {
@@ -40761,9 +39634,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            RDS snapshots inherit encryption from the source database. Ensure your RDS instances use CMK encryption:
+            To ensure RDS snapshots use customer-managed KMS encryption in CloudFormation, RDS snapshots inherit encryption from the source database. Ensure your RDS instances use CMK encryption:
 
             ```yaml
             Resources:
@@ -40827,7 +39698,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EMR clusters are not publicly accessible using the AWS Console:
 
             1. Navigate to the **EMR Console**.
             2. Select the cluster to review.
@@ -40836,9 +39707,7 @@ queries:
             5. Terminate the cluster and recreate it in a private subnet with no public IP assignment.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if an EMR cluster has a public master node:
+            To ensure EMR clusters are not publicly accessible using the AWS CLI, check if an EMR cluster has a public master node:
 
             ```bash
             aws emr describe-cluster \
@@ -40857,7 +39726,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure EMR clusters are not publicly accessible in Terraform:
 
             ```hcl
             resource "aws_emr_cluster" "example" {
@@ -40875,9 +39744,7 @@ queries:
             Launch EMR clusters in a private subnet to prevent public accessibility.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Launch EMR clusters in a private subnet to prevent public accessibility:
+            To ensure EMR clusters are not publicly accessible in CloudFormation, launch EMR clusters in a private subnet to prevent public accessibility:
 
             ```yaml
             Resources:
@@ -40972,7 +39839,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure EMR cluster logs are encrypted with CMK using the AWS Console:
 
             1. Navigate to the **EMR Console**.
             2. Select **Create cluster** or review an existing cluster.
@@ -40981,9 +39848,7 @@ queries:
             5. Enable **S3 encryption** with a **CMK** for log encryption.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Create a security configuration with CMK log encryption:
+            To ensure EMR cluster logs are encrypted with CMK using the AWS CLI, create a security configuration with CMK log encryption:
 
             ```bash
             aws emr create-security-configuration \
@@ -41002,9 +39867,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure an EMR security configuration with KMS log encryption and associate it with the cluster:
+            To ensure EMR cluster logs are encrypted with CMK in Terraform, configure an EMR security configuration with KMS log encryption and associate it with the cluster:
 
             ```hcl
             resource "aws_emr_security_configuration" "example" {
@@ -41034,9 +39897,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Create an EMR security configuration with KMS log encryption:
+            To ensure EMR cluster logs are encrypted with CMK in CloudFormation, create an EMR security configuration with KMS log encryption:
 
             ```yaml
             Resources:
@@ -41142,7 +40003,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Neptune clusters do not use default security groups using the AWS Console:
 
             1. Navigate to the **Neptune Console**.
             2. Select the cluster to review.
@@ -41152,9 +40013,7 @@ queries:
             6. Select **Apply immediately** or schedule for the next maintenance window.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check security groups for a Neptune cluster:
+            To ensure Neptune clusters do not use default security groups using the AWS CLI, check security groups for a Neptune cluster:
 
             ```bash
             aws neptune describe-db-clusters \
@@ -41171,7 +40030,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Neptune clusters do not use default security groups in Terraform:
 
             ```hcl
             resource "aws_neptune_cluster" "example" {
@@ -41185,7 +40044,7 @@ queries:
             Always specify explicit `vpc_security_group_ids` rather than relying on the default security group.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Neptune clusters do not use default security groups in CloudFormation:
 
             ```yaml
             Resources:
@@ -41273,7 +40132,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DocumentDB clusters do not use default security groups using the AWS Console:
 
             1. Navigate to the **DocumentDB Console**.
             2. Select the cluster to review.
@@ -41283,9 +40142,7 @@ queries:
             6. Select **Apply immediately** or schedule for the next maintenance window.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check security groups for a DocumentDB cluster:
+            To ensure DocumentDB clusters do not use default security groups using the AWS CLI, check security groups for a DocumentDB cluster:
 
             ```bash
             aws docdb describe-db-clusters \
@@ -41302,7 +40159,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DocumentDB clusters do not use default security groups in Terraform:
 
             ```hcl
             resource "aws_docdb_cluster" "example" {
@@ -41318,7 +40175,7 @@ queries:
             Always specify explicit `vpc_security_group_ids` rather than relying on the default security group.
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DocumentDB clusters do not use default security groups in CloudFormation:
 
             ```yaml
             Resources:
@@ -41408,7 +40265,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Redshift managed passwords use CMK encryption using the AWS Console:
 
             1. Navigate to the **Redshift Console**.
             2. Select the cluster to review.
@@ -41417,9 +40274,7 @@ queries:
             5. If using an AWS-managed key, modify the cluster to specify a CMK for the managed password.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the Secrets Manager KMS key for a Redshift cluster:
+            To ensure Redshift managed passwords use CMK encryption using the AWS CLI, check the Secrets Manager KMS key for a Redshift cluster:
 
             ```bash
             aws redshift describe-clusters \
@@ -41436,7 +40291,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Redshift managed passwords use CMK encryption in Terraform:
 
             ```hcl
             resource "aws_redshift_cluster" "example" {
@@ -41450,7 +40305,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Redshift managed passwords use CMK encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -41539,7 +40394,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudFront distributions use SNI-only SSL using the AWS Console:
 
             1. Navigate to the **CloudFront Console**.
             2. Select the distribution, then choose **Edit** under **Settings**.
@@ -41547,9 +40402,7 @@ queries:
             4. Select **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check the SSL support method for a distribution:
+            To ensure CloudFront distributions use SNI-only SSL using the AWS CLI, check the SSL support method for a distribution:
 
             ```bash
             aws cloudfront get-distribution \
@@ -41568,7 +40421,7 @@ queries:
             In the config file, set `ViewerCertificate.SSLSupportMethod` to `sni-only`.
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudFront distributions use SNI-only SSL in Terraform:
 
             ```hcl
             resource "aws_cloudfront_distribution" "example" {
@@ -41583,7 +40436,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudFront distributions use SNI-only SSL in CloudFormation:
 
             ```yaml
             Resources:
@@ -41663,7 +40516,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure CloudFront distributions have access logging enabled using the AWS Console:
 
             1. Navigate to the **CloudFront Console**.
             2. Select the distribution to configure.
@@ -41674,9 +40527,7 @@ queries:
             7. Select **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Enable access logging on a distribution:
+            To ensure CloudFront distributions have access logging enabled using the AWS CLI, enable access logging on a distribution:
 
             ```bash
             aws cloudfront get-distribution-config --id <distribution-id> > config.json
@@ -41692,7 +40543,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure CloudFront distributions have access logging enabled in Terraform:
 
             ```hcl
             resource "aws_cloudfront_distribution" "example" {
@@ -41707,7 +40558,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure CloudFront distributions have access logging enabled in CloudFormation:
 
             ```yaml
             Resources:
@@ -41793,7 +40644,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DAX clusters enforce encryption in transit using the AWS Console:
 
             1. Navigate to the **DAX Console**.
             2. Select the cluster to review.
@@ -41803,9 +40654,7 @@ queries:
             6. Delete the old unencrypted cluster.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check encryption in transit for DAX clusters:
+            To ensure DAX clusters enforce encryption in transit using the AWS CLI, check encryption in transit for DAX clusters:
 
             ```bash
             aws dax describe-clusters \
@@ -41824,7 +40673,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DAX clusters enforce encryption in transit in Terraform:
 
             ```hcl
             resource "aws_dax_cluster" "example" {
@@ -41837,7 +40686,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DAX clusters enforce encryption in transit in CloudFormation:
 
             ```yaml
             Resources:
@@ -41909,7 +40758,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECS containers enable init process using the AWS Console:
 
             1. Navigate to the **ECS Console**.
             2. Select **Task definitions** in the left panel.
@@ -41920,9 +40769,7 @@ queries:
             7. Update the service to use the new revision.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check if init process is enabled in a task definition:
+            To ensure ECS containers enable init process using the AWS CLI, check if init process is enabled in a task definition:
 
             ```bash
             aws ecs describe-task-definition \
@@ -41940,9 +40787,7 @@ queries:
             In the task definition JSON, set `linuxParameters.initProcessEnabled` to `true` for each container.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable the init process in ECS task definition container definitions:
+            To ensure ECS containers enable init process in Terraform, enable the init process in ECS task definition container definitions:
 
             ```hcl
             resource "aws_ecs_task_definition" "example" {
@@ -41959,9 +40804,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Enable the init process in ECS task definition container definitions:
+            To ensure ECS containers enable init process in CloudFormation, enable the init process in ECS task definition container definitions:
 
             ```yaml
             Resources:
@@ -42028,7 +40871,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Lambda functions are deployed within a VPC using the AWS Console:
 
             1. Navigate to the **Lambda Console**.
             2. Select the function to review.
@@ -42039,9 +40882,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check VPC configuration for a Lambda function:
+            To ensure Lambda functions are deployed within a VPC using the AWS CLI, check VPC configuration for a Lambda function:
 
             ```bash
             aws lambda get-function-configuration \
@@ -42058,7 +40899,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Lambda functions are deployed within a VPC in Terraform:
 
             ```hcl
             resource "aws_lambda_function" "example" {
@@ -42076,7 +40917,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Lambda functions are deployed within a VPC in CloudFormation:
 
             ```yaml
             Resources:
@@ -42153,7 +40994,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ECR repository policies restrict access using the AWS Console:
 
             1. Navigate to the **ECR Console**.
             2. Select the repository to review.
@@ -42163,9 +41004,7 @@ queries:
             6. Save the updated policy.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            View the repository policy:
+            To ensure ECR repository policies restrict access using the AWS CLI, view the repository policy:
 
             ```bash
             aws ecr get-repository-policy \
@@ -42183,9 +41022,7 @@ queries:
             Ensure the policy JSON replaces `"Principal": "*"` with specific account ARNs or includes conditions like `aws:PrincipalOrgID`.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            ECR repository policies are evaluated at runtime and cannot be fully validated in Terraform statically. However, ensure your `aws_ecr_repository_policy` resources use specific principals:
+            To ensure ECR repository policies restrict access in Terraform, ECR repository policies are evaluated at runtime and cannot be fully validated in Terraform statically. However, ensure your `aws_ecr_repository_policy` resources use specific principals:
 
             ```hcl
             resource "aws_ecr_repository_policy" "example" {
@@ -42209,9 +41046,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
-
-            Ensure your ECR repository policies use specific principals rather than wildcards:
+            To ensure ECR repository policies restrict access in CloudFormation, ensure your ECR repository policies use specific principals rather than wildcards:
 
             ```yaml
             Resources:
@@ -42285,7 +41120,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure ElastiCache clusters use CMK encryption using the AWS Console:
 
             1. Navigate to the **ElastiCache Console**.
             2. Select the replication group to review.
@@ -42295,9 +41130,7 @@ queries:
             6. Restore the backup to the new replication group and update your application endpoints.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check encryption configuration for an ElastiCache cluster:
+            To ensure ElastiCache clusters use CMK encryption using the AWS CLI, check encryption configuration for an ElastiCache cluster:
 
             ```bash
             aws elasticache describe-replication-groups \
@@ -42317,7 +41150,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure ElastiCache clusters use CMK encryption in Terraform:
 
             ```hcl
             resource "aws_elasticache_replication_group" "example" {
@@ -42331,7 +41164,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure ElastiCache clusters use CMK encryption in CloudFormation:
 
             ```yaml
             Resources:
@@ -42422,7 +41255,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure Kinesis streams use customer-managed KMS keys using the AWS Console:
 
             1. Navigate to the **Kinesis Console**.
             2. Select **Data streams** in the left panel.
@@ -42432,9 +41265,7 @@ queries:
             6. Select **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check encryption configuration for a Kinesis stream:
+            To ensure Kinesis streams use customer-managed KMS keys using the AWS CLI, check encryption configuration for a Kinesis stream:
 
             ```bash
             aws kinesis describe-stream \
@@ -42452,7 +41283,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Kinesis streams use customer-managed KMS keys in Terraform:
 
             ```hcl
             resource "aws_kinesis_stream" "example" {
@@ -42465,7 +41296,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure Kinesis streams use customer-managed KMS keys in CloudFormation:
 
             ```yaml
             Resources:
@@ -42558,7 +41389,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using AWS Console**
+            To ensure DynamoDB tables use customer-managed KMS keys using the AWS Console:
 
             1. Navigate to the **DynamoDB Console**.
             2. Select **Tables** in the left panel.
@@ -42569,9 +41400,7 @@ queries:
             7. Select **Save changes**.
         - id: cli
           desc: |
-            **Using AWS CLI**
-
-            Check encryption configuration for a DynamoDB table:
+            To ensure DynamoDB tables use customer-managed KMS keys using the AWS CLI, check encryption configuration for a DynamoDB table:
 
             ```bash
             aws dynamodb describe-table \
@@ -42588,7 +41417,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DynamoDB tables use customer-managed KMS keys in Terraform:
 
             ```hcl
             resource "aws_dynamodb_table" "example" {
@@ -42603,7 +41432,7 @@ queries:
             ```
         - id: cloudformation
           desc: |
-            **Using CloudFormation**
+            To ensure DynamoDB tables use customer-managed KMS keys in CloudFormation:
 
             ```yaml
             Resources:

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -325,9 +325,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To update using Microsoft Azure Portal:
+            To ensure Azure VM OS disks are encrypted with CMK using the Azure Portal:
 
             1. Log into the Azure Portal and navigate to **Disks**.
             2. Select the OS disk you wish to encrypt.
@@ -336,21 +334,21 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure VM OS disks are encrypted with CMK using the Azure CLI:
 
             ```bash
             az vm encryption enable --resource-group <ResourceGroupName> --name <VMName> --disk-encryption-keyvault <KeyVaultName> --key-encryption-key <KeyName> --volume-type OS
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure VM OS disks are encrypted with CMK using PowerShell:
 
             ```powershell
             Set-AzVMDiskEncryptionExtension -ResourceGroupName <ResourceGroupName> -VMName <VMName> -KeyVaultUrl <KeyVaultUrl> -VolumeType OS
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure VM OS disks are encrypted with CMK in Terraform:
 
             __Encrypt disks Linux VM__
 
@@ -406,7 +404,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure VM OS disks are encrypted with CMK in Bicep:
 
             __Encrypt disks Linux VM__
 
@@ -585,7 +583,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To restrict SSH access on disallowed TCP ports using the Azure Portal:
 
             1. In the Azure Portal, navigate to **Network Security Groups (NSG)** associated with your VMs.
             2. Review or modify the inbound security rules:
@@ -593,23 +591,21 @@ queries:
               - Ensure that the `destination_port_range` does not include TCP port 22 unless absolutely necessary and from a secure source.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update or create a new NSG rule to restrict SSH access:
+            To restrict SSH access on disallowed TCP ports using the Azure CLI, update or create a new NSG rule to restrict SSH access:
 
             ```bash
             az network nsg rule create --resource-group <ResourceGroupName> --nsg-name <NSGName> --name RestrictSSH --priority 1001 --direction Inbound --access Deny --protocol Tcp --source-address-prefixes <YourSecureIPRange> --destination-port-ranges 22
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To restrict SSH access on disallowed TCP ports using PowerShell:
 
             ```powershell
             New-AzNetworkSecurityRuleConfig -Name RestrictSSH -Protocol Tcp -Direction Inbound -Priority 1001 -SourceAddressPrefix <YourSecureIPRange> -SourcePortRange * -DestinationAddressPrefix * -DestinationPortRange 22 -Access Allow
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To restrict SSH access on disallowed TCP ports in Terraform:
 
             ```hcl
             # Ensure the `source_address_prefix` is configured to a restrictive CIDR address
@@ -634,7 +630,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To restrict SSH access on disallowed TCP ports in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
@@ -793,7 +789,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To restrict RDP access on disallowed TCP ports using the Azure Portal:
 
             1. Log into the Azure Portal and navigate to **Network Security Groups**.
             2. Select the NSG associated with your VM.
@@ -801,23 +797,21 @@ queries:
             4. Preferably, change the `source_address_prefix` to more restrictive settings, such as a specific IP range or a secure VPN gateway.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update or create a new NSG rule to restrict RDP access:
+            To restrict RDP access on disallowed TCP ports using the Azure CLI, update or create a new NSG rule to restrict RDP access:
 
             ```bash
             az network nsg rule create --resource-group <ResourceGroupName> --nsg-name <NSGName> --name RestrictRDP --priority 1001 --direction Inbound --access Deny --protocol Tcp --source-address-prefixes <YourSecureIPRange> --destination-port-ranges 3389
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To restrict RDP access on disallowed TCP ports using PowerShell:
 
             ```powershell
             New-AzNetworkSecurityRuleConfig -Name RestrictRDP -Protocol Tcp -Direction Inbound -Priority 1001 -SourceAddressPrefix <YourSecureIPRange> -SourcePortRange * -DestinationAddressPrefix * -DestinationPortRange 3389 -Access Allow
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To restrict RDP access on disallowed TCP ports in Terraform:
 
             ```hcl
             # Ensure the `source_address_prefix` is configured to a restrictive CIDR address
@@ -842,7 +836,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To restrict RDP access on disallowed TCP ports in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
@@ -1001,7 +995,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To restrict VNC access on disallowed TCP ports using the Azure Portal:
 
             1. Log into the Azure Portal and navigate to **Network Security Groups**.
             2. Select the NSG associated with your VM.
@@ -1009,23 +1003,21 @@ queries:
             4. Preferably, change the `source_address_prefix` to more restrictive settings, such as a specific IP range or a secure VPN gateway.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update or create a new NSG rule to restrict VNC access:
+            To restrict VNC access on disallowed TCP ports using the Azure CLI, update or create a new NSG rule to restrict VNC access:
 
             ```bash
             az network nsg rule create --resource-group <ResourceGroupName> --nsg-name <NSGName> --name RestrictVNC --priority 1001 --direction Inbound --access Deny --protocol Tcp --source-address-prefixes <YourSecureIPRange> --destination-port-ranges 5900
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To restrict VNC access on disallowed TCP ports using PowerShell:
 
             ```powershell
             New-AzNetworkSecurityRuleConfig -Name RestrictVNC -Protocol Tcp -Direction Inbound -Priority 1001 -SourceAddressPrefix <YourSecureIPRange> -SourcePortRange * -DestinationAddressPrefix * -DestinationPortRange 5900 -Access Allow
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To restrict VNC access on disallowed TCP ports in Terraform:
 
             ```hcl
             # Ensure the `source_address_prefix` is configured to a restrictive CIDR address
@@ -1050,7 +1042,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To restrict VNC access on disallowed TCP ports in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
@@ -1192,7 +1184,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To mandate HTTPS for Secure Data Transfer to Azure storage accounts using the Azure Portal:
 
             1. Navigate to **Storage Accounts** in the Azure portal.
             2. Select the storage account you want to configure.
@@ -1201,23 +1193,21 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable 'Secure transfer required' for an individual storage account in a resource group:
+            To mandate HTTPS for Secure Data Transfer to Azure storage accounts using the Azure CLI, enable 'Secure transfer required' for an individual storage account in a resource group:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --https-only true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To mandate HTTPS for Secure Data Transfer to Azure storage accounts using PowerShell:
 
             ```powershell
             Set-AzStorageAccount -Name <StorageAccountName> -ResourceGroupName <ResourceGroupName> -EnableHttpsTrafficOnly $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To mandate HTTPS for Secure Data Transfer to Azure storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example_storage_account" {
@@ -1227,7 +1217,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To mandate HTTPS for Secure Data Transfer to Azure storage accounts in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -1337,7 +1327,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure blob anonymous access and storage public access are disabled using the Azure Portal:
 
             1. Go to Storage Accounts.
             2. For each storage account, go to Networking in Security + networking.
@@ -1347,7 +1337,7 @@ queries:
             6. For each container, change the access level to 'Private (no anonymous access)'.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure blob anonymous access and storage public access are disabled using the Azure CLI:
 
             - Disable public network access:
 
@@ -1362,7 +1352,7 @@ queries:
               ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure blob anonymous access and storage public access are disabled using PowerShell:
 
             - Disable public network access:
 
@@ -1377,7 +1367,7 @@ queries:
               ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure blob anonymous access and storage public access are disabled in Terraform:
 
             ```hcl
             # Ensure the `allow_nested_items_to_be_public` is set to `false`
@@ -1397,7 +1387,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure blob anonymous access and storage public access are disabled in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -1501,7 +1491,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To enforce Deny as Default Network Access for Azure Storage Accounts using the Azure Portal:
 
             1. Log into the Azure Portal and navigate to **Storage Accounts**.
             2. Select the storage account you wish to configure.
@@ -1511,9 +1501,7 @@ queries:
             6. Save your changes to enforce that all unrecognized network traffic is blocked by default.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To set the default network access rule to "Deny" for a new storage account, use the following Azure CLI command:
+            To enforce Deny as Default Network Access for Azure Storage Accounts using the Azure CLI, set the default network access rule to "Deny" for a new storage account, use the following Azure CLI command:
 
             ```bash
             az storage account create --name <StorageAccountName> --resource-group <ResourceGroupName> --location <Location> --default-action Deny
@@ -1522,9 +1510,7 @@ queries:
             This command updates the storage account to deny all traffic by default, significantly enhancing the security posture by limiting access to only configured exceptions.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To set the default network access rule to "Deny" for a new storage account, use the following PowerShell command:
+            To enforce Deny as Default Network Access for Azure Storage Accounts using PowerShell, set the default network access rule to "Deny" for a new storage account, use the following PowerShell command:
 
             ```powershell
             New-AzStorageAccount -ResourceGroupName <ResourceGroupName> -Name <StorageAccountName> -Location <Location> -SkuName Standard_LRS -Kind StorageV2 -DefaultAction Deny
@@ -1533,7 +1519,7 @@ queries:
             This command updates the storage account to deny all traffic by default, significantly enhancing the security posture by limiting access to only configured exceptions.
         - id: terraform
           desc: |
-            **Using Terraform**
+            To enforce Deny as Default Network Access for Azure Storage Accounts in Terraform:
 
             ```hcl
             # Ensure the `default_action` is set to `Deny`
@@ -1561,7 +1547,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To enforce Deny as Default Network Access for Azure Storage Accounts in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -1667,7 +1653,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure "Trusted Microsoft Services" have access to Azure storage accounts using the Azure Portal:
 
             1. Navigate to **Storage Accounts** in the Azure Portal.
             2. Select the storage account you want to configure.
@@ -1676,23 +1662,21 @@ queries:
             5. Save your changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable trusted Microsoft services for a storage account:
+            To ensure "Trusted Microsoft Services" have access to Azure storage accounts using the Azure CLI, enable trusted Microsoft services for a storage account:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --bypass AzureServices
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure "Trusted Microsoft Services" have access to Azure storage accounts using PowerShell:
 
             ```powershell
             Set-AzStorageAccount -Name <StorageAccountName> -ResourceGroupName <ResourceGroupName> -NetworkRuleSetBypass AzureServices
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure "Trusted Microsoft Services" have access to Azure storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -1706,7 +1690,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure "Trusted Microsoft Services" have access to Azure storage accounts in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -1824,7 +1808,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure minimum 30-Day retention for SQL server Audit Logs using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server you want to configure.
@@ -1833,23 +1817,21 @@ queries:
             5. Select **Save** to apply the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update the audit retention policy for a specific SQL server:
+            To ensure minimum 30-Day retention for SQL server Audit Logs using the Azure CLI, update the audit retention policy for a specific SQL server:
 
             ```bash
             az sql db audit-policy update --name <DatabaseName> --resource-group <ResourceGroupName> --retention-days 30
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure minimum 30-Day retention for SQL server Audit Logs using PowerShell:
 
             ```powershell
             Set-AzSqlDatabaseAuditingPolicy -ResourceGroupName <ResourceGroupName> -ServerName <ServerName> -DatabaseName <DatabaseName> -RetentionDays 30
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure minimum 30-Day retention for SQL server Audit Logs in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -1871,7 +1853,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure minimum 30-Day retention for SQL server Audit Logs in Bicep:
 
             ```bicep
             resource sqlServerAudit 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
@@ -1959,7 +1941,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP) using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server you want to configure.
@@ -1969,9 +1951,7 @@ queries:
             6. Save your changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Ensure that the start and end IP addresses in the firewall rules are set to secure IPs within your controlled network range, effectively blocking public access.
+            To ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP) using the Azure CLI, ensure that the start and end IP addresses in the firewall rules are set to secure IPs within your controlled network range, effectively blocking public access.
 
             ```bash
             # Replace <server-name>, <resource-group>, and <rule-name> with your specific details
@@ -1988,7 +1968,7 @@ queries:
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP) using PowerShell:
 
             ```powershell
             # Replace <server-name>, <resource-group>, and <rule-name> with your specific details
@@ -2005,7 +1985,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP) in Terraform:
 
             __mySQL__
 
@@ -2044,7 +2024,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP) in Bicep:
 
             ```bicep
             resource sqlFirewallRule 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
@@ -2139,7 +2119,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service managed identities are enabled for Entra ID using the Azure Portal:
 
             1. Log in to the Azure Portal
             2. Navigate to **App Services**.
@@ -2148,16 +2128,14 @@ queries:
             5. Save your changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable a system-assigned managed identity for an App Service:
+            To ensure App Service managed identities are enabled for Entra ID using the Azure CLI, enable a system-assigned managed identity for an App Service:
 
             ```bash
             az webapp identity assign --resource-group <RESOURCE_GROUP_NAME> --name <APP_NAME>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure App Service managed identities are enabled for Entra ID using PowerShell:
 
             ```powershell
             $app = Get-AzWebApp -ResourceGroupName <RESOURCE_GROUP_NAME> -Name <APP_NAME>
@@ -2166,7 +2144,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service managed identities are enabled for Entra ID in Terraform:
 
             ```hcl
             resource "azurerm_service_plan" "example" {
@@ -2192,7 +2170,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service managed identities are enabled for Entra ID in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2024-04-01' = {
@@ -2315,7 +2293,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Key Vaults are configured with Recovery features using the Azure Portal:
 
             1. Log in to the Azure Portal at https://portal.azure.com.
             2. Navigate to **Key Vaults**.
@@ -2325,16 +2303,14 @@ queries:
             6. Save your changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable Purge Protection for a specific Key Vault:
+            To ensure Key Vaults are configured with Recovery features using the Azure CLI, enable Purge Protection for a specific Key Vault:
 
             ```bash
             az keyvault update --name <VaultName> --resource-group <ResourceGroupName> --set properties.enablePurgeProtection=true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Key Vaults are configured with Recovery features using PowerShell:
 
             ```powershell
             $vault = Get-AzKeyVault -VaultName <VaultName> -ResourceGroupName <ResourceGroupName>
@@ -2343,7 +2319,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Key Vaults are configured with Recovery features in Terraform:
 
             ```hcl
             resource "azurerm_key_vault" "example" {
@@ -2356,7 +2332,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Key Vaults are configured with Recovery features in Bicep:
 
             ```bicep
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
@@ -2439,9 +2415,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To update using Microsoft Azure Portal:
+            To ensure that Web Apps use the latest available version of TLS encryption using the Azure Portal:
             1. Log into Microsoft Azure Portal at https://portal.azure.com
             2. Go to **App Services**.
             3. For each app:
@@ -2451,25 +2425,19 @@ queries:
               d. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To set the minimum TLS version to 1.2 for a new app service:
+            To ensure that Web Apps use the latest available version of TLS encryption using the Azure CLI, set the minimum TLS version to 1.2 for a new app service:
 
             ```bash
             az webapp create --name <APP_NAME> --resource-group <RESOURCE_GROUP_NAME> --plan <APP_SERVICE_PLAN> --min-tls-version 1.2
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            Get-AzWebApp | foreach {
+            To ensure that Web Apps use the latest available version of TLS encryption using PowerShell, get-AzWebApp | foreach {
               Set-AzWebApp -ResourceGroupName $_.ResourceGroup -Name $_.Name -MinTlsVersion "1.2"
             }
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To set the minimum TLS version to 1.2 for an app service:
+            To ensure that Web Apps use the latest available version of TLS encryption in Terraform, set the minimum TLS version to 1.2 for an app service:
 
             ```hcl
             resource "azurerm_service_plan" "example" {
@@ -2493,7 +2461,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that Web Apps use the latest available version of TLS encryption in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2024-04-01' = {
@@ -2631,7 +2599,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure expiration dates are set for all Key Vault keys and secrets using the Azure Portal:
 
             1. Log into Microsoft Azure Portal at https://portal.azure.com.
             2. Go to **Key vaults**.
@@ -2641,9 +2609,7 @@ queries:
                c. For each key/secret, set an expiration date.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To set an expiration date for a key or secret in a key vault:
+            To ensure expiration dates are set for all Key Vault keys and secrets using the Azure CLI, set an expiration date for a key or secret in a key vault:
 
             - For keys:
 
@@ -2658,9 +2624,7 @@ queries:
               ```
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To set an expiration date for a key or secret in a key vault:
+            To ensure expiration dates are set for all Key Vault keys and secrets using PowerShell, set an expiration date for a key or secret in a key vault:
 
             - For keys:
 
@@ -2679,9 +2643,7 @@ queries:
               ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To set an expiration date for a key or secret in a key vault:
+            To ensure expiration dates are set for all Key Vault keys and secrets in Terraform, set an expiration date for a key or secret in a key vault:
 
             ```hcl
             resource "azurerm_key_vault_key" "example" {
@@ -2710,7 +2672,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure expiration dates are set for all Key Vault keys and secrets in Bicep:
 
             ```bicep
             resource keyVaultKey 'Microsoft.KeyVault/vaults/keys@2023-07-01' = {
@@ -2797,7 +2759,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure all operations in Azure Key Vault are logged using the Azure Portal:
 
             1. Log into Microsoft Azure Portal at https://portal.azure.com.
             2. Navigate to **Key Vaults**.
@@ -2808,18 +2770,14 @@ queries:
             7. Save the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To create or update diagnostic settings for a Key Vault:
+            To ensure all operations in Azure Key Vault are logged using the Azure CLI, create or update diagnostic settings for a Key Vault:
 
             ```bash
             az monitor diagnostic-settings create --name "defaultLogs" --resource <Key Vault Resource ID> --logs '[{"category": "audit", "enabled": true}, {"category": "allLogs", "enabled": true}]' --storage-account <Storage Account ID> | --workspace <Log Analytics Workspace ID> | --event-hub <Event Hub Name>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To create or update diagnostic settings for a Key Vault:
+            To ensure all operations in Azure Key Vault are logged using PowerShell, create or update diagnostic settings for a Key Vault:
 
             ```powershell
             $logs = @(
@@ -2830,9 +2788,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To create or update diagnostic settings for a Key Vault:
+            To ensure all operations in Azure Key Vault are logged in Terraform, create or update diagnostic settings for a Key Vault:
 
             ```hcl
             resource "azurerm_monitor_diagnostic_setting" "example" {
@@ -2873,7 +2829,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure all operations in Azure Key Vault are logged in Bicep:
 
             ```bicep
             resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -2962,9 +2918,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To create or update activity log alerts in Microsoft Azure Portal:
+            To ensure activity log alerts exist for NSG create, update, and delete using the Azure Portal, create or update activity log alerts in Microsoft Azure Portal:
 
             1. Log into Microsoft Azure Portal at https://portal.azure.com.
             2. Go to **Monitor**.
@@ -2986,9 +2940,7 @@ queries:
             14. Select the **Create** button.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To create an activity log alert for network security group changes:
+            To ensure activity log alerts exist for NSG create, update, and delete using the Azure CLI, create an activity log alert for network security group changes:
 
             ```bash
             az monitor activity-log alert create --name <AlertName> --resource-group <ResourceGroupName> --scopes <ResourceID> --condition "category == 'Administrative' and operationName == 'Microsoft.Network/networkSecurityGroups/write'" --action-group <ActionGroupID>
@@ -3001,9 +2953,7 @@ queries:
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To create an activity log alert for network security group changes:
+            To ensure activity log alerts exist for NSG create, update, and delete using PowerShell, create an activity log alert for network security group changes:
 
             ```powershell
             New-AzActivityLogAlert -Name <AlertName> -ResourceGroupName <ResourceGroupName> -Location <Location> -Condition "category == 'Administrative' and operationName == 'Microsoft.Network/networkSecurityGroups/write'" -ActionGroupId <ActionGroupID>
@@ -3016,9 +2966,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To create an activity log alert for network security group changes:
+            To ensure activity log alerts exist for NSG create, update, and delete in Terraform, create an activity log alert for network security group changes:
 
             ```hcl
             resource "azurerm_monitor_activity_log_alert" "example" {
@@ -3042,7 +2990,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure activity log alerts exist for NSG create, update, and delete in Bicep:
 
             ```bicep
             resource activityLogAlert 'Microsoft.Insights/activityLogAlerts@2020-10-01' = {
@@ -3130,9 +3078,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To enable high severity alert notifications in Microsoft Azure Portal:
+            To ensure that "Notify about alerts with high severity" is enabled using the Azure Portal, enable high severity alert notifications in Microsoft Azure Portal:
 
               1. Log into Microsoft Azure Portal at https://portal.azure.com.
               2. Select `Microsoft Defender for Cloud` from the Portal Menu.
@@ -3142,9 +3088,7 @@ queries:
               6. Select `Save` to apply the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Use the following command to update the security contact settings to enable high severity alert notifications. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
+            To ensure that "Notify about alerts with high severity" is enabled using the Azure CLI, use the following command to update the security contact settings to enable high severity alert notifications. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
 
               ```bash
               az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --out tsv | xargs -L1 bash -c 'curl -X PUT -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://management.azure.com/subscriptions/<$0>/providers/Microsoft.Security/securityContacts/default1?api-version=2017-08-01-preview -d "@input.json"'
@@ -3166,9 +3110,7 @@ queries:
               ```
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To enable high severity alert notifications, use the following PowerShell command. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
+            To ensure that "Notify about alerts with high severity" is enabled using PowerShell, enable high severity alert notifications, use the following PowerShell command. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
 
               ```powershell
               $securityContact = @{
@@ -3185,9 +3127,7 @@ queries:
               ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To enable high severity alert notifications, use the following Terraform configuration. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
+            To ensure that "Notify about alerts with high severity" is enabled in Terraform, enable high severity alert notifications, use the following Terraform configuration. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
 
             ```hcl
             resource "azurerm_security_center_contact" "example" {
@@ -3199,7 +3139,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that "Notify about alerts with high severity" is enabled in Bicep:
 
             ```bicep
             resource securityContact 'Microsoft.Security/securityContacts@2023-12-01-preview' = {
@@ -3295,9 +3235,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To enforce SSL connections:
+            To ensure SSL connection enabled for PostgreSQL database servers using the Azure Portal, enforce SSL connections:
 
             1. Access the Azure Portal at https://portal.azure.com.
             2. Navigate to `Azure Database for PostgreSQL server`.
@@ -3308,9 +3246,7 @@ queries:
             Consistency in enforcement is key. Verify that all PostgreSQL servers within your Azure environment have this setting enabled to maintain a high security standard.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            For a batch update or to automate the enforcement across multiple servers, use the Azure CLI:
+            To ensure SSL connection enabled for PostgreSQL database servers using the Azure CLI, for a batch update or to automate the enforcement across multiple servers, use the Azure CLI:
 
             ```bash
             az postgres server update --resource-group <resourceGroupName> --name <serverName> --ssl-enforcement Enabled
@@ -3319,9 +3255,7 @@ queries:
             Automate this process using scripts to iterate over all PostgreSQL servers in a subscription or resource group, ensuring no server is left without SSL enforcement.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To enforce SSL connections across all PostgreSQL servers in a resource group, you can use the following PowerShell script:
+            To ensure SSL connection enabled for PostgreSQL database servers using PowerShell, enforce SSL connections across all PostgreSQL servers in a resource group, you can use the following PowerShell script:
 
             ```powershell
             $servers = Get-AzPostgreSqlServer -ResourceGroupName <ResourceGroupName>
@@ -3333,9 +3267,7 @@ queries:
             This script iterates over all PostgreSQL servers in the specified resource group and sets SSL enforcement to `Enabled`. Regularly running such scripts can help maintain compliance over time, especially in dynamic environments where new servers are frequently deployed.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To enforce SSL connections for PostgreSQL servers, you can use the following Terraform configuration:
+            To ensure SSL connection enabled for PostgreSQL database servers in Terraform, enforce SSL connections for PostgreSQL servers, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_postgresql_server" "example" {
@@ -3353,7 +3285,7 @@ queries:
             This configuration ensures that SSL connections are enforced for the PostgreSQL server. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SSL connection enabled for PostgreSQL database servers in Bicep:
 
             ```bicep
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
@@ -3432,9 +3364,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To enforce SSL connections and ensure the use of the latest TLS version:
+            To ensure SSL is enabled with latest TLS for MySQL Database Server using the Azure Portal, enforce SSL connections and ensure the use of the latest TLS version:
 
             1. Access the Azure Portal at https://portal.azure.com.
             2. Navigate to `Azure Database for MySQL servers`.
@@ -3446,9 +3376,7 @@ queries:
             Regular reviews and updates of these settings are recommended to adapt to new TLS versions as they become available, ensuring that the security configurations remain up-to-date.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To enforce SSL connections and set the latest TLS version for MySQL servers, use the following Azure CLI command:
+            To ensure SSL is enabled with latest TLS for MySQL Database Server using the Azure CLI, enforce SSL connections and set the latest TLS version for MySQL servers, use the following Azure CLI command:
 
             ```bash
             az mysql server update --resource-group <resourceGroupName> --name <serverName> --ssl-enforcement Enabled --minimal-tls-version TLS1_2
@@ -3457,9 +3385,7 @@ queries:
             This command updates the specified MySQL server to enforce SSL connections and sets the minimum TLS version to 1.2. Adjust the `--minimal-tls-version` parameter as needed to specify the latest supported version.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To enforce SSL connections and set the latest TLS version for MySQL servers, use the following PowerShell command:
+            To ensure SSL is enabled with latest TLS for MySQL Database Server using PowerShell, enforce SSL connections and set the latest TLS version for MySQL servers, use the following PowerShell command:
 
             ```powershell
             $server = Get-AzMySqlServer -ResourceGroupName <resourceGroupName> -Name <serverName>
@@ -3471,9 +3397,7 @@ queries:
             This command retrieves the specified MySQL server, updates the SSL enforcement and TLS version settings, and applies the changes.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To enforce SSL connections and set the latest TLS version for MySQL servers, use the following Terraform configuration:
+            To ensure SSL is enabled with latest TLS for MySQL Database Server in Terraform, enforce SSL connections and set the latest TLS version for MySQL servers, use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_mysql_server" "example" {
@@ -3491,7 +3415,7 @@ queries:
             This configuration ensures that SSL connections are enforced and sets the minimum TLS version to 1.2 for the MySQL server. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SSL is enabled with latest TLS for MySQL Database Server in Bicep:
 
             ```bicep
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
@@ -3570,9 +3494,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To restrict public network access in Microsoft Azure Portal:
+            To ensure SQL server public access is disabled or limited to selected networks using the Azure Portal, restrict public network access in Microsoft Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **SQL servers** and select the server you wish to configure.
@@ -3582,9 +3504,7 @@ queries:
             6. If selecting **Selected networks**, ensure you configure the necessary firewall rules or virtual network settings to specify which networks can access the server.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To disable public network access for all SQL servers in a subscription, you can use the following Azure CLI command for each server:
+            To ensure SQL server public access is disabled or limited to selected networks using the Azure CLI, disable public network access for all SQL servers in a subscription, you can use the following Azure CLI command for each server:
 
             ```bash
             az sql server update --name <ServerName> --resource-group <ResourceGroupName> --set publicNetworkAccess='Disabled'
@@ -3593,9 +3513,7 @@ queries:
             Replace `<ServerName>` and `<ResourceGroupName>` with your actual server names and resource group names. For granular control, manually configure network settings in the Azure Portal to specify allowed networks if opting for the "Selected networks" setting.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To disable public network access for SQL servers, you can use the following PowerShell command:
+            To ensure SQL server public access is disabled or limited to selected networks using PowerShell, disable public network access for SQL servers, you can use the following PowerShell command:
 
             ```powershell
             $server = Get-AzSqlServer -ResourceGroupName <ResourceGroupName> -ServerName <ServerName>
@@ -3606,9 +3524,7 @@ queries:
             This command retrieves the specified SQL server, updates the public network access setting to disabled, and applies the changes. Regularly review and update these settings to ensure compliance with security best practices.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To disable public network access for SQL servers, you can use the following Terraform configuration:
+            To ensure SQL server public access is disabled or limited to selected networks in Terraform, disable public network access for SQL servers, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -3625,7 +3541,7 @@ queries:
             This configuration ensures that public network access is disabled for the specified SQL server. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL server public access is disabled or limited to selected networks in Bicep:
 
             ```bicep
             resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
@@ -3705,9 +3621,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To restrict public network access in Microsoft Azure Portal:
+            To ensure Key Vault public access is disabled or limited to selected networks using the Azure Portal, restrict public network access in Microsoft Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **Key vaults** and select the key vault you wish to configure.
@@ -3720,9 +3634,7 @@ queries:
               - Link to specific **Virtual networks** to restrict access to designated networks only.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To disable public network access for all key vaults in a subscription, you can use the following Azure CLI command for each key vault:
+            To ensure Key Vault public access is disabled or limited to selected networks using the Azure CLI, disable public network access for all key vaults in a subscription, you can use the following Azure CLI command for each key vault:
 
             ```bash
             az keyvault update --name <KeyVaultName> --resource-group <ResourceGroupName> --set properties.publicNetworkAccess='Disabled'
@@ -3731,9 +3643,7 @@ queries:
             Replace `<KeyVaultName>` and `<ResourceGroupName>` with your actual key vault names and resource group names. For granular control, manually configure network settings in the Azure Portal to specify allowed networks if opting for the "Enabled" setting.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To disable public network access for key vaults, you can use the following PowerShell command:
+            To ensure Key Vault public access is disabled or limited to selected networks using PowerShell, disable public network access for key vaults, you can use the following PowerShell command:
 
             ```powershell
             $keyVault = Get-AzKeyVault -ResourceGroupName <ResourceGroupName> -VaultName <KeyVaultName>
@@ -3744,9 +3654,7 @@ queries:
             This command retrieves the specified key vault, updates the public network access setting to disabled, and applies the changes. Regularly review and update these settings to ensure compliance with security best practices.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To disable public network access for key vaults, you can use the following Terraform configuration:
+            To ensure Key Vault public access is disabled or limited to selected networks in Terraform, disable public network access for key vaults, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_key_vault" "example" {
@@ -3762,7 +3670,7 @@ queries:
             This configuration ensures that public network access is disabled for the specified key vault. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Key Vault public access is disabled or limited to selected networks in Bicep:
 
             ```bicep
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
@@ -3845,9 +3753,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To enable auditing for SQL servers in Microsoft Azure Portal:
+            To ensure that all activities on SQL server are audited using the Azure Portal, enable auditing for SQL servers in Microsoft Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **SQL servers** and select the server you want to configure.
@@ -3858,9 +3764,7 @@ queries:
             7. Select `Save` to apply the settings.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            For each SQL server, enable auditing and specify the log retention settings and destination. Here's how you can enable auditing to a Storage Account with a retention period:
+            To ensure that all activities on SQL server are audited using the Azure CLI, for each SQL server, enable auditing and specify the log retention settings and destination. Here's how you can enable auditing to a Storage Account with a retention period:
 
             ```bash
             az sql server audit-policy update --name <ServerName> --resource-group <ResourceGroupName> --state Enabled --blob-storage-target-state Enabled --storage-endpoint <StorageAccountBlobEndpoint> --storage-key <StorageAccountKey> --retention-days 90
@@ -3869,9 +3773,7 @@ queries:
             Replace placeholders with your specific details. Similar commands can be executed to set up auditing with Log Analytics or Event Hub as the destination. Ensuring that auditing is enabled and properly configured across all SQL servers in your Azure environment is a key step in maintaining a strong security and compliance posture.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To enable auditing for SQL servers, you can use the following PowerShell command:
+            To ensure that all activities on SQL server are audited using PowerShell, enable auditing for SQL servers, you can use the following PowerShell command:
 
             ```powershell
             Set-AzSqlServerAudit -ResourceGroupName <ResourceGroupName> -ServerName <ServerName> -State Enabled -StorageAccountName <StorageAccountName> -StorageAccountKey <StorageAccountKey> -RetentionDays 90
@@ -3880,9 +3782,7 @@ queries:
             This command enables auditing for the specified SQL server and configures the storage account and retention period. Regularly review and update these settings to ensure compliance with security best practices.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To enable auditing for SQL servers, you can use the following Terraform configuration:
+            To ensure that all activities on SQL server are audited in Terraform, enable auditing for SQL servers, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -3906,7 +3806,7 @@ queries:
             This configuration ensures that auditing is enabled for the specified SQL server and configures the storage account and retention period. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that all activities on SQL server are audited in Bicep:
 
             ```bicep
             resource sqlServerAudit 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
@@ -3991,9 +3891,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To enable TDE for SQL databases in Microsoft Azure Portal:
+            To ensure that transparent data encryption is enabled for SQL Server databases using the Azure Portal, enable TDE for SQL databases in Microsoft Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **SQL databases** under your SQL Server instances.
@@ -4003,9 +3901,7 @@ queries:
             6. Save the changes to apply TDE to the selected database.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To enable TDE for a specific database, use the following command:
+            To ensure that transparent data encryption is enabled for SQL Server databases using the Azure CLI, enable TDE for a specific database, use the following command:
 
             ```bash
             az sql db tde set --database <DatabaseName> --resource-group <ResourceGroupName> --server <ServerName> --status Enabled
@@ -4014,9 +3910,7 @@ queries:
             Replace `<DatabaseName>`, `<ResourceGroupName>`, and `<ServerName>` with your actual database, resource group, and server names. This command enables TDE for the specified database.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To enable TDE for SQL databases, use the following PowerShell command:
+            To ensure that transparent data encryption is enabled for SQL Server databases using PowerShell, enable TDE for SQL databases, use the following PowerShell command:
 
             ```powershell
             Set-AzSqlDatabaseTransparentDataEncryption -DatabaseName <DatabaseName> -ServerName <ServerName> -ResourceGroupName <ResourceGroupName> -State 'Enabled'
@@ -4025,9 +3919,7 @@ queries:
             Replace `<DatabaseName>`, `<ServerName>`, and `<ResourceGroupName>` with your actual database, server, and resource group names. This command enables TDE for the specified database.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To enable TDE for SQL databases, you can use the following Terraform configuration:
+            To ensure that transparent data encryption is enabled for SQL Server databases in Terraform, enable TDE for SQL databases, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_mssql_database" "example" {
@@ -4040,7 +3932,7 @@ queries:
             This configuration ensures that TDE is enabled for the specified SQL database. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that transparent data encryption is enabled for SQL Server databases in Bicep:
 
             ```bicep
             resource tde 'Microsoft.Sql/servers/databases/transparentDataEncryption@2023-08-01-preview' = {
@@ -4103,9 +3995,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To configure diagnostic settings in the Azure Portal:
+            To ensure that diagnostic settings exist for the subscription using the Azure Portal, configure diagnostic settings in the Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **Monitor** and then **Activity log**.
@@ -4116,9 +4006,7 @@ queries:
             7. Save the configuration to ensure continuous monitoring.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To create or update diagnostic settings for a subscription, use the following command:
+            To ensure that diagnostic settings exist for the subscription using the Azure CLI, create or update diagnostic settings for a subscription, use the following command:
 
             ```bash
             az monitor diagnostic-settings create --name <NameOfSetting> --resource /subscriptions/{subscriptionId} --logs '[{"category": "Administrative", "enabled": true}, {"category": "Security", "enabled": true}, {"category": "Alert", "enabled": true}, {"category": "Policy", "enabled": true}]' --storage-account <StorageAccountId> --workspace <LogAnalyticsWorkspaceId> --event-hub <EventHubName>
@@ -4127,9 +4015,7 @@ queries:
             Replace the placeholders with your specific resource IDs and desired diagnostic setting name.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To configure diagnostic settings with PowerShell, use the following command:
+            To ensure that diagnostic settings exist for the subscription using PowerShell, configure diagnostic settings with PowerShell, use the following command:
 
             ```powershell
             $subsId = "<SubscriptionId>"
@@ -4144,9 +4030,7 @@ queries:
             Modify the script to match your specific resource IDs and configuration preferences. It's crucial to routinely review and update these settings to adapt to any changes in your Azure environment or organizational requirements.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To configure diagnostic settings for a subscription, you can use the following Terraform configuration:
+            To ensure that diagnostic settings exist for the subscription in Terraform, configure diagnostic settings for a subscription, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_monitor_diagnostic_setting" "example" {
@@ -4180,7 +4064,7 @@ queries:
             This configuration ensures that the specified log categories are collected for the Azure resource. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that diagnostic settings exist for the subscription in Bicep:
 
             ```bicep
             resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -4264,9 +4148,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To configure diagnostic settings for essential categories in the Azure Portal:
+            To ensure that diagnostic settings collect essential security categories using the Azure Portal, configure diagnostic settings for essential categories in the Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **Monitor** and then **Activity log**.
@@ -4276,9 +4158,7 @@ queries:
             6. Save the configuration to ensure continuous monitoring.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To create or update diagnostic settings for capturing essential log categories, use:
+            To ensure that diagnostic settings collect essential security categories using the Azure CLI, create or update diagnostic settings for capturing essential log categories, use:
 
             ```bash
             az monitor diagnostic-settings create --name <NameOfSetting> --resource /subscriptions/{subscriptionId} --logs '[{"category": "Administrative", "enabled": true}, {"category": "Security", "enabled": true}, {"category": "Alert", "enabled": true}, {"category": "Policy", "enabled": true}]' --storage-account <StorageAccountId> --workspace <LogAnalyticsWorkspaceId> --event-hub <EventHubName>
@@ -4287,9 +4167,7 @@ queries:
             Replace the placeholders with your specific resource IDs and desired diagnostic setting name.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To configure diagnostic settings with PowerShell, use the following command:
+            To ensure that diagnostic settings collect essential security categories using PowerShell, configure diagnostic settings with PowerShell, use the following command:
 
             ```powershell
             $subsId = "<SubscriptionId>"
@@ -4304,9 +4182,7 @@ queries:
             Modify the script to match your specific resource IDs and configuration preferences. It's crucial to routinely review and update these settings to adapt to any changes in your Azure environment or organizational requirements.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To configure diagnostic settings for essential categories, you can use the following Terraform configuration:
+            To ensure that diagnostic settings collect essential security categories in Terraform, configure diagnostic settings for essential categories, you can use the following Terraform configuration:
 
             ```hcl
             resource "azurerm_monitor_diagnostic_setting" "example" {
@@ -4340,7 +4216,7 @@ queries:
             This configuration ensures that the specified log categories are collected for the Azure resource. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure that diagnostic settings collect essential security categories in Bicep:
 
             ```bicep
             resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -4460,9 +4336,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            To restrict UDP traffic in Microsoft Azure Portal:
+            To restrict access on disallowed UDP ports using the Azure Portal, restrict UDP traffic in Microsoft Azure Portal:
 
             1. Log into the Azure Portal at https://portal.azure.com.
             2. Navigate to **Network Security Groups** and select the NSG associated with your resources.
@@ -4471,9 +4345,7 @@ queries:
             5. For services requiring UDP access, consider using secure alternatives or private connections (e.g., VPNs, ExpressRoute).
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            To restrict UDP traffic using the Azure CLI, you can delete or update the NSG rules that allow disallowed UDP ports:
+            To restrict access on disallowed UDP ports using the Azure CLI, delete or update the NSG rules that allow disallowed UDP ports:
 
             ```bash
             az network nsg rule list --resource-group <ResourceGroupName> --nsg-name <NSGName> --query "[].{Name:name, Protocol:protocol, Access:access, Direction:direction, SourceAddressPrefix:sourceAddressPrefix, DestinationPortRange:destinationPortRange}" -o table
@@ -4482,9 +4354,7 @@ queries:
             Review the output and identify any rules allowing disallowed UDP ports. Then, either delete or update those rules as needed.
         - id: powershell
           desc: |
-            **Using PowerShell**
-
-            To restrict UDP traffic using PowerShell, you can use the following command to list NSG rules:
+            To restrict access on disallowed UDP ports using PowerShell, use the following command to list NSG rules:
 
             ```powershell
             Get-AzNetworkSecurityRuleConfig -NetworkSecurityGroup <NSGName> | Where-Object { $_.Access -eq "Allow" -and $_.Direction -eq "Inbound" -and $_.Protocol -match "UDP|*" }
@@ -4493,9 +4363,7 @@ queries:
             Review the output and identify any rules allowing disallowed UDP ports. Then, either delete or update those rules as needed.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To restrict UDP traffic using Terraform, you can modify the NSG rules in your configuration:
+            To restrict access on disallowed UDP ports in Terraform, modify the NSG rules in your configuration:
 
             ```hcl
             resource "azurerm_network_security_rule" "example" {
@@ -4513,7 +4381,7 @@ queries:
             Replace `<DisallowedPort>` with the specific port you want to restrict. Regularly review and update your Terraform configurations to ensure compliance with security best practices.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To restrict access on disallowed UDP ports in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
@@ -4680,7 +4548,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure blob soft delete is enabled for Azure Storage accounts using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -4690,14 +4558,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure blob soft delete is enabled for Azure Storage accounts using the Azure CLI:
 
             ```bash
             az storage account blob-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --enable-delete-retention true --delete-retention-days 7
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure blob soft delete is enabled for Azure Storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -4716,7 +4584,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure blob soft delete is enabled for Azure Storage accounts in Bicep:
 
             ```bicep
             resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
@@ -4817,7 +4685,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure container soft delete is enabled for Azure Storage accounts using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -4827,14 +4695,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure container soft delete is enabled for Azure Storage accounts using the Azure CLI:
 
             ```bash
             az storage account blob-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --enable-container-delete-retention true --container-delete-retention-days 7
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure container soft delete is enabled for Azure Storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -4853,7 +4721,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure container soft delete is enabled for Azure Storage accounts in Bicep:
 
             ```bicep
             resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
@@ -4954,7 +4822,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Storage accounts enforce minimum TLS 1.2 using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -4963,14 +4831,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Storage accounts enforce minimum TLS 1.2 using the Azure CLI:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --min-tls-version TLS1_2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Storage accounts enforce minimum TLS 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -4984,7 +4852,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Storage accounts enforce minimum TLS 1.2 in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -5082,7 +4950,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure threat detection is enabled on Azure SQL servers using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the server.
@@ -5092,14 +4960,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure threat detection is enabled on Azure SQL servers using the Azure CLI:
 
             ```bash
             az sql server threat-policy update --resource-group <ResourceGroupName> --server <ServerName> --state Enabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure threat detection is enabled on Azure SQL servers in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server_security_alert_policy" "example" {
@@ -5110,7 +4978,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure threat detection is enabled on Azure SQL servers in Bicep:
 
             ```bicep
             resource sqlThreatDetection 'Microsoft.Sql/servers/securityAlertPolicies@2023-08-01-preview' = {
@@ -5181,7 +5049,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure an Entra ID administrator is configured for SQL servers using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the server.
@@ -5190,14 +5058,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure an Entra ID administrator is configured for SQL servers using the Azure CLI:
 
             ```bash
             az sql server ad-admin create --resource-group <ResourceGroupName> --server-name <ServerName> --display-name <AdminDisplayName> --object-id <AdminObjectId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure an Entra ID administrator is configured for SQL servers in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -5214,7 +5082,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure an Entra ID administrator is configured for SQL servers in Bicep:
 
             ```bicep
             resource sqlAdAdmin 'Microsoft.Sql/servers/administrators@2023-08-01-preview' = {
@@ -5288,7 +5156,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Key Vault uses RBAC authorization using the Azure Portal:
 
             1. Navigate to **Key Vaults** in the Azure Portal.
             2. Select the Key Vault.
@@ -5297,14 +5165,14 @@ queries:
             5. Select **Apply**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Key Vault uses RBAC authorization using the Azure CLI:
 
             ```bash
             az keyvault update --name <VaultName> --resource-group <ResourceGroupName> --enable-rbac-authorization true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Key Vault uses RBAC authorization in Terraform:
 
             ```hcl
             resource "azurerm_key_vault" "example" {
@@ -5318,7 +5186,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Key Vault uses RBAC authorization in Bicep:
 
             ```bicep
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
@@ -5391,7 +5259,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Key Vault keys have auto-rotation enabled using the Azure Portal:
 
             1. Navigate to **Key Vaults** in the Azure Portal.
             2. Select the Key Vault and go to **Keys**.
@@ -5401,14 +5269,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Key Vault keys have auto-rotation enabled using the Azure CLI:
 
             ```bash
             az keyvault key rotation-policy update --vault-name <VaultName> --name <KeyName> --value @rotation-policy.json
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Key Vault keys have auto-rotation enabled in Terraform:
 
             ```hcl
             resource "azurerm_key_vault_key" "example" {
@@ -5430,7 +5298,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Key Vault keys have auto-rotation enabled in Bicep:
 
             ```bicep
             resource keyVaultKey 'Microsoft.KeyVault/vaults/keys@2023-07-01' = {
@@ -5525,7 +5393,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Key Vault has private endpoint connections configured using the Azure Portal:
 
             1. Navigate to **Key Vaults** in the Azure Portal.
             2. Select the Key Vault.
@@ -5536,7 +5404,7 @@ queries:
             7. Select **Review + create**, then **Create**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Key Vault has private endpoint connections configured using the Azure CLI:
 
             ```bash
             az network private-endpoint create \
@@ -5550,7 +5418,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Key Vault has private endpoint connections configured in Terraform:
 
             ```hcl
             resource "azurerm_private_endpoint" "keyvault" {
@@ -5569,7 +5437,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Key Vault has private endpoint connections configured in Bicep:
 
             ```bicep
             resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
@@ -5653,7 +5521,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure VM data disks are encrypted with CMK using the Azure Portal:
 
             1. Navigate to **Disks** in the Azure Portal.
             2. Select the data disk you wish to encrypt.
@@ -5662,14 +5530,14 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure VM data disks are encrypted with CMK using the Azure CLI:
 
             ```bash
             az disk update --resource-group <ResourceGroupName> --name <DiskName> --encryption-type EncryptionAtRestWithCustomerKey --disk-encryption-set <DiskEncryptionSetId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure VM data disks are encrypted with CMK in Terraform:
 
             ```hcl
             resource "azurerm_managed_disk" "example" {
@@ -5684,7 +5552,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure VM data disks are encrypted with CMK in Bicep:
 
             ```bicep
             resource managedDisk 'Microsoft.Compute/disks@2024-03-02' = {
@@ -5775,7 +5643,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Network Watcher flow logs are enabled using the Azure Portal:
 
             1. Navigate to **Network Watcher** in the Azure Portal.
             2. Select **NSG flow logs** under **Logs**.
@@ -5786,14 +5654,14 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Network Watcher flow logs are enabled using the Azure CLI:
 
             ```bash
             az network watcher flow-log create --location <Location> --name <FlowLogName> --nsg <NSGResourceId> --storage-account <StorageAccountId> --enabled true --retention 90
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Network Watcher flow logs are enabled in Terraform:
 
             ```hcl
             resource "azurerm_network_watcher_flow_log" "example" {
@@ -5813,7 +5681,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Network Watcher flow logs are enabled in Bicep:
 
             ```bicep
             resource flowLog 'Microsoft.Network/networkWatchers/flowLogs@2024-05-01' = {
@@ -5879,7 +5747,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Servers is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -5887,14 +5755,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Servers is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name VirtualMachines --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Servers is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "servers" {
@@ -5904,7 +5772,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Servers is enabled in Bicep:
 
             ```bicep
             resource defenderForServers 'Microsoft.Security/pricings@2024-01-01' = {
@@ -5961,7 +5829,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for App Service is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -5969,14 +5837,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for App Service is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name AppServices --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for App Service is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "app_services" {
@@ -5986,7 +5854,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for App Service is enabled in Bicep:
 
             ```bicep
             resource defenderForAppServices 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6043,7 +5911,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Azure SQL Databases is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6051,14 +5919,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Azure SQL Databases is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name SqlServers --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Azure SQL Databases is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "sql_servers" {
@@ -6068,7 +5936,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Azure SQL Databases is enabled in Bicep:
 
             ```bicep
             resource defenderForSqlDatabases 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6125,7 +5993,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Storage is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6133,14 +6001,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Storage is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name StorageAccounts --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Storage is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "storage" {
@@ -6150,7 +6018,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Storage is enabled in Bicep:
 
             ```bicep
             resource defenderForStorage 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6207,7 +6075,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Key Vault is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6215,14 +6083,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Key Vault is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name KeyVaults --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Key Vault is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "key_vaults" {
@@ -6232,7 +6100,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Key Vault is enabled in Bicep:
 
             ```bicep
             resource defenderForKeyVault 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6289,7 +6157,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Containers is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6297,14 +6165,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Containers is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name Containers --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Containers is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "containers" {
@@ -6314,7 +6182,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Containers is enabled in Bicep:
 
             ```bicep
             resource defenderForContainers 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6371,7 +6239,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Resource Manager is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6379,14 +6247,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Resource Manager is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name Arm --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Resource Manager is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "arm" {
@@ -6396,7 +6264,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Resource Manager is enabled in Bicep:
 
             ```bicep
             resource defenderForArm 'Microsoft.Security/pricings@2024-01-01' = {
@@ -6454,7 +6322,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure auto-provisioning of the monitoring agent is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -6463,14 +6331,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure auto-provisioning of the monitoring agent is enabled using the Azure CLI:
 
             ```bash
             az security auto-provisioning-setting update --name default --auto-provision On
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure auto-provisioning of the monitoring agent is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_auto_provisioning" "example" {
@@ -6479,7 +6347,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure auto-provisioning of the monitoring agent is enabled in Bicep:
 
             ```bicep
             resource autoProvisioning 'Microsoft.Security/autoProvisioningSettings@2017-08-01-preview' = {
@@ -6550,9 +6418,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            RBAC cannot be disabled after cluster creation. To ensure RBAC is enabled:
+            To ensure RBAC is enabled on Azure Kubernetes Service clusters using the Azure Portal, RBAC cannot be disabled after cluster creation. To ensure RBAC is enabled:
 
             1. When creating a new AKS cluster, navigate to **Kubernetes services**.
             2. Select **Create** and configure your cluster.
@@ -6562,16 +6428,14 @@ queries:
             For existing clusters without RBAC, you must recreate the cluster with RBAC enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            When creating a new cluster, RBAC is enabled by default:
+            To ensure RBAC is enabled on Azure Kubernetes Service clusters using the Azure CLI, when creating a new cluster, RBAC is enabled by default:
 
             ```bash
             az aks create --resource-group <ResourceGroupName> --name <ClusterName> --enable-rbac
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure RBAC is enabled on Azure Kubernetes Service clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -6594,7 +6458,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure RBAC is enabled on Azure Kubernetes Service clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -6690,7 +6554,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS API server has authorized IP ranges configured using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -6700,14 +6564,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure AKS API server has authorized IP ranges configured using the Azure CLI:
 
             ```bash
             az aks update --resource-group <ResourceGroupName> --name <ClusterName> --api-server-authorized-ip-ranges <IPRange1>,<IPRange2>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS API server has authorized IP ranges configured in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -6733,7 +6597,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS API server has authorized IP ranges configured in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -6838,9 +6702,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            Network policy must be configured at cluster creation time:
+            To ensure AKS clusters have a network policy configured using the Azure Portal, network policy must be configured at cluster creation time:
 
             1. Navigate to **Kubernetes services** and select **Create**.
             2. Under **Networking**, select a **Network policy** option (Azure or Calico).
@@ -6849,16 +6711,14 @@ queries:
             For existing clusters, network policy cannot be changed. You must recreate the cluster with network policy enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            When creating a new cluster:
+            To ensure AKS clusters have a network policy configured using the Azure CLI, when creating a new cluster:
 
             ```bash
             az aks create --resource-group <ResourceGroupName> --name <ClusterName> --network-plugin azure --network-policy azure
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters have a network policy configured in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -6885,7 +6745,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters have a network policy configured in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -6987,7 +6847,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service web apps enforce HTTPS using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -6996,14 +6856,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service web apps enforce HTTPS using the Azure CLI:
 
             ```bash
             az webapp update --resource-group <ResourceGroupName> --name <WebAppName> --set httpsOnly=true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service web apps enforce HTTPS in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -7018,7 +6878,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service web apps enforce HTTPS in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2024-04-01' = {
@@ -7128,7 +6988,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service FTP basic auth publishing credentials are disabled using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -7137,14 +6997,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service FTP basic auth publishing credentials are disabled using the Azure CLI:
 
             ```bash
             az resource update --resource-group <ResourceGroupName> --name ftp --namespace Microsoft.Web --resource-type basicPublishingCredentialsPolicies --parent sites/<WebAppName> --set properties.allow=false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service FTP basic auth publishing credentials are disabled in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -7162,7 +7022,7 @@ queries:
             For Windows web apps, use `azurerm_windows_web_app` with the same `site_config` block.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service FTP basic auth publishing credentials are disabled in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -7271,7 +7131,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service SCM basic auth publishing credentials are disabled using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -7280,14 +7140,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service SCM basic auth publishing credentials are disabled using the Azure CLI:
 
             ```bash
             az resource update --resource-group <ResourceGroupName> --name scm --namespace Microsoft.Web --resource-type basicPublishingCredentialsPolicies --parent sites/<WebAppName> --set properties.allow=false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service SCM basic auth publishing credentials are disabled in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -7316,7 +7176,7 @@ queries:
             For Windows web apps, use `azurerm_windows_web_app` with the same approach.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service SCM basic auth publishing credentials are disabled in Bicep:
 
             ```bicep
             resource scmBasicAuth 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
@@ -7414,7 +7274,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis disables the non-SSL port using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the Redis cache instance.
@@ -7423,14 +7283,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis disables the non-SSL port using the Azure CLI:
 
             ```bash
             az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set enableNonSslPort=false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis disables the non-SSL port in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -7446,7 +7306,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cache for Redis disables the non-SSL port in Bicep:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
@@ -7525,7 +7385,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis disables public network access using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the Redis cache instance.
@@ -7535,14 +7395,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis disables public network access using the Azure CLI:
 
             ```bash
             az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set publicNetworkAccess=Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis disables public network access in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -7557,7 +7417,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cache for Redis disables public network access in Bicep:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
@@ -7641,9 +7501,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            Private cluster must be configured at cluster creation time:
+            To ensure AKS clusters are configured as private clusters using the Azure Portal, private cluster must be configured at cluster creation time:
 
             1. Navigate to **Kubernetes services** and select **Create**.
             2. Under **Networking**, enable **Private cluster**.
@@ -7652,23 +7510,21 @@ queries:
             For existing public clusters, you must recreate the cluster as a private cluster.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            When creating a new cluster:
+            To ensure AKS clusters are configured as private clusters using the Azure CLI, when creating a new cluster:
 
             ```bash
             az aks create --resource-group <ResourceGroupName> --name <ClusterName> --enable-private-cluster
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure AKS clusters are configured as private clusters using PowerShell:
 
             ```powershell
             New-AzAksCluster -ResourceGroupName <ResourceGroupName> -Name <ClusterName> -EnablePrivateCluster
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters are configured as private clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -7691,7 +7547,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters are configured as private clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -7795,7 +7651,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure run command is disabled on AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -7804,21 +7660,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure run command is disabled on AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --resource-group <ResourceGroupName> --name <ClusterName> --disable-run-command
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure run command is disabled on AKS clusters using PowerShell:
 
             ```powershell
             Set-AzAksCluster -ResourceGroupName <ResourceGroupName> -Name <ClusterName> -DisableRunCommand
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure run command is disabled on AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -7841,7 +7697,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure run command is disabled on AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -7945,7 +7801,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Policy add-on is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -7954,23 +7810,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            For an existing cluster:
+            To ensure Azure Policy add-on is enabled for AKS clusters using the Azure CLI, for an existing cluster:
 
             ```bash
             az aks enable-addons --resource-group <ResourceGroupName> --name <ClusterName> --addons azure-policy
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Policy add-on is enabled for AKS clusters using PowerShell:
 
             ```powershell
             Set-AzAksCluster -ResourceGroupName <ResourceGroupName> -Name <ClusterName> -EnableAzurePolicy
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Policy add-on is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -7994,7 +7848,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Policy add-on is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8100,7 +7954,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure private AKS clusters do not expose a public FQDN using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the private AKS cluster.
@@ -8109,21 +7963,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure private AKS clusters do not expose a public FQDN using the Azure CLI:
 
             ```bash
             az aks update --resource-group <ResourceGroupName> --name <ClusterName> --disable-public-fqdn
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure private AKS clusters do not expose a public FQDN using PowerShell:
 
             ```powershell
             Set-AzAksCluster -ResourceGroupName <ResourceGroupName> -Name <ClusterName> -DisablePublicFqdn
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure private AKS clusters do not expose a public FQDN in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8147,7 +8001,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure private AKS clusters do not expose a public FQDN in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8231,7 +8085,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender profile is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8239,14 +8093,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender profile is enabled for AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-defender
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender profile is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8263,7 +8117,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender profile is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8339,7 +8193,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Image Cleaner is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8347,14 +8201,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Image Cleaner is enabled for AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-image-cleaner
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Image Cleaner is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8370,7 +8224,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Image Cleaner is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8468,7 +8322,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure workload identity is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8476,14 +8330,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure workload identity is enabled for AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-workload-identity
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure workload identity is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8499,7 +8353,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure workload identity is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8593,7 +8447,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS agent pool nodes have encryption at host enabled using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8601,16 +8455,14 @@ queries:
             4. Create a new node pool with the encryption at host option enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Encryption at host must be enabled when creating or adding a node pool:
+            To ensure AKS agent pool nodes have encryption at host enabled using the Azure CLI, encryption at host must be enabled when creating or adding a node pool:
 
             ```bash
             az aks nodepool add --cluster-name <ClusterName> --resource-group <ResourceGroupName> --name <NodePoolName> --enable-encryption-at-host
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS agent pool nodes have encryption at host enabled in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8642,7 +8494,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS agent pool nodes have encryption at host enabled in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8738,7 +8590,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS clusters use Azure CNI or overlay networking instead of kubenet using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8746,16 +8598,14 @@ queries:
             4. Network plugin is set at cluster creation.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            The network plugin cannot be changed on existing clusters. Create a new cluster with Azure CNI:
+            To ensure AKS clusters use Azure CNI or overlay networking instead of kubenet using the Azure CLI, the network plugin cannot be changed on existing clusters. Create a new cluster with Azure CNI:
 
             ```bash
             az aks create --name <ClusterName> --resource-group <ResourceGroupName> --network-plugin azure
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters use Azure CNI or overlay networking instead of kubenet in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8772,7 +8622,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters use Azure CNI or overlay networking instead of kubenet in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8864,7 +8714,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Container Insights monitoring is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8873,14 +8723,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Container Insights monitoring is enabled for AKS clusters using the Azure CLI:
 
             ```bash
             az aks enable-addons --addon monitoring --name <ClusterName> --resource-group <ResourceGroupName>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Container Insights monitoring is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -8897,7 +8747,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Container Insights monitoring is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -8991,7 +8841,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the cluster.
@@ -8999,14 +8849,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters using the Azure CLI:
 
             ```bash
             az aks enable-addons --addon azure-keyvault-secrets-provider --name <ClusterName> --resource-group <ResourceGroupName>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -9023,7 +8873,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -9132,7 +8982,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure client certificate auth is enabled for App Service web apps using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -9141,21 +8991,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure client certificate auth is enabled for App Service web apps using the Azure CLI:
 
             ```bash
             az webapp update --resource-group <ResourceGroupName> --name <WebAppName> --set clientCertEnabled=true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure client certificate auth is enabled for App Service web apps using PowerShell:
 
             ```powershell
             Set-AzWebApp -ResourceGroupName <ResourceGroupName> -Name <WebAppName> -ClientCertEnabled $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure client certificate auth is enabled for App Service web apps in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -9171,7 +9021,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure client certificate auth is enabled for App Service web apps in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2024-04-01' = {
@@ -9288,7 +9138,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure remote debugging is disabled for App Service web apps using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -9297,21 +9147,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure remote debugging is disabled for App Service web apps using the Azure CLI:
 
             ```bash
             az webapp config set --resource-group <ResourceGroupName> --name <WebAppName> --remote-debugging-enabled false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure remote debugging is disabled for App Service web apps using PowerShell:
 
             ```powershell
             Set-AzWebApp -ResourceGroupName <ResourceGroupName> -Name <WebAppName> -RemoteDebuggingEnabled $false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure remote debugging is disabled for App Service web apps in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -9327,7 +9177,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure remote debugging is disabled for App Service web apps in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -9447,7 +9297,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure HTTP 2.0 is enabled for App Service web apps using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -9456,21 +9306,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure HTTP 2.0 is enabled for App Service web apps using the Azure CLI:
 
             ```bash
             az webapp config set --resource-group <ResourceGroupName> --name <WebAppName> --http20-enabled true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure HTTP 2.0 is enabled for App Service web apps using PowerShell:
 
             ```powershell
             Set-AzWebApp -ResourceGroupName <ResourceGroupName> -Name <WebAppName> -Http20Enabled $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure HTTP 2.0 is enabled for App Service web apps in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -9486,7 +9336,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure HTTP 2.0 is enabled for App Service web apps in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -9600,7 +9450,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service apps require FTPS for file deployment using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the app.
@@ -9609,14 +9459,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service apps require FTPS for file deployment using the Azure CLI:
 
             ```bash
             az webapp config set --resource-group <ResourceGroupName> --name <AppName> --ftps-state FtpsOnly
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service apps require FTPS for file deployment in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -9632,7 +9482,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service apps require FTPS for file deployment in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -9746,7 +9596,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service apps do not allow CORS access from all origins using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the app.
@@ -9756,7 +9606,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service apps do not allow CORS access from all origins using the Azure CLI:
 
             ```bash
             az webapp cors remove --resource-group <ResourceGroupName> --name <AppName> --allowed-origins "*"
@@ -9764,7 +9614,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service apps do not allow CORS access from all origins in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -9782,7 +9632,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service apps do not allow CORS access from all origins in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -9904,7 +9754,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Function apps have authentication enabled using the Azure Portal:
 
             1. Navigate to **Function Apps** in the Azure Portal.
             2. Select the function app.
@@ -9915,14 +9765,14 @@ queries:
             7. Select **Add**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Function apps have authentication enabled using the Azure CLI:
 
             ```bash
             az functionapp auth update --resource-group <ResourceGroupName> --name <FunctionAppName> --enabled true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Function apps have authentication enabled in Terraform:
 
             ```hcl
             resource "azurerm_linux_function_app" "example" {
@@ -9945,7 +9795,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Function apps have authentication enabled in Bicep:
 
             ```bicep
             resource authSettings 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -10061,7 +9911,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Function apps use private endpoints using the Azure Portal:
 
             1. Navigate to **Function Apps** in the Azure Portal.
             2. Select the function app.
@@ -10072,14 +9922,14 @@ queries:
             7. Select **OK**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Function apps use private endpoints using the Azure CLI:
 
             ```bash
             az network private-endpoint create --resource-group <ResourceGroupName> --name <PrivateEndpointName> --vnet-name <VNetName> --subnet <SubnetName> --private-connection-resource-id <FunctionAppResourceId> --group-id sites --connection-name <ConnectionName>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Function apps use private endpoints in Terraform:
 
             ```hcl
             resource "azurerm_private_endpoint" "example" {
@@ -10098,7 +9948,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Function apps use private endpoints in Bicep:
 
             ```bicep
             resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
@@ -10215,7 +10065,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis uses minimum TLS version 1.2 using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the Redis cache instance.
@@ -10224,21 +10074,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis uses minimum TLS version 1.2 using the Azure CLI:
 
             ```bash
             az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set minimumTlsVersion=1.2
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Cache for Redis uses minimum TLS version 1.2 using PowerShell:
 
             ```powershell
             Set-AzRedisCache -ResourceGroupName <ResourceGroupName> -Name <RedisCacheName> -MinimumTlsVersion "1.2"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis uses minimum TLS version 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -10253,7 +10103,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cache for Redis uses minimum TLS version 1.2 in Bicep:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
@@ -10336,7 +10186,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis uses a supported version using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the Redis cache instance.
@@ -10347,21 +10197,21 @@ queries:
             Note: Upgrading the Redis version may require a brief period of downtime. Plan the upgrade during a maintenance window.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis uses a supported version using the Azure CLI:
 
             ```bash
             az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set redisVersion=6
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Cache for Redis uses a supported version using PowerShell:
 
             ```powershell
             Set-AzRedisCache -ResourceGroupName <ResourceGroupName> -Name <RedisCacheName> -RedisVersion "6"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis uses a supported version in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -10376,7 +10226,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cache for Redis uses a supported version in Bicep:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
@@ -10454,7 +10304,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis requires authentication using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the Redis cache instance.
@@ -10463,14 +10313,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis requires authentication using the Azure CLI:
 
             ```bash
             az redis update --name <RedisCacheName> --resource-group <ResourceGroupName> --set redisConfiguration.authnotrequired=no
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis requires authentication in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -10488,9 +10338,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
-
-            Azure Cache for Redis requires authentication by default. Ensure `authnotrequired` is not set to `yes` in the Redis configuration:
+            To ensure Azure Cache for Redis requires authentication in Bicep, azure Cache for Redis requires authentication by default. Ensure `authnotrequired` is not set to `yes` in the Redis configuration:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2024-03-01' = {
@@ -10574,7 +10422,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure cross-tenant replication is disabled for Azure Storage accounts using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -10583,21 +10431,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure cross-tenant replication is disabled for Azure Storage accounts using the Azure CLI:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --allow-cross-tenant-replication false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure cross-tenant replication is disabled for Azure Storage accounts using PowerShell:
 
             ```powershell
             Set-AzStorageAccount -ResourceGroupName <ResourceGroupName> -Name <StorageAccountName> -AllowCrossTenantReplication $false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure cross-tenant replication is disabled for Azure Storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -10611,7 +10459,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure cross-tenant replication is disabled for Azure Storage accounts in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -10716,7 +10564,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SFTP is disabled on Azure Storage accounts unless required using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -10725,21 +10573,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure SFTP is disabled on Azure Storage accounts unless required using the Azure CLI:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --enable-sftp false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure SFTP is disabled on Azure Storage accounts unless required using PowerShell:
 
             ```powershell
             Set-AzStorageAccount -ResourceGroupName <ResourceGroupName> -Name <StorageAccountName> -EnableSftp $false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SFTP is disabled on Azure Storage accounts unless required in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -10753,7 +10601,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SFTP is disabled on Azure Storage accounts unless required in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -10858,7 +10706,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure shared key access is disabled for Azure Storage accounts using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -10867,21 +10715,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure shared key access is disabled for Azure Storage accounts using the Azure CLI:
 
             ```bash
             az storage account update --name <StorageAccountName> --resource-group <ResourceGroupName> --allow-shared-key-access false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure shared key access is disabled for Azure Storage accounts using PowerShell:
 
             ```powershell
             Set-AzStorageAccount -ResourceGroupName <ResourceGroupName> -Name <StorageAccountName> -AllowSharedKeyAccess $false
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure shared key access is disabled for Azure Storage accounts in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -10895,7 +10743,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure shared key access is disabled for Azure Storage accounts in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -11003,7 +10851,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure virtual machines do not have public IP addresses directly attached using the Azure Portal:
 
             1. Navigate to **Virtual machines** in the Azure Portal.
             2. Select the virtual machine with a public IP address.
@@ -11014,16 +10862,14 @@ queries:
             7. Consider using Azure Bastion, a load balancer, or Azure Firewall for secure access.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Disassociate a public IP from a VM's network interface:
+            To ensure virtual machines do not have public IP addresses directly attached using the Azure CLI, disassociate a public IP from a VM's network interface:
 
             ```bash
             az network nic ip-config update --resource-group <ResourceGroupName> --nic-name <NICName> --name <IPConfigName> --remove PublicIpAddress
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure virtual machines do not have public IP addresses directly attached using PowerShell:
 
             ```powershell
             $nic = Get-AzNetworkInterface -ResourceGroupName <ResourceGroupName> -Name <NICName>
@@ -11032,9 +10878,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the network interface does not include a public IP address:
+            To ensure virtual machines do not have public IP addresses directly attached in Terraform, ensure the network interface does not include a public IP address:
 
             ```hcl
             resource "azurerm_network_interface" "example" {
@@ -11052,9 +10896,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
-
-            Create a NIC without a public IP address:
+            To ensure virtual machines do not have public IP addresses directly attached in Bicep, create a NIC without a public IP address:
 
             ```bicep
             resource nic 'Microsoft.Network/networkInterfaces@2024-05-01' = {
@@ -11191,7 +11033,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure virtual machines use managed disks using the Azure Portal:
 
             1. Navigate to **Virtual machines** in the Azure Portal.
             2. Stop (deallocate) the virtual machine.
@@ -11201,9 +11043,7 @@ queries:
             6. Restart the virtual machine.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Convert a VM to use managed disks:
+            To ensure virtual machines use managed disks using the Azure CLI, convert a VM to use managed disks:
 
             ```bash
             az vm deallocate --resource-group <ResourceGroupName> --name <VMName>
@@ -11212,7 +11052,7 @@ queries:
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure virtual machines use managed disks using PowerShell:
 
             ```powershell
             Stop-AzVM -ResourceGroupName <ResourceGroupName> -Name <VMName> -Force
@@ -11221,9 +11061,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure VMs are configured with managed disks:
+            To ensure virtual machines use managed disks in Terraform, ensure VMs are configured with managed disks:
 
             ```hcl
             resource "azurerm_linux_virtual_machine" "example" {
@@ -11244,7 +11082,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure virtual machines use managed disks in Bicep:
 
             ```bicep
             resource vm 'Microsoft.Compute/virtualMachines@2024-07-01' = {
@@ -11375,7 +11213,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure unattached disks are encrypted with Customer Managed Keys using the Azure Portal:
 
             1. Navigate to **Disks** in the Azure Portal.
             2. Select the unattached disk you wish to encrypt.
@@ -11384,14 +11222,14 @@ queries:
             5. Save the changes.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure unattached disks are encrypted with Customer Managed Keys using the Azure CLI:
 
             ```bash
             az disk update --resource-group <ResourceGroupName> --name <DiskName> --encryption-type EncryptionAtRestWithCustomerKey --disk-encryption-set <DiskEncryptionSetId>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure unattached disks are encrypted with Customer Managed Keys using PowerShell:
 
             ```powershell
             $disk = Get-AzDisk -ResourceGroupName <ResourceGroupName> -DiskName <DiskName>
@@ -11402,7 +11240,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure unattached disks are encrypted with Customer Managed Keys in Terraform:
 
             ```hcl
             resource "azurerm_managed_disk" "example" {
@@ -11417,7 +11255,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure unattached disks are encrypted with Customer Managed Keys in Bicep:
 
             ```bicep
             resource managedDisk 'Microsoft.Compute/disks@2024-03-02' = {
@@ -11529,7 +11367,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure DDoS Protection is enabled on virtual networks using the Azure Portal:
 
             1. Navigate to **Virtual networks** in the Azure Portal.
             2. Select the virtual network.
@@ -11538,14 +11376,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure DDoS Protection is enabled on virtual networks using the Azure CLI:
 
             ```bash
             az network vnet update --resource-group <ResourceGroupName> --name <VNetName> --ddos-protection true --ddos-protection-plan <DDoSProtectionPlanId>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure DDoS Protection is enabled on virtual networks using PowerShell:
 
             ```powershell
             $vnet = Get-AzVirtualNetwork -ResourceGroupName <ResourceGroupName> -Name <VNetName>
@@ -11556,7 +11394,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DDoS Protection is enabled on virtual networks in Terraform:
 
             ```hcl
             resource "azurerm_network_ddos_protection_plan" "example" {
@@ -11579,7 +11417,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure DDoS Protection is enabled on virtual networks in Bicep:
 
             ```bicep
             resource ddosProtectionPlan 'Microsoft.Network/ddosProtectionPlans@2024-05-01' = {
@@ -11696,7 +11534,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure VM protection is enabled on virtual networks using the Azure Portal:
 
             1. Navigate to **Virtual networks** in the Azure Portal.
             2. Select the VNet.
@@ -11704,14 +11542,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure VM protection is enabled on virtual networks using the Azure CLI:
 
             ```bash
             az network vnet update --resource-group <ResourceGroupName> --name <VNetName> --vm-protection true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure VM protection is enabled on virtual networks using PowerShell:
 
             ```powershell
             $vnet = Get-AzVirtualNetwork -ResourceGroupName <ResourceGroupName> -Name <VNetName>
@@ -11720,7 +11558,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure VM protection is enabled on virtual networks in Terraform:
 
             ```hcl
             resource "azurerm_virtual_network" "example" {
@@ -11733,7 +11571,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure VM protection is enabled on virtual networks in Bicep:
 
             ```bicep
             resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
@@ -11840,7 +11678,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure default outbound access is disabled on subnets using the Azure Portal:
 
             1. Navigate to **Virtual networks** in the Azure Portal.
             2. Select the virtual network.
@@ -11850,14 +11688,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure default outbound access is disabled on subnets using the Azure CLI:
 
             ```bash
             az network vnet subnet update --resource-group <ResourceGroupName> --vnet-name <VNetName> --name <SubnetName> --default-outbound false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure default outbound access is disabled on subnets using PowerShell:
 
             ```powershell
             $vnet = Get-AzVirtualNetwork -ResourceGroupName <ResourceGroupName> -Name <VNetName>
@@ -11867,7 +11705,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure default outbound access is disabled on subnets in Terraform:
 
             ```hcl
             resource "azurerm_subnet" "example" {
@@ -11880,7 +11718,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure default outbound access is disabled on subnets in Bicep:
 
             ```bicep
             resource subnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
@@ -11997,7 +11835,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To restrict access on disallowed TCP database ports using the Azure Portal:
 
             1. Log into the Azure Portal and navigate to **Network Security Groups**.
             2. Select the NSG associated with your resources.
@@ -12005,23 +11843,21 @@ queries:
             4. Change the `source_address_prefix` to more restrictive settings, such as a specific IP range, virtual network, or private endpoint.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update or create NSG rules to restrict database port access:
+            To restrict access on disallowed TCP database ports using the Azure CLI, update or create NSG rules to restrict database port access:
 
             ```bash
             az network nsg rule create --resource-group <ResourceGroupName> --nsg-name <NSGName> --name RestrictDBPorts --priority 1001 --direction Inbound --access Deny --protocol Tcp --source-address-prefixes "*" --destination-port-ranges 1433 3306 5432 27017
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To restrict access on disallowed TCP database ports using PowerShell:
 
             ```powershell
             New-AzNetworkSecurityRuleConfig -Name RestrictDBPorts -Protocol Tcp -Direction Inbound -Priority 1001 -SourceAddressPrefix * -SourcePortRange * -DestinationAddressPrefix * -DestinationPortRange 1433,3306,5432,27017 -Access Deny
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To restrict access on disallowed TCP database ports in Terraform:
 
             ```hcl
             # Ensure database ports are not exposed to the internet
@@ -12046,7 +11882,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To restrict access on disallowed TCP database ports in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
@@ -12185,7 +12021,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Cosmos DB is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -12193,21 +12029,21 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Cosmos DB is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name CosmosDbs --tier Standard
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Microsoft Defender for Cosmos DB is enabled using PowerShell:
 
             ```powershell
             Set-AzSecurityPricing -Name CosmosDbs -PricingTier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Cosmos DB is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "cosmos_db" {
@@ -12217,7 +12053,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Cosmos DB is enabled in Bicep:
 
             ```bicep
             resource defenderForCosmosDb 'Microsoft.Security/pricings@2024-01-01' = {
@@ -12280,7 +12116,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for open-source relational databases is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -12288,21 +12124,21 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for open-source relational databases is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name OpenSourceRelationalDatabases --tier Standard
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Microsoft Defender for open-source relational databases is enabled using PowerShell:
 
             ```powershell
             Set-AzSecurityPricing -Name OpenSourceRelationalDatabases -PricingTier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for open-source relational databases is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "open_source_dbs" {
@@ -12312,7 +12148,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for open-source relational databases is enabled in Bicep:
 
             ```bicep
             resource defenderForOsrdb 'Microsoft.Security/pricings@2024-01-01' = {
@@ -12376,7 +12212,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender Cloud Security Posture Management is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -12385,21 +12221,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender Cloud Security Posture Management is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name CloudPosture --tier Standard
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Microsoft Defender Cloud Security Posture Management is enabled using PowerShell:
 
             ```powershell
             Set-AzSecurityPricing -Name CloudPosture -PricingTier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender Cloud Security Posture Management is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "cspm" {
@@ -12409,7 +12245,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender Cloud Security Posture Management is enabled in Bicep:
 
             ```bicep
             resource defenderCspm 'Microsoft.Security/pricings@2024-01-01' = {
@@ -12486,7 +12322,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public network access is disabled for Azure Cosmos DB accounts using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -12496,21 +12332,21 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure public network access is disabled for Azure Cosmos DB accounts using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-public-network false
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure public network access is disabled for Azure Cosmos DB accounts using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -PublicNetworkAccess "Disabled"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public network access is disabled for Azure Cosmos DB accounts in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -12523,7 +12359,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public network access is disabled for Azure Cosmos DB accounts in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -12625,7 +12461,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure local authentication is disabled for Azure Cosmos DB accounts using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -12635,21 +12471,21 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure local authentication is disabled for Azure Cosmos DB accounts using the Azure CLI:
 
             ```bash
             az resource update --ids <CosmosDBResourceId> --set properties.disableLocalAuth=true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure local authentication is disabled for Azure Cosmos DB accounts using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -DisableLocalAuth $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure local authentication is disabled for Azure Cosmos DB accounts in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -12662,7 +12498,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure local authentication is disabled for Azure Cosmos DB accounts in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -12764,7 +12600,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure virtual network filtering is enabled for Azure Cosmos DB accounts using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -12774,7 +12610,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure virtual network filtering is enabled for Azure Cosmos DB accounts using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-virtual-network true
@@ -12782,14 +12618,14 @@ queries:
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure virtual network filtering is enabled for Azure Cosmos DB accounts using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -EnableVirtualNetwork $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure virtual network filtering is enabled for Azure Cosmos DB accounts in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -12806,7 +12642,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure virtual network filtering is enabled for Azure Cosmos DB accounts in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -12915,7 +12751,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure key-based metadata write access is disabled for Cosmos DB using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -12924,21 +12760,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure key-based metadata write access is disabled for Cosmos DB using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --disable-key-based-metadata-write-access true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure key-based metadata write access is disabled for Cosmos DB using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -DisableKeyBasedMetadataWriteAccess $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure key-based metadata write access is disabled for Cosmos DB in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -12951,7 +12787,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure key-based metadata write access is disabled for Cosmos DB in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13053,7 +12889,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure automatic failover is enabled for Azure Cosmos DB accounts using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -13062,21 +12898,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure automatic failover is enabled for Azure Cosmos DB accounts using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-automatic-failover true
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure automatic failover is enabled for Azure Cosmos DB accounts using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -EnableAutomaticFailover $true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure automatic failover is enabled for Azure Cosmos DB accounts in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13099,7 +12935,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure automatic failover is enabled for Azure Cosmos DB accounts in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13202,7 +13038,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB accounts use minimum TLS version 1.2 using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -13211,21 +13047,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cosmos DB accounts use minimum TLS version 1.2 using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --minimal-tls-version Tls12
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Cosmos DB accounts use minimum TLS version 1.2 using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -MinimalTlsVersion "Tls12"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB accounts use minimum TLS version 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13238,7 +13074,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB accounts use minimum TLS version 1.2 in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13340,7 +13176,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB network ACL bypass is set to None using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -13349,21 +13185,21 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cosmos DB network ACL bypass is set to None using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --network-acl-bypass None
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Cosmos DB network ACL bypass is set to None using PowerShell:
 
             ```powershell
             Update-AzCosmosDBAccount -ResourceGroupName <ResourceGroupName> -Name <CosmosDBAccountName> -NetworkAclBypass "None"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB network ACL bypass is set to None in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13376,7 +13212,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB network ACL bypass is set to None in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13478,7 +13314,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB accounts use customer-managed keys for encryption using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account.
@@ -13491,14 +13327,14 @@ queries:
             **Note**: Customer-managed key encryption must be configured at account creation time. Existing accounts using Microsoft-managed keys may need to be recreated.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cosmos DB accounts use customer-managed keys for encryption using the Azure CLI:
 
             ```bash
             az cosmosdb create --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --key-uri "https://<KeyVaultName>.vault.azure.net/keys/<KeyName>/<KeyVersion>" --assign-identity "<ManagedIdentityResourceId>" --default-identity "UserAssignedIdentity=<ManagedIdentityResourceId>"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB accounts use customer-managed keys for encryption in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13515,7 +13351,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB accounts use customer-managed keys for encryption in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13608,7 +13444,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public Cosmos DB accounts have IP firewall rules configured using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account and go to **Networking**.
@@ -13616,14 +13452,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure public Cosmos DB accounts have IP firewall rules configured using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --ip-range-filter "203.0.113.0/24,198.51.100.0/24"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public Cosmos DB accounts have IP firewall rules configured in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13638,7 +13474,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public Cosmos DB accounts have IP firewall rules configured in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -13739,16 +13575,14 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Cosmos DB accounts have private endpoints configured using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account and go to **Networking** > **Private endpoint connections**.
             3. Select **+ Private endpoint** and configure a private endpoint in the target virtual network.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Disable public network access and create a private endpoint for the Cosmos DB account:
+            To ensure Cosmos DB accounts have private endpoints configured using the Azure CLI, disable public network access and create a private endpoint for the Cosmos DB account:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-public-network false
@@ -13757,7 +13591,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cosmos DB accounts have private endpoints configured in Terraform:
 
             ```hcl
             resource "azurerm_private_endpoint" "example" {
@@ -13776,7 +13610,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Cosmos DB accounts have private endpoints configured in Bicep:
 
             ```bicep
             resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
@@ -13882,7 +13716,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB accounts do not allow wildcard CORS origins using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account and go to **Settings** > **CORS**.
@@ -13890,16 +13724,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Update CORS allowed origins to specific domains instead of wildcard:
+            To ensure Azure Cosmos DB accounts do not allow wildcard CORS origins using the Azure CLI, update CORS allowed origins to specific domains instead of wildcard:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --cors-allowed-origins "https://specific-domain.com"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB accounts do not allow wildcard CORS origins in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -13919,7 +13751,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB accounts do not allow wildcard CORS origins in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -14023,7 +13855,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB accounts use continuous backup policy using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the account.
@@ -14031,14 +13863,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cosmos DB accounts use continuous backup policy using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --backup-policy-type Continuous
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB accounts use continuous backup policy in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -14055,7 +13887,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB accounts use continuous backup policy in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -14145,7 +13977,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure multi-region Cosmos DB accounts have multi-region write enabled using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the account.
@@ -14153,14 +13985,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure multi-region Cosmos DB accounts have multi-region write enabled using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --enable-multiple-write-locations true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure multi-region Cosmos DB accounts have multi-region write enabled in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -14184,7 +14016,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure multi-region Cosmos DB accounts have multi-region write enabled in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -14283,7 +14115,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cosmos DB accounts use bounded staleness or strong consistency using the Azure Portal:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the account.
@@ -14291,14 +14123,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cosmos DB accounts use bounded staleness or strong consistency using the Azure CLI:
 
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --default-consistency-level BoundedStaleness
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cosmos DB accounts use bounded staleness or strong consistency in Terraform:
 
             ```hcl
             resource "azurerm_cosmosdb_account" "example" {
@@ -14317,7 +14149,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cosmos DB accounts use bounded staleness or strong consistency in Bicep:
 
             ```bicep
             resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -14426,7 +14258,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Firewall threat intelligence is set to Deny mode using the Azure Portal:
 
             1. Navigate to **Firewalls** in the Azure Portal.
             2. Select the Azure Firewall instance.
@@ -14435,14 +14267,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Firewall threat intelligence is set to Deny mode using the Azure CLI:
 
             ```bash
             az network firewall update --name <FirewallName> --resource-group <ResourceGroupName> --threat-intel-mode Deny
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Firewall threat intelligence is set to Deny mode using PowerShell:
 
             ```powershell
             $firewall = Get-AzFirewall -Name <FirewallName> -ResourceGroupName <ResourceGroupName>
@@ -14451,7 +14283,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Firewall threat intelligence is set to Deny mode in Terraform:
 
             ```hcl
             resource "azurerm_firewall" "example" {
@@ -14465,7 +14297,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Firewall threat intelligence is set to Deny mode in Bicep:
 
             ```bicep
             resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
@@ -14571,7 +14403,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Firewall uses Premium SKU for advanced threat protection using the Azure Portal:
 
             1. Navigate to **Firewalls** in the Azure Portal.
             2. Select the Azure Firewall instance.
@@ -14580,21 +14412,21 @@ queries:
             5. Migrate existing firewall rules and policies to the new Premium firewall.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Firewall uses Premium SKU for advanced threat protection using the Azure CLI:
 
             ```bash
             az network firewall create --name <FirewallName> --resource-group <ResourceGroupName> --location <Location> --sku AZFW_VNet --tier Premium
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Firewall uses Premium SKU for advanced threat protection using PowerShell:
 
             ```powershell
             New-AzFirewall -Name <FirewallName> -ResourceGroupName <ResourceGroupName> -Location <Location> -SkuName "AZFW_VNet" -SkuTier "Premium"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Firewall uses Premium SKU for advanced threat protection in Terraform:
 
             ```hcl
             resource "azurerm_firewall" "example" {
@@ -14607,7 +14439,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Firewall uses Premium SKU for advanced threat protection in Bicep:
 
             ```bicep
             resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
@@ -14712,7 +14544,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Firewall has a firewall policy attached using the Azure Portal:
 
             1. Navigate to **Firewalls** in the Azure Portal.
             2. Select the Azure Firewall instance.
@@ -14722,14 +14554,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Firewall has a firewall policy attached using the Azure CLI:
 
             ```bash
             az network firewall update --name <FirewallName> --resource-group <ResourceGroupName> --firewall-policy <PolicyResourceId>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Firewall has a firewall policy attached using PowerShell:
 
             ```powershell
             $policy = Get-AzFirewallPolicy -Name <PolicyName> -ResourceGroupName <ResourceGroupName>
@@ -14739,7 +14571,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Firewall has a firewall policy attached in Terraform:
 
             ```hcl
             resource "azurerm_firewall_policy" "example" {
@@ -14759,7 +14591,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Firewall has a firewall policy attached in Bicep:
 
             ```bicep
             resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
@@ -14876,7 +14708,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Firewall Policy has IDPS set to Deny mode using the Azure Portal:
 
             1. Navigate to **Firewall Policies** in the Azure Portal.
             2. Select the firewall policy.
@@ -14886,14 +14718,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Firewall Policy has IDPS set to Deny mode using the Azure CLI:
 
             ```bash
             az network firewall policy update --name <PolicyName> --resource-group <ResourceGroupName> --idps-mode Deny
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Firewall Policy has IDPS set to Deny mode using PowerShell:
 
             ```powershell
             $policy = Get-AzFirewallPolicy -Name <PolicyName> -ResourceGroupName <ResourceGroupName>
@@ -14902,7 +14734,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Firewall Policy has IDPS set to Deny mode in Terraform:
 
             ```hcl
             resource "azurerm_firewall_policy" "example" {
@@ -14918,7 +14750,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Firewall Policy has IDPS set to Deny mode in Bicep:
 
             ```bicep
             resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
@@ -15029,7 +14861,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public network access is disabled for Azure Batch accounts using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15039,21 +14871,21 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure public network access is disabled for Azure Batch accounts using the Azure CLI:
 
             ```bash
             az batch account update --name <BatchAccountName> --resource-group <ResourceGroupName> --public-network-access Disabled
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure public network access is disabled for Azure Batch accounts using PowerShell:
 
             ```powershell
             Set-AzBatchAccount -AccountName <BatchAccountName> -ResourceGroupName <ResourceGroupName> -PublicNetworkAccess "Disabled"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public network access is disabled for Azure Batch accounts in Terraform:
 
             ```hcl
             resource "azurerm_batch_account" "example" {
@@ -15065,7 +14897,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public network access is disabled for Azure Batch accounts in Bicep:
 
             ```bicep
             resource batchAccount 'Microsoft.Batch/batchAccounts@2024-07-01' = {
@@ -15167,7 +14999,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Batch accounts use Entra ID authentication using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15177,21 +15009,21 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Batch accounts use Entra ID authentication using the Azure CLI:
 
             ```bash
             az batch account update --name <BatchAccountName> --resource-group <ResourceGroupName> --allowed-authentication-modes AAD
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Batch accounts use Entra ID authentication using PowerShell:
 
             ```powershell
             Set-AzBatchAccount -AccountName <BatchAccountName> -ResourceGroupName <ResourceGroupName> -AllowedAuthenticationMode "AAD"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Batch accounts use Entra ID authentication in Terraform:
 
             ```hcl
             resource "azurerm_batch_account" "example" {
@@ -15204,7 +15036,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Batch accounts use Entra ID authentication in Bicep:
 
             ```bicep
             resource batchAccount 'Microsoft.Batch/batchAccounts@2024-07-01' = {
@@ -15316,7 +15148,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Batch accounts use customer-managed encryption keys using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15326,21 +15158,21 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Batch accounts use customer-managed encryption keys using the Azure CLI:
 
             ```bash
             az batch account update --name <BatchAccountName> --resource-group <ResourceGroupName> --encryption-key-source Microsoft.KeyVault --encryption-key-identifier <KeyVaultKeyId>
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Batch accounts use customer-managed encryption keys using PowerShell:
 
             ```powershell
             Set-AzBatchAccount -AccountName <BatchAccountName> -ResourceGroupName <ResourceGroupName> -EncryptionKeySource "Microsoft.KeyVault" -EncryptionKeyIdentifier <KeyVaultKeyId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Batch accounts use customer-managed encryption keys in Terraform:
 
             ```hcl
             resource "azurerm_batch_account" "example" {
@@ -15355,7 +15187,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Batch accounts use customer-managed encryption keys in Bicep:
 
             ```bicep
             resource batchAccount 'Microsoft.Batch/batchAccounts@2024-07-01' = {
@@ -15457,7 +15289,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Batch accounts have diagnostic settings enabled using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15468,21 +15300,21 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Batch accounts have diagnostic settings enabled using the Azure CLI:
 
             ```bash
             az monitor diagnostic-settings create --name <SettingName> --resource <BatchAccountResourceId> --workspace <LogAnalyticsWorkspaceId> --logs '[{"category":"ServiceLog","enabled":true},{"category":"AuditLog","enabled":true}]'
             ```
         - id: powershell
           desc: |
-            **Using PowerShell**
+            To ensure Azure Batch accounts have diagnostic settings enabled using PowerShell:
 
             ```powershell
             Set-AzDiagnosticSetting -ResourceId <BatchAccountResourceId> -Name <SettingName> -WorkspaceId <LogAnalyticsWorkspaceId> -Enabled $true -Category "ServiceLog","AuditLog"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Batch accounts have diagnostic settings enabled in Terraform:
 
             ```hcl
             resource "azurerm_monitor_diagnostic_setting" "example" {
@@ -15501,7 +15333,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Batch accounts have diagnostic settings enabled in Bicep:
 
             ```bicep
             resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -15580,7 +15412,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Batch accounts have private endpoint connections configured using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15591,7 +15423,7 @@ queries:
             7. Select **Review + create**, then **Create**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Batch accounts have private endpoint connections configured using the Azure CLI:
 
             ```bash
             az network private-endpoint create \
@@ -15605,7 +15437,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Batch accounts have private endpoint connections configured in Terraform:
 
             ```hcl
             resource "azurerm_private_endpoint" "batch" {
@@ -15624,7 +15456,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Batch accounts have private endpoint connections configured in Bicep:
 
             ```bicep
             resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
@@ -15739,7 +15571,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Batch pools have disk encryption enabled using the Azure Portal:
 
             1. Navigate to **Batch accounts** in the Azure Portal.
             2. Select the Batch account.
@@ -15751,9 +15583,7 @@ queries:
             Note: Disk encryption configuration can only be set at pool creation time. Existing pools must be recreated with the encryption configuration.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Disk encryption must be specified at pool creation time:
+            To ensure Azure Batch pools have disk encryption enabled using the Azure CLI, disk encryption must be specified at pool creation time:
 
             ```bash
             az batch pool create \
@@ -15765,7 +15595,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Batch pools have disk encryption enabled in Terraform:
 
             ```hcl
             resource "azurerm_batch_pool" "example" {
@@ -15792,7 +15622,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Batch pools have disk encryption enabled in Bicep:
 
             ```bicep
             resource batchPool 'Microsoft.Batch/batchAccounts/pools@2024-07-01' = {
@@ -15892,7 +15722,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure SQL servers enforce minimal TLS version 1.2 using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server.
@@ -15901,14 +15731,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure SQL servers enforce minimal TLS version 1.2 using the Azure CLI:
 
             ```bash
             az sql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version 1.2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure SQL servers enforce minimal TLS version 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -15923,7 +15753,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure SQL servers enforce minimal TLS version 1.2 in Bicep:
 
             ```bicep
             @secure()
@@ -15989,7 +15819,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL flexible servers disable public network access using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -15999,14 +15829,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL flexible servers disable public network access using the Azure CLI:
 
             ```bash
             az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL flexible servers disable public network access in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server" "example" {
@@ -16022,7 +15852,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL flexible servers disable public network access in Bicep:
 
             ```bicep
             resource postgresFlexServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
@@ -16088,7 +15918,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL flexible servers enforce customer-managed key encryption using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -16098,16 +15928,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Configure customer-managed key encryption when creating or updating the server:
+            To ensure PostgreSQL flexible servers enforce customer-managed key encryption using the Azure CLI, configure customer-managed key encryption when creating or updating the server:
 
             ```bash
             az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL flexible servers enforce customer-managed key encryption in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server" "example" {
@@ -16130,7 +15958,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL flexible servers enforce customer-managed key encryption in Bicep:
 
             ```bicep
             resource postgresFlexServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
@@ -16202,7 +16030,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL servers enforce minimum TLS version 1.2 using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL** in the Azure Portal.
             2. Select the server instance.
@@ -16211,14 +16039,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL servers enforce minimum TLS version 1.2 using the Azure CLI:
 
             ```bash
             az postgres server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL servers enforce minimum TLS version 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_server" "example" {
@@ -16232,7 +16060,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL servers enforce minimum TLS version 1.2 in Bicep:
 
             ```bicep
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
@@ -16295,7 +16123,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure MySQL flexible servers disable public network access using the Azure Portal:
 
             1. Navigate to **Azure Database for MySQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -16305,14 +16133,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure MySQL flexible servers disable public network access using the Azure CLI:
 
             ```bash
             az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --public-access Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure MySQL flexible servers disable public network access in Terraform:
 
             ```hcl
             resource "azurerm_mysql_flexible_server" "example" {
@@ -16329,7 +16157,7 @@ queries:
             When `delegated_subnet_id` is set, public network access is automatically disabled.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure MySQL flexible servers disable public network access in Bicep:
 
             ```bicep
             resource mysqlFlexServer 'Microsoft.DBforMySQL/flexibleServers@2023-12-30' = {
@@ -16395,7 +16223,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure MySQL flexible servers enforce customer-managed key encryption using the Azure Portal:
 
             1. Navigate to **Azure Database for MySQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -16405,16 +16233,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Configure customer-managed key encryption when creating or updating the server:
+            To ensure MySQL flexible servers enforce customer-managed key encryption using the Azure CLI, configure customer-managed key encryption when creating or updating the server:
 
             ```bash
             az mysql flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --key <KeyIdentifier> --identity <UserAssignedIdentityId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure MySQL flexible servers enforce customer-managed key encryption in Terraform:
 
             ```hcl
             resource "azurerm_mysql_flexible_server" "example" {
@@ -16437,7 +16263,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure MySQL flexible servers enforce customer-managed key encryption in Bicep:
 
             ```bicep
             resource mysqlFlexServer 'Microsoft.DBforMySQL/flexibleServers@2023-12-30' = {
@@ -16509,7 +16335,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure MySQL servers enforce minimum TLS version 1.2 using the Azure Portal:
 
             1. Navigate to **Azure Database for MySQL** in the Azure Portal.
             2. Select the server instance.
@@ -16518,14 +16344,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure MySQL servers enforce minimum TLS version 1.2 using the Azure CLI:
 
             ```bash
             az mysql server update --name <ServerName> --resource-group <ResourceGroupName> --minimal-tls-version TLS1_2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure MySQL servers enforce minimum TLS version 1.2 in Terraform:
 
             ```hcl
             resource "azurerm_mysql_server" "example" {
@@ -16539,7 +16365,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure MySQL servers enforce minimum TLS version 1.2 in Bicep:
 
             ```bicep
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
@@ -16589,7 +16415,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for SQL Servers on Machines is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -16597,14 +16423,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for SQL Servers on Machines is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name SqlServerVirtualMachines --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for SQL Servers on Machines is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "example" {
@@ -16614,7 +16440,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for SQL Servers on Machines is enabled in Bicep:
 
             ```bicep
             resource defenderForSqlMachines 'Microsoft.Security/pricings@2024-01-01' = {
@@ -16673,7 +16499,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS clusters have disk CSI driver enabled for node pool encryption using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -16684,9 +16510,7 @@ queries:
             Note: Disk encryption set must be configured at cluster or node pool creation time and cannot be changed afterward.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable encryption at host when creating or adding a node pool:
+            To ensure AKS clusters have disk CSI driver enabled for node pool encryption using the Azure CLI, enable encryption at host when creating or adding a node pool:
 
             ```bash
             az aks nodepool add --cluster-name <ClusterName> --resource-group <ResourceGroupName> --name <PoolName> --enable-encryption-at-host
@@ -16699,7 +16523,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters have disk CSI driver enabled for node pool encryption in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -16716,7 +16540,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters have disk CSI driver enabled for node pool encryption in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -16808,7 +16632,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Application Gateways enforce TLS 1.2 or higher using the Azure Portal:
 
             1. Navigate to **Application gateways** in the Azure Portal.
             2. Select the Application Gateway.
@@ -16818,7 +16642,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Application Gateways enforce TLS 1.2 or higher using the Azure CLI:
 
             ```bash
             az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --min-protocol-version TLSv1_2 --policy-type Custom
@@ -16831,7 +16655,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Gateways enforce TLS 1.2 or higher in Terraform:
 
             ```hcl
             resource "azurerm_application_gateway" "example" {
@@ -16849,7 +16673,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Application Gateways enforce TLS 1.2 or higher in Bicep:
 
             ```bicep
             resource appGateway 'Microsoft.Network/applicationGateways@2024-05-01' = {
@@ -16958,7 +16782,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure VPN gateways use route-based type for IKEv2 protocol support using the Azure Portal:
 
             1. Navigate to **Virtual network gateways** in the Azure Portal.
             2. Select the VPN gateway.
@@ -16968,16 +16792,14 @@ queries:
             Note: VPN type is set at gateway creation and cannot be changed. Policy-based gateways must be recreated as route-based to support IKEv2.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            VPN type must be specified when creating the gateway. Policy-based gateways must be recreated as route-based:
+            To ensure VPN gateways use route-based type for IKEv2 protocol support using the Azure CLI, VPN type must be specified when creating the gateway. Policy-based gateways must be recreated as route-based:
 
             ```bash
             az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw1
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure VPN gateways use route-based type for IKEv2 protocol support in Terraform:
 
             ```hcl
             resource "azurerm_virtual_network_gateway" "example" {
@@ -16997,7 +16819,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure VPN gateways use route-based type for IKEv2 protocol support in Bicep:
 
             ```bicep
             resource vpnGateway 'Microsoft.Network/virtualNetworkGateways@2024-05-01' = {
@@ -17108,7 +16930,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Databricks workspaces disable public network access using the Azure Portal:
 
             1. Navigate to **Azure Databricks** in the Azure Portal.
             2. Select the workspace.
@@ -17118,14 +16940,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Databricks workspaces disable public network access using the Azure CLI:
 
             ```bash
             az databricks workspace update --name <WorkspaceName> --resource-group <ResourceGroupName> --public-network-access Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Databricks workspaces disable public network access in Terraform:
 
             ```hcl
             resource "azurerm_databricks_workspace" "example" {
@@ -17138,7 +16960,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Databricks workspaces disable public network access in Bicep:
 
             ```bicep
             resource databricksWorkspace 'Microsoft.Databricks/workspaces@2024-05-01' = {
@@ -17222,7 +17044,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for Endpoint integration is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -17231,14 +17053,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for Endpoint integration is enabled using the Azure CLI:
 
             ```bash
             az security setting create --name WDATP --setting-kind DataExportSettings --enabled true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for Endpoint integration is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_setting" "example" {
@@ -17248,7 +17070,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for Endpoint integration is enabled in Bicep:
 
             ```bicep
             resource defenderForEndpoint 'Microsoft.Security/settings@2022-05-01' = {
@@ -17302,7 +17124,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Microsoft Defender for APIs is enabled using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
             2. Select **Environment settings** and choose the subscription.
@@ -17310,14 +17132,14 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Microsoft Defender for APIs is enabled using the Azure CLI:
 
             ```bash
             az security pricing create --name Api --tier Standard
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Microsoft Defender for APIs is enabled in Terraform:
 
             ```hcl
             resource "azurerm_security_center_subscription_pricing" "apis" {
@@ -17327,7 +17149,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Microsoft Defender for APIs is enabled in Bicep:
 
             ```bicep
             resource defenderForApis 'Microsoft.Security/pricings@2024-01-01' = {
@@ -17394,7 +17216,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service web apps use a strong minimum TLS cipher suite using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -17403,14 +17225,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service web apps use a strong minimum TLS cipher suite using the Azure CLI:
 
             ```bash
             az webapp config set --name <WebAppName> --resource-group <ResourceGroupName> --min-tls-cipher-suite TLS_AES_256_GCM_SHA384
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service web apps use a strong minimum TLS cipher suite in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -17426,7 +17248,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service web apps use a strong minimum TLS cipher suite in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2024-04-01' = {
@@ -17530,7 +17352,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure end-to-end encryption is enabled for App Service web apps using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the web app.
@@ -17539,16 +17361,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable end-to-end TLS encryption for an App Service web app:
+            To ensure end-to-end encryption is enabled for App Service web apps using the Azure CLI, enable end-to-end TLS encryption for an App Service web app:
 
             ```bash
             az webapp update --resource-group <ResourceGroupName> --name <AppName> --set siteConfig.endToEndEncryptionEnabled=true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure end-to-end encryption is enabled for App Service web apps in Terraform:
 
             __Linux Web App__
 
@@ -17581,7 +17401,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure end-to-end encryption is enabled for App Service web apps in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2024-04-01' = {
@@ -17682,7 +17502,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS clusters have node OS auto-upgrade enabled using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -17691,14 +17511,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure AKS clusters have node OS auto-upgrade enabled using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --node-os-upgrade-channel SecurityPatch
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters have node OS auto-upgrade enabled in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -17717,7 +17537,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters have node OS auto-upgrade enabled in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -17823,7 +17643,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure local accounts are disabled on AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -17832,14 +17652,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure local accounts are disabled on AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --disable-local-accounts
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure local accounts are disabled on AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -17867,7 +17687,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure local accounts are disabled on AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -17968,7 +17788,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public network access is disabled on AKS clusters using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -17978,7 +17798,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure public network access is disabled on AKS clusters using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --enable-private-cluster --disable-public-fqdn
@@ -17991,7 +17811,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public network access is disabled on AKS clusters in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -18017,7 +17837,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public network access is disabled on AKS clusters in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -18110,7 +17930,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS clusters have auto-upgrade enabled using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -18119,14 +17939,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure AKS clusters have auto-upgrade enabled using the Azure CLI:
 
             ```bash
             az aks update --name <ClusterName> --resource-group <ResourceGroupName> --auto-upgrade-channel stable
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS clusters have auto-upgrade enabled in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -18145,7 +17965,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS clusters have auto-upgrade enabled in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
@@ -18237,7 +18057,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure password-only auth is disabled on PostgreSQL flexible servers using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -18247,16 +18067,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            First, ensure Entra ID authentication is enabled, then disable password authentication:
+            To ensure password-only auth is disabled on PostgreSQL flexible servers using the Azure CLI, first, ensure Entra ID authentication is enabled, then disable password authentication:
 
             ```bash
             az postgres flexible-server update --name <ServerName> --resource-group <ResourceGroupName> --active-directory-auth Enabled --password-auth Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure password-only auth is disabled on PostgreSQL flexible servers in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server" "example" {
@@ -18272,7 +18090,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure password-only auth is disabled on PostgreSQL flexible servers in Bicep:
 
             ```bicep
             resource postgresFlexServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
@@ -18344,7 +18162,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Storage accounts only allow SMB 3.0 and later using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -18353,14 +18171,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Storage accounts only allow SMB 3.0 and later using the Azure CLI:
 
             ```bash
             az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --versions "SMB3.0;SMB3.1.1"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Storage accounts only allow SMB 3.0 and later in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -18379,7 +18197,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Storage accounts only allow SMB 3.0 and later in Bicep:
 
             ```bicep
             resource fileServices 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
@@ -18479,7 +18297,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Storage accounts use strong SMB channel encryption using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -18488,14 +18306,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Storage accounts use strong SMB channel encryption using the Azure CLI:
 
             ```bash
             az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --channel-encryption "AES-128-CCM;AES-128-GCM;AES-256-GCM"
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Storage accounts use strong SMB channel encryption in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -18514,7 +18332,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Storage accounts use strong SMB channel encryption in Bicep:
 
             ```bicep
             resource fileServices 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
@@ -18607,7 +18425,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure VPN gateways use Generation2 for stronger cryptographic standards using the Azure Portal:
 
             1. Navigate to **Virtual network gateways** in the Azure Portal.
             2. Select the VPN gateway.
@@ -18617,16 +18435,14 @@ queries:
             Note: VPN gateway generation is set at creation time and cannot be changed. Existing Generation1 gateways must be recreated as Generation2.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            VPN gateway generation must be specified at creation time. Existing Generation1 gateways must be recreated as Generation2:
+            To ensure VPN gateways use Generation2 for stronger cryptographic standards using the Azure CLI, VPN gateway generation must be specified at creation time. Existing Generation1 gateways must be recreated as Generation2:
 
             ```bash
             az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw2 --vpn-gateway-generation Generation2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure VPN gateways use Generation2 for stronger cryptographic standards in Terraform:
 
             ```hcl
             resource "azurerm_virtual_network_gateway" "example" {
@@ -18647,7 +18463,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure VPN gateways use Generation2 for stronger cryptographic standards in Bicep:
 
             ```bicep
             resource vpnGateway 'Microsoft.Network/virtualNetworkGateways@2024-05-01' = {
@@ -18759,7 +18575,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public network access is disabled for Azure managed disks using the Azure Portal:
 
             1. Navigate to **Disks** in the Azure Portal.
             2. Select the managed disk.
@@ -18768,14 +18584,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure public network access is disabled for Azure managed disks using the Azure CLI:
 
             ```bash
             az disk update --name <DiskName> --resource-group <ResourceGroupName> --public-network-access Disabled --network-access-policy DenyAll
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public network access is disabled for Azure managed disks in Terraform:
 
             ```hcl
             resource "azurerm_managed_disk" "example" {
@@ -18791,7 +18607,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public network access is disabled for Azure managed disks in Bicep:
 
             ```bicep
             resource managedDisk 'Microsoft.Compute/disks@2024-03-02' = {
@@ -19611,9 +19427,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            Node resource group restriction level is a CLI/API-only setting and cannot be configured through the Azure Portal. Use the Azure CLI or Terraform to set or update this configuration.
+            To ensure AKS node resource group access is restricted using the Azure Portal, node resource group restriction level is a CLI/API-only setting and cannot be configured through the Azure Portal. Use the Azure CLI or Terraform to set or update this configuration.
 
             To verify the current setting in the Portal:
 
@@ -19622,9 +19436,7 @@ queries:
             3. Under **Properties**, review the node resource group name, but note that the restriction level is not visible in the Portal.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Create a new cluster with node resource group restrictions:
+            To ensure AKS node resource group access is restricted using the Azure CLI, create a new cluster with node resource group restrictions:
 
             ```bash
             az aks create --resource-group <ResourceGroupName> --name <ClusterName> --nrg-lockdown-restriction-level ReadOnly
@@ -19637,7 +19449,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS node resource group access is restricted in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -19652,7 +19464,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS node resource group access is restricted in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
@@ -19720,7 +19532,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS uses WireGuard for transit encryption using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -19729,9 +19541,7 @@ queries:
             Note: WireGuard transit encryption is only configurable via Azure CLI or API. It cannot be enabled through the Azure Portal.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable WireGuard transit encryption when creating a new cluster:
+            To ensure AKS uses WireGuard for transit encryption using the Azure CLI, enable WireGuard transit encryption when creating a new cluster:
 
             ```bash
             az aks create --resource-group <ResourceGroupName> --name <ClusterName> --network-plugin azure --network-plugin-mode overlay --network-dataplane cilium --pod-cidr 192.168.0.0/16 --enable-wireguard
@@ -19744,9 +19554,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
-
-            Note: WireGuard transit encryption is configured through the Azure CNI Overlay networking profile. Bicep support for the `advancedNetworking.security` property may be limited. Use Azure CLI to enable WireGuard on AKS clusters.
+            To ensure AKS uses WireGuard for transit encryption in Bicep, note: WireGuard transit encryption is configured through the Azure CNI Overlay networking profile. Bicep support for the `advancedNetworking.security` property may be limited. Use Azure CLI to enable WireGuard on AKS clusters.
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
@@ -19763,9 +19571,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            WireGuard transit encryption for AKS is only configurable via Azure CLI or the Azure API. The `azurerm_kubernetes_cluster` Terraform resource does not currently support the WireGuard enablement flag. Use the Azure CLI to enable WireGuard on the cluster after provisioning with Terraform.
+            To ensure AKS uses WireGuard for transit encryption in Terraform, wireGuard transit encryption for AKS is only configurable via Azure CLI or the Azure API. The `azurerm_kubernetes_cluster` Terraform resource does not currently support the WireGuard enablement flag. Use the Azure CLI to enable WireGuard on the cluster after provisioning with Terraform.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/wireguard
         title: WireGuard-based encryption in AKS
@@ -19811,7 +19617,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure AKS etcd is encrypted with Key Vault KMS using the Azure Portal:
 
             1. Navigate to **Kubernetes services** in the Azure Portal.
             2. Select the AKS cluster.
@@ -19820,16 +19626,14 @@ queries:
             Note: etcd KMS encryption is only configurable via Azure CLI or API. It cannot be enabled through the Azure Portal.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable KMS encryption on a new or existing AKS cluster:
+            To ensure AKS etcd is encrypted with Key Vault KMS using the Azure CLI, enable KMS encryption on a new or existing AKS cluster:
 
             ```bash
             az aks update --resource-group <ResourceGroupName> --name <ClusterName> --enable-azure-keyvault-kms --azure-keyvault-kms-key-id <KeyVaultKeyId> --azure-keyvault-kms-key-vault-network-access Public
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure AKS etcd is encrypted with Key Vault KMS in Terraform:
 
             ```hcl
             resource "azurerm_kubernetes_cluster" "example" {
@@ -19848,7 +19652,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure AKS etcd is encrypted with Key Vault KMS in Bicep:
 
             ```bicep
             resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
@@ -19916,9 +19720,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
-
-            There is no direct toggle in the Azure Portal to disable SSH for App Service on Linux. To restrict SSH access:
+            To ensure App Service has SSH access disabled using the Azure Portal, there is no direct toggle in the Azure Portal to disable SSH for App Service on Linux. To restrict SSH access:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
@@ -19928,9 +19730,7 @@ queries:
             For Linux App Services, SSH access can be fully disabled by using a custom container image that does not include an SSH server, or by restricting network access to the SCM/Kudu endpoint.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Restrict access to the SCM site to disable SSH access:
+            To ensure App Service has SSH access disabled using the Azure CLI, restrict access to the SCM site to disable SSH access:
 
             ```bash
             az webapp config access-restriction add --resource-group <ResourceGroupName> --name <AppName> --scm-site true --rule-name DenyAll --priority 100 --action Deny --ip-address 0.0.0.0/0
@@ -19939,14 +19739,10 @@ queries:
             Alternatively, use a custom container that does not include an SSH server to eliminate SSH access entirely.
         - id: bicep
           desc: |
-            **Using Bicep**
-
-            Note: SSH enablement for App Service on Linux is primarily controlled through the container configuration and is not directly configurable via a Bicep property. Use the Azure Portal or CLI to disable SSH.
+            To ensure App Service has SSH access disabled in Bicep, note: SSH enablement for App Service on Linux is primarily controlled through the container configuration and is not directly configurable via a Bicep property. Use the Azure Portal or CLI to disable SSH.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            SSH access for Azure App Service on Linux is controlled at the container level rather than through a Terraform resource property. Ensure your custom Docker container does not expose an SSH server, or use the Azure CLI to disable SSH after deployment.
+            To ensure App Service has SSH access disabled in Terraform, SSH access for Azure App Service on Linux is controlled at the container level rather than through a Terraform resource property. Ensure your custom Docker container does not expose an SSH server, or use the Azure CLI to disable SSH after deployment.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session
         title: Configure SSH for Azure App Service
@@ -19992,7 +19788,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service disables public network access using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
@@ -20002,14 +19798,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service disables public network access using the Azure CLI:
 
             ```bash
             az webapp update --resource-group <ResourceGroupName> --name <AppName> --set publicNetworkAccess=Disabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service disables public network access in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -20024,7 +19820,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service disables public network access in Bicep:
 
             ```bicep
             resource webApp 'Microsoft.Web/sites@2023-01-01' = {
@@ -20099,7 +19895,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service SCM endpoint uses TLS 1.2+ using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
@@ -20109,14 +19905,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service SCM endpoint uses TLS 1.2+ using the Azure CLI:
 
             ```bash
             az webapp config set --resource-group <ResourceGroupName> --name <AppName> --min-tls-version 1.2 --scm-min-tls-version 1.2
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service SCM endpoint uses TLS 1.2+ in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -20132,7 +19928,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service SCM endpoint uses TLS 1.2+ in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2023-01-01' = {
@@ -20209,7 +20005,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service routes all traffic through VNet using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
@@ -20218,7 +20014,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service routes all traffic through VNet using the Azure CLI:
 
             ```bash
             az webapp vnet-integration add --resource-group <ResourceGroupName> --name <AppName> --vnet <VNetName> --subnet <SubnetName>
@@ -20226,7 +20022,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service routes all traffic through VNet in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -20244,7 +20040,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service routes all traffic through VNet in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2023-01-01' = {
@@ -20312,7 +20108,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure App Service IP restrictions default to deny using the Azure Portal:
 
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
@@ -20322,14 +20118,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure App Service IP restrictions default to deny using the Azure CLI:
 
             ```bash
             az webapp config access-restriction set --resource-group <ResourceGroupName> --name <AppName> --default-action Deny
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure App Service IP restrictions default to deny in Terraform:
 
             ```hcl
             resource "azurerm_linux_web_app" "example" {
@@ -20345,7 +20141,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure App Service IP restrictions default to deny in Bicep:
 
             ```bicep
             resource webAppConfig 'Microsoft.Web/sites/config@2023-01-01' = {
@@ -20401,7 +20197,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure storage accounts use customer-managed keys using the Azure Portal:
 
             1. Navigate to **Storage accounts** in the Azure Portal.
             2. Select the storage account.
@@ -20411,14 +20207,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure storage accounts use customer-managed keys using the Azure CLI:
 
             ```bash
             az storage account update --resource-group <ResourceGroupName> --name <StorageAccountName> --encryption-key-source Microsoft.Keyvault --encryption-key-vault <KeyVaultUri> --encryption-key-name <KeyName>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure storage accounts use customer-managed keys in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -20441,7 +20237,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure storage accounts use customer-managed keys in Bicep:
 
             ```bicep
             resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
@@ -20534,7 +20330,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SQL Server uses Azure AD-only authentication using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server.
@@ -20543,14 +20339,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure SQL Server uses Azure AD-only authentication using the Azure CLI:
 
             ```bash
             az sql server ad-only-auth enable --resource-group <ResourceGroupName> --name <ServerName>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQL Server uses Azure AD-only authentication in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -20568,7 +20364,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL Server uses Azure AD-only authentication in Bicep:
 
             ```bicep
             resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
@@ -20651,7 +20447,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SQL Server TDE uses customer-managed keys using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server.
@@ -20661,14 +20457,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure SQL Server TDE uses customer-managed keys using the Azure CLI:
 
             ```bash
             az sql server tde-key set --resource-group <ResourceGroupName> --server <ServerName> --server-key-type AzureKeyVault --kid <KeyVaultKeyId>
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQL Server TDE uses customer-managed keys in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server_transparent_data_encryption" "example" {
@@ -20678,7 +20474,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL Server TDE uses customer-managed keys in Bicep:
 
             ```bicep
             resource sqlServerEncryption 'Microsoft.Sql/servers/encryptionProtector@2022-05-01-preview' = {
@@ -20741,7 +20537,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL Flexible Server uses CMK encryption using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -20751,14 +20547,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL Flexible Server uses CMK encryption using the Azure CLI:
 
             ```bash
             az postgres flexible-server update --resource-group <ResourceGroupName> --name <ServerName> --key <KeyVaultKeyId> --identity <UserAssignedIdentityId>
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL Flexible Server uses CMK encryption in Bicep:
 
             ```bicep
             resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
@@ -20781,7 +20577,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL Flexible Server uses CMK encryption in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server" "example" {
@@ -20845,7 +20641,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL Flexible Server has geo-redundant backup using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -20855,16 +20651,14 @@ queries:
             Note: Geo-redundant backup must be enabled at server creation time and cannot be changed afterward.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Geo-redundant backup must be enabled at server creation:
+            To ensure PostgreSQL Flexible Server has geo-redundant backup using the Azure CLI, geo-redundant backup must be enabled at server creation:
 
             ```bash
             az postgres flexible-server create --resource-group <ResourceGroupName> --name <ServerName> --geo-redundant-backup Enabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL Flexible Server has geo-redundant backup in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server" "example" {
@@ -20879,7 +20673,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL Flexible Server has geo-redundant backup in Bicep:
 
             ```bicep
             resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
@@ -20944,7 +20738,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure MySQL Flexible Server uses CMK encryption using the Azure Portal:
 
             1. Navigate to **Azure Database for MySQL flexible servers** in the Azure Portal.
             2. Select the server instance.
@@ -20954,14 +20748,14 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure MySQL Flexible Server uses CMK encryption using the Azure CLI:
 
             ```bash
             az mysql flexible-server update --resource-group <ResourceGroupName> --name <ServerName> --key <KeyVaultKeyId> --identity <UserAssignedIdentityId>
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure MySQL Flexible Server uses CMK encryption in Bicep:
 
             ```bicep
             resource mysqlServer 'Microsoft.DBforMySQL/flexibleServers@2022-01-01' = {
@@ -20984,7 +20778,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure MySQL Flexible Server uses CMK encryption in Terraform:
 
             ```hcl
             resource "azurerm_mysql_flexible_server" "example" {
@@ -21048,7 +20842,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Azure Cache for Redis uses CMK encryption using the Azure Portal:
 
             1. Navigate to **Azure Cache for Redis** in the Azure Portal.
             2. Select the cache instance.
@@ -21060,7 +20854,7 @@ queries:
             Note: CMK encryption must be configured at cache creation time. To enable CMK on an existing cache, the cache must be recreated with CMK enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Azure Cache for Redis uses CMK encryption using the Azure CLI:
 
             ```bash
             az redis create \
@@ -21076,7 +20870,7 @@ queries:
             Note: CMK encryption must be configured at cache creation time. To update an existing cache, recreate it with CMK enabled.
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Azure Cache for Redis uses CMK encryption in Terraform:
 
             ```hcl
             resource "azurerm_redis_cache" "example" {
@@ -21099,7 +20893,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Azure Cache for Redis uses CMK encryption in Bicep:
 
             ```bicep
             resource redisCache 'Microsoft.Cache/redis@2023-08-01' = {
@@ -21193,7 +20987,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Application Gateway enforces TLS 1.2+ using the Azure Portal:
 
             1. Navigate to **Application gateways** in the Azure Portal.
             2. Select the Application Gateway.
@@ -21202,14 +20996,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Application Gateway enforces TLS 1.2+ using the Azure CLI:
 
             ```bash
             az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --min-protocol-version TLSv1_2 --policy-type Custom --cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Gateway enforces TLS 1.2+ in Terraform:
 
             ```hcl
             resource "azurerm_application_gateway" "example" {
@@ -21231,7 +21025,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Application Gateway enforces TLS 1.2+ in Bicep:
 
             ```bicep
             resource appGateway 'Microsoft.Network/applicationGateways@2023-05-01' = {
@@ -21306,7 +21100,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Application Gateway has no weak SSL ciphers using the Azure Portal:
 
             1. Navigate to **Application gateways** in the Azure Portal.
             2. Select the Application Gateway.
@@ -21316,9 +21110,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Use a predefined policy that excludes weak ciphers:
+            To ensure Application Gateway has no weak SSL ciphers using the Azure CLI, use a predefined policy that excludes weak ciphers:
 
             ```bash
             az network application-gateway ssl-policy set --gateway-name <GatewayName> --resource-group <ResourceGroupName> --policy-type Predefined --policy-name AppGwSslPolicy20220101
@@ -21331,7 +21123,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Application Gateway has no weak SSL ciphers in Bicep:
 
             ```bicep
             resource appGateway 'Microsoft.Network/applicationGateways@2023-05-01' = {
@@ -21354,7 +21146,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Application Gateway has no weak SSL ciphers in Terraform:
 
             ```hcl
             resource "azurerm_application_gateway" "example" {
@@ -21413,7 +21205,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure public IP addresses have DDoS protection using the Azure Portal:
 
             1. Navigate to **Public IP addresses** in the Azure Portal.
             2. Select the public IP address.
@@ -21423,9 +21215,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable DDoS Protection on a virtual network:
+            To ensure public IP addresses have DDoS protection using the Azure CLI, enable DDoS Protection on a virtual network:
 
             ```bash
             az network ddos-protection create --resource-group <ResourceGroupName> --name <DdosPlanName>
@@ -21439,7 +21229,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure public IP addresses have DDoS protection in Bicep:
 
             ```bicep
             resource publicIp 'Microsoft.Network/publicIPAddresses@2023-05-01' = {
@@ -21461,7 +21251,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public IP addresses have DDoS protection in Terraform:
 
             ```hcl
             resource "azurerm_public_ip" "example" {
@@ -21522,7 +21312,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure NSG rules do not allow unrestricted egress using the Azure Portal:
 
             1. Navigate to **Network security groups**.
             2. Select the NSG.
@@ -21530,9 +21320,7 @@ queries:
             4. Edit or delete the rule to restrict to specific destinations and ports.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            List outbound rules that allow unrestricted egress:
+            To ensure NSG rules do not allow unrestricted egress using the Azure CLI, list outbound rules that allow unrestricted egress:
 
             ```bash
             az network nsg rule list --resource-group <ResourceGroupName> --nsg-name <NsgName> --query "[?direction=='Outbound' && access=='Allow' && destinationAddressPrefix=='*' && destinationPortRange=='*']"
@@ -21551,7 +21339,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure NSG rules do not allow unrestricted egress in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
@@ -21591,7 +21379,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure NSG rules do not allow unrestricted egress in Terraform:
 
             ```hcl
             resource "azurerm_network_security_rule" "deny_all_outbound" {
@@ -21693,21 +21481,21 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure network interface IP forwarding is disabled using the Azure Portal:
 
             1. Navigate to **Network interfaces**.
             2. Select the interface.
             3. Under **Settings** > **IP configurations**, disable **IP forwarding**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure network interface IP forwarding is disabled using the Azure CLI:
 
             ```bash
             az network nic update --name <nic-name> --resource-group <rg> --ip-forwarding false
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure network interface IP forwarding is disabled in Bicep:
 
             ```bicep
             resource nic 'Microsoft.Network/networkInterfaces@2023-05-01' = {
@@ -21730,7 +21518,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure network interface IP forwarding is disabled in Terraform:
 
             ```hcl
             resource "azurerm_network_interface" "example" {
@@ -21811,7 +21599,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure sensitive ports are not exposed to the entire network using the Azure Portal:
 
             1. Navigate to **Network security groups**.
             2. Review inbound rules that allow traffic from `*` or `Internet`.
@@ -21819,9 +21607,7 @@ queries:
             4. Remove rules that expose sensitive ports to the internet.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            List inbound rules that expose sensitive ports to the internet:
+            To ensure sensitive ports are not exposed to the entire network using the Azure CLI, list inbound rules that expose sensitive ports to the internet:
 
             ```bash
             az network nsg rule list --resource-group <ResourceGroupName> --nsg-name <NsgName> --query "[?direction=='Inbound' && access=='Allow' && sourceAddressPrefix=='*']"
@@ -21840,7 +21626,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure sensitive ports are not exposed to the entire network in Bicep:
 
             ```bicep
             resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
@@ -21874,7 +21660,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure sensitive ports are not exposed to the entire network in Terraform:
 
             ```hcl
             resource "azurerm_network_security_rule" "deny_sensitive_ports" {
@@ -21987,9 +21773,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Deploy VMs with SSH key authentication only:
+            To ensure password authentication is disabled on Linux VMs using the Azure CLI, deploy VMs with SSH key authentication only:
 
             ```bash
             az vm create \
@@ -22001,7 +21785,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure password authentication is disabled on Linux VMs in Bicep:
 
             ```bicep
             resource linuxVM 'Microsoft.Compute/virtualMachines@2023-07-01' = {
@@ -22029,7 +21813,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure password authentication is disabled on Linux VMs in Terraform:
 
             ```hcl
             resource "azurerm_linux_virtual_machine" "example" {
@@ -22050,7 +21834,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure password authentication is disabled on Linux VMs using the Azure Portal:
 
             1. Navigate to **Virtual machines**.
             2. When creating a new Linux VM, select **SSH public key** as the authentication type.
@@ -22116,7 +21900,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL 'log_connections' is enabled using the Azure CLI:
 
             ```bash
             az postgres flexible-server parameter set \
@@ -22125,7 +21909,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL 'log_connections' is enabled in Bicep:
 
             ```bicep
             resource logConnectionsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
@@ -22139,7 +21923,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL 'log_connections' is enabled in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server_configuration" "log_connections" {
@@ -22150,7 +21934,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL 'log_connections' is enabled using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers**.
             2. Select the server instance.
@@ -22216,7 +22000,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL 'log_checkpoints' is enabled using the Azure CLI:
 
             ```bash
             az postgres flexible-server parameter set \
@@ -22225,7 +22009,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL 'log_checkpoints' is enabled in Bicep:
 
             ```bicep
             resource logCheckpointsConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
@@ -22239,7 +22023,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL 'log_checkpoints' is enabled in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server_configuration" "log_checkpoints" {
@@ -22250,7 +22034,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL 'log_checkpoints' is enabled using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers**.
             2. Select the server instance.
@@ -22316,7 +22100,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure PostgreSQL 'connection_throttling' is enabled using the Azure CLI:
 
             ```bash
             az postgres flexible-server parameter set \
@@ -22325,7 +22109,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure PostgreSQL 'connection_throttling' is enabled in Bicep:
 
             ```bicep
             resource connectionThrottleConfig 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = {
@@ -22339,7 +22123,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure PostgreSQL 'connection_throttling' is enabled in Terraform:
 
             ```hcl
             resource "azurerm_postgresql_flexible_server_configuration" "connection_throttle" {
@@ -22350,7 +22134,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure PostgreSQL 'connection_throttling' is enabled using the Azure Portal:
 
             1. Navigate to **Azure Database for PostgreSQL flexible servers**.
             2. Select the server instance.
@@ -22418,7 +22202,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure SQL audit log retention is at least 90 days using the Azure CLI:
 
             ```bash
             az sql server audit-policy update \
@@ -22428,7 +22212,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL audit log retention is at least 90 days in Bicep:
 
             ```bicep
             resource sqlAudit 'Microsoft.Sql/servers/auditingSettings@2022-05-01-preview' = {
@@ -22444,7 +22228,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQL audit log retention is at least 90 days in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server_extended_auditing_policy" "example" {
@@ -22456,7 +22240,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SQL audit log retention is at least 90 days using the Azure Portal:
 
             1. Navigate to **SQL servers**.
             2. Select the server.
@@ -22522,7 +22306,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure SQL threat alert email addresses are configured using the Azure CLI:
 
             ```bash
             az sql server threat-policy update \
@@ -22532,7 +22316,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL threat alert email addresses are configured in Bicep:
 
             ```bicep
             resource sqlThreatPolicy 'Microsoft.Sql/servers/securityAlertPolicies@2022-05-01-preview' = {
@@ -22548,7 +22332,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQL threat alert email addresses are configured in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server_security_alert_policy" "example" {
@@ -22560,7 +22344,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SQL threat alert email addresses are configured using the Azure Portal:
 
             1. Navigate to **SQL servers**.
             2. Select the server.
@@ -22629,9 +22413,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable all threat detection types:
+            To ensure SQL threat detection types are configured using the Azure CLI, enable all threat detection types:
 
             ```bash
             az sql server threat-policy update \
@@ -22641,7 +22423,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure SQL threat detection types are configured in Bicep:
 
             ```bicep
             resource sqlThreatPolicy 'Microsoft.Sql/servers/securityAlertPolicies@2022-05-01-preview' = {
@@ -22655,7 +22437,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SQL threat detection types are configured in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server_security_alert_policy" "example" {
@@ -22667,7 +22449,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure SQL threat detection types are configured using the Azure Portal:
 
             1. Navigate to **SQL servers**.
             2. Select the server.
@@ -22739,9 +22521,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Configure log profile retention:
+            To ensure activity log retention is at least 365 days using the Azure CLI, configure log profile retention:
 
             ```bash
             az monitor log-profiles update \
@@ -22750,7 +22530,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure activity log retention is at least 365 days in Bicep:
 
             ```bicep
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
@@ -22775,7 +22555,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure activity log retention is at least 365 days in Terraform:
 
             ```hcl
             resource "azurerm_monitor_log_profile" "example" {
@@ -22794,7 +22574,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure activity log retention is at least 365 days using the Azure Portal:
 
             1. Navigate to **Monitor** > **Activity log**.
             2. Select **Export Activity Logs** to view diagnostic settings.
@@ -22869,7 +22649,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure activity logs capture events from all locations using the Azure CLI:
 
             ```bash
             az monitor log-profiles update \
@@ -22878,7 +22658,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure activity logs capture events from all locations in Bicep:
 
             ```bicep
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
@@ -22902,7 +22682,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure activity logs capture events from all locations in Terraform:
 
             ```hcl
             resource "azurerm_monitor_log_profile" "example" {
@@ -22928,7 +22708,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure activity logs capture events from all locations using the Azure Portal:
 
             1. Navigate to **Monitor** > **Activity log**.
             2. Select **Export Activity Logs**.
@@ -22997,7 +22777,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure log profile captures all activity categories using the Azure CLI:
 
             ```bash
             az monitor log-profiles update \
@@ -23006,7 +22786,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure log profile captures all activity categories in Bicep:
 
             ```bicep
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
@@ -23031,7 +22811,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure log profile captures all activity categories in Terraform:
 
             ```hcl
             resource "azurerm_monitor_log_profile" "example" {
@@ -23050,7 +22830,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure log profile captures all activity categories using the Azure Portal:
 
             1. Navigate to **Monitor** > **Activity log**.
             2. Select **Export Activity Logs**.
@@ -23129,7 +22909,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure security contact notification emails are configured using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** > **Environment settings**.
             2. Select the subscription.
@@ -23138,16 +22918,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Configure a security contact with email notifications:
+            To ensure security contact notification emails are configured using the Azure CLI, configure a security contact with email notifications:
 
             ```bash
             az security contact create --name default --email "security@example.com" --alert-notifications "On" --alerts-to-admins "On"
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure security contact notification emails are configured in Bicep:
 
             ```bicep
             resource securityContact 'Microsoft.Security/securityContacts@2020-01-01-preview' = {
@@ -23169,7 +22947,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure security contact notification emails are configured in Terraform:
 
             ```hcl
             resource "azurerm_security_center_contact" "example" {
@@ -23235,7 +23013,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure security contacts are enabled and active using the Azure Portal:
 
             1. Navigate to **Microsoft Defender for Cloud** > **Environment settings**.
             2. Select the subscription.
@@ -23244,16 +23022,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Create and enable a security contact:
+            To ensure security contacts are enabled and active using the Azure CLI, create and enable a security contact:
 
             ```bash
             az security contact create --name default --email "security@example.com" --alert-notifications "On" --alerts-to-admins "On"
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure security contacts are enabled and active in Bicep:
 
             ```bicep
             resource securityContact 'Microsoft.Security/securityContacts@2020-01-01-preview' = {
@@ -23275,7 +23051,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure security contacts are enabled and active in Terraform:
 
             ```hcl
             resource "azurerm_security_center_contact" "example" {
@@ -23342,9 +23118,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            List custom roles with wildcard actions:
+            To ensure custom RBAC roles use least privilege actions using the Azure CLI, list custom roles with wildcard actions:
 
             ```bash
             az role definition list --custom-role-only \
@@ -23358,7 +23132,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure custom RBAC roles use least privilege actions in Bicep:
 
             ```bicep
             resource customRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
@@ -23385,7 +23159,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure custom RBAC roles use least privilege actions in Terraform:
 
             ```hcl
             resource "azurerm_role_definition" "example" {
@@ -23409,7 +23183,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure custom RBAC roles use least privilege actions using the Azure Portal:
 
             1. Navigate to **Subscriptions** > **Access control (IAM)**.
             2. Select **Roles** and find the custom role.
@@ -23479,9 +23253,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Remove the role definition write permission from custom roles:
+            To ensure custom roles do not allow role creation using the Azure CLI, remove the role definition write permission from custom roles:
 
             ```bash
             az role definition update --role-definition @role.json
@@ -23490,7 +23262,7 @@ queries:
             Ensure `Microsoft.Authorization/roleDefinitions/write` is not in the `actions` array.
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure custom roles do not allow role creation in Bicep:
 
             ```bicep
             resource customRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
@@ -23518,7 +23290,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure custom roles do not allow role creation in Terraform:
 
             ```hcl
             resource "azurerm_role_definition" "example" {
@@ -23543,7 +23315,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure custom roles do not allow role creation using the Azure Portal:
 
             1. Navigate to **Subscriptions** > **Access control (IAM)**.
             2. Select **Roles** and find the custom role.
@@ -23616,9 +23388,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using Azure CLI**
-
-            Enable queue logging:
+            To ensure Queue Services logging is enabled for storage using the Azure CLI, enable queue logging:
 
             ```bash
             az storage logging update \
@@ -23629,16 +23399,14 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
-
-            Note: Storage Queue analytics logging (read, write, delete) is configured through the data plane API, not through ARM/Bicep resource definitions. Use Azure CLI or Azure PowerShell to enable queue logging after provisioning the storage account.
+            To ensure Queue Services logging is enabled for storage in Bicep, note: Storage Queue analytics logging (read, write, delete) is configured through the data plane API, not through ARM/Bicep resource definitions. Use Azure CLI or Azure PowerShell to enable queue logging after provisioning the storage account.
 
             ```bash
             az storage logging update --account-name <storage-account> --services q --log rwd --retention 90
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Queue Services logging is enabled for storage in Terraform:
 
             ```hcl
             resource "azurerm_storage_account" "example" {
@@ -23661,7 +23429,7 @@ queries:
             ```
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Queue Services logging is enabled for storage using the Azure Portal:
 
             1. Navigate to **Storage accounts**.
             2. Select the storage account.
@@ -23757,7 +23525,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Data Factory disables public network access using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Data factories** and select the target Data Factory instance.
@@ -23766,7 +23534,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Data Factory disables public network access using the Azure CLI:
 
             ```bash
             az datafactory update \
@@ -23776,7 +23544,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Data Factory disables public network access in Terraform:
 
             ```hcl
             resource "azurerm_data_factory" "example" {
@@ -23789,7 +23557,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Data Factory disables public network access in Bicep:
 
             ```bicep
             resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' = {
@@ -23874,7 +23642,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Data Factory uses customer-managed key encryption using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Data factories** and select the target Data Factory instance.
@@ -23887,7 +23655,7 @@ queries:
             Note: CMK encryption must be configured during Data Factory creation. To enable CMK on an existing factory, it must be recreated with CMK enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Data Factory uses customer-managed key encryption using the Azure CLI:
 
             ```bash
             az datafactory update \
@@ -23900,7 +23668,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Data Factory uses customer-managed key encryption in Terraform:
 
             ```hcl
             resource "azurerm_data_factory" "example" {
@@ -23914,7 +23682,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Data Factory uses customer-managed key encryption in Bicep:
 
             ```bicep
             resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' = {
@@ -24008,7 +23776,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Data Factory uses managed identity using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Data factories** and select the target Data Factory instance.
@@ -24019,7 +23787,7 @@ queries:
             Note: A system-assigned managed identity is automatically created when the Data Factory is created. If the identity was removed, re-enable it from this blade.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Data Factory uses managed identity using the Azure CLI:
 
             ```bash
             az datafactory update \
@@ -24029,7 +23797,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Data Factory uses managed identity in Terraform:
 
             ```hcl
             resource "azurerm_data_factory" "example" {
@@ -24044,7 +23812,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Data Factory uses managed identity in Bicep:
 
             ```bicep
             resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' = {
@@ -24128,7 +23896,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Synapse Analytics disables public network access using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Azure Synapse Analytics** and select the target workspace.
@@ -24137,7 +23905,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Synapse Analytics disables public network access using the Azure CLI:
 
             ```bash
             az synapse workspace update \
@@ -24147,7 +23915,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Synapse Analytics disables public network access in Terraform:
 
             ```hcl
             resource "azurerm_synapse_workspace" "example" {
@@ -24163,7 +23931,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Synapse Analytics disables public network access in Bicep:
 
             ```bicep
             @secure()
@@ -24255,7 +24023,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Synapse Analytics uses managed virtual network using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. When creating a new Synapse workspace, go to the **Networking** tab.
@@ -24266,7 +24034,7 @@ queries:
             **Note**: Managed virtual network can only be enabled during workspace creation. Existing workspaces without it must be recreated.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Synapse Analytics uses managed virtual network using the Azure CLI:
 
             ```bash
             az synapse workspace create \
@@ -24281,7 +24049,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Synapse Analytics uses managed virtual network in Terraform:
 
             ```hcl
             resource "azurerm_synapse_workspace" "example" {
@@ -24297,7 +24065,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Synapse Analytics uses managed virtual network in Bicep:
 
             ```bicep
             @secure()
@@ -24389,7 +24157,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Synapse uses Azure AD-only authentication using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Azure Synapse Analytics** and select the target workspace.
@@ -24399,7 +24167,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Synapse uses Azure AD-only authentication using the Azure CLI:
 
             ```bash
             # Set Azure AD admin
@@ -24417,7 +24185,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Synapse uses Azure AD-only authentication in Terraform:
 
             ```hcl
             resource "azurerm_synapse_workspace" "example" {
@@ -24437,7 +24205,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Synapse uses Azure AD-only authentication in Bicep:
 
             ```bicep
             @secure()
@@ -24532,7 +24300,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            **Using Azure Portal**
+            To ensure Synapse uses customer-managed key encryption using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Azure Synapse Analytics** and select the target workspace.
@@ -24544,7 +24312,7 @@ queries:
             Note: CMK encryption must be configured at workspace creation time. To enable CMK on an existing workspace, it must be recreated with CMK enabled.
         - id: cli
           desc: |
-            **Using Azure CLI**
+            To ensure Synapse uses customer-managed key encryption using the Azure CLI:
 
             ```bash
             az synapse workspace update \
@@ -24556,7 +24324,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Synapse uses customer-managed key encryption in Terraform:
 
             ```hcl
             resource "azurerm_synapse_workspace" "example" {
@@ -24575,7 +24343,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            **Using Bicep**
+            To ensure Synapse uses customer-managed key encryption in Bicep:
 
             ```bicep
             @secure()

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -336,9 +336,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To provision or update a compute instance with a custom service account:
+            To ensure that instances are not configured to use the default service account in Terraform, provision or update a compute instance with a custom service account:
 
             ```hcl
             resource "google_compute_instance" "default" {
@@ -355,9 +353,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            To change the policy using the GCP Console, follow these steps:
+            To ensure that instances are not configured to use the default service account using the Google Cloud Console, change the policy using the GCP Console, follow these steps:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Select the Organization and Project where the instance you want to update is running.
@@ -371,9 +367,7 @@ queries:
             10. Select **START**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update the service account using the `gcloud` CLI:
+            To ensure that instances are not configured to use the default service account using the Google Cloud CLI, update the service account using the `gcloud` CLI:
 
             1. Stop the instance:
 
@@ -493,9 +487,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To provision or update a compute instance with Terraform:
+            To ensure instances do not use default service account with full API access in Terraform, provision or update a compute instance with Terraform:
 
             ```hcl
             resource "google_service_account" "default" {
@@ -518,9 +510,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            To change the policy using the Google Cloud Console:
+            To ensure instances do not use default service account with full API access using the Google Cloud Console, change the policy using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Select the Organization and Project where the instance you want to update is running.
@@ -534,9 +524,7 @@ queries:
             10. Select **START**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update the service account using the `gcloud` CLI:
+            To ensure instances do not use default service account with full API access using the Google Cloud CLI, update the service account using the `gcloud` CLI:
 
             1. Stop the instance:
 
@@ -668,9 +656,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To configure OS Login for a project:
+            To ensure oslogin is enabled for compute instances in Terraform, configure OS Login for a project:
 
             ```hcl
             resource "google_compute_project_metadata" "default" {
@@ -696,9 +682,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            To configure OS Login for a project via Google Cloud Console:
+            To ensure oslogin is enabled for compute instances using the Google Cloud Console, configure OS Login for a project via Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Metadata** page.
             2. Select **EDIT**.
@@ -714,9 +698,7 @@ queries:
             5. Select **SAVE**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update OS Login for a project using the `gcloud` CLI:
+            To ensure oslogin is enabled for compute instances using the Google Cloud CLI, update OS Login for a project using the `gcloud` CLI:
 
             ```bash
             gcloud compute project-info add-metadata --metadata enable-oslogin=TRUE
@@ -809,9 +791,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To update public access configuration using Terraform, ensure `allUsers` and `allAuthenticatedUsers` are not set:
+            To ensure Cloud Storage buckets are not anonymously or publicly accessible in Terraform, update public access configuration using Terraform, ensure `allUsers` and `allAuthenticatedUsers` are not set:
 
             ```hcl
             resource "google_storage_bucket_iam_binding" "binding" {
@@ -832,7 +812,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Storage buckets are not anonymously or publicly accessible using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Cloud Storage Bucket** page.
             2. For the bucket you want to enforce public access prevention on, select the more actions menu.
@@ -841,9 +821,7 @@ queries:
             5. Select **Confirm**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update public access configuration using the `gcloud` cli, ensure `allUsers` and `allAuthenticatedUsers` are not set by removing them:
+            To ensure Cloud Storage buckets are not anonymously or publicly accessible using the Google Cloud CLI, update public access configuration using the `gcloud` cli, ensure `allUsers` and `allAuthenticatedUsers` are not set by removing them:
 
             ```bash
             # Example: Remove allUsers binding for objectViewer role
@@ -926,7 +904,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure that Cloud Storage buckets have uniform bucket-level access enabled in Terraform:
 
             ```hcl
             resource "google_storage_bucket" "example" {
@@ -937,7 +915,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that Cloud Storage buckets have uniform bucket-level access enabled using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Cloud Storage Buckets** page.
             2. In the list of buckets, select the name of the desired bucket.
@@ -946,7 +924,7 @@ queries:
             5. In the pop-up menu that appears, select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that Cloud Storage buckets have uniform bucket-level access enabled using the Google Cloud CLI:
 
             ```bash
             # Enable uniform bucket-level access
@@ -1029,9 +1007,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the `public_access_prevention` property to `enforced` in your bucket configuration:
+            To ensure that Cloud Storage buckets enforce public access prevention in Terraform, set the `public_access_prevention` property to `enforced` in your bucket configuration:
 
             ```hcl
             resource "google_storage_bucket" "example" {
@@ -1042,7 +1018,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that Cloud Storage buckets enforce public access prevention using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Cloud Storage Buckets** page.
             2. Select the name of the bucket you want to configure.
@@ -1051,7 +1027,7 @@ queries:
             5. Select **Confirm**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that Cloud Storage buckets enforce public access prevention using the Google Cloud CLI:
 
             ```bash
             gcloud storage buckets update gs://BUCKET_NAME --public-access-prevention
@@ -1131,9 +1107,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a Cloud KMS key and set it as the default encryption key for the bucket:
+            To ensure Cloud Storage buckets are encrypted with CMEK in Terraform, configure a Cloud KMS key and set it as the default encryption key for the bucket:
 
             ```hcl
             resource "google_kms_key_ring" "example" {
@@ -1157,7 +1131,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Storage buckets are encrypted with CMEK using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Cloud Storage Buckets** page.
             2. Select the name of the bucket you want to configure.
@@ -1168,7 +1142,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Storage buckets are encrypted with CMEK using the Google Cloud CLI:
 
             ```bash
             gcloud storage buckets update gs://BUCKET_NAME --default-encryption-key=projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY
@@ -1250,9 +1224,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a retention policy on the bucket. Note that locking a retention policy is an irreversible action:
+            To ensure that Cloud Storage buckets have a locked retention policy configured in Terraform, configure a retention policy on the bucket. Note that locking a retention policy is an irreversible action:
 
             ```hcl
             resource "google_storage_bucket" "example" {
@@ -1267,7 +1239,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that Cloud Storage buckets have a locked retention policy configured using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Cloud Storage Buckets** page.
             2. Select the name of the bucket you want to configure.
@@ -1278,7 +1250,7 @@ queries:
             7. To lock the policy, select **Lock** and confirm. Note that this action is irreversible.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that Cloud Storage buckets have a locked retention policy configured using the Google Cloud CLI:
 
             1. Set a retention policy on the bucket:
 
@@ -1370,9 +1342,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `access` block in your BigQuery dataset does not include `allUsers` or `allAuthenticatedUsers`:
+            To ensure that BigQuery datasets are not anonymously or publicly accessible in Terraform, ensure the `access` block in your BigQuery dataset does not include `allUsers` or `allAuthenticatedUsers`:
 
             ```hcl
             resource "google_bigquery_dataset" "example" {
@@ -1404,7 +1374,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that BigQuery datasets are not anonymously or publicly accessible using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Select the dataset you want to configure.
@@ -1413,7 +1383,7 @@ queries:
             5. Select **Done**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that BigQuery datasets are not anonymously or publicly accessible using the Google Cloud CLI:
 
             1. Retrieve the current dataset access configuration:
 
@@ -1520,9 +1490,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a Cloud KMS key as the default encryption key for the BigQuery dataset:
+            To ensure a default CMEK is specified for all BigQuery datasets in Terraform, configure a Cloud KMS key as the default encryption key for the BigQuery dataset:
 
             ```hcl
             resource "google_kms_key_ring" "example" {
@@ -1546,7 +1514,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure a default CMEK is specified for all BigQuery datasets using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Select the dataset you want to configure.
@@ -1557,7 +1525,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure a default CMEK is specified for all BigQuery datasets using the Google Cloud CLI:
 
             ```bash
             bq update --default_kms_key=projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY PROJECT_ID:DATASET_ID
@@ -1642,9 +1610,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure CMEK encryption on individual BigQuery tables:
+            To ensure all BigQuery tables are encrypted with CMEK in Terraform, configure CMEK encryption on individual BigQuery tables:
 
             ```hcl
             resource "google_bigquery_table" "example" {
@@ -1680,7 +1646,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure all BigQuery tables are encrypted with CMEK using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Navigate to the dataset and select the table.
@@ -1688,7 +1654,7 @@ queries:
             4. If the table uses Google-managed encryption, recreate it with CMEK or set a dataset-level default CMEK and copy the data.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure all BigQuery tables are encrypted with CMEK using the Google Cloud CLI:
 
             1. Check the encryption configuration of a table:
 
@@ -1780,9 +1746,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure CMEK encryption on the BigQuery dataset so all models inherit customer-managed encryption:
+            To ensure all BigQuery models are encrypted with CMEK in Terraform, configure CMEK encryption on the BigQuery dataset so all models inherit customer-managed encryption:
 
             ```hcl
             resource "google_bigquery_dataset" "example" {
@@ -1806,7 +1770,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure all BigQuery models are encrypted with CMEK using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Navigate to the dataset containing the model.
@@ -1814,7 +1778,7 @@ queries:
             4. If the model uses Google-managed encryption, recreate the model with a CMEK-encrypted dataset default or specify CMEK during model creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure all BigQuery models are encrypted with CMEK using the Google Cloud CLI:
 
             1. Ensure the dataset has a default CMEK configured so all new models inherit it:
 
@@ -1903,9 +1867,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `use_legacy_sql` attribute is set to `false` in the `view` block of your BigQuery table resource:
+            To ensure that BigQuery views do not use Legacy SQL in Terraform, ensure the `use_legacy_sql` attribute is set to `false` in the `view` block of your BigQuery table resource:
 
             ```hcl
             resource "google_bigquery_table" "example" {
@@ -1920,7 +1882,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that BigQuery views do not use Legacy SQL using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Navigate to the dataset and select the view.
@@ -1928,7 +1890,7 @@ queries:
             4. If it does, recreate the view using GoogleSQL (standard SQL) syntax.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that BigQuery views do not use Legacy SQL using the Google Cloud CLI:
 
             1. Check the view definition:
 
@@ -2024,9 +1986,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Remove any `access` blocks that use the `domain` field and replace them with specific user or group grants:
+            To ensure that BigQuery datasets do not grant domain-wide access in Terraform, remove any `access` blocks that use the `domain` field and replace them with specific user or group grants:
 
             ```hcl
             resource "google_bigquery_dataset" "example" {
@@ -2046,7 +2006,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure that BigQuery datasets do not grant domain-wide access using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **BigQuery** page.
             2. Select the dataset you want to configure.
@@ -2056,7 +2016,7 @@ queries:
             6. Select **Done**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure that BigQuery datasets do not grant domain-wide access using the Google Cloud CLI:
 
             1. Retrieve the current dataset access configuration:
 
@@ -2160,7 +2120,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud SQL MySQL instances are not publicly exposed in Terraform:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -2181,7 +2141,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL MySQL instances are not publicly exposed using the Google Cloud Console:
 
             1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
             2.  Select the name of the target instance to view its configuration details.
@@ -2194,7 +2154,7 @@ queries:
             To proactively enforce that new Cloud SQL instances are not created with public IP addresses, implement the `Restrict Public IP access on Cloud SQL instances` Organization Policy. You can configure this policy at: https://console.cloud.google.com/iam-admin/orgpolicies/sql-restrictPublicIp
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL MySQL instances are not publicly exposed using the Google Cloud CLI:
 
             1.  Modify the target instance to remove its public IP address and ensure it's associated with a VPC network for private IP access. Replace `INSTANCE_NAME` with the actual instance name and `VPC_NETWORK_NAME` with the desired VPC network name:
                 ```bash
@@ -2302,7 +2262,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL MySQL connections require SSL/TLS using the Google Cloud Console:
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
             2.  Select the name of the target MySQL instance.
@@ -2315,7 +2275,7 @@ queries:
             Always configure new Cloud SQL MySQL instances with the "Allow only SSL connections" option enabled during creation via the Console. Regularly audit instances to ensure compliance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL MySQL connections require SSL/TLS using the Google Cloud CLI:
 
             1.  Enable the SSL Mode to be "ENCRYPTED_ONLY":
                 ```bash
@@ -2328,9 +2288,7 @@ queries:
             Always configure new Cloud SQL MySQL instances with the `--ssl-mode=ENCRYPTED_ONLY` flag during creation via the CLI. Regularly audit instances to ensure compliance.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `ENCRYPTED_ONLY`:
+            To ensure Cloud SQL MySQL connections require SSL/TLS in Terraform, ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `ENCRYPTED_ONLY`:
 
             ```hcl
             resource "google_sql_database_instance" "default" {
@@ -2462,7 +2420,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure 'skip_show_database' flag is enabled for Cloud SQL MySQL using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
@@ -2473,18 +2431,14 @@ queries:
             7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the flag for a specific MySQL instance:
+            To ensure 'skip_show_database' flag is enabled for Cloud SQL MySQL using the Google Cloud CLI, update the flag for a specific MySQL instance:
             ```bash
             gcloud sql instances patch INSTANCE_NAME --database-flags skip_show_database=on
             ```
             *Note: This command overwrites all existing flags. To preserve other flags, you must include them in the `--database-flags` argument (e.g., `--database-flags skip_show_database=on,other_flag=value`).*
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
+            To ensure 'skip_show_database' flag is enabled for Cloud SQL MySQL in Terraform, ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
             ```hcl
             resource "google_sql_database_instance" "mysql_instance" {
               name             = "my-mysql-instance"
@@ -2614,7 +2568,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure 'local_infile' flag is disabled for Cloud SQL MySQL using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target MySQL instance.
@@ -2625,18 +2579,14 @@ queries:
             7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the flag for a specific MySQL instance:
+            To ensure 'local_infile' flag is disabled for Cloud SQL MySQL using the Google Cloud CLI, update the flag for a specific MySQL instance:
             ```bash
             gcloud sql instances patch INSTANCE_NAME --database-flags local_infile=off
             ```
             *Note: This command overwrites all existing flags. To preserve other flags, you must include them in the `--database-flags` argument (e.g., `--database-flags local_infile=off,other_flag=value`).*
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
+            To ensure 'local_infile' flag is disabled for Cloud SQL MySQL in Terraform, ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
             ```hcl
             resource "google_sql_database_instance" "mysql_instance" {
               name             = "my-mysql-instance"
@@ -2769,7 +2719,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL PostgreSQL 'log_error_verbosity' is DEFAULT or verbose using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
@@ -2780,9 +2730,7 @@ queries:
             7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the flag for a specific PostgreSQL instance (choose `default` or `verbose`):
+            To ensure Cloud SQL PostgreSQL 'log_error_verbosity' is DEFAULT or verbose using the Google Cloud CLI, update the flag for a specific PostgreSQL instance (choose `default` or `verbose`):
             ```bash
             # Example using default
             gcloud sql instances patch INSTANCE_NAME --database-flags log_error_verbosity=default
@@ -2793,9 +2741,7 @@ queries:
             *Note: This command overwrites all existing flags. To preserve other flags, you must include them in the `--database-flags` argument (e.g., `--database-flags log_error_verbosity=default,other_flag=value`).*
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting (choose `default` or `verbose`):
+            To ensure Cloud SQL PostgreSQL 'log_error_verbosity' is DEFAULT or verbose in Terraform, ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting (choose `default` or `verbose`):
             ```hcl
             resource "google_sql_database_instance" "postgres_instance" {
               name             = "my-postgres-instance"
@@ -2933,7 +2879,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure 'log_connections' flag is enabled for Cloud SQL PostgreSQL using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
@@ -2944,18 +2890,14 @@ queries:
             7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the flag for a specific PostgreSQL instance:
+            To ensure 'log_connections' flag is enabled for Cloud SQL PostgreSQL using the Google Cloud CLI, update the flag for a specific PostgreSQL instance:
             ```bash
             gcloud sql instances patch INSTANCE_NAME --database-flags log_connections=on
             ```
             *Note: This command overwrites all existing flags. To preserve other flags, you must include them in the `--database-flags` argument (e.g., `--database-flags log_connections=on,other_flag=value`).*
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
+            To ensure 'log_connections' flag is enabled for Cloud SQL PostgreSQL in Terraform, ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
             ```hcl
             resource "google_sql_database_instance" "postgres_instance" {
               name             = "my-postgres-instance"
@@ -3088,7 +3030,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure 'log_disconnections' flag is enabled for Cloud SQL PostgreSQL using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2.  Select the target PostgreSQL instance.
@@ -3099,18 +3041,14 @@ queries:
             7.  Select **Save**. Review the **Flags** section on the instance overview page to confirm.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the flag for a specific PostgreSQL instance:
+            To ensure 'log_disconnections' flag is enabled for Cloud SQL PostgreSQL using the Google Cloud CLI, update the flag for a specific PostgreSQL instance:
             ```bash
             gcloud sql instances patch INSTANCE_NAME --database-flags log_disconnections=on
             ```
             *Note: This command overwrites all existing flags. To preserve other flags, you must include them in the `--database-flags` argument (e.g., `--database-flags log_disconnections=on,other_flag=value`).*
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
+            To ensure 'log_disconnections' flag is enabled for Cloud SQL PostgreSQL in Terraform, ensure the `database_flags` block within your `google_sql_database_instance` resource includes the setting:
             ```hcl
             resource "google_sql_database_instance" "postgres_instance" {
               name             = "my-postgres-instance"
@@ -3257,7 +3195,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure public IP addresses are not assigned to VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "example" {
@@ -3281,7 +3219,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure public IP addresses are not assigned to VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the target instance to open its details page.
@@ -3296,7 +3234,7 @@ queries:
             Utilize the Organization Policy `constraints/compute.vmExternalIpAccess` to restrict or deny the assignment of external IP addresses to VMs across your organization or specific folders/projects. Configure this policy at: [https://console.cloud.google.com/orgpolicies/compute-vmExternalIpAccess](https://console.cloud.google.com/orgpolicies/compute-vmExternalIpAccess)
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure public IP addresses are not assigned to VM instances using the Google Cloud CLI:
 
             1. First, identify the name of the access configuration associated with the external IP. Describe the instance:
             ```bash
@@ -3415,7 +3353,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure the default service account is not used on VM instances in Terraform:
 
             ```hcl
             # Create a custom service account with appropriate permissions
@@ -3461,7 +3399,7 @@ queries:
             }
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure the default service account is not used on VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance you want to modify.
@@ -3473,7 +3411,7 @@ queries:
             8. Select the `START / RESUME` button at the top to restart the instance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure the default service account is not used on VM instances using the Google Cloud CLI:
 
             1. Stop the target instance:
             ```bash
@@ -3598,7 +3536,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure "Block Project-Wide SSH Keys" is enabled for VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "example" {
@@ -3626,7 +3564,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure "Block Project-Wide SSH Keys" is enabled for VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -3637,9 +3575,7 @@ queries:
             7. Repeat these steps for all instances where project-wide keys should be blocked.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Enable the setting by adding or updating the instance metadata:
+            To ensure "Block Project-Wide SSH Keys" is enabled for VM instances using the Google Cloud CLI, enable the setting by adding or updating the instance metadata:
             ```bash
             gcloud compute instances add-metadata INSTANCE_NAME --zone=ZONE --metadata block-project-ssh-keys=true
             ```
@@ -3750,7 +3686,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Confidential VM Service is enabled for all VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "confidential_vm" {
@@ -3785,7 +3721,7 @@ queries:
           desc: |
             The Confidential VM service can only be activated when creating a new VM instance. It cannot be enabled on an existing instance.
 
-            **Using Google Cloud Console**
+            To ensure Confidential VM Service is enabled for all VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select `CREATE INSTANCE`.
@@ -3799,9 +3735,7 @@ queries:
           desc: |
             The Confidential VM service can only be activated when creating a new VM instance. It cannot be enabled on an existing instance.
 
-            **Using Google Cloud CLI**
-
-            Use the `--confidential-compute` flag during instance creation. You must also set the maintenance policy to `TERMINATE`.
+            To ensure Confidential VM Service is enabled for all VM instances using the Google Cloud CLI, use the `--confidential-compute` flag during instance creation. You must also set the maintenance policy to `TERMINATE`.
 
             ```bash
             gcloud compute instances create INSTANCE_NAME \
@@ -3916,7 +3850,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Secure Boot is enabled for all VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "shielded_vm" {
@@ -3959,7 +3893,7 @@ queries:
           desc: |
             Secure Boot can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **Using Google Cloud Console**
+            To ensure Secure Boot is enabled for all VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -3976,9 +3910,7 @@ queries:
           desc: |
             Secure Boot can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **Using Google Cloud CLI**
-
-            Ensure the instance uses a compatible image. You can list public Shielded VM images:
+            To ensure Secure Boot is enabled for all VM instances using the Google Cloud CLI, ensure the instance uses a compatible image. You can list public Shielded VM images:
             ```bash
             gcloud compute images list --project gce-UEFI-images --no-standard-images --filter="shieldedVmFeatures:(SECURE_BOOT)"
             ```
@@ -4095,7 +4027,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure vTPM is enabled for all VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "vtpm_enabled_vm" {
@@ -4138,7 +4070,7 @@ queries:
           desc: |
             vTPM can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **Using Google Cloud Console**
+            To ensure vTPM is enabled for all VM instances using the Google Cloud Console:
 
             1. Navigate to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Locate and select the instance you want to modify.
@@ -4155,9 +4087,7 @@ queries:
           desc: |
             vTPM can only be enabled on instances using an OS image that supports Shielded VM features.
 
-            **Using Google Cloud CLI**
-
-            Ensure the instance uses a compatible image. You can list public Shielded VM images:
+            To ensure vTPM is enabled for all VM instances using the Google Cloud CLI, ensure the instance uses a compatible image. You can list public Shielded VM images:
             ```bash
             gcloud compute images list --project gce-uefi-images --no-standard-images --filter="shieldedVmFeatures:(VTPM)"
             ```
@@ -4276,7 +4206,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Integrity Monitoring is enabled for all VM instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "integrity_monitoring_vm" {
@@ -4319,7 +4249,7 @@ queries:
           desc: |
             Integrity Monitoring requires an instance using an OS image that supports Shielded VM features, and vTPM must also be enabled.
 
-            **Using Google Cloud Console**
+            To ensure Integrity Monitoring is enabled for all VM instances using the Google Cloud Console:
 
             1. Go to the `VM instances` page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the name of the instance to modify.
@@ -4337,7 +4267,7 @@ queries:
           desc: |
             Integrity Monitoring requires an instance using an OS image that supports Shielded VM features, and vTPM must also be enabled.
 
-            **Using Google Cloud CLI**
+            To ensure Integrity Monitoring is enabled for all VM instances using the Google Cloud CLI:
 
             1. Verify that the instance uses a compatible Shielded VM image. You can list public Shielded VM images that support Integrity Monitoring:
             ```bash
@@ -4464,7 +4394,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL PostgreSQL instances are not publicly exposed using the Google Cloud Console:
 
             1.  Navigate to the Cloud SQL Instances page in the Google Cloud Console: https://console.cloud.google.com/sql/instances.
             2.  Select the name of the target PostgreSQL instance to open its configuration details.
@@ -4477,7 +4407,7 @@ queries:
             To ensure new Cloud SQL instances are not created with public IP addresses, enforce the `Restrict Public IP access on Cloud SQL instances` Organization Policy. Configure this policy at: https://console.cloud.google.com/iam-admin/orgpolicies/sql-restrictPublicIp.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL PostgreSQL instances are not publicly exposed using the Google Cloud CLI:
 
             1.  Modify the target instance to remove its public IP address and ensure it's associated with a VPC network for private IP access. Replace `INSTANCE_NAME` with the actual instance name and `VPC_NETWORK_NAME` with the desired VPC network name:
                 ```bash
@@ -4491,9 +4421,7 @@ queries:
                 Check the `ipAddresses` section in the output to confirm the absence of an entry with `type: PRIMARY`.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `ipv4_enabled` attribute within the `ip_configuration` block is set to `false` or omitted (defaults to false if private network is configured):
+            To ensure Cloud SQL PostgreSQL instances are not publicly exposed in Terraform, ensure the `ipv4_enabled` attribute within the `ip_configuration` block is set to `false` or omitted (defaults to false if private network is configured):
 
             ```hcl
             resource "google_sql_database_instance" "default" {
@@ -4614,7 +4542,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL for SQL Server instances are not publicly exposed using the Google Cloud Console:
 
             1.  Access the Cloud SQL Instances overview page in the Google Cloud Console: https://console.cloud.google.com/sql/instances
             2.  Select the name of the target SQL Server instance to view its configuration details.
@@ -4627,7 +4555,7 @@ queries:
             To proactively enforce that new Cloud SQL instances are not created with public IP addresses, implement the `Restrict Public IP access on Cloud SQL instances` Organization Policy. You can configure this policy at: https://console.cloud.google.com/iam-admin/orgpolicies/sql-restrictPublicIp
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL for SQL Server instances are not publicly exposed using the Google Cloud CLI:
 
             1.  Modify the target instance to remove its public IP address and ensure it's associated with a VPC network for private IP access. Replace `INSTANCE_NAME` with the actual instance name and `VPC_NETWORK_NAME` with the desired VPC network name:
                 ```bash
@@ -4641,9 +4569,7 @@ queries:
                 Check the `ipAddresses` section in the output to confirm the absence of an entry with `type: PRIMARY`.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `ipv4_enabled` attribute within the `ip_configuration` block is set to `false` or omitted (defaults to false if private network is configured):
+            To ensure Cloud SQL for SQL Server instances are not publicly exposed in Terraform, ensure the `ipv4_enabled` attribute within the `ip_configuration` block is set to `false` or omitted (defaults to false if private network is configured):
 
             ```hcl
             resource "google_sql_database_instance" "default" {
@@ -4767,7 +4693,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL PostgreSQL connections require SSL/TLS using the Google Cloud Console:
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
             2.  Select the name of the target PostgreSQL instance.
@@ -4780,7 +4706,7 @@ queries:
             Always configure new Cloud SQL PostgreSQL instances with the "Allow only SSL connections" option enabled during creation via the Console. Regularly audit instances to ensure compliance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL PostgreSQL connections require SSL/TLS using the Google Cloud CLI:
 
             1.  Enable the SSL Mode to be "ENCRYPTED_ONLY":
                 ```bash
@@ -4793,9 +4719,7 @@ queries:
             Always configure new Cloud SQL PostgreSQL instances with the `--ssl-mode=ENCRYPTED_ONLY` flag during creation via the CLI. Regularly audit instances to ensure compliance.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `ENCRYPTED_ONLY`:
+            To ensure Cloud SQL PostgreSQL connections require SSL/TLS in Terraform, ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `ENCRYPTED_ONLY`:
 
             ```hcl
             resource "google_sql_database_instance" "default" {
@@ -4921,7 +4845,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL for SQL Server connections require SSL/TLS using the Google Cloud Console:
 
             1.  Access the Cloud SQL Instances overview page: https://console.cloud.google.com/sql/instances
             2.  Select the name of the target SQL Server instance.
@@ -4934,7 +4858,7 @@ queries:
             Always configure new Cloud SQL for SQL Server instances with the "Allow only SSL connections" option enabled during creation via the Console. Regularly audit instances to ensure compliance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL for SQL Server connections require SSL/TLS using the Google Cloud CLI:
 
             1.  Enable the SSL Mode to be "ENCRYPTED_ONLY":
                 ```bash
@@ -4947,9 +4871,7 @@ queries:
             Always configure new Cloud SQL for SQL Server instances with the `--ssl-mode=ENCRYPTED_ONLY` flag during creation via the CLI. Regularly audit instances to ensure compliance.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `"ENCRYPTED_ONLY"`:
+            To ensure Cloud SQL for SQL Server connections require SSL/TLS in Terraform, ensure the `ssl_mode` attribute within the `ip_configuration` block is set to `"ENCRYPTED_ONLY"`:
 
             ```hcl
             resource "google_sql_database_instance" "default" {
@@ -5071,7 +4993,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible using the Google Cloud Console:
 
             1.  Navigate to the Cloud KMS Keys page: https://console.cloud.google.com/security/kms/keys
             2.  Select the key ring containing the target cryptokey.
@@ -5087,7 +5009,7 @@ queries:
             When creating new cryptokeys or modifying IAM policies, ensure that `allUsers` and `allAuthenticatedUsers` are never added as members. Regularly audit cryptokey permissions to ensure compliance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible using the Google Cloud CLI:
 
             1. List all Cloud KMS `Cryptokeys`:
             ```bash
@@ -5105,9 +5027,7 @@ queries:
             When creating new cryptokeys or modifying IAM policies via CLI, ensure that `allUsers` and `allAuthenticatedUsers` are never included in policy bindings. Regularly audit cryptokey permissions to ensure compliance.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure that IAM policy resources for KMS crypto keys do not include `allUsers` or `allAuthenticatedUsers` as members:
+            To ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible in Terraform, ensure that IAM policy resources for KMS crypto keys do not include `allUsers` or `allAuthenticatedUsers` as members:
 
             ```hcl
             # Good example - specific users/service accounts only
@@ -5244,7 +5164,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days using the Google Cloud Console:
 
             1. Access the `Cryptographic Keys` page: [https://console.cloud.google.com/security/kms](https://console.cloud.google.com/security/kms).
             2. Select the desired key ring.
@@ -5253,18 +5173,14 @@ queries:
             5. In the pop-up window, set a new rotation period (in days) to be less than 90 days, and specify a "Starting on" date for the rotation to begin.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update and schedule rotation by `ROTATION_PERIOD` and `NEXT_ROTATION_TIME` for each key:
+            To ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days using the Google Cloud CLI, update and schedule rotation by `ROTATION_PERIOD` and `NEXT_ROTATION_TIME` for each key:
 
             ```bash
             gcloud kms keys update KEY_NAME --keyring=KEY_RING --location=LOCATION --next-rotation-time=NEXT_ROTATION_TIME --rotation-period=ROTATION_PERIOD
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure automatic key rotation for your KMS cryptokeys by setting a rotation period of 90 days or less:
+            To ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days in Terraform, configure automatic key rotation for your KMS cryptokeys by setting a rotation period of 90 days or less:
 
             ```hcl
             resource "google_kms_crypto_key" "example" {
@@ -5372,9 +5288,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure the destroy scheduled duration when creating crypto keys:
+            To ensure KMS crypto keys have a destroy scheduled duration of 24h+ in Terraform, configure the destroy scheduled duration when creating crypto keys:
 
             ```hcl
             resource "google_kms_crypto_key" "example" {
@@ -5393,9 +5307,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            The destroy scheduled duration is set at key creation time and cannot be modified after creation. To ensure compliance:
+            To ensure KMS crypto keys have a destroy scheduled duration of 24h+ using the Google Cloud Console, the destroy scheduled duration is set at key creation time and cannot be modified after creation. To ensure compliance:
 
             1. Navigate to **Security** > **Key Management** in the GCP Console.
             2. When creating a new crypto key, expand **Advanced settings**.
@@ -5403,9 +5315,7 @@ queries:
             4. For existing keys with insufficient duration, create a new key with the correct duration and re-encrypt data with the new key.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Set the destroy scheduled duration when creating a new crypto key:
+            To ensure KMS crypto keys have a destroy scheduled duration of 24h+ using the Google Cloud CLI, set the destroy scheduled duration when creating a new crypto key:
 
             ```bash
             gcloud kms keys create KEY_NAME \
@@ -5500,9 +5410,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Create keyrings in a specific regional location:
+            To ensure KMS keyrings are not in the global location in Terraform, create keyrings in a specific regional location:
 
             ```hcl
             resource "google_kms_key_ring" "example" {
@@ -5512,9 +5420,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            KMS keyring location cannot be changed after creation. To create a properly located keyring:
+            To ensure KMS keyrings are not in the global location using the Google Cloud Console, KMS keyring location cannot be changed after creation. To create a properly located keyring:
 
             1. Navigate to **Security** > **Key Management** in the GCP Console.
             2. Select **Create Key Ring**.
@@ -5523,9 +5429,7 @@ queries:
             5. For existing global keyrings, create a new regional keyring, create new keys, and re-encrypt data with the new keys.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a keyring in a specific regional location:
+            To ensure KMS keyrings are not in the global location using the Google Cloud CLI, create a keyring in a specific regional location:
 
             ```bash
             gcloud kms keyrings create KEY_RING_NAME \
@@ -5629,9 +5533,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure automatic rotation for ENCRYPT_DECRYPT crypto keys:
+            To ensure KMS ENCRYPT_DECRYPT crypto keys have automatic rotation configured in Terraform, configure automatic rotation for ENCRYPT_DECRYPT crypto keys:
 
             ```hcl
             resource "google_kms_crypto_key" "example" {
@@ -5649,7 +5551,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure KMS ENCRYPT_DECRYPT crypto keys have automatic rotation configured using the Google Cloud Console:
 
             1. Navigate to **Security** > **Key Management** in the GCP Console.
             2. Select the key ring containing the target crypto key.
@@ -5658,9 +5560,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Configure automatic rotation for an existing crypto key:
+            To ensure KMS ENCRYPT_DECRYPT crypto keys have automatic rotation configured using the Google Cloud CLI, configure automatic rotation for an existing crypto key:
 
             ```bash
             gcloud kms keys update KEY_NAME \
@@ -5772,23 +5672,19 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure That DNSSEC Is Enabled for Cloud DNS using the Google Cloud Console:
 
             1. Go to `Cloud DNS` by navigating to [https://console.cloud.google.com/net-services/dns/zones](https://console.cloud.google.com/net-services/dns/zones).
             2. For each zone of `Type` `Public`, switch `DNSSEC` to `On`.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Use the below command to enable `DNSSEC` for Cloud DNS Zone Name:
+            To ensure That DNSSEC Is Enabled for Cloud DNS using the Google Cloud CLI, use the below command to enable `DNSSEC` for Cloud DNS Zone Name:
             ```bash
             gcloud dns managed-zones update ZONE_NAME --dnssec-state on
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable DNSSEC for managed DNS zones by setting the `dnssec_config` block with `state = "on"`:
+            To ensure That DNSSEC Is Enabled for Cloud DNS in Terraform, enable DNSSEC for managed DNS zones by setting the `dnssec_config` block with `state = "on"`:
 
             ```hcl
             resource "google_dns_managed_zone" "example" {
@@ -5892,7 +5788,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC using the Google Cloud Console:
 
             1. Navigate to **Network services > Cloud DNS** in the Google Cloud Console.
             2. Select the managed zone you want to configure.
@@ -5903,7 +5799,7 @@ queries:
             7. Select **Save** to apply the new configuration.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC using the Google Cloud CLI:
 
             1. To change DNSSEC settings on an already enabled managed zone, first disable it:
 
@@ -5928,9 +5824,7 @@ queries:
             | ECDSAP384SHA384 | 384 | 384 |
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Avoid using RSASHA1 for key-signing keys in your DNSSEC configuration. Use stronger algorithms like RSASHA256, RSASHA512, or ECDSA variants:
+            To ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC in Terraform, avoid using RSASHA1 for key-signing keys in your DNSSEC configuration. Use stronger algorithms like RSASHA256, RSASHA512, or ECDSA variants:
 
             ```hcl
             resource "google_dns_managed_zone" "example" {
@@ -6047,7 +5941,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure RSASHA1 is not used for the zone-signing key in Cloud DNS using the Google Cloud Console:
 
             1. Navigate to **Network services > Cloud DNS** in the Google Cloud Console.
             2. Select the managed zone you want to configure.
@@ -6058,7 +5952,7 @@ queries:
             7. Select **Save** to apply the new configuration.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure RSASHA1 is not used for the zone-signing key in Cloud DNS using the Google Cloud CLI:
 
             1. To change DNSSEC settings on an already enabled managed zone, first disable it:
 
@@ -6083,9 +5977,7 @@ queries:
             | ECDSAP384SHA384 | 384 | 384 |
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Avoid using RSASHA1 for zone-signing keys in your DNSSEC configuration. Use stronger algorithms like RSASHA256, RSASHA512, or ECDSA variants:
+            To ensure RSASHA1 is not used for the zone-signing key in Cloud DNS in Terraform, avoid using RSASHA1 for zone-signing keys in your DNSSEC configuration. Use stronger algorithms like RSASHA256, RSASHA512, or ECDSA variants:
 
             ```hcl
             resource "google_dns_managed_zone" "example" {
@@ -6202,7 +6094,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure DNSSEC uses NSEC3 for authenticated denial-of-existence using the Google Cloud Console:
 
             1. Navigate to **Network services > Cloud DNS** in the Google Cloud Console.
             2. Select the managed zone you want to configure.
@@ -6213,7 +6105,7 @@ queries:
             7. Select **Save** to apply the new configuration.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure DNSSEC uses NSEC3 for authenticated denial-of-existence using the Google Cloud CLI:
 
             1. To change DNSSEC settings on an already enabled managed zone, first disable it:
 
@@ -6228,9 +6120,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure NSEC3 as the denial-of-existence mechanism in your DNSSEC configuration:
+            To ensure DNSSEC uses NSEC3 for authenticated denial-of-existence in Terraform, configure NSEC3 as the denial-of-existence mechanism in your DNSSEC configuration:
 
             ```hcl
             resource "google_dns_managed_zone" "example" {
@@ -6358,9 +6248,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To restrict SSH access to a specific IP range:
+            To ensure SSH access is restricted from the internet in Terraform, restrict SSH access to a specific IP range:
 
             ```hcl
             resource "google_compute_firewall" "allow_ssh" {
@@ -6395,7 +6283,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure SSH access is restricted from the internet using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Navigate to **VPC Network** > **Firewall**.
@@ -6405,9 +6293,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update a firewall rule to restrict SSH access:
+            To ensure SSH access is restricted from the internet using the Google Cloud CLI, update a firewall rule to restrict SSH access:
 
             ```bash
             gcloud compute firewall-rules update RULE_NAME \
@@ -6519,9 +6405,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            To restrict RDP access to a specific IP range:
+            To ensure RDP access is restricted from the internet in Terraform, restrict RDP access to a specific IP range:
 
             ```hcl
             resource "google_compute_firewall" "allow_rdp" {
@@ -6539,7 +6423,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure RDP access is restricted from the internet using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Navigate to **VPC Network** > **Firewall**.
@@ -6549,9 +6433,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update a firewall rule to restrict RDP access:
+            To ensure RDP access is restricted from the internet using the Google Cloud CLI, update a firewall rule to restrict RDP access:
 
             ```bash
             gcloud compute firewall-rules update RULE_NAME \
@@ -6664,9 +6546,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Instead of allowing all protocols, create targeted rules for specific services:
+            To ensure firewall rules do not allow unrestricted ingress on all protocols in Terraform, instead of allowing all protocols, create targeted rules for specific services:
 
             ```hcl
             resource "google_compute_firewall" "allow_https" {
@@ -6685,7 +6565,7 @@ queries:
             Remove or modify any rules that use `protocol = "all"` with `source_ranges = ["0.0.0.0/0"]`.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure firewall rules do not allow unrestricted ingress on all protocols using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Navigate to **VPC Network** > **Firewall**.
@@ -6696,9 +6576,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To delete an overly permissive firewall rule:
+            To ensure firewall rules do not allow unrestricted ingress on all protocols using the Google Cloud CLI, delete an overly permissive firewall rule:
 
             ```bash
             gcloud compute firewall-rules delete RULE_NAME
@@ -6821,9 +6699,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Restrict database access to internal networks only:
+            To ensure firewall rules block internet ingress to database ports in Terraform, restrict database access to internal networks only:
 
             ```hcl
             resource "google_compute_firewall" "allow_mysql" {
@@ -6843,7 +6719,7 @@ queries:
             For Cloud SQL instances, prefer using Cloud SQL Auth Proxy or private IP connectivity instead of firewall rules.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure firewall rules block internet ingress to database ports using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Navigate to **VPC Network** > **Firewall**.
@@ -6853,9 +6729,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update a firewall rule to restrict database port access:
+            To ensure firewall rules block internet ingress to database ports using the Google Cloud CLI, update a firewall rule to restrict database port access:
 
             ```bash
             gcloud compute firewall-rules update RULE_NAME \
@@ -6968,9 +6842,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Always specify explicit ports in firewall allow rules:
+            To ensure firewall rules do not allow unrestricted internet ingress in Terraform, always specify explicit ports in firewall allow rules:
 
             ```hcl
             resource "google_compute_firewall" "allow_web" {
@@ -6997,7 +6869,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure firewall rules do not allow unrestricted internet ingress using the Google Cloud Console:
 
             1. Log in to the GCP Console at https://console.cloud.google.com.
             2. Navigate to **VPC Network** > **Firewall**.
@@ -7008,9 +6880,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            To update a firewall rule to specify explicit ports:
+            To ensure firewall rules do not allow unrestricted internet ingress using the Google Cloud CLI, update a firewall rule to specify explicit ports:
 
             ```bash
             gcloud compute firewall-rules update RULE_NAME \
@@ -7110,9 +6980,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable legacy ABAC in your GKE cluster configuration:
+            To ensure legacy authorization (ABAC) is disabled on GKE clusters in Terraform, disable legacy ABAC in your GKE cluster configuration:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -7125,7 +6993,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure legacy authorization (ABAC) is disabled on GKE clusters using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster you want to configure.
@@ -7134,7 +7002,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure legacy authorization (ABAC) is disabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME --zone ZONE --no-enable-legacy-authorization
@@ -7216,9 +7084,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable master authorized networks in your GKE cluster configuration:
+            To ensure master authorized networks are enabled on GKE clusters in Terraform, enable master authorized networks in your GKE cluster configuration:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -7235,7 +7101,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure master authorized networks are enabled on GKE clusters using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster you want to configure.
@@ -7245,7 +7111,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure master authorized networks are enabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME --zone ZONE --enable-master-authorized-networks --master-authorized-networks CIDR1,CIDR2
@@ -7327,9 +7193,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable Cloud Logging in your GKE cluster configuration:
+            To ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters in Terraform, enable Cloud Logging in your GKE cluster configuration:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -7341,7 +7205,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster you want to configure.
@@ -7350,7 +7214,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME --zone ZONE --logging=SYSTEM,WORKLOAD
@@ -7432,9 +7296,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable network policy in your GKE cluster configuration:
+            To ensure network policy is enabled on GKE clusters in Terraform, enable network policy in your GKE cluster configuration:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -7455,7 +7317,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure network policy is enabled on GKE clusters using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster you want to configure.
@@ -7464,7 +7326,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure network policy is enabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME --zone ZONE --update-addons=NetworkPolicy=ENABLED
@@ -7549,9 +7411,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure alpha features are not enabled in your GKE cluster configuration:
+            To ensure Kubernetes alpha features are disabled on GKE clusters in Terraform, ensure alpha features are not enabled in your GKE cluster configuration:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -7565,18 +7425,14 @@ queries:
             Note: Alpha features cannot be disabled on an existing cluster. You must create a new cluster without alpha features and migrate your workloads.
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Alpha features cannot be disabled on an existing cluster. To remediate:
+            To ensure Kubernetes alpha features are disabled on GKE clusters using the Google Cloud Console, alpha features cannot be disabled on an existing cluster. To remediate:
 
             1. Create a new GKE cluster without alpha features enabled.
             2. Migrate your workloads to the new cluster.
             3. Delete the alpha cluster.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Alpha features cannot be disabled on an existing cluster. Create a new cluster without the `--enable-kubernetes-alpha` flag:
+            To ensure Kubernetes alpha features are disabled on GKE clusters using the Google Cloud CLI, alpha features cannot be disabled on an existing cluster. Create a new cluster without the `--enable-kubernetes-alpha` flag:
 
             ```bash
             gcloud container clusters create CLUSTER_NAME --zone ZONE
@@ -7662,7 +7518,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Workload Identity is enabled on GKE clusters in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -7676,7 +7532,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Workload Identity is enabled on GKE clusters using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select the cluster you want to update.
@@ -7686,7 +7542,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Workload Identity is enabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME \
@@ -7775,7 +7631,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure private cluster is enabled on GKE clusters in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -7791,9 +7647,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: Private cluster configuration cannot be changed on an existing cluster. You must create a new cluster:
+            To ensure private cluster is enabled on GKE clusters using the Google Cloud Console, note: Private cluster configuration cannot be changed on an existing cluster. You must create a new cluster:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select **Create**.
@@ -7803,7 +7657,7 @@ queries:
             6. Complete the cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure private cluster is enabled on GKE clusters using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters create CLUSTER_NAME \
@@ -7892,7 +7746,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure shielded GKE nodes are enabled in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -7909,7 +7763,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure shielded GKE nodes are enabled using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select the cluster you want to update.
@@ -7917,7 +7771,7 @@ queries:
             4. Ensure that **Shielded GKE Nodes** is enabled.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure shielded GKE nodes are enabled using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME \
@@ -8015,7 +7869,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure GKE clusters use a release channel for version management in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -8029,7 +7883,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE clusters use a release channel for version management using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select the cluster you want to update.
@@ -8039,7 +7893,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure GKE clusters use a release channel for version management using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME \
@@ -8127,9 +7981,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Always create VPC networks in custom subnet mode:
+            To ensure legacy networks do not exist in the project in Terraform, always create VPC networks in custom subnet mode:
 
             ```hcl
             resource "google_compute_network" "example" {
@@ -8141,9 +7993,7 @@ queries:
             Note: To migrate from a legacy network, create a new VPC network, migrate resources, and then delete the legacy network.
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Legacy networks cannot be converted to VPC networks. To remediate:
+            To ensure legacy networks do not exist in the project using the Google Cloud Console, legacy networks cannot be converted to VPC networks. To remediate:
 
             1. Create a new VPC network in custom mode.
             2. Create subnets in the regions you need.
@@ -8152,9 +8002,7 @@ queries:
             5. Delete the legacy network.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a new VPC network in custom mode and migrate resources:
+            To ensure legacy networks do not exist in the project using the Google Cloud CLI, create a new VPC network in custom mode and migrate resources:
 
             ```bash
             # Create a new VPC network
@@ -8240,9 +8088,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable VPC Flow Logs on subnetworks:
+            To ensure VPC Flow Logs are enabled on subnetworks in Terraform, enable VPC Flow Logs on subnetworks:
 
             ```hcl
             resource "google_compute_subnetwork" "example" {
@@ -8260,7 +8106,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure VPC Flow Logs are enabled on subnetworks using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **VPC network > VPC networks** page.
             2. Select the network containing the subnet.
@@ -8271,7 +8117,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure VPC Flow Logs are enabled on subnetworks using the Google Cloud CLI:
 
             ```bash
             gcloud compute networks subnets update SUBNET_NAME --region=REGION --enable-flow-logs --logging-aggregation-interval=interval-5-sec --logging-flow-sampling=0.5 --logging-metadata=include-all
@@ -8353,9 +8199,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable Private Google Access on subnetworks:
+            To ensure Private Google Access is enabled on subnetworks in Terraform, enable Private Google Access on subnetworks:
 
             ```hcl
             resource "google_compute_subnetwork" "example" {
@@ -8368,7 +8212,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Private Google Access is enabled on subnetworks using the Google Cloud Console:
 
             1. In the Google Cloud console, go to the **VPC network > VPC networks** page.
             2. Select the network containing the subnet.
@@ -8378,7 +8222,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Private Google Access is enabled on subnetworks using the Google Cloud CLI:
 
             ```bash
             gcloud compute networks subnets update SUBNET_NAME --region=REGION --enable-private-ip-google-access
@@ -8465,7 +8309,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure authentication is enabled for Cloud Redis instances in Terraform:
 
             ```hcl
             resource "google_redis_instance" "cache" {
@@ -8479,7 +8323,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure authentication is enabled for Cloud Redis instances using the Google Cloud Console:
 
             1. Go to the **Memorystore > Redis** page in the Google Cloud Console.
             2. Select the instance you want to update.
@@ -8488,7 +8332,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure authentication is enabled for Cloud Redis instances using the Google Cloud CLI:
 
             ```bash
             gcloud redis instances update INSTANCE_NAME \
@@ -8581,7 +8425,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Redis instances are encrypted with CMEK in Terraform:
 
             ```hcl
             resource "google_redis_instance" "cache" {
@@ -8600,9 +8444,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at instance creation time and cannot be added to an existing instance.
+            To ensure Cloud Redis instances are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at instance creation time and cannot be added to an existing instance.
 
             1. Go to the **Memorystore > Redis** page in the Google Cloud Console.
             2. Select **Create Instance**.
@@ -8611,9 +8453,7 @@ queries:
             5. Complete the instance creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at instance creation time.
+            To ensure Cloud Redis instances are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at instance creation time.
 
             ```bash
             gcloud redis instances create INSTANCE_NAME \
@@ -8723,9 +8563,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Avoid creating `google_service_account_key` resources. Instead, use attached service accounts:
+            To ensure user-managed service account keys are not created in Terraform, avoid creating `google_service_account_key` resources. Instead, use attached service accounts:
 
             ```hcl
             resource "google_service_account" "example" {
@@ -8758,7 +8596,7 @@ queries:
             Remove any existing `google_service_account_key` resources from your Terraform configuration.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure user-managed service account keys are not created using the Google Cloud Console:
 
             1. Navigate to **IAM & Admin > Service Accounts** in the Google Cloud Console.
             2. Select each service account and go to the **Keys** tab.
@@ -8766,9 +8604,7 @@ queries:
             4. Migrate workloads to use attached service accounts or Workload Identity Federation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            List all user-managed keys for a service account:
+            To ensure user-managed service account keys are not created using the Google Cloud CLI, list all user-managed keys for a service account:
 
             ```bash
             gcloud iam service-accounts keys list --iam-account=SA_EMAIL --managed-by=user
@@ -8845,7 +8681,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure default Compute Engine and App Engine service accounts are disabled using the Google Cloud Console:
 
             1. Navigate to **IAM & Admin > Service Accounts** in the Google Cloud Console.
             2. Identify the default Compute Engine service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`) and App Engine service account (`PROJECT_ID@appspot.gserviceaccount.com`).
@@ -8853,9 +8689,7 @@ queries:
             4. Ensure all workloads have been migrated to custom service accounts before disabling.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Disable the default Compute Engine service account:
+            To ensure default Compute Engine and App Engine service accounts are disabled using the Google Cloud CLI, disable the default Compute Engine service account:
 
             ```bash
             gcloud iam service-accounts disable PROJECT_NUMBER-compute@developer.gserviceaccount.com
@@ -8868,9 +8702,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use custom service accounts for your workloads instead of default service accounts. Create dedicated service accounts with minimal permissions:
+            To ensure default Compute Engine and App Engine service accounts are disabled in Terraform, use custom service accounts for your workloads instead of default service accounts. Create dedicated service accounts with minimal permissions:
 
             ```hcl
             resource "google_service_account" "custom" {
@@ -8951,9 +8783,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use `time_rotating` with a `replace_triggered_by` lifecycle meta-argument to ensure service account keys are rotated within 90 days:
+            To ensure service account keys are rotated within 90 days in Terraform, use `time_rotating` with a `replace_triggered_by` lifecycle meta-argument to ensure service account keys are rotated within 90 days:
 
             ```hcl
             resource "time_rotating" "sa_key_rotation" {
@@ -8977,7 +8807,7 @@ queries:
             Note: When the `time_rotating` resource triggers, Terraform will destroy the old key and create a new one on the next apply. Ensure consumers are updated to use the new key.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure service account keys are rotated within 90 days using the Google Cloud Console:
 
             1. Navigate to **IAM & Admin > Service Accounts** in the Google Cloud Console.
             2. For each service account, select the **Keys** tab.
@@ -8985,9 +8815,7 @@ queries:
             4. Create a new key, update all consumers, then delete the old key.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            List keys and their creation dates:
+            To ensure service account keys are rotated within 90 days using the Google Cloud CLI, list keys and their creation dates:
 
             ```bash
             gcloud iam service-accounts keys list --iam-account=SA_EMAIL --managed-by=user
@@ -9052,7 +8880,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure there are no disabled service account keys left undeleted using the Google Cloud Console:
 
             1. Navigate to **IAM & Admin > Service Accounts** in the Google Cloud Console.
             2. For each service account, select the **Keys** tab.
@@ -9060,9 +8888,7 @@ queries:
             4. Select the disabled key and select **Delete**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            List keys and identify disabled ones:
+            To ensure there are no disabled service account keys left undeleted using the Google Cloud CLI, list keys and identify disabled ones:
 
             ```bash
             gcloud iam service-accounts keys list --iam-account=SA_EMAIL --managed-by=user
@@ -9075,9 +8901,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Terraform manages service account keys declaratively. To ensure disabled keys are removed, avoid managing keys outside of Terraform. If you use the `google_service_account_key` resource, Terraform will track the key lifecycle:
+            To ensure there are no disabled service account keys left undeleted in Terraform, terraform manages service account keys declaratively. To ensure disabled keys are removed, avoid managing keys outside of Terraform. If you use the `google_service_account_key` resource, Terraform will track the key lifecycle:
 
             ```hcl
             resource "google_service_account_key" "example" {
@@ -9157,9 +8981,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure log bucket retention:
+            To ensure Cloud Logging log buckets have at least 30-day retention in Terraform, configure log bucket retention:
 
             ```hcl
             resource "google_logging_project_bucket_config" "example" {
@@ -9171,7 +8993,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Logging log buckets have at least 30-day retention using the Google Cloud Console:
 
             1. Navigate to **Logging > Logs Storage** in the Google Cloud Console.
             2. Select the log bucket you want to configure.
@@ -9179,9 +9001,7 @@ queries:
             4. Select **Update bucket** to save.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the retention period for a log bucket:
+            To ensure Cloud Logging log buckets have at least 30-day retention using the Google Cloud CLI, update the retention period for a log bucket:
 
             ```bash
             gcloud logging buckets update BUCKET_ID --location=LOCATION --retention-days=30
@@ -9270,9 +9090,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a locked log bucket:
+            To ensure Cloud Logging log buckets are locked to prevent tampering in Terraform, configure a locked log bucket:
 
             ```hcl
             resource "google_logging_project_bucket_config" "example" {
@@ -9287,7 +9105,7 @@ queries:
             Note: Once a bucket is locked, it cannot be unlocked or deleted.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Logging log buckets are locked to prevent tampering using the Google Cloud Console:
 
             1. Navigate to **Logging > Logs Storage** in the Google Cloud Console.
             2. Select the log bucket you want to lock.
@@ -9295,9 +9113,7 @@ queries:
             4. Confirm the action. Note: This action is irreversible.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Lock a log bucket:
+            To ensure Cloud Logging log buckets are locked to prevent tampering using the Google Cloud CLI, lock a log bucket:
 
             ```bash
             gcloud logging buckets update BUCKET_ID --location=LOCATION --locked
@@ -9389,7 +9205,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Logging log buckets are encrypted with CMEK in Terraform:
 
             ```hcl
             resource "google_logging_project_bucket_config" "example" {
@@ -9405,7 +9221,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Logging log buckets are encrypted with CMEK using the Google Cloud Console:
 
             1. Navigate to **Logging > Logs Storage** in the Google Cloud Console.
             2. Select the log bucket to update.
@@ -9415,9 +9231,7 @@ queries:
             6. Select **Update bucket**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update a log bucket with CMEK:
+            To ensure Cloud Logging log buckets are encrypted with CMEK using the Google Cloud CLI, update a log bucket with CMEK:
 
             ```bash
             gcloud logging buckets update BUCKET_ID \
@@ -9507,9 +9321,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a log sink:
+            To ensure Cloud Logging has at least one sink configured for log export in Terraform, configure a log sink:
 
             ```hcl
             resource "google_logging_project_sink" "audit_sink" {
@@ -9521,7 +9333,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Logging has at least one sink configured for log export using the Google Cloud Console:
 
             1. Navigate to **Logging > Log Router** in the Google Cloud Console.
             2. Select **Create Sink**.
@@ -9531,9 +9343,7 @@ queries:
             6. Select **Create Sink**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a log sink to Cloud Storage:
+            To ensure Cloud Logging has at least one sink configured for log export using the Google Cloud CLI, create a log sink to Cloud Storage:
 
             ```bash
             gcloud logging sinks create SINK_NAME storage.googleapis.com/BUCKET_NAME \
@@ -9612,7 +9422,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Pub/Sub topics are encrypted with CMEK in Terraform:
 
             ```hcl
             resource "google_pubsub_topic" "example" {
@@ -9622,7 +9432,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Pub/Sub topics are encrypted with CMEK using the Google Cloud Console:
 
             1. Navigate to **Pub/Sub > Topics** in the Google Cloud Console.
             2. Select **Create Topic** or select an existing topic.
@@ -9631,9 +9441,7 @@ queries:
             5. Select **Create** or **Update**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a topic with CMEK:
+            To ensure Pub/Sub topics are encrypted with CMEK using the Google Cloud CLI, create a topic with CMEK:
 
             ```bash
             gcloud pubsub topics create TOPIC_NAME \
@@ -9713,7 +9521,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Pub/Sub subscriptions have an expiration policy configured in Terraform:
 
             ```hcl
             resource "google_pubsub_subscription" "example" {
@@ -9727,7 +9535,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Pub/Sub subscriptions have an expiration policy configured using the Google Cloud Console:
 
             1. Navigate to **Pub/Sub > Subscriptions** in the Google Cloud Console.
             2. Select the subscription to update.
@@ -9736,7 +9544,7 @@ queries:
             5. Select **Update**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Pub/Sub subscriptions have an expiration policy configured using the Google Cloud CLI:
 
             ```bash
             gcloud pubsub subscriptions update SUBSCRIPTION_NAME \
@@ -9820,9 +9628,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure IAM bindings do not include public members:
+            To ensure Pub/Sub topics are not anonymously or publicly accessible in Terraform, ensure IAM bindings do not include public members:
 
             ```hcl
             resource "google_pubsub_topic_iam_binding" "example" {
@@ -9836,7 +9642,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Pub/Sub topics are not anonymously or publicly accessible using the Google Cloud Console:
 
             1. Navigate to **Pub/Sub > Topics** in the Google Cloud Console.
             2. Select the topic to update.
@@ -9845,9 +9651,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Remove public access from a topic:
+            To ensure Pub/Sub topics are not anonymously or publicly accessible using the Google Cloud CLI, remove public access from a topic:
 
             ```bash
             gcloud pubsub topics remove-iam-policy-binding TOPIC_NAME \
@@ -9941,9 +9745,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure IAM bindings do not include public members:
+            To ensure Pub/Sub subscriptions are not anonymously or publicly accessible in Terraform, ensure IAM bindings do not include public members:
 
             ```hcl
             resource "google_pubsub_subscription_iam_binding" "example" {
@@ -9957,7 +9759,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Pub/Sub subscriptions are not anonymously or publicly accessible using the Google Cloud Console:
 
             1. Navigate to **Pub/Sub > Subscriptions** in the Google Cloud Console.
             2. Select the subscription to update.
@@ -9966,9 +9768,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Remove public access from a subscription:
+            To ensure Pub/Sub subscriptions are not anonymously or publicly accessible using the Google Cloud CLI, remove public access from a subscription:
 
             ```bash
             gcloud pubsub subscriptions remove-iam-policy-binding SUBSCRIPTION_NAME \
@@ -10066,7 +9866,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Functions do not allow all ingress traffic in Terraform:
 
             ```hcl
             resource "google_cloudfunctions_function" "example" {
@@ -10082,7 +9882,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions do not allow all ingress traffic using the Google Cloud Console:
 
             1. Navigate to **Cloud Functions** in the Google Cloud Console.
             2. Select the function to update.
@@ -10091,9 +9891,7 @@ queries:
             5. Select **Next** and then **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update ingress settings:
+            To ensure Cloud Functions do not allow all ingress traffic using the Google Cloud CLI, update ingress settings:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -10179,7 +9977,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Functions do not use the default service account in Terraform:
 
             ```hcl
             resource "google_service_account" "function_sa" {
@@ -10199,7 +9997,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions do not use the default service account using the Google Cloud Console:
 
             1. Navigate to **Cloud Functions** in the Google Cloud Console.
             2. Select the function to update.
@@ -10209,7 +10007,7 @@ queries:
             6. Select **Next** and then **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Functions do not use the default service account using the Google Cloud CLI:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -10296,7 +10094,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Functions have a VPC connector configured in Terraform:
 
             ```hcl
             resource "google_vpc_access_connector" "connector" {
@@ -10319,7 +10117,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions have a VPC connector configured using the Google Cloud Console:
 
             1. Navigate to **Cloud Functions** in the Google Cloud Console.
             2. Select the function to update.
@@ -10329,7 +10127,7 @@ queries:
             6. Select **Next** and then **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Functions have a VPC connector configured using the Google Cloud CLI:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -10416,7 +10214,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Functions use customer-managed encryption keys (CMEK) in Terraform:
 
             ```hcl
             resource "google_cloudfunctions2_function" "example" {
@@ -10433,7 +10231,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions use customer-managed encryption keys (CMEK) using the Google Cloud Console:
 
             1. Navigate to **Cloud Functions** in the Google Cloud Console.
             2. Select the function or select **Create Function**.
@@ -10443,9 +10241,7 @@ queries:
             6. Deploy the function.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Deploy a function with CMEK:
+            To ensure Cloud Functions use customer-managed encryption keys (CMEK) using the Google Cloud CLI, deploy a function with CMEK:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -10533,7 +10329,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run services do not allow all ingress traffic in Terraform:
 
             ```hcl
             resource "google_cloud_run_v2_service" "example" {
@@ -10550,7 +10346,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run services do not allow all ingress traffic using the Google Cloud Console:
 
             1. Navigate to **Cloud Run** in the Google Cloud Console.
             2. Select the service to update.
@@ -10559,7 +10355,7 @@ queries:
             5. Select **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run services do not allow all ingress traffic using the Google Cloud CLI:
 
             ```bash
             gcloud run services update SERVICE_NAME \
@@ -10641,7 +10437,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run services use customer-managed encryption keys (CMEK) in Terraform:
 
             ```hcl
             resource "google_cloud_run_v2_service" "example" {
@@ -10659,7 +10455,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run services use customer-managed encryption keys (CMEK) using the Google Cloud Console:
 
             1. Navigate to **Cloud Run** in the Google Cloud Console.
             2. Select the service or select **Create Service**.
@@ -10668,7 +10464,7 @@ queries:
             5. Deploy the service.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run services use customer-managed encryption keys (CMEK) using the Google Cloud CLI:
 
             ```bash
             gcloud run services update SERVICE_NAME \
@@ -10759,7 +10555,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run services do not use the default service account in Terraform:
 
             ```hcl
             resource "google_service_account" "run_sa" {
@@ -10782,7 +10578,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run services do not use the default service account using the Google Cloud Console:
 
             1. Navigate to **Cloud Run** in the Google Cloud Console.
             2. Select the service to update.
@@ -10791,7 +10587,7 @@ queries:
             5. Select **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run services do not use the default service account using the Google Cloud CLI:
 
             ```bash
             gcloud run services update SERVICE_NAME \
@@ -10889,7 +10685,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run services have VPC access configured in Terraform:
 
             ```hcl
             resource "google_cloud_run_v2_service" "example" {
@@ -10910,7 +10706,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run services have VPC access configured using the Google Cloud Console:
 
             1. Navigate to **Cloud Run** in the Google Cloud Console.
             2. Select the service to update.
@@ -10919,7 +10715,7 @@ queries:
             5. Select **Deploy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run services have VPC access configured using the Google Cloud CLI:
 
             ```bash
             gcloud run services update SERVICE_NAME \
@@ -11011,7 +10807,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run jobs do not use the default service account in Terraform:
 
             ```hcl
             resource "google_service_account" "job_sa" {
@@ -11036,7 +10832,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run jobs do not use the default service account using the Google Cloud Console:
 
             1. Navigate to **Cloud Run > Jobs** in the Google Cloud Console.
             2. Select the job to update.
@@ -11045,7 +10841,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run jobs do not use the default service account using the Google Cloud CLI:
 
             ```bash
             gcloud run jobs update JOB_NAME \
@@ -11151,7 +10947,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Run jobs use customer-managed encryption keys (CMEK) in Terraform:
 
             ```hcl
             resource "google_cloud_run_v2_job" "example" {
@@ -11171,7 +10967,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Run jobs use customer-managed encryption keys (CMEK) using the Google Cloud Console:
 
             1. Navigate to **Cloud Run > Jobs** in the Google Cloud Console.
             2. Select the job or select **Create Job**.
@@ -11180,7 +10976,7 @@ queries:
             5. Save the job.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Run jobs use customer-managed encryption keys (CMEK) using the Google Cloud CLI:
 
             ```bash
             gcloud run jobs update JOB_NAME \
@@ -11268,7 +11064,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Dataproc clusters have disk encryption configured with CMEK in Terraform:
 
             ```hcl
             resource "google_dataproc_cluster" "example" {
@@ -11284,7 +11080,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Dataproc clusters have disk encryption configured with CMEK using the Google Cloud Console:
 
             1. Navigate to **Dataproc > Clusters** in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -11293,7 +11089,7 @@ queries:
             5. Complete cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Dataproc clusters have disk encryption configured with CMEK using the Google Cloud CLI:
 
             ```bash
             gcloud dataproc clusters create CLUSTER_NAME \
@@ -11386,7 +11182,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Dataproc clusters use internal IP addresses only in Terraform:
 
             ```hcl
             resource "google_dataproc_cluster" "example" {
@@ -11403,7 +11199,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Dataproc clusters use internal IP addresses only using the Google Cloud Console:
 
             1. Navigate to **Dataproc > Clusters** in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -11412,7 +11208,7 @@ queries:
             5. Complete cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Dataproc clusters use internal IP addresses only using the Google Cloud CLI:
 
             ```bash
             gcloud dataproc clusters create CLUSTER_NAME \
@@ -11499,7 +11295,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Dataproc clusters have Shielded VM features enabled in Terraform:
 
             ```hcl
             resource "google_dataproc_cluster" "example" {
@@ -11519,7 +11315,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Dataproc clusters have Shielded VM features enabled using the Google Cloud Console:
 
             1. Navigate to **Dataproc > Clusters** in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -11528,7 +11324,7 @@ queries:
             5. Complete cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Dataproc clusters have Shielded VM features enabled using the Google Cloud CLI:
 
             ```bash
             gcloud dataproc clusters create CLUSTER_NAME \
@@ -11649,7 +11445,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Dataproc clusters do not use the default service account in Terraform:
 
             ```hcl
             resource "google_service_account" "dataproc_sa" {
@@ -11670,7 +11466,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Dataproc clusters do not use the default service account using the Google Cloud Console:
 
             1. Navigate to **Dataproc > Clusters** in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -11679,7 +11475,7 @@ queries:
             5. Complete cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Dataproc clusters do not use the default service account using the Google Cloud CLI:
 
             ```bash
             gcloud dataproc clusters create CLUSTER_NAME \
@@ -11783,7 +11579,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Binary Authorization default rule does not allow all images in Terraform:
 
             ```hcl
             resource "google_binary_authorization_policy" "policy" {
@@ -11798,7 +11594,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Binary Authorization default rule does not allow all images using the Google Cloud Console:
 
             1. Navigate to **Security > Binary Authorization** in the Google Cloud Console.
             2. Select **Edit Policy**.
@@ -11807,9 +11603,7 @@ queries:
             5. Select **Save Policy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Export the current policy:
+            To ensure Binary Authorization default rule does not allow all images using the Google Cloud CLI, export the current policy:
 
             ```bash
             gcloud container binauthz policy export > policy.yaml
@@ -11900,7 +11694,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Binary Authorization global policy evaluation is enabled in Terraform:
 
             ```hcl
             resource "google_binary_authorization_policy" "policy" {
@@ -11917,7 +11711,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Binary Authorization global policy evaluation is enabled using the Google Cloud Console:
 
             1. Navigate to **Security > Binary Authorization** in the Google Cloud Console.
             2. Select **Edit Policy**.
@@ -11925,9 +11719,7 @@ queries:
             4. Select **Save Policy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Export the current policy:
+            To ensure Binary Authorization global policy evaluation is enabled using the Google Cloud CLI, export the current policy:
 
             ```bash
             gcloud container binauthz policy export > policy.yaml
@@ -12020,7 +11812,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure API keys have API target restrictions configured in Terraform:
 
             ```hcl
             resource "google_apikeys_key" "example" {
@@ -12037,7 +11829,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure API keys have API target restrictions configured using the Google Cloud Console:
 
             1. Navigate to **APIs & Services > Credentials** in the Google Cloud Console.
             2. Select the API key to update.
@@ -12046,7 +11838,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure API keys have API target restrictions configured using the Google Cloud CLI:
 
             ```bash
             gcloud services api-keys update KEY_ID \
@@ -12138,7 +11930,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure API keys have application restrictions configured in Terraform:
 
             ```hcl
             resource "google_apikeys_key" "example" {
@@ -12158,7 +11950,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure API keys have application restrictions configured using the Google Cloud Console:
 
             1. Navigate to **APIs & Services > Credentials** in the Google Cloud Console.
             2. Select the API key to update.
@@ -12170,9 +11962,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Add IP restrictions:
+            To ensure API keys have application restrictions configured using the Google Cloud CLI, add IP restrictions:
 
             ```bash
             gcloud services api-keys update KEY_ID \
@@ -12266,9 +12056,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use Terraform to manage API keys with restrictions. To rotate a stale key, update the resource to force recreation:
+            To ensure API keys have been rotated within 90 days in Terraform, use Terraform to manage API keys with restrictions. To rotate a stale key, update the resource to force recreation:
 
             ```hcl
             resource "google_apikeys_key" "example" {
@@ -12287,7 +12075,7 @@ queries:
             Note: To rotate the key, use `terraform apply -replace=google_apikeys_key.example` to force recreation. Ensure all consumers are updated to use the new key value.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure API keys have been rotated within 90 days using the Google Cloud Console:
 
             1. Navigate to **APIs & Services > Credentials** in the Google Cloud Console.
             2. Identify API keys that have not been updated recently.
@@ -12296,9 +12084,7 @@ queries:
             5. Delete the old key.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            List API keys and their creation dates:
+            To ensure API keys have been rotated within 90 days using the Google Cloud CLI, list API keys and their creation dates:
 
             ```bash
             gcloud services api-keys list --project=PROJECT_ID
@@ -12369,9 +12155,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Prevent default network creation and create a custom network:
+            To ensure the default network does not exist in the project in Terraform, prevent default network creation and create a custom network:
 
             ```hcl
             resource "google_compute_network" "custom" {
@@ -12391,7 +12175,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure the default network does not exist in the project using the Google Cloud Console:
 
             1. Navigate to **VPC network > VPC networks** in the Google Cloud Console.
             2. Select the **default** network.
@@ -12400,9 +12184,7 @@ queries:
             5. Create a custom VPC network with explicit subnet and firewall configurations.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Delete the default network:
+            To ensure the default network does not exist in the project using the Google Cloud CLI, delete the default network:
 
             ```bash
             gcloud compute networks delete default
@@ -12482,7 +12264,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure DNS logging is enabled for VPC networks in Terraform:
 
             ```hcl
             resource "google_dns_policy" "logging" {
@@ -12496,7 +12278,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure DNS logging is enabled for VPC networks using the Google Cloud Console:
 
             1. Navigate to **Network services > Cloud DNS** in the Google Cloud Console.
             2. Select **DNS Server Policies** tab.
@@ -12506,7 +12288,7 @@ queries:
             6. Select **Create**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure DNS logging is enabled for VPC networks using the Google Cloud CLI:
 
             ```bash
             gcloud dns policies create dns-logging-policy \
@@ -12590,7 +12372,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure subnetworks do not use overly broad IP CIDR ranges using the Google Cloud Console:
 
             1. Navigate to **VPC network > VPC networks** in the Google Cloud Console.
             2. Review each subnet's IP address range.
@@ -12599,9 +12381,7 @@ queries:
             5. Delete the oversized subnets.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            List subnets and their CIDR ranges:
+            To ensure subnetworks do not use overly broad IP CIDR ranges using the Google Cloud CLI, list subnets and their CIDR ranges:
 
             ```bash
             gcloud compute networks subnets list --format="table(name,region,ipCidrRange)"
@@ -12617,9 +12397,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define subnets with appropriately sized CIDR ranges:
+            To ensure subnetworks do not use overly broad IP CIDR ranges in Terraform, define subnets with appropriately sized CIDR ranges:
 
             ```hcl
             resource "google_compute_subnetwork" "example" {
@@ -12716,9 +12494,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            For Cloud Memorystore for Redis instances:
+            To ensure in-transit encryption is enabled for Cloud Memorystore for Redis in Terraform, for Cloud Memorystore for Redis instances:
 
             ```hcl
             resource "google_redis_instance" "cache" {
@@ -12732,9 +12508,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: In-transit encryption must be configured at instance creation time and cannot be changed on an existing instance.
+            To ensure in-transit encryption is enabled for Cloud Memorystore for Redis using the Google Cloud Console, note: In-transit encryption must be configured at instance creation time and cannot be changed on an existing instance.
 
             1. Go to the **Memorystore > Redis** page in the Google Cloud Console.
             2. Select **Create Instance**.
@@ -12742,9 +12516,7 @@ queries:
             4. Complete the instance creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: In-transit encryption must be configured at instance creation time.
+            To ensure in-transit encryption is enabled for Cloud Memorystore for Redis using the Google Cloud CLI, note: In-transit encryption must be configured at instance creation time.
 
             For Cloud Memorystore for Redis instances:
 
@@ -12841,7 +12613,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Redis instances use the Standard HA tier in Terraform:
 
             ```hcl
             resource "google_redis_instance" "cache" {
@@ -12853,9 +12625,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: The tier cannot be changed after instance creation.
+            To ensure Cloud Redis instances use the Standard HA tier using the Google Cloud Console, note: The tier cannot be changed after instance creation.
 
             1. Navigate to **Memorystore > Redis** in the Google Cloud Console.
             2. Select **Create Instance**.
@@ -12863,9 +12633,7 @@ queries:
             4. Complete instance creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: The tier cannot be changed after instance creation.
+            To ensure Cloud Redis instances use the Standard HA tier using the Google Cloud CLI, note: The tier cannot be changed after instance creation.
 
             ```bash
             gcloud redis instances create INSTANCE_NAME \
@@ -12954,7 +12722,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure IAM authentication is enabled for Memorystore Redis Cluster in Terraform:
 
             ```hcl
             resource "google_redis_cluster" "cluster" {
@@ -12967,7 +12735,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure IAM authentication is enabled for Memorystore Redis Cluster using the Google Cloud Console:
 
             1. Go to the **Memorystore > Redis Cluster** page in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -12977,7 +12745,7 @@ queries:
             For existing clusters, update the authorization mode in the cluster settings.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure IAM authentication is enabled for Memorystore Redis Cluster using the Google Cloud CLI:
 
             ```bash
             gcloud redis clusters create CLUSTER_NAME \
@@ -13065,7 +12833,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure deletion protection is enabled for Memorystore Redis Cluster in Terraform:
 
             ```hcl
             resource "google_redis_cluster" "cluster" {
@@ -13078,7 +12846,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure deletion protection is enabled for Memorystore Redis Cluster using the Google Cloud Console:
 
             1. Go to the **Memorystore > Redis Cluster** page in the Google Cloud Console.
             2. Select the cluster you want to update.
@@ -13087,7 +12855,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure deletion protection is enabled for Memorystore Redis Cluster using the Google Cloud CLI:
 
             ```bash
             gcloud redis clusters update CLUSTER_NAME \
@@ -13177,9 +12945,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a Cloud KMS key and set it as the encryption key for the secret:
+            To ensure Secret Manager secrets are encrypted with CMEK in Terraform, configure a Cloud KMS key and set it as the encryption key for the secret:
 
             ```hcl
             resource "google_kms_key_ring" "example" {
@@ -13209,7 +12975,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Secret Manager secrets are encrypted with CMEK using the Google Cloud Console:
 
             1. Navigate to **Security > Secret Manager** in the Google Cloud Console.
             2. Select **Create Secret** or select an existing secret.
@@ -13220,9 +12986,7 @@ queries:
             Note: Encryption configuration is set at secret creation time. To change encryption on an existing secret, you must create a new secret with CMEK and migrate the secret versions.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a secret with CMEK encryption:
+            To ensure Secret Manager secrets are encrypted with CMEK using the Google Cloud CLI, create a secret with CMEK encryption:
 
             ```bash
             gcloud secrets create SECRET_ID \
@@ -13333,9 +13097,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure rotation on a Secret Manager secret with a Pub/Sub topic for rotation notifications:
+            To ensure Secret Manager secrets have rotation configured in Terraform, configure rotation on a Secret Manager secret with a Pub/Sub topic for rotation notifications:
 
             ```hcl
             resource "google_pubsub_topic" "rotation" {
@@ -13361,7 +13123,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Secret Manager secrets have rotation configured using the Google Cloud Console:
 
             1. Navigate to **Security > Secret Manager** in the Google Cloud Console.
             2. Select the secret you want to configure.
@@ -13373,9 +13135,7 @@ queries:
             8. Select **Update Secret**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Configure rotation on an existing secret:
+            To ensure Secret Manager secrets have rotation configured using the Google Cloud CLI, configure rotation on an existing secret:
 
             ```bash
             gcloud secrets update SECRET_ID \
@@ -13472,9 +13232,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure that IAM policy resources for Secret Manager secrets do not include `allUsers` or `allAuthenticatedUsers` as members:
+            To ensure Secret Manager secrets do not have overly permissive IAM policies in Terraform, ensure that IAM policy resources for Secret Manager secrets do not include `allUsers` or `allAuthenticatedUsers` as members:
 
             ```hcl
             # Correct - specific service accounts only
@@ -13489,7 +13247,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Secret Manager secrets do not have overly permissive IAM policies using the Google Cloud Console:
 
             1. Navigate to **Security > Secret Manager** in the Google Cloud Console.
             2. Select the secret you want to review.
@@ -13502,7 +13260,7 @@ queries:
             6. Replace removed principals with specific identities that require access.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Secret Manager secrets do not have overly permissive IAM policies using the Google Cloud CLI:
 
             1. List the IAM policy for a secret:
 
@@ -13619,7 +13377,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure IP forwarding is not enabled on compute instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "example" {
@@ -13643,9 +13401,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            IP forwarding can only be set at instance creation time and cannot be changed on a running instance. To disable it:
+            To ensure IP forwarding is not enabled on compute instances using the Google Cloud Console, IP forwarding can only be set at instance creation time and cannot be changed on a running instance. To disable it:
 
             1. Note the configuration of the existing instance.
             2. Create a new instance with **IP forwarding** set to **Off** in the **Networking** section.
@@ -13653,9 +13409,7 @@ queries:
             4. Delete the old instance.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            IP forwarding is set at creation time. To verify an instance's setting:
+            To ensure IP forwarding is not enabled on compute instances using the Google Cloud CLI, IP forwarding is set at creation time. To verify an instance's setting:
 
             ```bash
             gcloud compute instances describe INSTANCE_NAME --zone=ZONE --format='get(canIpForward)'
@@ -13736,7 +13490,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure interactive serial port access is disabled on compute instances in Terraform:
 
             ```hcl
             resource "google_compute_instance" "example" {
@@ -13761,7 +13515,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure interactive serial port access is disabled on compute instances using the Google Cloud Console:
 
             1. Go to the **VM instances** page: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).
             2. Select the instance name.
@@ -13773,9 +13527,7 @@ queries:
             Enforce the `constraints/compute.disableSerialPortAccess` Organization Policy to prevent serial port access across your organization: [https://console.cloud.google.com/iam-admin/orgpolicies/compute-disableSerialPortAccess](https://console.cloud.google.com/iam-admin/orgpolicies/compute-disableSerialPortAccess).
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Remove or set the serial port metadata to false:
+            To ensure interactive serial port access is disabled on compute instances using the Google Cloud CLI, remove or set the serial port metadata to false:
 
             ```bash
             gcloud compute instances add-metadata INSTANCE_NAME --zone=ZONE --metadata=serial-port-enable=false
@@ -13870,7 +13622,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Compute Engine disks are encrypted with CMEK in Terraform:
 
             ```hcl
             resource "google_compute_disk" "example" {
@@ -13886,7 +13638,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Compute Engine disks are encrypted with CMEK using the Google Cloud Console:
 
             1. Go to the **Disks** page: [https://console.cloud.google.com/compute/disks](https://console.cloud.google.com/compute/disks).
             2. Select **Create disk**.
@@ -13897,7 +13649,7 @@ queries:
             Note: Existing disks cannot be converted to CMEK. Create a new CMEK-encrypted disk and copy data from the existing disk.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Compute Engine disks are encrypted with CMEK using the Google Cloud CLI:
 
             ```bash
             gcloud compute disks create DISK_NAME \
@@ -13982,7 +13734,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure external forwarding rules do not forward all ports in Terraform:
 
             ```hcl
             resource "google_compute_forwarding_rule" "example" {
@@ -13995,7 +13747,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure external forwarding rules do not forward all ports using the Google Cloud Console:
 
             1. Go to the **Load balancing** page: [https://console.cloud.google.com/net-services/loadbalancing](https://console.cloud.google.com/net-services/loadbalancing).
             2. Select the load balancer associated with the forwarding rule.
@@ -14004,9 +13756,7 @@ queries:
             5. Save the configuration.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Forwarding rules cannot be modified in place. Create a new forwarding rule with specific ports:
+            To ensure external forwarding rules do not forward all ports using the Google Cloud CLI, forwarding rules cannot be modified in place. Create a new forwarding rule with specific ports:
 
             ```bash
             gcloud compute forwarding-rules create NEW_RULE_NAME \
@@ -14107,7 +13857,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud SQL authorized networks are not overly permissive in Terraform:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -14130,7 +13880,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL authorized networks are not overly permissive using the Google Cloud Console:
 
             1. Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2. Select the instance.
@@ -14140,9 +13890,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Update the authorized networks to use specific CIDR ranges:
+            To ensure Cloud SQL authorized networks are not overly permissive using the Google Cloud CLI, update the authorized networks to use specific CIDR ranges:
 
             ```bash
             gcloud sql instances patch INSTANCE_NAME \
@@ -14268,7 +14016,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud SQL instances have a password policy enabled in Terraform:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -14290,7 +14038,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL instances have a password policy enabled using the Google Cloud Console:
 
             1. Navigate to the Cloud SQL Instances page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2. Select the instance.
@@ -14300,7 +14048,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud SQL instances have a password policy enabled using the Google Cloud CLI:
 
             ```bash
             gcloud sql instances patch INSTANCE_NAME \
@@ -14409,7 +14157,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud SQL instances are encrypted with CMEK in Terraform:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -14426,9 +14174,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at instance creation time.
+            To ensure Cloud SQL instances are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at instance creation time.
 
             1. Go to the **Cloud SQL Instances** page: [https://console.cloud.google.com/sql/instances](https://console.cloud.google.com/sql/instances).
             2. Select **Create instance**.
@@ -14437,9 +14183,7 @@ queries:
             5. Complete instance creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at instance creation time.
+            To ensure Cloud SQL instances are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at instance creation time.
 
             ```bash
             gcloud sql instances create INSTANCE_NAME \
@@ -14531,7 +14275,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure GKE cluster has application-layer secrets encryption enabled in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -14546,7 +14290,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE cluster has application-layer secrets encryption enabled using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster.
@@ -14556,7 +14300,7 @@ queries:
             6. Save the changes.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure GKE cluster has application-layer secrets encryption enabled using the Google Cloud CLI:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME \
@@ -14642,7 +14386,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure GKE cluster node pools have Secure Boot enabled in Terraform:
 
             ```hcl
             resource "google_container_cluster" "primary" {
@@ -14663,7 +14407,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE cluster node pools have Secure Boot enabled using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page.
             2. Select the cluster.
@@ -14675,7 +14419,7 @@ queries:
             Note: Changing Shielded VM settings on a node pool requires re-creating nodes.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure GKE cluster node pools have Secure Boot enabled using the Google Cloud CLI:
 
             ```bash
             gcloud container node-pools update NODE_POOL_NAME \
@@ -14783,9 +14527,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Replace plaintext environment variables with Secret Manager references:
+            To ensure Cloud Functions do not store secrets in plaintext env vars in Terraform, replace plaintext environment variables with Secret Manager references:
 
             ```hcl
             resource "google_cloudfunctions2_function" "example" {
@@ -14810,7 +14552,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions do not store secrets in plaintext env vars using the Google Cloud Console:
 
             1. Navigate to **Cloud Functions** in the Google Cloud Console.
             2. Select the function.
@@ -14821,9 +14563,7 @@ queries:
             7. Deploy the function.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Remove the plaintext environment variable and add a Secret Manager reference:
+            To ensure Cloud Functions do not store secrets in plaintext env vars using the Google Cloud CLI, remove the plaintext environment variable and add a Secret Manager reference:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -14938,7 +14678,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud Functions use a user-managed Artifact Registry repository in Terraform:
 
             ```hcl
             resource "google_artifact_registry_repository" "functions" {
@@ -14962,7 +14702,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Functions use a user-managed Artifact Registry repository using the Google Cloud Console:
 
             1. First, create an Artifact Registry Docker repository if one does not exist.
             2. Navigate to **Cloud Functions** in the Google Cloud Console.
@@ -14972,9 +14712,7 @@ queries:
             6. Deploy the function.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Deploy the function with a user-managed Artifact Registry repository:
+            To ensure Cloud Functions use a user-managed Artifact Registry repository using the Google Cloud CLI, deploy the function with a user-managed Artifact Registry repository:
 
             ```bash
             gcloud functions deploy FUNCTION_NAME \
@@ -15055,9 +14793,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set `preview` to `false` on all security policy rules:
+            To ensure Cloud Armor security policy rules are not in preview-only mode in Terraform, set `preview` to `false` on all security policy rules:
 
             ```hcl
             resource "google_compute_security_policy" "policy" {
@@ -15079,7 +14815,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Armor security policy rules are not in preview-only mode using the Google Cloud Console:
 
             1. Go to the **Network Security > Cloud Armor policies** page.
             2. Select the security policy.
@@ -15088,7 +14824,7 @@ queries:
             5. Select **Update**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Armor security policy rules are not in preview-only mode using the Google Cloud CLI:
 
             ```bash
             gcloud compute security-policies rules update PRIORITY \
@@ -15175,9 +14911,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the default rule action to deny:
+            To ensure Cloud Armor security policy default rule does not allow all traffic in Terraform, set the default rule action to deny:
 
             ```hcl
             resource "google_compute_security_policy" "policy" {
@@ -15216,7 +14950,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud Armor security policy default rule does not allow all traffic using the Google Cloud Console:
 
             1. Go to the **Network Security > Cloud Armor policies** page.
             2. Select the security policy.
@@ -15226,7 +14960,7 @@ queries:
             6. Select **Update**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud Armor security policy default rule does not allow all traffic using the Google Cloud CLI:
 
             ```bash
             gcloud compute security-policies rules update 2147483647 \
@@ -15312,7 +15046,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SSL policies enforce a minimum TLS version of 1.2 in Terraform:
 
             ```hcl
             resource "google_compute_ssl_policy" "modern" {
@@ -15323,7 +15057,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure SSL policies enforce a minimum TLS version of 1.2 using the Google Cloud Console:
 
             1. Go to the **Network Security > SSL Policies** page.
             2. Select the SSL policy or select **Create SSL Policy**.
@@ -15332,7 +15066,7 @@ queries:
             5. Attach the policy to your target HTTPS proxy or SSL proxy.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure SSL policies enforce a minimum TLS version of 1.2 using the Google Cloud CLI:
 
             ```bash
             gcloud compute ssl-policies update SSL_POLICY_NAME \
@@ -15413,7 +15147,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure SSL policies use MODERN or RESTRICTED profile in Terraform:
 
             ```hcl
             resource "google_compute_ssl_policy" "modern" {
@@ -15424,7 +15158,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure SSL policies use MODERN or RESTRICTED profile using the Google Cloud Console:
 
             1. Go to the **Network Security > SSL Policies** page.
             2. Select the SSL policy.
@@ -15432,7 +15166,7 @@ queries:
             4. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure SSL policies use MODERN or RESTRICTED profile using the Google Cloud CLI:
 
             ```bash
             gcloud compute ssl-policies update SSL_POLICY_NAME \
@@ -15499,9 +15233,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Use Google-managed SSL certificates for automatic renewal, or manage self-managed certificates with Terraform:
+            To ensure SSL certificates are not expired or expiring within 30 days in Terraform, use Google-managed SSL certificates for automatic renewal, or manage self-managed certificates with Terraform:
 
             ```hcl
             # Option 1: Google-managed certificate (recommended - auto-renews)
@@ -15533,7 +15265,7 @@ queries:
             Note: For self-managed certificates, pass the private key via a sensitive variable or secrets manager rather than reading it from a file in version control. Update the certificate before it expires and run `terraform apply` to deploy the renewal.
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure SSL certificates are not expired or expiring within 30 days using the Google Cloud Console:
 
             1. Go to the **Certificate Manager** page or **Load Balancing > SSL Certificates** page.
             2. Identify certificates that are expired or expiring within 30 days.
@@ -15541,9 +15273,7 @@ queries:
             4. Update the target HTTPS proxy to use the new certificate.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a new self-managed certificate with the renewed key and certificate:
+            To ensure SSL certificates are not expired or expiring within 30 days using the Google Cloud CLI, create a new self-managed certificate with the renewed key and certificate:
 
             ```bash
             gcloud compute ssl-certificates create NEW_CERT_NAME \
@@ -15613,7 +15343,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure Cloud NAT does not use endpoint-independent mapping in Terraform:
 
             ```hcl
             resource "google_compute_router_nat" "nat" {
@@ -15629,7 +15359,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud NAT does not use endpoint-independent mapping using the Google Cloud Console:
 
             1. Go to the **Network services > Cloud NAT** page.
             2. Select the NAT gateway.
@@ -15638,7 +15368,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Cloud NAT does not use endpoint-independent mapping using the Google Cloud CLI:
 
             ```bash
             gcloud compute routers nats update NAT_NAME \
@@ -15721,7 +15451,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure audit logging is enabled for all services in Terraform:
 
             ```hcl
             resource "google_project_iam_audit_config" "all_services" {
@@ -15743,16 +15473,14 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure audit logging is enabled for all services using the Google Cloud Console:
 
             1. Go to the **IAM & Admin > Audit Logs** page.
             2. In the **Default Audit Config** section at the top, ensure that **Admin Read**, **Data Read**, and **Data Write** are enabled for all services.
             3. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Get the current IAM policy:
+            To ensure audit logging is enabled for all services using the Google Cloud CLI, get the current IAM policy:
 
             ```bash
             gcloud projects get-iam-policy PROJECT_ID --format=json > policy.json
@@ -15854,7 +15582,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure VM external IP access is restricted via organization policy in Terraform:
 
             ```hcl
             resource "google_org_policy_policy" "vm_external_ip" {
@@ -15887,7 +15615,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure VM external IP access is restricted via organization policy using the Google Cloud Console:
 
             1. Go to the **IAM & Admin > Organization Policies** page.
             2. Search for **Define allowed external IPs for VM instances** (`compute.vmExternalIpAccess`).
@@ -15896,9 +15624,7 @@ queries:
             5. Select **Set Policy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Deny all external IPs:
+            To ensure VM external IP access is restricted via organization policy using the Google Cloud CLI, deny all external IPs:
 
             ```bash
             gcloud resource-manager org-policies deny \
@@ -15978,7 +15704,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure serial port access is disabled via organization policy in Terraform:
 
             ```hcl
             resource "google_org_policy_policy" "disable_serial_port" {
@@ -15994,7 +15720,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure serial port access is disabled via organization policy using the Google Cloud Console:
 
             1. Go to the **IAM & Admin > Organization Policies** page.
             2. Search for **Disable VM serial port access** (`compute.disableSerialPortAccess`).
@@ -16003,7 +15729,7 @@ queries:
             5. Select **Set Policy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure serial port access is disabled via organization policy using the Google Cloud CLI:
 
             ```bash
             gcloud resource-manager org-policies enable-enforce \
@@ -16094,7 +15820,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
+            To ensure uniform bucket-level access is enforced via organization policy in Terraform:
 
             ```hcl
             resource "google_org_policy_policy" "uniform_bucket_access" {
@@ -16110,7 +15836,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure uniform bucket-level access is enforced via organization policy using the Google Cloud Console:
 
             1. Go to the **IAM & Admin > Organization Policies** page.
             2. Search for **Enforce uniform bucket-level access** (`storage.uniformBucketLevelAccess`).
@@ -16119,7 +15845,7 @@ queries:
             5. Select **Set Policy**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure uniform bucket-level access is enforced via organization policy using the Google Cloud CLI:
 
             ```bash
             gcloud resource-manager org-policies enable-enforce \
@@ -16210,9 +15936,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Note: CMEK must be configured at database creation time.
+            To ensure Firestore databases are encrypted with CMEK in Terraform, note: CMEK must be configured at database creation time.
 
             ```hcl
             resource "google_firestore_database" "database" {
@@ -16228,9 +15952,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at database creation time and cannot be added to existing databases.
+            To ensure Firestore databases are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at database creation time and cannot be added to existing databases.
 
             1. Go to the **Firestore** page in the Google Cloud Console.
             2. Select **Create Database**.
@@ -16239,9 +15961,7 @@ queries:
             5. Complete the database creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at database creation time.
+            To ensure Firestore databases are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at database creation time.
 
             ```bash
             gcloud firestore databases create \
@@ -16326,9 +16046,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Note: CMEK must be configured at database creation time.
+            To ensure Spanner databases are encrypted with CMEK in Terraform, note: CMEK must be configured at database creation time.
 
             ```hcl
             resource "google_spanner_database" "database" {
@@ -16342,9 +16060,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at database creation time.
+            To ensure Spanner databases are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at database creation time.
 
             1. Go to the **Spanner** page in the Google Cloud Console.
             2. Select an instance and select **Create Database**.
@@ -16353,9 +16069,7 @@ queries:
             5. Complete the database creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at database creation time.
+            To ensure Spanner databases are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at database creation time.
 
             ```bash
             gcloud spanner databases create DATABASE_ID \
@@ -16438,9 +16152,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure Bigtable clusters are encrypted with CMEK in Terraform, note: CMEK must be configured at cluster creation time.
 
             ```hcl
             resource "google_bigtable_instance" "instance" {
@@ -16457,9 +16169,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure Bigtable clusters are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at cluster creation time.
 
             1. Go to the **Bigtable** page in the Google Cloud Console.
             2. Select **Create Instance**.
@@ -16468,9 +16178,7 @@ queries:
             5. Complete the instance creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure Bigtable clusters are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at cluster creation time.
 
             ```bash
             cbt createinstance INSTANCE_ID DISPLAY_NAME \
@@ -16554,9 +16262,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure AlloyDB clusters are encrypted with CMEK in Terraform, note: CMEK must be configured at cluster creation time.
 
             ```hcl
             resource "google_alloydb_cluster" "cluster" {
@@ -16574,9 +16280,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure AlloyDB clusters are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at cluster creation time.
 
             1. Go to the **AlloyDB** page in the Google Cloud Console.
             2. Select **Create Cluster**.
@@ -16585,9 +16289,7 @@ queries:
             5. Complete the cluster creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at cluster creation time.
+            To ensure AlloyDB clusters are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at cluster creation time.
 
             ```bash
             gcloud alloydb clusters create CLUSTER_ID \
@@ -16671,9 +16373,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure `enable_public_ip` is not set to `true` in the instance configuration:
+            To ensure AlloyDB instances do not have public IP addresses in Terraform, ensure `enable_public_ip` is not set to `true` in the instance configuration:
 
             ```hcl
             resource "google_alloydb_instance" "primary" {
@@ -16688,7 +16388,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure AlloyDB instances do not have public IP addresses using the Google Cloud Console:
 
             1. Go to the **AlloyDB** page in the Google Cloud Console.
             2. Select the cluster and instance.
@@ -16697,7 +16397,7 @@ queries:
             5. Select **Update Instance**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure AlloyDB instances do not have public IP addresses using the Google Cloud CLI:
 
             ```bash
             gcloud alloydb instances update INSTANCE_ID \
@@ -16785,9 +16485,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable Security Posture with vulnerability scanning:
+            To ensure GKE clusters have Security Posture enabled in Terraform, enable Security Posture with vulnerability scanning:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -16802,7 +16500,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE clusters have Security Posture enabled using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select the cluster you want to configure.
@@ -16813,9 +16511,7 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Enable Security Posture on an existing cluster:
+            To ensure GKE clusters have Security Posture enabled using the Google Cloud CLI, enable Security Posture on an existing cluster:
 
             ```bash
             gcloud container clusters update CLUSTER_NAME \
@@ -16910,9 +16606,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the IKE version to 2 on VPN tunnels:
+            To ensure VPN tunnels use IKE version 2 in Terraform, set the IKE version to 2 on VPN tunnels:
 
             ```hcl
             resource "google_compute_vpn_tunnel" "example" {
@@ -16926,9 +16620,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            IKE version cannot be changed on an existing VPN tunnel. To use IKEv2:
+            To ensure VPN tunnels use IKE version 2 using the Google Cloud Console, IKE version cannot be changed on an existing VPN tunnel. To use IKEv2:
 
             1. Go to the **Network Connectivity > VPN** page in the Google Cloud Console.
             2. Select **Create VPN tunnel** or recreate the existing tunnel.
@@ -16937,9 +16629,7 @@ queries:
             5. Delete the old IKEv1 tunnel after verifying the new tunnel is operational.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Create a VPN tunnel with IKEv2:
+            To ensure VPN tunnels use IKE version 2 using the Google Cloud CLI, create a VPN tunnel with IKEv2:
 
             ```bash
             gcloud compute vpn-tunnels create TUNNEL_NAME \
@@ -17026,9 +16716,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a surge upgrade strategy for node pools:
+            To ensure GKE node pools have an upgrade strategy configured in Terraform, configure a surge upgrade strategy for node pools:
 
             ```hcl
             resource "google_container_node_pool" "example" {
@@ -17066,7 +16754,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE node pools have an upgrade strategy configured using the Google Cloud Console:
 
             1. Go to the **Kubernetes Engine > Clusters** page in the Google Cloud Console.
             2. Select the cluster containing the node pool.
@@ -17078,9 +16766,7 @@ queries:
             8. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Configure a surge upgrade strategy:
+            To ensure GKE node pools have an upgrade strategy configured using the Google Cloud CLI, configure a surge upgrade strategy:
 
             ```bash
             gcloud container node-pools update NODE_POOL_NAME \
@@ -17195,9 +16881,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set connector enforcement to REQUIRED:
+            To ensure Cloud SQL instances require Cloud SQL connectors for all connections in Terraform, set connector enforcement to REQUIRED:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -17215,7 +16899,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL instances require Cloud SQL connectors for all connections using the Google Cloud Console:
 
             1. Go to the **SQL** page in the Google Cloud Console.
             2. Select the instance you want to configure.
@@ -17225,9 +16909,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Enable connector enforcement on an existing instance:
+            To ensure Cloud SQL instances require Cloud SQL connectors for all connections using the Google Cloud CLI, enable connector enforcement on an existing instance:
 
             ```bash
             gcloud sql instances patch INSTANCE_NAME \
@@ -17329,9 +17011,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure the backup vault with access restrictions:
+            To ensure Backup & DR vault access is restricted in Terraform, configure the backup vault with access restrictions:
 
             ```hcl
             resource "google_backup_dr_backup_vault" "example" {
@@ -17343,7 +17023,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Backup & DR vault access is restricted using the Google Cloud Console:
 
             1. Go to the **Backup and DR** page in the Google Cloud Console.
             2. Select **Backup Vaults**.
@@ -17352,7 +17032,7 @@ queries:
             5. Ensure access restrictions are not set to **Unrestricted**.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Backup & DR vault access is restricted using the Google Cloud CLI:
 
             ```bash
             gcloud backup-dr backup-vaults update VAULT_NAME \
@@ -17438,9 +17118,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure CMEK encryption when creating a Vertex AI endpoint:
+            To ensure Vertex AI endpoints are encrypted with CMEK in Terraform, configure CMEK encryption when creating a Vertex AI endpoint:
 
             ```hcl
             resource "google_vertex_ai_endpoint" "example" {
@@ -17465,9 +17143,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at endpoint creation time.
+            To ensure Vertex AI endpoints are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at endpoint creation time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Online prediction > Endpoints**.
@@ -17477,9 +17153,7 @@ queries:
             6. Complete the endpoint creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at endpoint creation time.
+            To ensure Vertex AI endpoints are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at endpoint creation time.
 
             ```bash
             gcloud ai endpoints create \
@@ -17562,9 +17236,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure Private Service Connect when creating a Vertex AI endpoint:
+            To ensure Vertex AI endpoints use Private Service Connect in Terraform, configure Private Service Connect when creating a Vertex AI endpoint:
 
             ```hcl
             resource "google_vertex_ai_endpoint" "example" {
@@ -17586,9 +17258,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: Private Service Connect must be configured at endpoint creation time.
+            To ensure Vertex AI endpoints use Private Service Connect using the Google Cloud Console, note: Private Service Connect must be configured at endpoint creation time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Online prediction > Endpoints**.
@@ -17598,9 +17268,7 @@ queries:
             6. Complete the endpoint creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: Private Service Connect must be configured at endpoint creation time.
+            To ensure Vertex AI endpoints use Private Service Connect using the Google Cloud CLI, note: Private Service Connect must be configured at endpoint creation time.
 
             ```bash
             gcloud ai endpoints create \
@@ -17683,9 +17351,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at model upload time.
+            To ensure Vertex AI models are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at model upload time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Model Registry**.
@@ -17695,9 +17361,7 @@ queries:
             6. Complete the model upload.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at model upload time.
+            To ensure Vertex AI models are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at model upload time.
 
             ```bash
             gcloud ai models upload \
@@ -17757,9 +17421,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure CMEK encryption when creating a Vertex AI dataset:
+            To ensure Vertex AI datasets are encrypted with CMEK in Terraform, configure CMEK encryption when creating a Vertex AI dataset:
 
             ```hcl
             resource "google_vertex_ai_dataset" "example" {
@@ -17784,9 +17446,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at dataset creation time.
+            To ensure Vertex AI datasets are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at dataset creation time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Datasets**.
@@ -17796,9 +17456,7 @@ queries:
             6. Complete the dataset creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at dataset creation time.
+            To ensure Vertex AI datasets are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at dataset creation time.
 
             ```bash
             gcloud ai datasets create \
@@ -17869,9 +17527,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with CMEK encryption, or submit pipeline jobs via the gcloud CLI or API with CMEK configured:
+            To ensure Vertex AI pipeline jobs are encrypted with CMEK in Terraform, vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with CMEK encryption, or submit pipeline jobs via the gcloud CLI or API with CMEK configured:
 
             ```hcl
             resource "google_vertex_ai_custom_job" "example" {
@@ -17908,9 +17564,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at pipeline job creation time.
+            To ensure Vertex AI pipeline jobs are encrypted with CMEK using the Google Cloud Console, note: CMEK must be configured at pipeline job creation time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Pipelines**.
@@ -17920,9 +17574,7 @@ queries:
             6. Submit the pipeline run.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at pipeline job submission time.
+            To ensure Vertex AI pipeline jobs are encrypted with CMEK using the Google Cloud CLI, note: CMEK must be configured at pipeline job submission time.
 
             ```bash
             gcloud ai pipelines create \
@@ -17969,9 +17621,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with VPC networking, or submit pipeline jobs via the gcloud CLI or API with a network configured:
+            To ensure Vertex AI pipeline jobs use a VPC network in Terraform, vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with VPC networking, or submit pipeline jobs via the gcloud CLI or API with a network configured:
 
             ```hcl
             resource "google_vertex_ai_custom_job" "example" {
@@ -18001,7 +17651,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Vertex AI pipeline jobs use a VPC network using the Google Cloud Console:
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Pipelines**.
@@ -18010,7 +17660,7 @@ queries:
             5. Submit the pipeline run.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Vertex AI pipeline jobs use a VPC network using the Google Cloud CLI:
 
             ```bash
             gcloud ai pipelines create \
@@ -18062,9 +17712,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with a custom service account, or submit pipeline jobs via the gcloud CLI or API with a custom service account configured:
+            To ensure Vertex AI pipeline jobs don't use default SA in Terraform, vertex AI pipeline jobs are not directly managed as Terraform resources. Use `google_vertex_ai_custom_job` for Terraform-managed ML jobs with a custom service account, or submit pipeline jobs via the gcloud CLI or API with a custom service account configured:
 
             ```hcl
             resource "google_vertex_ai_custom_job" "example" {
@@ -18100,7 +17748,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Vertex AI pipeline jobs don't use default SA using the Google Cloud Console:
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Pipelines**.
@@ -18109,7 +17757,7 @@ queries:
             5. Submit the pipeline run.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
+            To ensure Vertex AI pipeline jobs don't use default SA using the Google Cloud CLI:
 
             ```bash
             gcloud ai pipelines create \
@@ -18170,9 +17818,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure CMEK encryption when creating a Vertex AI feature online store:
+            To ensure Vertex AI feature online stores use CMEK in Terraform, configure CMEK encryption when creating a Vertex AI feature online store:
 
             ```hcl
             resource "google_vertex_ai_feature_online_store" "example" {
@@ -18204,9 +17850,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Note: CMEK must be configured at feature online store creation time.
+            To ensure Vertex AI feature online stores use CMEK using the Google Cloud Console, note: CMEK must be configured at feature online store creation time.
 
             1. Go to the **Vertex AI** page in the Google Cloud Console.
             2. Navigate to **Feature Store > Online Stores**.
@@ -18216,9 +17860,7 @@ queries:
             6. Complete the store creation.
         - id: cli
           desc: |
-            **Using Google Cloud CLI**
-
-            Note: CMEK must be configured at creation time.
+            To ensure Vertex AI feature online stores use CMEK using the Google Cloud CLI, note: CMEK must be configured at creation time.
 
             ```bash
             gcloud ai feature-online-stores create STORE_NAME \
@@ -18291,7 +17933,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure firewall rules do not allow unrestricted egress using the Google Cloud Console:
 
             1. Navigate to **VPC Network** > **Firewall**.
             2. Identify egress rules with destination range `0.0.0.0/0` and protocol `all`.
@@ -18299,9 +17941,7 @@ queries:
             4. Create targeted egress rules that allow only required outbound traffic.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            List unrestricted egress rules:
+            To ensure firewall rules do not allow unrestricted egress using the gcloud CLI, list unrestricted egress rules:
 
             ```bash
             gcloud compute firewall-rules list \
@@ -18316,9 +17956,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure egress rules specify restricted destinations and protocols:
+            To ensure firewall rules do not allow unrestricted egress in Terraform, ensure egress rules specify restricted destinations and protocols:
 
             ```hcl
             resource "google_compute_firewall" "allow_egress" {
@@ -18416,16 +18054,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure egress firewall rules do not allow all ports using the Google Cloud Console:
 
             1. Navigate to **VPC Network** > **Firewall**.
             2. Identify egress rules with destination range `0.0.0.0/0` that allow traffic without port restrictions.
             3. Edit the rule to specify explicit ports (e.g., TCP 443 for HTTPS).
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            List internet-facing egress rules:
+            To ensure egress firewall rules do not allow all ports using the gcloud CLI, list internet-facing egress rules:
 
             ```bash
             gcloud compute firewall-rules list \
@@ -18447,9 +18083,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure egress rules specify explicit protocols and ports:
+            To ensure egress firewall rules do not allow all ports in Terraform, ensure egress rules specify explicit protocols and ports:
 
             ```hcl
             resource "google_compute_firewall" "allow_egress" {
@@ -18547,14 +18181,10 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            The legacy metadata endpoint setting cannot be directly edited via the GCP Console. Use the gcloud CLI or Terraform to configure this setting on node pools.
+            To ensure legacy metadata endpoints are disabled on GKE nodes using the Google Cloud Console, the legacy metadata endpoint setting cannot be directly edited via the GCP Console. Use the gcloud CLI or Terraform to configure this setting on node pools.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Update a node pool to disable legacy endpoints:
+            To ensure legacy metadata endpoints are disabled on GKE nodes using the gcloud CLI, update a node pool to disable legacy endpoints:
 
             ```bash
             gcloud container node-pools update <pool-name> \
@@ -18563,9 +18193,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable legacy metadata endpoints in the node config:
+            To ensure legacy metadata endpoints are disabled on GKE nodes in Terraform, disable legacy metadata endpoints in the node config:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -18652,9 +18280,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            For GKE 1.19 and later, basic authentication and client certificate UI elements have been removed from the GCP Console, and these legacy authentication methods are disabled by default. No Console action is required for current GKE versions.
+            To ensure GKE legacy client authentication is disabled using the Google Cloud Console, for GKE 1.19 and later, basic authentication and client certificate UI elements have been removed from the GCP Console, and these legacy authentication methods are disabled by default. No Console action is required for current GKE versions.
 
             For older clusters still using legacy authentication, use the gcloud CLI to disable basic auth:
 
@@ -18664,9 +18290,7 @@ queries:
             ```
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Disable basic auth and client certificates on an existing cluster:
+            To ensure GKE legacy client authentication is disabled using the gcloud CLI, disable basic auth and client certificates on an existing cluster:
 
             ```bash
             gcloud container clusters update <cluster-name> \
@@ -18682,9 +18306,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Disable legacy authentication in your GKE cluster:
+            To ensure GKE legacy client authentication is disabled in Terraform, disable legacy authentication in your GKE cluster:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -18768,7 +18390,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE node auto-upgrade is enabled using the Google Cloud Console:
 
             1. Navigate to **Kubernetes Engine** > **Clusters**.
             2. Select the cluster.
@@ -18778,9 +18400,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Enable auto-upgrade on a node pool:
+            To ensure GKE node auto-upgrade is enabled using the gcloud CLI, enable auto-upgrade on a node pool:
 
             ```bash
             gcloud container node-pools update <pool-name> \
@@ -18789,9 +18409,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable auto-upgrade in the node pool management block:
+            To ensure GKE node auto-upgrade is enabled in Terraform, enable auto-upgrade in the node pool management block:
 
             ```hcl
             resource "google_container_node_pool" "example" {
@@ -18868,7 +18486,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE node auto-repair is enabled using the Google Cloud Console:
 
             1. Navigate to **Kubernetes Engine** > **Clusters**.
             2. Select the cluster.
@@ -18878,9 +18496,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Enable auto-repair on a node pool:
+            To ensure GKE node auto-repair is enabled using the gcloud CLI, enable auto-repair on a node pool:
 
             ```bash
             gcloud container node-pools update <pool-name> \
@@ -18889,9 +18505,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable auto-repair in the node pool management block:
+            To ensure GKE node auto-repair is enabled in Terraform, enable auto-repair in the node pool management block:
 
             ```hcl
             resource "google_container_node_pool" "example" {
@@ -18968,7 +18582,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE nodes use a dedicated service account using the Google Cloud Console:
 
             1. Create a dedicated service account in **IAM & Admin** > **Service Accounts**.
             2. Grant the service account only the roles needed for GKE nodes (e.g., `roles/logging.logWriter`, `roles/monitoring.metricWriter`, `roles/artifactregistry.reader`).
@@ -18977,9 +18591,7 @@ queries:
             **Note:** Existing node pools cannot have their service account changed. You must create a new node pool with the dedicated service account, migrate workloads to the new pool, and then delete the old node pool.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Create a dedicated service account and use it for a node pool:
+            To ensure GKE nodes use a dedicated service account using the gcloud CLI, create a dedicated service account and use it for a node pool:
 
             ```bash
             gcloud iam service-accounts create gke-nodes \
@@ -18991,9 +18603,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Specify a dedicated service account in the node config:
+            To ensure GKE nodes use a dedicated service account in Terraform, specify a dedicated service account in the node config:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -19079,9 +18689,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            VPC-native mode must be set at cluster creation:
+            To ensure GKE clusters use VPC-native IP aliasing using the Google Cloud Console, VPC-native mode must be set at cluster creation:
 
             1. Go to **Kubernetes Engine** > **Clusters** > **Create**.
             2. In the **Networking** section, ensure **VPC-native** is selected.
@@ -19091,9 +18699,7 @@ queries:
             **Note:** Existing non-VPC-native (routes-based) clusters cannot be migrated to VPC-native mode. You must create a new VPC-native cluster, migrate workloads, and decommission the old cluster.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            VPC-native mode must be set at cluster creation and cannot be changed later:
+            To ensure GKE clusters use VPC-native IP aliasing using the gcloud CLI, VPC-native mode must be set at cluster creation and cannot be changed later:
 
             ```bash
             gcloud container clusters create <cluster-name> \
@@ -19103,9 +18709,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable VPC-native mode with an `ip_allocation_policy` block:
+            To ensure GKE clusters use VPC-native IP aliasing in Terraform, enable VPC-native mode with an `ip_allocation_policy` block:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -19179,7 +18783,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE nodes use Container-Optimized OS using the Google Cloud Console:
 
             1. Navigate to **Kubernetes Engine** > **Clusters**.
             2. Select the cluster and click the **Nodes** tab.
@@ -19188,9 +18792,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Update a node pool to use COS:
+            To ensure GKE nodes use Container-Optimized OS using the gcloud CLI, update a node pool to use COS:
 
             ```bash
             gcloud container node-pools update <pool-name> \
@@ -19199,9 +18801,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Specify COS as the image type in the node config:
+            To ensure GKE nodes use Container-Optimized OS in Terraform, specify COS as the image type in the node config:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -19287,7 +18887,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure Cloud SQL instances have automated backups enabled using the Google Cloud Console:
 
             1. Navigate to **SQL** > **Instances**.
             2. Select the instance.
@@ -19297,9 +18897,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Enable automated backups:
+            To ensure Cloud SQL instances have automated backups enabled using the gcloud CLI, enable automated backups:
 
             ```bash
             gcloud sql instances patch <instance-name> \
@@ -19307,9 +18905,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable automated backups in the settings block:
+            To ensure Cloud SQL instances have automated backups enabled in Terraform, enable automated backups in the settings block:
 
             ```hcl
             resource "google_sql_database_instance" "example" {
@@ -19397,7 +18993,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure cross-database ownership chaining is disabled using the Google Cloud Console:
 
             1. Navigate to **SQL** > **Instances**.
             2. Select the SQL Server instance.
@@ -19406,7 +19002,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
+            To ensure cross-database ownership chaining is disabled using the gcloud CLI:
 
             ```bash
             gcloud sql instances patch <instance-name> \
@@ -19414,9 +19010,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the database flag in the settings block:
+            To ensure cross-database ownership chaining is disabled in Terraform, set the database flag in the settings block:
 
             ```hcl
             resource "google_sql_database_instance" "sqlserver" {
@@ -19514,7 +19108,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure contained database authentication is disabled using the Google Cloud Console:
 
             1. Navigate to **SQL** > **Instances**.
             2. Select the SQL Server instance.
@@ -19523,7 +19117,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
+            To ensure contained database authentication is disabled using the gcloud CLI:
 
             ```bash
             gcloud sql instances patch <instance-name> \
@@ -19531,9 +19125,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the database flag in the settings block:
+            To ensure contained database authentication is disabled in Terraform, set the database flag in the settings block:
 
             ```hcl
             resource "google_sql_database_instance" "sqlserver" {
@@ -19630,7 +19222,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure 'log_lock_waits' is enabled for Cloud SQL PostgreSQL using the Google Cloud Console:
 
             1. Navigate to **SQL** > **Instances**.
             2. Select the PostgreSQL instance.
@@ -19639,7 +19231,7 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
+            To ensure 'log_lock_waits' is enabled for Cloud SQL PostgreSQL using the gcloud CLI:
 
             ```bash
             gcloud sql instances patch <instance-name> \
@@ -19647,9 +19239,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Set the database flag in the settings block:
+            To ensure 'log_lock_waits' is enabled for Cloud SQL PostgreSQL in Terraform, set the database flag in the settings block:
 
             ```hcl
             resource "google_sql_database_instance" "postgres" {
@@ -19745,16 +19335,14 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure firewall rules do not allow full port range access using the Google Cloud Console:
 
             1. Navigate to **VPC Network** > **Firewall**.
             2. Identify rules with source range `0.0.0.0/0` or `::/0` that allow large port ranges.
             3. Edit the rule to restrict to only the specific ports required (e.g., `80`, `443`).
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            List internet-facing ingress rules:
+            To ensure firewall rules do not allow full port range access using the gcloud CLI, list internet-facing ingress rules:
 
             ```bash
             gcloud compute firewall-rules list \
@@ -19770,9 +19358,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure firewall rules use specific ports instead of large ranges:
+            To ensure firewall rules do not allow full port range access in Terraform, ensure firewall rules use specific ports instead of large ranges:
 
             ```hcl
             resource "google_compute_firewall" "allow_web" {
@@ -19874,7 +19460,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure default network firewall rules are restricted using the Google Cloud Console:
 
             1. Navigate to **VPC Network** > **Firewall**.
             2. Identify rules named `default-allow-*`.
@@ -19882,9 +19468,7 @@ queries:
             4. Create replacement rules that allow only the specific traffic required.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            List default rules:
+            To ensure default network firewall rules are restricted using the gcloud CLI, list default rules:
 
             ```bash
             gcloud compute firewall-rules list --filter="name~'^default-allow'"
@@ -19903,9 +19487,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Avoid using the default network and its auto-created rules. Create a custom VPC with explicit firewall rules:
+            To ensure default network firewall rules are restricted in Terraform, avoid using the default network and its auto-created rules. Create a custom VPC with explicit firewall rules:
 
             ```hcl
             resource "google_compute_network" "custom" {
@@ -19997,9 +19579,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            CSEK must be specified at disk creation time and cannot be added to existing disks.
+            To ensure Compute Engine disks are encrypted with CSEK using the Google Cloud Console, CSEK must be specified at disk creation time and cannot be added to existing disks.
 
             1. Navigate to **Compute Engine** > **Disks** > **Create disk**.
             2. Under **Encryption**, select **Customer-supplied key**.
@@ -20007,9 +19587,7 @@ queries:
             4. Select **Create**.
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Create a disk with a customer-supplied encryption key:
+            To ensure Compute Engine disks are encrypted with CSEK using the gcloud CLI, create a disk with a customer-supplied encryption key:
 
             ```bash
             gcloud compute disks create <disk-name> \
@@ -20020,9 +19598,7 @@ queries:
             The key file is a JSON file containing the base64-encoded 256-bit AES key.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Specify a customer-supplied encryption key when creating a disk:
+            To ensure Compute Engine disks are encrypted with CSEK in Terraform, specify a customer-supplied encryption key when creating a disk:
 
             ```hcl
             resource "google_compute_disk" "example" {
@@ -20105,9 +19681,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Update a node pool to use the GKE Metadata Server:
+            To ensure GKE workload metadata concealment is enabled using the gcloud CLI, update a node pool to use the GKE Metadata Server:
 
             ```bash
             gcloud container node-pools update <pool-name> \
@@ -20124,7 +19698,7 @@ queries:
             ```
         - id: console
           desc: |
-            **Using Google Cloud Console**
+            To ensure GKE workload metadata concealment is enabled using the Google Cloud Console:
 
             1. Navigate to **Kubernetes Engine** > **Clusters**.
             2. Select the cluster and click the **Nodes** tab.
@@ -20133,9 +19707,7 @@ queries:
             5. Select **Save**.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure workload metadata mode in the node config:
+            To ensure GKE workload metadata concealment is enabled in Terraform, configure workload metadata mode in the node config:
 
             ```hcl
             resource "google_container_cluster" "example" {
@@ -20226,9 +19798,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            **Using gcloud CLI**
-
-            Enable private endpoint on an existing cluster:
+            To ensure GKE control plane uses a private endpoint using the gcloud CLI, enable private endpoint on an existing cluster:
 
             ```bash
             gcloud container clusters update <cluster-name> \
@@ -20247,9 +19817,7 @@ queries:
             Note: Enabling the private endpoint requires that all API access come from within the VPC or through authorized networks.
         - id: console
           desc: |
-            **Using Google Cloud Console**
-
-            Private endpoint can be configured at cluster creation or enabled on an existing cluster:
+            To ensure GKE control plane uses a private endpoint using the Google Cloud Console, private endpoint can be configured at cluster creation or enabled on an existing cluster:
 
             **For new clusters:**
 
@@ -20268,9 +19836,7 @@ queries:
             **Warning:** Enabling the private endpoint on an existing cluster will remove public API access. Ensure all API clients can reach the control plane via the VPC before making this change.
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable the private endpoint in the private cluster config:
+            To ensure GKE control plane uses a private endpoint in Terraform, enable the private endpoint in the private cluster config:
 
             ```hcl
             resource "google_container_cluster" "example" {

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -88,22 +88,22 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To enable MFA for IAM users using the OCI Console:
 
-            1. Sign in to the OCI Console.
-            2. Navigate to **Identity & Security > Users**.
-            3. Select the user.
-            4. Under **Resources**, select **Multi-Factor Authentication**.
-            5. Select **Enable Multi-Factor Authentication** and follow the setup instructions.
+            1. Navigate to **Identity & Security > Users**.
+            2. Select the user.
+            3. Under **Resources**, select **Multi-Factor Authentication**.
+            4. Select **Enable Multi-Factor Authentication** and follow the setup instructions.
+            5. Repeat for each active user that does not have MFA enabled.
         - id: cli
           desc: |
-            **Using OCI CLI**
-
-            MFA must be enabled by each user through the Console. Administrators can verify MFA status:
+            MFA must be enabled by each user through the Console. To identify users without MFA using the OCI CLI, list their MFA status:
 
             ```bash
             oci iam user list --query "data[?\"is-mfa-activated\"==\`false\`].{Name:name, MFA:\"is-mfa-activated\"}" --output table
             ```
+
+            Contact each listed user and direct them to enable MFA through their OCI Console profile settings.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/usingmfa.htm
         title: CIS OCI Foundations Benchmark 1.7
@@ -139,22 +139,20 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To verify IAM user email addresses using the OCI Console:
 
             1. Navigate to **Identity & Security > Users**.
             2. Identify users with unverified email addresses.
             3. Contact those users and ask them to verify their email through their user profile settings.
         - id: cli
           desc: |
-            **Using OCI CLI**
-
-            List active users with unverified email addresses:
+            To identify users with unverified email addresses using the OCI CLI, list their verification status:
 
             ```bash
             oci iam user list --query "data[?\"lifecycle-state\"=='ACTIVE' && \"email-verified\"==\`false\` && email!=null].{Name:name, Email:email, Verified:\"email-verified\"}" --output table
             ```
 
-            Contact identified users and ask them to verify their email through the OCI Console.
+            Contact each listed user and ask them to verify their email through the OCI Console.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingusers.htm
         title: OCI IAM user management
@@ -206,11 +204,11 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To replace overly permissive IAM policies with scoped policies using the OCI Console:
 
-            1. Navigate to **Identity & Security > Policies** in the OCI Console.
+            1. Navigate to **Identity & Security > Policies**.
             2. Identify policies containing `manage all-resources in tenancy`.
-            3. Replace with scoped policies:
+            3. Replace with scoped policies that grant access to specific resource types in specific compartments:
 
             ```
             # Instead of:
@@ -222,15 +220,13 @@ queries:
             ```
         - id: cli
           desc: |
-            **Using OCI CLI**
-
-            List all policies and identify overly permissive statements:
+            To identify and replace overly permissive IAM policies using the OCI CLI, start by listing all policies in the tenancy:
 
             ```bash
             oci iam policy list --compartment-id TENANCY_OCID --all --query "data[].{Name:name, Statements:statements}" --output table
             ```
 
-            Update a policy to use scoped statements:
+            Review the output for any statements containing `manage all-resources in tenancy`. For each match, update the policy to use compartment-scoped statements with specific resource types:
 
             ```bash
             oci iam policy update --policy-id POLICY_OCID \
@@ -238,9 +234,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define scoped IAM policies in your Terraform configuration instead of granting `manage all-resources in tenancy`:
+            To enforce scoped IAM policies in Terraform, define policies that grant access to specific resource types in specific compartments instead of `manage all-resources in tenancy`:
 
             ```hcl
             resource "oci_identity_policy" "network_admins" {
@@ -324,23 +318,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To remove active API keys from inactive users using the OCI Console:
 
             1. Navigate to **Identity & Security > Users**.
             2. Select the inactive user.
             3. Under **Resources**, select **API Keys**.
-            4. Delete active API keys.
+            4. Delete all active API keys associated with the user.
         - id: cli
           desc: |
-            **Using OCI CLI**
-
-            List API keys for an inactive user:
+            To remove active API keys from inactive users using the OCI CLI, start by listing the keys for the user:
 
             ```bash
             oci iam user api-key list --user-id USER_OCID
             ```
 
-            Delete an active API key:
+            For each key with an `ACTIVE` state, delete it by specifying its fingerprint:
 
             ```bash
             oci iam user api-key delete --user-id USER_OCID --fingerprint KEY_FINGERPRINT
@@ -382,23 +374,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To remove active auth tokens from inactive users using the OCI Console:
 
             1. Navigate to **Identity & Security > Users**.
             2. Select the inactive user.
             3. Under **Resources**, select **Auth Tokens**.
-            4. Delete active auth tokens.
+            4. Delete all active auth tokens associated with the user.
         - id: cli
           desc: |
-            **Using OCI CLI**
-
-            List auth tokens for an inactive user:
+            To remove active auth tokens from inactive users using the OCI CLI, start by listing the tokens for the user:
 
             ```bash
             oci iam auth-token list --user-id USER_OCID
             ```
 
-            Delete an active auth token:
+            For each token with an `ACTIVE` state, delete it:
 
             ```bash
             oci iam auth-token delete --user-id USER_OCID --auth-token-id TOKEN_OCID
@@ -457,25 +447,23 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To restrict public access on an Object Storage bucket using the OCI Console:
 
             1. Navigate to **Object Storage > Buckets**.
-            2. Select the bucket.
+            2. Select the bucket identified in this finding.
             3. Select **Edit Visibility**.
             4. Set visibility to **Private**.
             5. Select **Save Changes**.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To restrict public access on an Object Storage bucket using the OCI CLI, set the access type to `NoPublicAccess`:
 
             ```bash
             oci os bucket update --bucket-name BUCKET_NAME --public-access-type NoPublicAccess
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Ensure the `access_type` is set to `NoPublicAccess` in your Terraform configuration:
+            To restrict public access on an Object Storage bucket in Terraform, set the `access_type` to `NoPublicAccess`:
 
             ```hcl
             resource "oci_objectstorage_bucket" "example" {
@@ -561,25 +549,23 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To enable versioning on an Object Storage bucket using the OCI Console:
 
             1. Navigate to **Object Storage > Buckets**.
-            2. Select the bucket.
+            2. Select the bucket identified in this finding.
             3. Select **Edit Versioning**.
             4. Enable versioning.
             5. Select **Save Changes**.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To enable versioning on an Object Storage bucket using the OCI CLI, update the bucket's versioning setting:
 
             ```bash
             oci os bucket update --bucket-name BUCKET_NAME --versioning Enabled
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable versioning on the bucket in your Terraform configuration:
+            To enable versioning on an Object Storage bucket in Terraform, set the `versioning` attribute to `Enabled`:
 
             ```hcl
             resource "oci_objectstorage_bucket" "example" {
@@ -665,25 +651,23 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To enable object event logging on an Object Storage bucket using the OCI Console:
 
             1. Navigate to **Object Storage > Buckets**.
-            2. Select the bucket.
+            2. Select the bucket identified in this finding.
             3. Select **Edit**.
             4. Enable **Emit Object Events**.
             5. Select **Save Changes**.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To enable object event logging on an Object Storage bucket using the OCI CLI, update the bucket's event setting:
 
             ```bash
             oci os bucket update --bucket-name BUCKET_NAME --object-events-enabled true
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Enable object event logging in your Terraform configuration:
+            To enable object event logging on an Object Storage bucket in Terraform, set the `object_events_enabled` attribute to `true`:
 
             ```hcl
             resource "oci_objectstorage_bucket" "example" {
@@ -766,26 +750,24 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To assign a customer-managed encryption key to an Object Storage bucket using the OCI Console:
 
             1. Navigate to **Object Storage > Buckets**.
-            2. Select the bucket.
+            2. Select the bucket identified in this finding.
             3. Select **Assign** next to Encryption Key.
             4. Choose **Encrypt using customer-managed keys**.
             5. Select the vault, master encryption key, and key version.
             6. Select **Assign**.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To assign a customer-managed encryption key to an Object Storage bucket using the OCI CLI, update the bucket with the KMS key OCID:
 
             ```bash
             oci os bucket update --bucket-name BUCKET_NAME --kms-key-id KEY_OCID
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Configure a customer-managed encryption key for the bucket in your Terraform configuration:
+            To assign a customer-managed encryption key to an Object Storage bucket in Terraform, create a vault and key, then reference the key in the bucket resource:
 
             ```hcl
             resource "oci_kms_vault" "example" {
@@ -889,16 +871,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To restrict unrestricted ingress rules in a VCN security list using the OCI Console:
 
             1. Navigate to **Networking > Virtual Cloud Networks**.
             2. Select the VCN.
             3. Select **Security Lists**.
             4. Select the security list with the overly permissive rule.
-            5. Edit or remove the ingress rule that allows all protocols from 0.0.0.0/0.
+            5. Edit or remove the ingress rule that allows all protocols from 0.0.0.0/0, replacing it with rules for specific protocols, ports, and trusted source CIDR blocks.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To restrict unrestricted ingress rules in a VCN security list using the OCI CLI, update the security list with scoped rules that specify protocols, ports, and trusted source CIDR blocks:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
@@ -906,9 +888,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define security list ingress rules with specific protocols and restricted source CIDR blocks instead of allowing all traffic from 0.0.0.0/0:
+            To restrict unrestricted ingress in a VCN security list in Terraform, define ingress rules with specific protocols, port ranges, and restricted source CIDR blocks instead of allowing all traffic from 0.0.0.0/0:
 
             ```hcl
             resource "oci_core_security_list" "example" {
@@ -1008,16 +988,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To restrict unrestricted TCP ingress rules in a VCN security list using the OCI Console:
 
             1. Navigate to **Networking > Virtual Cloud Networks**.
             2. Select the VCN.
             3. Select **Security Lists**.
             4. Select the security list.
-            5. Edit TCP ingress rules from 0.0.0.0/0 to specify destination port ranges.
+            5. Edit TCP ingress rules from 0.0.0.0/0 to specify destination port ranges, allowing only the ports required for your workload.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To restrict unrestricted TCP ingress rules in a VCN security list using the OCI CLI, update the security list with rules that include specific port ranges:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
@@ -1025,9 +1005,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Always specify `tcp_options` with port ranges when allowing TCP ingress from 0.0.0.0/0:
+            To restrict unrestricted TCP ingress in a VCN security list in Terraform, always specify `tcp_options` with explicit port ranges:
 
             ```hcl
             resource "oci_core_security_list" "example" {
@@ -1135,16 +1113,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using OCI Console**
+            To restrict unrestricted egress rules in a VCN security list using the OCI Console:
 
             1. Navigate to **Networking > Virtual Cloud Networks**.
             2. Select the VCN.
             3. Select **Security Lists**.
             4. Select the security list.
-            5. Edit egress rules to restrict destination and protocol.
+            5. Edit egress rules to specify destination CIDR blocks and protocols, replacing any rule that allows all traffic to 0.0.0.0/0.
         - id: cli
           desc: |
-            **Using OCI CLI**
+            To restrict unrestricted egress rules in a VCN security list using the OCI CLI, update the security list with scoped rules that specify destinations and protocols:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
@@ -1152,9 +1130,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform**
-
-            Define egress rules with specific destination CIDR blocks and protocols instead of allowing all traffic to 0.0.0.0/0:
+            To restrict unrestricted egress in a VCN security list in Terraform, define egress rules with specific destination CIDR blocks and protocols instead of allowing all traffic to 0.0.0.0/0:
 
             ```hcl
             resource "oci_core_security_list" "example" {


### PR DESCRIPTION
## Summary
- Replace redundant bold method headers (`**Using AWS Console**`, `**Using Terraform**`, etc.) in remediation tabs with contextual intro sentences that state the remediation goal and method together
- Example: `**Using AWS Console**` followed by steps becomes `To ensure MFA is enabled using the AWS Console:` followed by steps
- The tab label already communicates the method, so the bold header was noise — the new format gives the user immediate context on what they're about to do
- Applies to all remediation sections across AWS, Azure, GCP, and OCI security policies (~600+ remediation sections)
- Non-remediation bold headers (in `audit:` and `docs.desc:` blocks) are preserved

## Test plan
- [x] `cnspec policy lint` passes on all 4 modified files
- [ ] Verify remediation tabs render correctly in the UI
- [ ] Spot-check intro sentences read naturally across a sample of checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)