### PR TITLE
:bug: correct remaining invalid Azure CLI commands in remediation steps

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3073,7 +3073,7 @@ queries:
           Run the following command to check the notification settings for high severity alerts. Make sure the output is set to `true`, indicating that notifications for high severity alerts are enabled.
 
           ```bash
-          az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --out tsv | xargs -L1 bash -c 'curl -X GET -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://management.azure.com/subscriptions/$0/providers/Microsoft.Security/securityContacts?api-version=2020-01-01-preview' | jq '.|.[] | select(.name=="default")'|jq '.properties.alertNotifications'
+          az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --output tsv | xargs -L1 bash -c 'curl -X GET -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://management.azure.com/subscriptions/$0/providers/Microsoft.Security/securityContacts?api-version=2020-01-01-preview' | jq '.|.[] | select(.name=="default")'|jq '.properties.alertNotifications'
           ```
       remediation:
         - id: portal
@@ -3091,7 +3091,7 @@ queries:
             To ensure that "Notify about alerts with high severity" is enabled using the Azure CLI, use the following command to update the security contact settings to enable high severity alert notifications. Replace `<Your_Subscription_Id>` and `<validEmailAddress>` with the appropriate values.
 
               ```bash
-              az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --out tsv | xargs -L1 bash -c 'curl -X PUT -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://management.azure.com/subscriptions/<$0>/providers/Microsoft.Security/securityContacts/default1?api-version=2017-08-01-preview -d "@input.json"'
+              az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --output tsv | xargs -L1 bash -c 'curl -X PUT -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://management.azure.com/subscriptions/<$0>/providers/Microsoft.Security/securityContacts/default1?api-version=2017-08-01-preview -d "@input.json"'
               ```
 
               Ensure the `input.json` file contains the following data, with `<validEmailAddress>` replaced with your contact email:
@@ -8727,7 +8727,7 @@ queries:
             To ensure Container Insights monitoring is enabled for AKS clusters using the Azure CLI:
 
             ```bash
-            az aks enable-addons --addon monitoring --name <ClusterName> --resource-group <ResourceGroupName>
+            az aks enable-addons --addons monitoring --name <ClusterName> --resource-group <ResourceGroupName>
             ```
         - id: terraform
           desc: |
@@ -8853,7 +8853,7 @@ queries:
             To ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters using the Azure CLI:
 
             ```bash
-            az aks enable-addons --addon azure-keyvault-secrets-provider --name <ClusterName> --resource-group <ResourceGroupName>
+            az aks enable-addons --addons azure-keyvault-secrets-provider --name <ClusterName> --resource-group <ResourceGroupName>
             ```
         - id: terraform
           desc: |
@@ -22208,7 +22208,7 @@ queries:
 
             ```bash
             az sql server audit-policy update \
-              --resource-group <rg> --server <server> \
+              --resource-group <rg> --name <server> \
               --state Enabled --retention-days 90 \
               --storage-account <storage-account-id>
             ```
@@ -23660,13 +23660,14 @@ queries:
             To ensure Data Factory uses customer-managed key encryption using the Azure CLI:
 
             ```bash
-            az datafactory update \
+            az resource update \
               --resource-group <resource-group-name> \
-              --factory-name <data-factory-name> \
-              --encryption-vault-base-url "https://<key-vault-name>.vault.azure.net" \
-              --encryption-key-name "<key-name>" \
-              --encryption-key-version "<key-version>" \
-              --encryption-identity "<user-assigned-identity-resource-id>"
+              --name <data-factory-name> \
+              --resource-type Microsoft.DataFactory/factories \
+              --set properties.encryption.vaultBaseUrl="https://<key-vault-name>.vault.azure.net" \
+                   properties.encryption.keyName="<key-name>" \
+                   properties.encryption.keyVersion="<key-version>" \
+                   properties.encryption.identity.userAssignedIdentity="<user-assigned-identity-resource-id>"
             ```
         - id: terraform
           desc: |
@@ -23792,10 +23793,11 @@ queries:
             To ensure Data Factory uses managed identity using the Azure CLI:
 
             ```bash
-            az datafactory update \
+            az resource update \
               --resource-group <resource-group-name> \
-              --factory-name <data-factory-name> \
-              --identity-type "SystemAssigned"
+              --name <data-factory-name> \
+              --resource-type Microsoft.DataFactory/factories \
+              --set identity.type="SystemAssigned"
             ```
         - id: terraform
           desc: |
@@ -23910,10 +23912,11 @@ queries:
             To ensure Synapse Analytics disables public network access using the Azure CLI:
 
             ```bash
-            az synapse workspace update \
+            az resource update \
               --resource-group <resource-group-name> \
               --name <workspace-name> \
-              --public-network-access "Disabled"
+              --resource-type Microsoft.Synapse/workspaces \
+              --set properties.publicNetworkAccess="Disabled"
             ```
         - id: terraform
           desc: |
@@ -24047,7 +24050,7 @@ queries:
               --file-system <filesystem-name> \
               --sql-admin-login-user <admin-user> \
               --sql-admin-login-password <admin-password> \
-              --managed-virtual-network "default"
+              --enable-managed-virtual-network true
             ```
         - id: terraform
           desc: |
@@ -24180,10 +24183,9 @@ queries:
               --object-id <admin-object-id>
 
             # Enable Azure AD-only authentication
-            az synapse workspace update \
-              --resource-group <resource-group-name> \
-              --name <workspace-name> \
-              --azure-ad-only-auth true
+            az synapse ad-only-auth enable \
+              --resource-group-name <resource-group-name> \
+              --workspace-name <workspace-name>
             ```
         - id: terraform
           desc: |
@@ -24317,12 +24319,16 @@ queries:
             To ensure Synapse uses customer-managed key encryption using the Azure CLI:
 
             ```bash
-            az synapse workspace update \
-              --resource-group <resource-group-name> \
-              --name <workspace-name> \
+            az synapse workspace key create \
+              --resource-group-name <resource-group-name> \
+              --workspace-name <workspace-name> \
               --key-name "cmk" \
-              --encryption-key-name "<key-vault-key-name>" \
-              --encryption-key-identifier "https://<key-vault-name>.vault.azure.net/keys/<key-name>/<key-version>"
+              --key-identifier "https://<key-vault-name>.vault.azure.net/keys/<key-name>/<key-version>"
+
+            az synapse workspace activate \
+              --resource-group-name <resource-group-name> \
+              --workspace-name <workspace-name> \
+              --key-name "cmk"
             ```
         - id: terraform
           desc: |


### PR DESCRIPTION
## Summary
- Fix invalid Azure CLI flags for Synapse commands (`--resource-group` → `--resource-group-name`, `--name` → `--key-name`, use correct subcommands like `az synapse ad-only-auth enable`)
- Fix Data Factory commands to use `az resource update` instead of non-existent `az datafactory update` flags
- Fix `--out` → `--output`, `--addon` → `--addons`, `--server` → `--name` in various AKS, SQL, and security contact commands
- Fix Synapse workspace create `--managed-virtual-network` → `--enable-managed-virtual-network`

## Test plan
- [x] All commands validated against Azure CLI command schema (`validate_remediation_commands.py azure` passes with 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)