### PR TITLE
Add NOTE comment for check missing CLI remediation

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -8987,6 +8987,9 @@ queries:
         - Prevents credential leakage by enforcing secure authentication methods.
         - Ensures compliance with security best practices for infrastructure as code.
         - Reduces the attack surface by eliminating static credentials from codebases.
+      # NOTE (2026-03-29): CLI remediation not included because this is a Terraform-specific check
+      # about removing hard-coded credentials from provider blocks. The fix requires editing
+      # Terraform configuration files, not running AWS CLI commands.
       remediation:
         - id: console
           desc: |


### PR DESCRIPTION
## Summary
- Adds a dated `# NOTE (2026-03-29)` comment to `mondoo-aws-security-no-static-credentials-in-providers` explaining why CLI remediation is not included
- This is the only check across all 4 cloud policy files (AWS, Azure, GCP, OCI) that lacks CLI remediation — it is a Terraform-specific check about removing hard-coded credentials from provider blocks, so the fix requires editing Terraform files, not running AWS CLI commands

## Test plan
- [ ] Verify YAML validity of `content/mondoo-aws-security.mql.yaml`
- [ ] Confirm the comment is correctly placed above the `remediation:` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)