### PR TITLE
fix: rename mondoo.com/icon to mondoo.com/filter-icon in variant tags

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -514,23 +514,23 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EKS clusters are configured to use AWS Key Management Service (KMS) for encryption of Kubernetes secrets. By default, EKS uses a default KMS key for encryption, but organizations can create and manage their own customer-managed keys (CMKs) for enhanced security and compliance.
@@ -679,19 +679,19 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-private-controlplane-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-private-controlplane-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-private-controlplane-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-private-controlplane-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       refs:
         - url: https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html
@@ -815,19 +815,19 @@ queries:
       - uid: mondoo-aws-security-iam-root-access-key-check-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-root-access-key-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-root-access-key-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-root-access-key-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the AWS root user account does not have an active access key. The AWS root user has full administrative privileges over the AWS account, making it the most powerful identity in AWS. AWS best practices recommend that root user credentials should never be used for everyday operations, and instead, AWS Identity and Access Management (IAM) users or roles should be utilized for all administrative tasks.
@@ -955,19 +955,19 @@ queries:
       - uid: mondoo-aws-security-root-account-mfa-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-root-account-mfa-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-root-account-mfa-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-root-account-mfa-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Multi-Factor Authentication (MFA) is enabled for the AWS root user account. The root user has full administrative privileges over an AWS account, making it the most critical identity. Enabling MFA significantly enhances security by requiring an additional authentication factor beyond just the password.
@@ -1142,19 +1142,19 @@ queries:
       - uid: mondoo-aws-security-iam-password-policy-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-password-policy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-password-policy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-password-policy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS accounts enforce a strong IAM password policy to enhance security by preventing weak or easily guessable passwords. A well-defined password policy helps protect against brute-force attacks, credential stuffing, and unauthorized access.
@@ -1330,11 +1330,11 @@ queries:
       - uid: mondoo-aws-security-access-keys-rotated-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-access-keys-rotated-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS IAM user access keys are regularly rotated to reduce the risk of credential compromise. Access keys should be changed periodically to prevent long-term exposure and limit the impact of potential key leaks. AWS best practices recommend rotating IAM access keys every 90 days or less.
@@ -1460,19 +1460,19 @@ queries:
       - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all AWS IAM users with console access have Multi-Factor Authentication (MFA) enabled. MFA provides an additional layer of security beyond just a username and password, reducing the risk of unauthorized account access in case credentials are compromised.
@@ -1633,19 +1633,19 @@ queries:
       - uid: mondoo-aws-security-iam-group-has-users-check-aws
         tags:
           mondoo.com/filter-title: AWS IAM Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-group-has-users-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-group-has-users-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-group-has-users-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that IAM groups in AWS have at least one assigned user. IAM groups help manage permissions efficiently by allowing administrators to assign policies at the group level instead of managing permissions for individual IAM users. If IAM groups exist without any users, it indicates potential misconfigurations or unused access controls.
@@ -1791,19 +1791,19 @@ queries:
       - uid: mondoo-aws-security-iam-users-only-one-access-key-aws
         tags:
           mondoo.com/filter-title: AWS IAM User
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-users-only-one-access-key-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-users-only-one-access-key-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-users-only-one-access-key-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that each AWS IAM user has no more than one active access key. IAM users can have up to two access keys, but maintaining multiple active keys increases the risk of credential leakage and unauthorized access if one of the keys is compromised. Best practices dictate that only one active key should exist per IAM user to reduce attack surfaces and ensure proper key management.
@@ -1959,19 +1959,19 @@ queries:
       - uid: mondoo-aws-security-iam-user-no-inline-policies-check-aws
         tags:
           mondoo.com/filter-title: AWS IAM User
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS IAM users do not have directly attached policies and instead receive permissions exclusively through IAM groups. Assigning permissions via groups simplifies access management, enforces least privilege principles, and reduces the risk of misconfigured permissions at the individual user level.
@@ -2146,23 +2146,23 @@ queries:
       - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
         tags:
           mondoo.com/filter-title: AWS EC2 Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-vpc-default-security-group-closed-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-default-security-group-closed-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-default-security-group-closed-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-default-security-group-closed-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that the default security group (SG) for every AWS Virtual Private Cloud (VPC) is configured to restrict all inbound and outbound traffic. By default, AWS creates a default security group for each VPC, which allows unrestricted communication between instances associated with the group. This can pose a significant security risk if not properly restricted.
@@ -2297,19 +2297,19 @@ queries:
       - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) volume encryption is enabled by default in an AWS account. Enabling default encryption ensures that all newly created EBS volumes are encrypted automatically using AWS Key Management Service (KMS) keys. This eliminates the risk of unencrypted volumes being created inadvertently.
@@ -2423,19 +2423,19 @@ queries:
       - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon S3 Public Access Block settings are enabled at the account level to prevent accidental or intentional exposure of data stored in S3 buckets. Enforcing this setting at the account level ensures that no S3 bucket or object can be made public, even if bucket policies or ACLs attempt to allow public access.
@@ -2562,23 +2562,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-bucket
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that each Amazon S3 bucket has public access restrictions enforced to prevent unauthorized exposure of sensitive data. While account-level public access block settings provide a broad safeguard, bucket-level controls ensure that no individual bucket is unintentionally exposed due to misconfigurations in bucket policies, ACLs, or object permissions.
@@ -2803,23 +2803,23 @@ queries:
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EC2 instances do not have public IP addresses to prevent unintended exposure of cloud resources to the internet. Instances with public IPs can be directly accessed from the internet, increasing the risk of security breaches, unauthorized access, and potential data exfiltration.
@@ -2958,23 +2958,23 @@ queries:
       - uid: mondoo-aws-security-ec2-imdsv2-check-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-imdsv2-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imdsv2-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imdsv2-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imdsv2-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EC2 instances are configured to use Instance Metadata Service Version 2 (IMDSv2) instead of IMDSv1. IMDSv2 provides enhanced security by requiring session-based authentication using a token, reducing the risk of metadata theft and credential exposure.
@@ -3109,19 +3109,19 @@ queries:
       - uid: mondoo-aws-security-vpc-bpa-enabled-aws
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-vpc-bpa-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-bpa-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-bpa-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Virtual Private Cloud (VPC) Block Public Access (BPA) is enabled on all VPCs to prevent accidental exposure of resources to the internet. VPC BPA provides a centralized control to block the creation of Internet Gateways, public route table entries, and public security group rules, thereby preventing resources within the VPC from becoming publicly accessible.
@@ -3256,23 +3256,23 @@ queries:
       - uid: mondoo-aws-security-vpc-flow-logs-enabled-aws
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-vpc-flow-logs-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-flow-logs-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-flow-logs-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-flow-logs-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Virtual Private Cloud (VPC) flow logs are enabled for all VPCs to capture network traffic metadata. VPC Flow Logs provide visibility into network traffic patterns, allowing security teams to monitor, detect anomalies, and investigate incidents such as unauthorized access, data exfiltration, and security breaches.
@@ -3423,23 +3423,23 @@ queries:
       - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-aws
         tags:
           mondoo.com/filter-title: AWS DynamoDB Table
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DynamoDB tables are encrypted using AWS Key Management Service (KMS) to protect sensitive data at rest. DynamoDB encryption at rest ensures that data is automatically encrypted before being written to disk and decrypted when read, preventing unauthorized access to stored information.
@@ -3618,23 +3618,23 @@ queries:
       - uid: mondoo-aws-security-lambda-concurrency-check-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-concurrency-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-concurrency-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-concurrency-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-concurrency-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Lambda functions are configured with function-level concurrent execution limits to prevent excessive resource consumption and throttle protection at the account level. By default, Lambda functions share the account-level concurrency limit, which can lead to resource exhaustion, affecting other critical workloads if a single function consumes too many concurrent executions.
@@ -3771,19 +3771,19 @@ queries:
       - uid: mondoo-aws-lambda-function-public-access-prohibited-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-lambda-function-public-access-prohibited-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-lambda-function-public-access-prohibited-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-lambda-function-public-access-prohibited-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Lambda functions have resource-based policies that explicitly prohibit public access. Resource-based policies control who can invoke or access Lambda functions, and improperly configured policies may inadvertently allow unauthorized users to trigger functions or access sensitive functionality and data.
@@ -4051,23 +4051,23 @@ queries:
       - uid: mondoo-aws-security-rds-instance-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-instance-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         Amazon RDS utilizes the widely adopted AES-256 encryption algorithm, a standard in the industry, to safeguard the data stored within your DB instances. This encryption secures your information directly on the server infrastructure where your Amazon RDS DB instance resides. After encryption is enabled, Amazon RDS automatically manages access authentication and data decryption without requiring manual intervention, ensuring a minimal effect on database performance.
@@ -4235,19 +4235,19 @@ queries:
       - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-parameter-group-ssl-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon RDS database clusters have encryption in transit enforced through the appropriate cluster parameter group settings. Specifically, this verifies that the parameter `ssl` is set to "1" which mandates TLS/SSL connections for all database communications, preventing any unencrypted connections to the instances of the cluster.
@@ -4603,23 +4603,23 @@ queries:
       - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         Amazon RDS utilizes the industry-standard AES-256 encryption algorithm to safeguard the data stored within your DB clusters. This encryption secures your information directly across the cluster's underlying storage volume. Once encryption is enabled for the cluster, Amazon RDS automatically manages access authentication and data decryption transparently, designed to ensure a minimal impact on overall cluster performance.
@@ -4825,19 +4825,19 @@ queries:
       - uid: mondoo-aws-security-rds-cluster-public-access-check-aws
         tags:
           mondoo.com/filter-title: AWS RDS Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-cluster-public-access-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-public-access-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-public-access-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Relational Database Service (RDS) clusters and cluster instances are not publicly accessible to prevent unauthorized access to sensitive databases. By default, RDS instances can be configured to allow public access, which exposes them to the internet, increasing the risk of security breaches, unauthorized data access, and potential data exfiltration.
@@ -5036,23 +5036,23 @@ queries:
       - uid: mondoo-aws-security-rds-instance-public-access-check-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-instance-public-access-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-public-access-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-public-access-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-public-access-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Relational Database Service (RDS) instances are not publicly accessible to prevent unauthorized access to sensitive databases. By default, RDS instances can be configured to allow public access, which exposes them to the internet, increasing the risk of security breaches, unauthorized data access, and potential data exfiltration.
@@ -5198,23 +5198,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters are not publicly accessible to prevent unauthorized access and potential data breaches. A publicly accessible Redshift cluster can be reached from the internet, exposing it to security threats, including brute-force attacks and data exfiltration.
@@ -5354,23 +5354,23 @@ queries:
       - uid: mondoo-aws-security-ec2-volume-inuse-check-aws
         tags:
           mondoo.com/filter-title: AWS EBS Volume
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-volume-inuse-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-volume-inuse-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-volume-inuse-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-volume-inuse-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) volumes attached to EC2 instances are configured to be automatically deleted when the instance is terminated. When an EBS volume is created and attached to an instance, the `DeleteOnTermination` attribute determines whether the volume persists after instance termination.
@@ -5502,19 +5502,19 @@ queries:
       - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-aws
         tags:
           mondoo.com/filter-title: AWS EBS Snapshot
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) snapshots are not configured to be publicly restorable. A public snapshot can be accessed by anyone, potentially exposing sensitive data. AWS provides fine-grained access controls for EBS snapshots, and by default, snapshots are private unless explicitly shared.
@@ -5617,19 +5617,19 @@ queries:
       - uid: mondoo-aws-security-ebs-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS EBS Snapshot
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ebs-snapshot-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ebs-snapshot-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ebs-snapshot-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) snapshots are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that snapshot contents are stored securely. AWS KMS provides centralized key management and integrates with EBS snapshots to automatically encrypt and decrypt data transparently.
@@ -5809,23 +5809,23 @@ queries:
       - uid: mondoo-aws-security-ec2-encrypted-volumes-aws
         tags:
           mondoo.com/filter-title: AWS EBS Volume
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-encrypted-volumes-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-encrypted-volumes-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-encrypted-volumes-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-encrypted-volumes-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) volumes are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that volume contents are stored securely. AWS KMS provides centralized key management and integrates with EBS to automatically encrypt and decrypt data transparently.
@@ -6059,23 +6059,23 @@ queries:
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-aws
         tags:
           mondoo.com/filter-title: AWS EBS Volume
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic Block Store (EBS) volumes are encrypted using AWS Key Management Service (KMS) rather than the default EBS-managed encryption. While both methods encrypt data at rest, KMS encryption provides significantly stronger security controls including centralized key management, fine-grained access policies via IAM, automatic key rotation, and full audit trails through AWS CloudTrail.
@@ -6244,23 +6244,23 @@ queries:
       - uid: mondoo-aws-security-efs-encrypted-check-aws
         tags:
           mondoo.com/filter-title: AWS EFS File System
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-efs-encrypted-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-encrypted-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-encrypted-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-encrypted-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic File System (EFS) is configured to encrypt file data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that files are stored securely. AWS KMS provides centralized key management and integrates with EFS to automatically encrypt and decrypt data transparently.
@@ -6394,23 +6394,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS CloudWatch Log Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudWatch log groups are configured to encrypt log data at rest using AWS Key Management Service (KMS) Customer-Managed Keys (CMKs). CloudWatch Logs store critical operational and security data, and encrypting them using CMKs enhances security by providing better control over key management and access policies.
@@ -6547,23 +6547,23 @@ queries:
       - uid: mondoo-aws-security-elb-security-policy-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Application Load Balancer
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elb-security-policy-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-security-policy-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-security-policy-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-security-policy-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Application Load Balancers (ALBs) are configured with secure Transport Layer Security (TLS) policies that enforce strong encryption protocols and cipher suites. TLS security policies define which protocols and ciphers are supported when establishing secure connections between clients and the load balancer, protecting data in transit from interception and tampering.
@@ -6733,23 +6733,23 @@ queries:
       - uid: mondoo-aws-security-elb-ssl-listener-aws
         tags:
           mondoo.com/filter-title: AWS Application Load Balancer
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elb-ssl-listener-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-ssl-listener-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-ssl-listener-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-ssl-listener-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Application Load Balancers (ALBs) are configured with HTTPS listeners to encrypt traffic between clients and the load balancer. HTTPS listeners use TLS/SSL certificates to establish secure encrypted connections, protecting sensitive data transmitted over the network from eavesdropping and man-in-the-middle attacks.
@@ -6953,23 +6953,23 @@ queries:
       - uid: mondoo-aws-security-elb-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Application Load Balancer
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elb-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Application Load Balancers (ALBs) are configured with access logging enabled to capture detailed information about requests sent to the load balancer. Access logs provide comprehensive data including client IP addresses, request paths, latencies, response codes, and more, which are delivered to an Amazon S3 bucket for storage and analysis.
@@ -7187,23 +7187,23 @@ queries:
       - uid: mondoo-aws-security-elb-deletion-protection-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Application Load Balancer
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elb-deletion-protection-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-deletion-protection-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-deletion-protection-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-deletion-protection-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Application Load Balancers (ALBs) have deletion protection enabled to prevent accidental or unauthorized deletion. Deleting a load balancer without proper authorization or by mistake can result in application downtime, traffic disruption, and loss of critical configurations.
@@ -7335,23 +7335,23 @@ queries:
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS ES Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elasticsearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
@@ -7493,23 +7493,23 @@ queries:
       - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-aws
         tags:
           mondoo.com/filter-title: AWS ES Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elasticsearch Service domains have node-to-node encryption enabled. Node-to-node encryption provides an additional layer of security by encrypting data as it is transferred between nodes within the Elasticsearch cluster, protecting against potential internal network eavesdropping.
@@ -7631,23 +7631,23 @@ queries:
       - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-aws
         tags:
           mondoo.com/filter-title: AWS KMS Key
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Key Management Service (KMS) customer-managed keys (CMKs) have automatic key rotation enabled. Enabling key rotation ensures that cryptographic keys are periodically refreshed, reducing the risk of long-term key compromise and enhancing overall security.
@@ -7764,23 +7764,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-aws
         tags:
           mondoo.com/filter-title: AWS SageMaker Notebook Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-instance-kms-key-configured-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker notebook instances are configured to encrypt data at rest using AWS Key Management Service (KMS). Enabling KMS encryption enhances security by protecting sensitive machine learning (ML) data stored in SageMaker notebook instances from unauthorized access.
@@ -7915,23 +7915,23 @@ queries:
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CloudTrail has log file validation enabled to verify the integrity of logged events. Log file validation generates a digitally signed digest file containing a hash of each log that CloudTrail delivers, allowing you to determine whether a log file was modified, deleted, or unchanged after CloudTrail delivered it.
@@ -8123,23 +8123,23 @@ queries:
       - uid: mondoo-aws-security-cloud-trail-encryption-enabled-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloud-trail-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-encryption-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CloudTrail trails are configured to use AWS Key Management Service (KMS) for server-side encryption (SSE). Using KMS encryption protects log data from unauthorized access and enhances the security of audit logs.
@@ -8272,23 +8272,23 @@ queries:
       - uid: mondoo-aws-security-secgroup-restricted-ssh-aws
         tags:
           mondoo.com/filter-title: AWS Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secgroup-restricted-ssh-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-ssh-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-ssh-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-ssh-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS security groups are configured to restrict incoming SSH (port 22) traffic. Allowing unrestricted SSH access (0.0.0.0/0 or ::/0) poses a significant security risk by exposing instances to unauthorized access attempts, brute-force attacks, and potential exploitation by malicious actors.
@@ -8438,23 +8438,23 @@ queries:
       - uid: mondoo-aws-security-secgroup-restricted-vnc-aws
         tags:
           mondoo.com/filter-title: AWS Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secgroup-restricted-vnc-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-vnc-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-vnc-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-vnc-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS security groups do not allow unrestricted incoming Virtual Network Computing (VNC) traffic, which operates on ports 5900-5903. Allowing unrestricted VNC access (0.0.0.0/0 or ::/0) exposes instances to unauthorized access attempts, brute-force attacks, and remote exploitation.
@@ -8617,23 +8617,23 @@ queries:
       - uid: mondoo-aws-security-secgroup-restricted-rdp-aws
         tags:
           mondoo.com/filter-title: AWS Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secgroup-restricted-rdp-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-rdp-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-rdp-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restricted-rdp-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS security groups are not configured to allow unrestricted inbound Remote Desktop Protocol (RDP) traffic, which operates on port 3389. Allowing unrestricted RDP access (0.0.0.0/0 or ::/0) significantly increases the risk of brute-force attacks, unauthorized remote access, and exploitation by malicious actors.
@@ -8785,23 +8785,23 @@ queries:
       - uid: mondoo-aws-security-secgroup-restrict-traffic-aws
         tags:
           mondoo.com/filter-title: AWS Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secgroup-restrict-traffic-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restrict-traffic-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restrict-traffic-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-restrict-traffic-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS security groups do not allow unrestricted access to all IPs (0.0.0.0/0 or ::/0) on any port. Allowing open access to security groups exposes AWS resources to unauthorized access, increasing the risk of security breaches, brute-force attacks, and data exfiltration.
@@ -8961,15 +8961,15 @@ queries:
       - uid: mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-no-static-credentials-in-providers-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-no-static-credentials-in-providers-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS provider configurations in Terraform do not contain hard-coded access keys or secret keys. Hard-coded credentials pose a significant security risk, especially if the Terraform configuration is committed to version control systems.
@@ -9075,23 +9075,23 @@ queries:
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Gateway REST API
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-cache-enabled-and-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon API Gateway method settings have caching enabled and that cached data is encrypted. Caching improves performance by reducing the load on backend services, while encryption protects sensitive data stored in the cache.
@@ -9217,19 +9217,19 @@ queries:
       - uid: mondoo-aws-security-api-gw-execution-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Gateway REST API
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-api-gw-execution-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-execution-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-execution-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon API Gateway stages have access logging enabled. Access logs capture detailed information about API requests, which is essential for monitoring, troubleshooting, and security analysis.
@@ -9370,15 +9370,15 @@ queries:
       - uid: mondoo-aws-security-api-gw-require-authentication-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-require-authentication-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-require-authentication-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon API Gateway methods have authentication enabled. Methods without authentication (authorization set to NONE) should at minimum require an API key to prevent unauthorized access.
@@ -9501,23 +9501,23 @@ queries:
       - uid: mondoo-aws-security-api-gw-tls-aws
         tags:
           mondoo.com/filter-title: AWS Gateway REST API
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-api-gw-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-tls-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon API Gateway custom domain names are configured with TLS 1.2 security policy. Older TLS versions (1.0 and 1.1) have known vulnerabilities and should not be used.
@@ -9635,23 +9635,23 @@ queries:
       - uid: mondoo-aws-security-api-gw-xray-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Gateway REST API
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-api-gw-xray-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-xray-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-xray-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-api-gw-xray-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS X-Ray tracing is enabled on Amazon API Gateway REST APIs. X-Ray provides end-to-end visibility into requests as they travel through your API, helping with debugging, performance optimization, and security analysis.
@@ -9763,19 +9763,19 @@ queries:
       - uid: mondoo-aws-security-ec2-user-data-no-secrets-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-user-data-no-secrets-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-user-data-no-secrets-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-user-data-no-secrets-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 instance user data does not contain hard-coded secrets such as AWS access keys or secret keys. User data is often logged and can be accessed by anyone with permissions to describe instances, making it an insecure location for sensitive credentials.
@@ -9901,19 +9901,19 @@ queries:
       - uid: mondoo-aws-security-iam-no-wildcards-policies-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-no-wildcards-policies-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-no-wildcards-policies-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-no-wildcards-policies-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that IAM policies do not use wildcard (*) resources except in Deny statements. Using wildcards in Allow statements grants overly permissive access, violating the principle of least privilege.
@@ -10114,23 +10114,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-versioning-enabled-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-versioning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-versioning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-versioning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-versioning-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon S3 buckets have versioning enabled. Versioning preserves multiple versions of objects, providing protection against accidental deletions and enabling recovery of previous versions.
@@ -10247,23 +10247,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon S3 buckets have server access logging enabled. Access logs record all requests made to the bucket, providing valuable data for security analysis, auditing, and compliance.
@@ -10386,23 +10386,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon S3 buckets have default server-side encryption enabled. When enabled, all new objects are automatically encrypted using either Amazon S3-managed keys (SSE-S3) or AWS KMS keys (SSE-KMS).
@@ -10537,19 +10537,19 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon S3 buckets do not have public-read or public-read-write ACLs configured. Public ACLs expose bucket contents to the internet, risking unauthorized data access and breaches.
@@ -10666,23 +10666,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon S3 buckets do not have static website hosting enabled. When static website hosting is enabled on an S3 bucket, it serves content over an unauthenticated HTTP endpoint, which can expose data to the public internet.
@@ -10773,23 +10773,23 @@ queries:
       - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CloudTrail is configured with at least one multi-region trail that captures management events across all AWS regions. A single-region trail only records API activity in the region where it was created, leaving events in other regions unmonitored and potentially allowing attackers to operate undetected in regions where CloudTrail is not active.
@@ -10912,23 +10912,23 @@ queries:
       - uid: mondoo-aws-security-cloudfront-viewer-policy-https-distribution
         tags:
           mondoo.com/filter-title: AWS CloudFront Distribution
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-viewer-policy-https-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-viewer-policy-https-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-viewer-policy-https-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-viewer-policy-https-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudFront distributions are configured to require HTTPS for viewer connections, preventing content from being served over unencrypted HTTP. By default, CloudFront distributions can be configured with an "allow-all" viewer protocol policy, which permits both HTTP and HTTPS connections and exposes users to man-in-the-middle (MITM) attacks.
@@ -11092,23 +11092,23 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EKS clusters have control plane logging enabled. EKS control plane logging provides audit and diagnostic logs directly from the Amazon EKS control plane to CloudWatch Logs. These logs include API server, audit, authenticator, controller manager, and scheduler components that are essential for security monitoring and troubleshooting.
@@ -11248,23 +11248,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-encrypted-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-encrypted-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-encrypted-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
@@ -11406,23 +11406,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-enforce-https-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-enforce-https-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-enforce-https-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-enforce-https-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-enforce-https-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains are configured to enforce HTTPS for all connections. Without HTTPS enforcement, data transmitted between clients and the OpenSearch domain is unencrypted, exposing sensitive search queries, indexed data, and authentication credentials to potential interception.
@@ -11545,23 +11545,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-node-to-node-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains have node-to-node encryption enabled. Node-to-node encryption provides an additional layer of security by encrypting data as it is transferred between nodes within the OpenSearch cluster, protecting against potential internal network eavesdropping.
@@ -11684,23 +11684,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-tls-policy-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-tls-policy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-tls-policy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-tls-policy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-tls-policy-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains are configured with a TLS security policy that enforces TLS 1.2 or higher. Older TLS versions (1.0 and 1.1) have known vulnerabilities that can be exploited by attackers to intercept or decrypt encrypted traffic.
@@ -11825,23 +11825,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains have fine-grained access control (advanced security options) enabled. Fine-grained access control provides granular permissions for indices, documents, and fields, enabling role-based access control (RBAC) within the OpenSearch domain.
@@ -11989,23 +11989,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-audit-logging-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-audit-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-audit-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-audit-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-audit-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains have audit logging enabled. Audit logs capture authentication attempts, access to indices, queries executed, and changes to the domain configuration, providing a detailed record of activity for security monitoring and compliance.
@@ -12142,23 +12142,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-in-vpc-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-in-vpc-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-in-vpc-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-in-vpc-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-in-vpc-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains are deployed within a VPC rather than using a public endpoint. Domains deployed outside a VPC are accessible from the internet, significantly increasing the attack surface and risk of unauthorized access.
@@ -12293,23 +12293,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains do not have anonymous authentication enabled. When anonymous authentication is enabled, unauthenticated users can access the domain and its data without providing credentials, posing a severe security risk.
@@ -12437,23 +12437,23 @@ queries:
       - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-image-scan-on-push-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic Container Registry (ECR) repositories are configured with image scanning on push. When enabled, ECR automatically scans container images for known vulnerabilities as they are pushed to the repository, providing early detection of security issues in the CI/CD pipeline.
@@ -12573,23 +12573,23 @@ queries:
       - uid: mondoo-aws-security-ecr-tag-immutability-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecr-tag-immutability-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-tag-immutability-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-tag-immutability-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-tag-immutability-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECR repositories are configured with image tag immutability. When tag immutability is enabled, it prevents image tags from being overwritten, ensuring that once an image is tagged, the tag always refers to the same image digest.
@@ -12701,23 +12701,23 @@ queries:
       - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-no-privileged-containers-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-no-privileged-containers-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-no-privileged-containers-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-no-privileged-containers-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS task definitions do not configure containers to run in privileged mode. A privileged container has elevated access to the host system, effectively gaining root-level capabilities on the underlying EC2 instance or Fargate host.
@@ -12847,23 +12847,23 @@ queries:
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS task definitions configure containers with read-only root filesystems. A read-only root filesystem prevents processes inside the container from writing to the container's file system, forcing the use of explicit volume mounts for any writable data.
@@ -13006,23 +13006,23 @@ queries:
       - uid: mondoo-aws-security-ecs-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that all container definitions within Amazon ECS task definitions have a log configuration specified. Without logging, container activity goes unrecorded, making it impossible to detect security incidents, troubleshoot failures, or meet audit requirements.
@@ -13179,23 +13179,23 @@ queries:
       - uid: mondoo-aws-security-efs-backup-enabled-aws
         tags:
           mondoo.com/filter-title: AWS EFS File System
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-efs-backup-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-backup-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-backup-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-efs-backup-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elastic File System (EFS) file systems have automatic backups enabled through AWS Backup. Without backups, data stored in EFS is at risk of permanent loss due to accidental deletion, corruption, or ransomware attacks.
@@ -13314,23 +13314,23 @@ queries:
       - uid: mondoo-aws-security-elb-drop-invalid-headers-aws
         tags:
           mondoo.com/filter-title: AWS Application Load Balancer
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elb-drop-invalid-headers-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-drop-invalid-headers-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-drop-invalid-headers-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elb-drop-invalid-headers-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Application Load Balancers (ALBs) are configured to drop HTTP headers that are not valid. Invalid HTTP headers can be used in HTTP request smuggling attacks, which exploit discrepancies between how front-end and back-end servers parse HTTP requests to bypass security controls.
@@ -13461,23 +13461,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-aws
         tags:
           mondoo.com/filter-title: AWS SageMaker Notebook Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker notebook instances do not have direct internet access enabled. When direct internet access is enabled, the notebook instance can communicate directly with the internet, bypassing VPC network controls and potentially exposing sensitive data and models.
@@ -13607,23 +13607,23 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-aws
         tags:
           mondoo.com/filter-title: AWS EKS Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EKS clusters with public endpoint access enabled restrict the CIDR blocks that can reach the API server. By default, when public endpoint access is enabled, the API server is accessible from any IP address (0.0.0.0/0), exposing it to the entire internet.
@@ -13765,23 +13765,23 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-deletion-protection-aws
         tags:
           mondoo.com/filter-title: AWS EKS Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-deletion-protection-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-deletion-protection-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-deletion-protection-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-deletion-protection-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EKS clusters have deletion protection enabled. Deletion protection prevents accidental or unauthorized deletion of EKS clusters, which would result in the loss of all running workloads, configurations, and associated resources.
@@ -13906,23 +13906,23 @@ queries:
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CodeBuild projects are not configured to run in privileged mode. When privileged mode is enabled on a CodeBuild project, the Docker daemon runs inside the build container with elevated access to the underlying host, granting capabilities equivalent to root-level access on the build infrastructure.
@@ -14060,23 +14060,23 @@ queries:
       - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CodeBuild projects do not use plaintext credentials for pulling container images or storing sensitive values in environment variables. Credentials should be managed through secure mechanisms such as AWS Secrets Manager, AWS Systems Manager Parameter Store, or the CodeBuild-native credential management.
@@ -14291,23 +14291,23 @@ queries:
       - uid: mondoo-aws-security-neptune-cluster-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-cluster-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB clusters are configured with encryption at rest using AWS Key Management Service (KMS). Encryption at rest protects graph database data from unauthorized access by automatically encrypting data before it is written to the underlying storage infrastructure.
@@ -14444,23 +14444,23 @@ queries:
       - uid: mondoo-aws-security-guardduty-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-guardduty-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon GuardDuty is enabled in your AWS account. GuardDuty is a threat detection service that continuously monitors for malicious activity and unauthorized behavior across your AWS environment, analyzing events from AWS CloudTrail, VPC Flow Logs, and DNS logs.
@@ -14571,23 +14571,23 @@ queries:
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon GuardDuty detectors are configured to publish findings at least every 15 minutes. Timely publication of findings ensures security teams can respond quickly to detected threats.
@@ -14689,19 +14689,19 @@ queries:
       - uid: mondoo-aws-security-securityhub-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-securityhub-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-securityhub-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-securityhub-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Security Hub is enabled in your AWS account. Security Hub provides a comprehensive view of your security posture, aggregating findings from multiple AWS security services and third-party tools.
@@ -14780,19 +14780,19 @@ queries:
       - uid: mondoo-aws-security-config-recorder-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-config-recorder-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-recorder-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-recorder-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Config recorders are enabled and actively recording configuration changes. AWS Config provides an audit trail of resource configuration changes over time.
@@ -14891,23 +14891,23 @@ queries:
       - uid: mondoo-aws-security-config-recorder-all-resources-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-config-recorder-all-resources-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-recorder-all-resources-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-recorder-all-resources-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-recorder-all-resources-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Config recorders are configured to record all supported resource types, including global resources like IAM.
@@ -15024,23 +15024,23 @@ queries:
       - uid: mondoo-aws-security-secretsmanager-rotation-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Secretsmanager Secret
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secretsmanager-rotation-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-rotation-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-rotation-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-rotation-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that all AWS Secrets Manager secrets have automatic rotation enabled. Secrets that are not rotated regularly pose a significant security risk, as compromised credentials can be used indefinitely.
@@ -15140,23 +15140,23 @@ queries:
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Secretsmanager Secret
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Secrets Manager secrets are encrypted using a customer-managed KMS key rather than the default AWS-managed key.
@@ -15260,23 +15260,23 @@ queries:
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that IAM Access Analyzer is enabled with at least one active analyzer. Access Analyzer identifies resources shared with external entities, detecting unintended public or cross-account access.
@@ -15367,23 +15367,23 @@ queries:
       - uid: mondoo-aws-security-sns-topic-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sns-topic-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SNS topics are encrypted using AWS KMS. Without encryption, messages published to SNS topics are stored in plaintext, which could expose sensitive data.
@@ -15490,23 +15490,23 @@ queries:
       - uid: mondoo-aws-security-sns-topic-signature-version-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sns-topic-signature-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-signature-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-signature-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-topic-signature-version-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SNS topics are configured to use signature version 2 for message verification. Signature version 2 uses SHA-256 hashing, which is more secure than the older SHA-1 based signature version 1.
@@ -15608,23 +15608,23 @@ queries:
       - uid: mondoo-aws-security-sqs-queue-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sqs-queue-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SQS queues are encrypted using either SQS-managed server-side encryption (SSE-SQS) or AWS KMS keys (SSE-KMS).
@@ -15726,23 +15726,23 @@ queries:
       - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that SQS queues have a dead letter queue (DLQ) configured. A DLQ captures messages that cannot be processed successfully, preventing message loss and enabling investigation of processing failures.
@@ -15860,23 +15860,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-cluster
         tags:
           mondoo.com/filter-title: AWS ElastiCache Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ElastiCache clusters have encryption at rest enabled. Without encryption at rest, cached data is stored in plaintext, which could be exposed if the underlying storage is compromised.
@@ -15988,23 +15988,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-cluster
         tags:
           mondoo.com/filter-title: AWS ElastiCache Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-encryption-in-transit-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ElastiCache clusters have encryption in transit enabled, protecting data as it moves between clients and cache nodes.
@@ -16114,23 +16114,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cluster
         tags:
           mondoo.com/filter-title: AWS ElastiCache Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that ElastiCache Redis clusters have authentication enabled via Redis AUTH tokens, preventing unauthorized access to cached data.
@@ -16243,23 +16243,23 @@ queries:
       - uid: mondoo-aws-security-backup-vault-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-backup-vault-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-backup-vault-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-backup-vault-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-backup-vault-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Backup vaults are encrypted using a KMS key. Backup vaults store recovery points that may contain sensitive data from databases, file systems, and other resources.
@@ -16359,23 +16359,23 @@ queries:
       - uid: mondoo-aws-security-fsx-filesystem-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-fsx-filesystem-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon FSx file systems are encrypted at rest. FSx supports multiple file system types (Lustre, Windows File Server, ONTAP, OpenZFS) and all should be encrypted.
@@ -16482,23 +16482,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters are encrypted at rest. Unencrypted Redshift clusters store data warehouse data in plaintext, exposing sensitive business data to unauthorized access at the storage layer.
@@ -16605,23 +16605,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-audit-logging-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-audit-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-audit-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-audit-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-audit-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters have audit logging enabled. Audit logging records information about connections, user activities, and queries for security analysis and compliance.
@@ -16736,23 +16736,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters use enhanced VPC routing. With enhanced VPC routing, Redshift forces all COPY and UNLOAD traffic between your cluster and data repositories through your VPC, allowing you to use VPC security features such as security groups, network ACLs, and VPC endpoints.
@@ -16855,23 +16855,23 @@ queries:
       - uid: mondoo-aws-security-cloudfront-minimum-tls-version-distribution
         tags:
           mondoo.com/filter-title: AWS CloudFront Distribution
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-minimum-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-minimum-tls-version-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudFront distributions are configured with a minimum TLS protocol version of 1.2 or higher. Older TLS versions (1.0 and 1.1) have known vulnerabilities and should not be used.
@@ -16982,23 +16982,23 @@ queries:
       - uid: mondoo-aws-security-cloudfront-waf-enabled-distribution
         tags:
           mondoo.com/filter-title: AWS CloudFront Distribution
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-waf-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-waf-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-waf-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-waf-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudFront distributions have an AWS WAF web ACL associated for protection against common web exploits and attacks.
@@ -17100,19 +17100,19 @@ queries:
       - uid: mondoo-aws-security-rds-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS RDS Snapshot
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-snapshot-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-snapshot-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-snapshot-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon RDS snapshots are encrypted at rest. RDS snapshots contain full backups of database instances and may include sensitive data such as customer records, credentials, or financial information. Unencrypted snapshots expose this data if the snapshot is shared, copied, or the underlying storage is compromised.
@@ -17228,19 +17228,19 @@ queries:
       - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Machine Images (AMIs) owned by the account are not publicly shared. Public AMIs can be launched by anyone, potentially exposing proprietary software, embedded credentials, internal configurations, or sensitive data baked into the image.
@@ -17361,23 +17361,23 @@ queries:
       - uid: mondoo-aws-security-ecs-container-non-root-user-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-container-non-root-user-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-container-non-root-user-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-container-non-root-user-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-container-non-root-user-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS task definitions specify a non-root user for all container definitions. Running containers as root grants the process full administrative capabilities within the container, increasing the impact of a container breakout or compromise.
@@ -17515,23 +17515,23 @@ queries:
       - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS task definitions configure transit encryption for EFS (Elastic File System) volumes. When EFS volumes are mounted in ECS tasks without transit encryption, data is transmitted in plaintext between the ECS task and the EFS file system, exposing it to potential interception.
@@ -17690,23 +17690,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-aws
         tags:
           mondoo.com/filter-title: AWS CloudWatch Log Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-log-group-retention-set-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudWatch log groups have a defined retention period. Without a retention period, log groups retain data indefinitely by default, which can lead to uncontrolled storage costs and make it harder to manage log data lifecycle. Conversely, organizations need to ensure logs are retained long enough to support security investigations, forensic analysis, and compliance requirements.
@@ -17818,23 +17818,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-require-ssl-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-require-ssl-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-require-ssl-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-require-ssl-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-require-ssl-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters enforce SSL/TLS for all client connections by setting the `require_ssl` parameter to `true` in the cluster parameter group. Without SSL enforcement, database connections transmit data in plaintext, exposing queries and results to network interception.
@@ -17984,23 +17984,23 @@ queries:
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-aws
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that VPC subnets are not configured to automatically assign public IP addresses to instances launched within them. When a subnet has auto-assign public IP enabled, every instance launched in that subnet receives a public IP address by default, potentially exposing it to the internet.
@@ -18122,23 +18122,23 @@ queries:
       - uid: mondoo-aws-security-ec2-imds-hop-limit-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imds-hop-limit-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-imds-hop-limit-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 instances have the Instance Metadata Service (IMDS) HTTP PUT response hop limit set to 1. The hop limit controls how many network hops the metadata token can travel, and a value greater than 1 allows containers or reverse proxies running on the instance to reach the metadata service, increasing the risk of credential theft through SSRF attacks.
@@ -18271,19 +18271,19 @@ queries:
       - uid: mondoo-aws-security-guardduty-all-features-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon GuardDuty has all available protection features enabled, including S3 Protection, EKS Audit Log Monitoring, Malware Protection, RDS Login Activity Monitoring, and Lambda Network Activity Monitoring. Each feature provides threat detection coverage for a specific AWS service, and leaving any feature disabled creates blind spots in your security monitoring.
@@ -18462,23 +18462,23 @@ queries:
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB clusters have IAM database authentication enabled. IAM authentication allows managing database access using AWS IAM policies instead of relying solely on database-level passwords.
@@ -18592,19 +18592,19 @@ queries:
       - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
         tags:
           mondoo.com/filter-title: AWS KMS Key
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kms-grants-no-create-grant-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kms-grants-no-create-grant-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kms-grants-no-create-grant-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS KMS key grants do not include the `CreateGrant` operation. When a grant includes `CreateGrant`, the grantee can create additional grants on the same key, effectively delegating their own permissions to other principals without requiring changes to the key policy.
@@ -18715,7 +18715,7 @@ queries:
       - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
         tags:
           mondoo.com/filter-title: AWS KMS Key
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that AWS KMS key grants do not use wildcard (`*`) grantee principals. A wildcard principal in a KMS grant allows any AWS principal to use the granted operations on the key, effectively making the key publicly accessible for those operations.
@@ -18802,23 +18802,23 @@ queries:
       - uid: mondoo-aws-security-kms-key-origin-aws-kms-aws
         tags:
           mondoo.com/filter-title: AWS KMS Key
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kms-key-origin-aws-kms-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kms-key-origin-aws-kms-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kms-key-origin-aws-kms-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kms-key-origin-aws-kms-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that customer-managed AWS KMS keys use `AWS_KMS` as their key material origin rather than `EXTERNAL` (imported key material) or `AWS_CLOUDHSM`. When the origin is `AWS_KMS`, AWS generates and manages the key material within its hardened infrastructure, providing automatic security guarantees.
@@ -18953,23 +18953,23 @@ queries:
       - uid: mondoo-aws-security-codebuild-source-ssl-verification-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-source-ssl-verification-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CodeBuild projects have SSL verification enabled when fetching source code. When `insecureSsl` is set to `true`, CodeBuild skips TLS certificate verification when connecting to the source repository, making the build vulnerable to man-in-the-middle (MITM) attacks.
@@ -19099,23 +19099,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ElastiCache serverless caches are encrypted using a customer-managed AWS KMS key (CMK). While ElastiCache serverless caches are encrypted by default with AWS-managed keys, using a CMK provides additional control over key management, access policies, and rotation schedules.
@@ -19244,19 +19244,19 @@ queries:
       - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Inspector is enabled and actively scanning EC2 instances for vulnerabilities. Inspector automatically discovers and scans EC2 instances for software vulnerabilities and unintended network exposure.
@@ -19336,19 +19336,19 @@ queries:
       - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Inspector is enabled and actively scanning ECR container images for vulnerabilities. Inspector automatically scans container images pushed to ECR for software vulnerabilities.
@@ -19427,19 +19427,19 @@ queries:
       - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Inspector is enabled and actively scanning Lambda functions for vulnerabilities. Inspector scans Lambda functions and their associated layers for software vulnerabilities in application package dependencies.
@@ -19518,23 +19518,23 @@ queries:
       - uid: mondoo-aws-security-ssm-parameter-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ssm-parameter-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ssm-parameter-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ssm-parameter-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ssm-parameter-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Systems Manager Parameter Store parameters of type SecureString have an explicit KMS key configured for encryption. While SSM SecureString parameters are always encrypted, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
@@ -19631,23 +19631,23 @@ queries:
       - uid: mondoo-aws-security-dms-replication-not-public-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dms-replication-not-public-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-not-public-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-not-public-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-not-public-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Database Migration Service (DMS) replication instances are not publicly accessible. Public replication instances expose database migration traffic to the internet, increasing the risk of data interception.
@@ -19747,23 +19747,23 @@ queries:
       - uid: mondoo-aws-security-dms-replication-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dms-replication-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dms-replication-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Database Migration Service (DMS) replication instances have storage encryption enabled using KMS. Encrypting replication instance storage protects data at rest during the migration process.
@@ -19858,7 +19858,7 @@ queries:
       - uid: mondoo-aws-security-drs-replication-ebs-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that AWS Elastic Disaster Recovery (DRS) source server replication configurations have EBS encryption enabled. Encrypting replicated EBS volumes protects disaster recovery data at rest.
@@ -19916,23 +19916,23 @@ queries:
       - uid: mondoo-aws-security-timestream-database-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-timestream-database-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-database-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-database-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-database-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Timestream for LiveAnalytics databases have an explicit KMS key configured for encryption. While Timestream encrypts data by default, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
@@ -20027,23 +20027,23 @@ queries:
       - uid: mondoo-aws-security-timestream-influxdb-not-public-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-timestream-influxdb-not-public-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-not-public-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-not-public-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-not-public-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Timestream for InfluxDB instances and clusters are not configured with public accessibility. Publicly accessible database instances can be reached from the internet, significantly increasing the attack surface.
@@ -20156,23 +20156,23 @@ queries:
       - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Timestream for InfluxDB instances and clusters have log delivery enabled to an S3 bucket. Logging provides visibility into database operations, query patterns, and potential security events.
@@ -20290,19 +20290,19 @@ queries:
       - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPC network ACLs do not contain inbound rules that allow unrestricted access (0.0.0.0/0 or ::/0) to SSH (port 22) or RDP (port 3389). Unrestricted network ACL rules expose management ports to the entire internet.
@@ -20432,19 +20432,19 @@ queries:
       - uid: mondoo-aws-security-default-nacl-restrictive-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-default-nacl-restrictive-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-default-nacl-restrictive-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-default-nacl-restrictive-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the default network ACL in each VPC is configured to deny all inbound and outbound traffic. The default NACL is automatically associated with subnets that are not explicitly associated with a custom NACL, so a permissive default NACL can inadvertently expose resources.
@@ -20526,23 +20526,23 @@ queries:
       - uid: mondoo-aws-security-ec2-keypair-type-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-keypair-type-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-keypair-type-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-keypair-type-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-keypair-type-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 key pairs use modern key types (ED25519 or RSA). Legacy or unsupported key types may use weaker cryptographic algorithms that are more susceptible to attacks.
@@ -20637,23 +20637,23 @@ queries:
       - uid: mondoo-aws-security-rds-instance-iam-auth-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-instance-iam-auth-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-iam-auth-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-iam-auth-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-iam-auth-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS database instances have IAM database authentication enabled. IAM authentication allows managing database access through AWS IAM policies instead of relying solely on database-level passwords.
@@ -20752,19 +20752,19 @@ queries:
       - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-nodegroup-encrypted-volumes-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that EKS managed node groups have EBS volume encryption enabled by verifying that EBS encryption by default is active in all regions where EKS node groups are deployed. Node group EBS volumes inherit the account-level EBS encryption setting.
@@ -20888,23 +20888,23 @@ queries:
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EKS clusters are configured to use API-based IAM authentication mode (API or API_AND_CONFIG_MAP) rather than relying solely on the legacy aws-auth ConfigMap. API-based authentication provides a more robust and auditable authentication mechanism.
@@ -21014,7 +21014,7 @@ queries:
       - uid: mondoo-aws-security-eks-addon-healthy-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that all EKS cluster add-ons are in an ACTIVE status. Degraded or failed add-ons can indicate security vulnerabilities, missing patches, or operational issues that affect cluster security.
@@ -21086,23 +21086,23 @@ queries:
       - uid: mondoo-aws-security-ecs-cluster-container-insights-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-cluster-container-insights-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-container-insights-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-container-insights-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-container-insights-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS clusters have Container Insights enabled. Container Insights collects, aggregates, and summarizes metrics and logs from containerized applications and microservices.
@@ -21207,23 +21207,23 @@ queries:
       - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECS clusters have a KMS key configured for encrypting Fargate ephemeral storage. Fargate tasks use ephemeral storage for scratch space, and encrypting this storage with a customer-managed KMS key provides additional data protection.
@@ -21326,23 +21326,23 @@ queries:
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Certificate Manager (ACM) certificates use strong key algorithms. Certificates should use RSA-2048 or higher, or ECDSA key algorithms to provide adequate cryptographic strength.
@@ -21445,23 +21445,23 @@ queries:
       - uid: mondoo-aws-security-lambda-env-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-env-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-env-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-env-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-env-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Lambda functions with environment variables are configured with a KMS customer managed key (CMK) to encrypt those variables at rest. By default, Lambda encrypts environment variables with an AWS-managed key, but using a CMK provides centralized key management, audit logging, and fine-grained access control.
@@ -21586,23 +21586,23 @@ queries:
       - uid: mondoo-aws-security-lambda-code-signing-configured-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-code-signing-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-code-signing-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-code-signing-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-code-signing-configured-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Lambda functions have code signing configured to verify that only trusted code packages are deployed. Code signing uses AWS Signer to validate deployment packages against a set of allowed signing profiles, preventing unauthorized or tampered code from being deployed.
@@ -21742,23 +21742,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-notebook-imdsv2-aws
         tags:
           mondoo.com/filter-title: AWS SageMaker Notebook Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-notebook-imdsv2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-imdsv2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-imdsv2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-imdsv2-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker notebook instances are configured to require Instance Metadata Service Version 2 (IMDSv2). IMDSv1 is vulnerable to Server-Side Request Forgery (SSRF) attacks that can expose instance credentials and metadata to attackers.
@@ -21873,23 +21873,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-aws
         tags:
           mondoo.com/filter-title: AWS SageMaker Notebook Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker notebook instances have root access disabled. When root access is enabled, users within the notebook instance have full administrator privileges, which violates the principle of least privilege and increases the risk of privilege escalation.
@@ -22003,23 +22003,23 @@ queries:
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon S3 buckets are configured to use AWS KMS customer managed keys (CMKs) for server-side encryption rather than the default AES-256 (SSE-S3) encryption. While SSE-S3 provides encryption, KMS CMKs offer additional security benefits including key rotation control, access auditing, and fine-grained permissions.
@@ -22160,23 +22160,23 @@ queries:
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CodeBuild projects are configured with a KMS customer managed key (CMK) for encrypting build artifacts. By default, CodeBuild uses an AWS-managed key for artifact encryption, but a customer managed key provides audit logging, key rotation control, and fine-grained access permissions.
@@ -22307,23 +22307,23 @@ queries:
       - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB cluster snapshots are encrypted at rest. While the existing cluster encryption check verifies that Neptune clusters themselves are encrypted, snapshots can be shared across accounts, making their encryption status independently important.
@@ -22449,23 +22449,23 @@ queries:
       - uid: mondoo-aws-security-ec2-source-dest-check-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-source-dest-check-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-source-dest-check-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-source-dest-check-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-source-dest-check-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 instances have the source/destination check enabled. When this check is disabled, an instance can route network traffic that is not specifically destined for or originating from the instance, effectively allowing it to act as a network bridge, NAT gateway, or router.
@@ -22581,7 +22581,7 @@ queries:
       - uid: mondoo-aws-security-ec2-uefi-boot-mode-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon EC2 instances use UEFI boot mode instead of legacy BIOS. UEFI supports Secure Boot, which validates that boot software is signed and untampered, protecting against boot-level malware such as rootkits and bootkits.
@@ -22669,19 +22669,19 @@ queries:
       - uid: mondoo-aws-security-ec2-no-paravirtual-instances-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-no-paravirtual-instances-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-no-paravirtual-instances-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-no-paravirtual-instances-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon EC2 instances use Hardware Virtual Machine (HVM) virtualization instead of paravirtual (PV). PV instances use older virtualization technology with a larger attack surface and are not supported on modern instance types.
@@ -22789,7 +22789,7 @@ queries:
       - uid: mondoo-aws-security-ec2-hibernation-encrypted-check-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that EBS encryption by default is enabled in accounts where EC2 instances use hibernation. When an instance hibernates, the contents of RAM — which may contain credentials, encryption keys, session tokens, and other sensitive data — are written to the root EBS volume. Enabling EBS encryption by default ensures that all newly created volumes, including those used by hibernation-enabled instances, are automatically encrypted.
@@ -22892,19 +22892,19 @@ queries:
       - uid: mondoo-aws-security-route53-dnssec-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-route53-dnssec-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-dnssec-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-dnssec-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Route 53 public hosted zones have DNSSEC signing enabled. DNSSEC (Domain Name System Security Extensions) adds cryptographic signatures to DNS records, allowing resolvers to verify that responses have not been tampered with in transit.
@@ -23006,19 +23006,19 @@ queries:
       - uid: mondoo-aws-security-route53-query-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-route53-query-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-query-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-query-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Route 53 public hosted zones have DNS query logging configured. Query logging sends information about DNS queries to Amazon CloudWatch Logs, enabling visibility into DNS traffic patterns and supporting security monitoring.
@@ -23123,23 +23123,23 @@ queries:
       - uid: mondoo-aws-security-route53-health-check-not-disabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-route53-health-check-not-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-not-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-not-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-not-disabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that no Amazon Route 53 health checks are in a disabled state. Disabled health checks do not monitor endpoint availability, which can leave DNS failover routing non-functional and cause traffic to be directed to unhealthy or offline endpoints.
@@ -23257,23 +23257,23 @@ queries:
       - uid: mondoo-aws-security-route53-health-check-https-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-route53-health-check-https-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-https-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-https-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-route53-health-check-https-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Route 53 endpoint health checks use HTTPS rather than HTTP. Health checks using HTTP send requests in plaintext, which can be intercepted and do not validate the identity of the endpoint being checked.
@@ -23391,23 +23391,23 @@ queries:
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon AppStream 2.0 fleets do not have default internet access enabled. When enabled, streaming instances are assigned public IP addresses and can access the internet directly, bypassing network security controls such as firewalls, web proxies, and data loss prevention (DLP) systems.
@@ -23530,23 +23530,23 @@ queries:
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon AppStream 2.0 fleets have a maximum user session duration of 10 hours (36000 seconds) or less. Excessively long or unlimited session durations increase the risk of unattended sessions being hijacked or misused.
@@ -23653,23 +23653,23 @@ queries:
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon AppStream 2.0 fleets have an idle disconnect timeout configured and set to 15 minutes (900 seconds) or less. Without an idle timeout, abandoned sessions remain active indefinitely, leaving applications and data accessible.
@@ -23780,23 +23780,23 @@ queries:
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon AppStream 2.0 image builders do not have default internet access enabled. Image builders are used to create custom application images and may have access to sensitive configuration data, application binaries, and credentials during the image creation process.
@@ -23914,19 +23914,19 @@ queries:
       - uid: mondoo-aws-security-directoryservice-os-version-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-directoryservice-os-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-directoryservice-os-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-directoryservice-os-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Directory Service directories run on Windows Server 2019 or newer. Windows Server 2012 has reached end of life and no longer receives security patches from Microsoft, leaving directories vulnerable to known and future exploits.
@@ -24050,7 +24050,7 @@ queries:
       - uid: mondoo-aws-security-directoryservice-sso-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
     docs:
       desc: |
         This check ensures that AWS Directory Service directories have single sign-on (SSO) enabled. SSO is a critical security control that reduces password sprawl, centralizes access control, and provides a single point for access revocation across all directory-integrated applications.
@@ -24120,7 +24120,7 @@ queries:
       - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled-aws
         tags:
           mondoo.com/filter-title: "AWS Account"
-          mondoo.com/icon: "aws"
+          mondoo.com/filter-icon: "aws"
     docs:
       desc: |
         This check ensures that AWS Managed Microsoft AD directories have multi-factor authentication (MFA) enabled through RADIUS integration. MFA adds a critical second layer of authentication beyond passwords, significantly reducing the risk of unauthorized access from compromised credentials.
@@ -24222,23 +24222,23 @@ queries:
       - uid: mondoo-aws-security-documentdb-cluster-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-cluster-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DocumentDB clusters are configured with encryption at rest using AWS Key Management Service (KMS). Encryption at rest protects document database data from unauthorized access by automatically encrypting data before it is written to the underlying storage infrastructure.
@@ -24366,23 +24366,23 @@ queries:
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DocumentDB clusters are encrypted using a customer-managed AWS KMS key (CMK) rather than the default AWS-managed service key. Customer-managed keys provide greater control over the encryption lifecycle, including key rotation policies, access control, and audit capabilities.
@@ -24508,23 +24508,23 @@ queries:
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DocumentDB instances have automatic minor version upgrades enabled. When enabled, instances automatically receive minor engine version upgrades during the maintenance window, ensuring security patches and bug fixes are applied promptly.
@@ -24640,23 +24640,23 @@ queries:
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Cognito user pools have multi-factor authentication (MFA) set to "ON" (required for all users) rather than "OFF" or "OPTIONAL". When MFA is set to "OPTIONAL", individual users can choose not to configure MFA, leaving their accounts protected only by a password.
@@ -24776,23 +24776,23 @@ queries:
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Cognito user pools have advanced security features set to "ENFORCED" mode. Advanced security provides adaptive authentication, compromised credentials detection, and automated risk-based responses to suspicious sign-in attempts.
@@ -24911,23 +24911,23 @@ queries:
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Cognito identity pools do not allow unauthenticated (guest) identities. When enabled, unauthenticated access grants temporary AWS credentials to anonymous users without requiring any form of authentication, which can lead to unauthorized access to AWS resources.
@@ -25044,23 +25044,23 @@ queries:
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Cognito identity pools do not have the Basic (Classic) authentication flow enabled. The Classic flow passes IAM role selection to the client, while the Enhanced (Simplified) flow handles role selection server-side, providing better security.
@@ -25179,7 +25179,7 @@ queries:
       - uid: mondoo-aws-security-route53-domain-transfer-lock-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have the transfer lock (registrar lock) enabled. Transfer lock prevents unauthorized or accidental domain transfers to another registrar, which is one of the most damaging attacks against an organization's online presence.
@@ -25250,7 +25250,7 @@ queries:
       - uid: mondoo-aws-security-route53-domain-contact-privacy-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have privacy protection enabled for all contact types: admin, registrant, and tech. Without privacy protection, WHOIS records expose personal or organizational contact details to anyone who queries them.
@@ -25328,7 +25328,7 @@ queries:
       - uid: mondoo-aws-security-route53-domain-auto-renew-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have automatic renewal enabled. Without auto-renew, domains can accidentally expire if manual renewal is missed, allowing attackers to register the lapsed domain and hijack all associated services.
@@ -25398,23 +25398,23 @@ queries:
       - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MemoryDB clusters have encryption in transit (TLS) enabled. TLS encrypts all data transmitted between clients and the MemoryDB cluster, protecting sensitive data from interception on the network.
@@ -25530,23 +25530,23 @@ queries:
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MemoryDB clusters are encrypted at rest using a customer-managed AWS KMS key (CMK) rather than the default AWS-owned service key. While MemoryDB always encrypts data at rest, using a customer-managed key provides greater control over the encryption lifecycle.
@@ -25667,23 +25667,23 @@ queries:
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MemoryDB clusters have automatic minor version upgrades enabled. When enabled, clusters automatically receive minor engine version upgrades during the maintenance window, ensuring security patches and bug fixes are applied promptly.
@@ -25799,23 +25799,23 @@ queries:
       - uid: mondoo-aws-security-kinesis-stream-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kinesis-stream-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Kinesis data streams have server-side encryption enabled. Without encryption, data records stored in the stream are unencrypted, exposing sensitive streaming data to unauthorized access if the underlying storage is compromised.
@@ -25932,23 +25932,23 @@ queries:
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Kinesis data streams are encrypted using a customer-managed AWS KMS key (CMK) rather than the default AWS-managed `aws/kinesis` service key. Customer-managed keys provide greater control over the encryption lifecycle, including key rotation policies, access control, and audit capabilities.
@@ -26070,23 +26070,23 @@ queries:
       - uid: mondoo-aws-security-kinesis-firehose-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kinesis-firehose-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-firehose-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-firehose-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-firehose-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Kinesis Firehose delivery streams have server-side encryption enabled. Without encryption, data buffered in the delivery stream before delivery to its destination is stored unencrypted, exposing sensitive data to unauthorized access.
@@ -26220,23 +26220,23 @@ queries:
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Athena workgroups have the "enforce workgroup configuration" setting enabled. When this setting is disabled, individual users can override workgroup-level settings from their client, including the query result output location and encryption configuration.
@@ -26356,23 +26356,23 @@ queries:
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Athena workgroups have encryption configured for query results. Query results are written to S3, and without encryption configuration at the workgroup level, results may be stored unencrypted, exposing sensitive data queried from data lakes, CloudTrail logs, or other sources.
@@ -26513,23 +26513,23 @@ queries:
       - uid: mondoo-aws-security-workspaces-volume-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-workspaces-volume-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-volume-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-volume-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-volume-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon WorkSpaces instances have encryption enabled for both root and user volumes. Without volume encryption, data stored on the workspace — including operating system files, application data, and user documents — is unencrypted at rest.
@@ -26659,19 +26659,19 @@ queries:
       - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that WorkSpaces directories deny web browser access to workspaces. When web access is allowed, users can connect to their WorkSpaces from any web browser without requiring a managed device or the WorkSpaces client application, bypassing endpoint security controls.
@@ -26775,19 +26775,19 @@ queries:
       - uid: mondoo-aws-security-workspaces-directory-maintenance-mode-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-workspaces-directory-maintenance-mode-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-directory-maintenance-mode-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-workspaces-directory-maintenance-mode-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that WorkSpaces directories have automatic maintenance mode enabled in the default creation properties. When maintenance mode is enabled, WorkSpaces are automatically started during a daily maintenance window to install operating system and application updates.
@@ -26894,7 +26894,7 @@ queries:
       - uid: mondoo-aws-security-workspaces-no-unrestricted-inbound-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that security groups associated with Amazon WorkSpaces do not contain inbound rules allowing unrestricted access from `0.0.0.0/0` or `::/0`. Overly permissive security groups expose WorkSpaces to the entire internet, creating a direct attack path to corporate desktops.
@@ -27003,23 +27003,23 @@ queries:
       - uid: mondoo-aws-security-neptune-instance-public-access-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-instance-public-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-instance-public-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-instance-public-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-instance-public-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB instances are not publicly accessible. When a Neptune instance is marked as publicly accessible, it can potentially be reached from outside the VPC, exposing the graph database to unauthorized access from the internet.
@@ -27134,23 +27134,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-auto-software-update-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-auto-software-update-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-auto-software-update-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-auto-software-update-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-auto-software-update-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains have automatic software updates enabled. When enabled, OpenSearch automatically applies security patches and minor updates during the maintenance window without requiring manual intervention.
@@ -27268,23 +27268,23 @@ queries:
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB clusters are encrypted using a customer-managed AWS KMS key (CMK) rather than the default AWS-managed service key. Customer-managed keys provide greater control over the encryption lifecycle, including key rotation policies, access control, and audit capabilities.
@@ -27415,23 +27415,23 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters are encrypted using a customer-managed AWS KMS key (CMK). While Redshift supports encryption at rest with AWS-managed keys, using a CMK provides additional control over key management, access policies, and rotation schedules.
@@ -27561,11 +27561,11 @@ queries:
       - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters are configured to use the `Current` maintenance track rather than the `Trailing` track. The maintenance track determines which cluster version is applied during maintenance windows and directly affects the security posture of the cluster.
@@ -27669,23 +27669,23 @@ queries:
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon FSx file systems are encrypted using a customer-managed AWS KMS key (CMK). While FSx encrypts data at rest by default, using a CMK instead of the AWS-managed key provides additional control over key management, access policies, and rotation schedules.
@@ -27819,23 +27819,23 @@ queries:
       - uid: mondoo-aws-security-opensearch-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS OpenSearch Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-opensearch-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-opensearch-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon OpenSearch Service domains are encrypted at rest using a customer-managed AWS KMS key (CMK). While OpenSearch supports encryption at rest with the AWS-managed `aws/es` key, using a CMK provides additional control over key management, access policies, and rotation schedules.
@@ -27967,23 +27967,23 @@ queries:
       - uid: mondoo-aws-security-glue-job-security-configuration-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-job-security-configuration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-security-configuration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-security-configuration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-security-configuration-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue ETL jobs have a security configuration assigned. A Glue security configuration defines encryption settings for S3 targets, CloudWatch logs, and job bookmarks. Without a security configuration, Glue job outputs and logs are stored unencrypted.
@@ -28131,23 +28131,23 @@ queries:
       - uid: mondoo-aws-security-glue-crawler-security-configuration-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-crawler-security-configuration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-crawler-security-configuration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-crawler-security-configuration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-crawler-security-configuration-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue crawlers have a security configuration assigned. A Glue security configuration defines encryption settings for S3 targets, CloudWatch logs, and job bookmarks. Without a security configuration, data discovered and cataloged by crawlers may be processed without encryption protections.
@@ -28275,23 +28275,23 @@ queries:
       - uid: mondoo-aws-security-glue-catalog-encryption-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-catalog-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-catalog-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-catalog-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-catalog-encryption-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that the AWS Glue Data Catalog has encryption at rest enabled. The Data Catalog stores metadata about data sources, tables, schemas, and partitions. Without encryption, this metadata is stored in plaintext and could expose sensitive information about your data infrastructure.
@@ -28441,23 +28441,23 @@ queries:
       - uid: mondoo-aws-security-glue-security-config-s3-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-security-config-s3-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-s3-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-s3-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-s3-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue security configurations have S3 encryption enabled. When Glue jobs and crawlers write data to S3, the security configuration controls whether that data is encrypted. Without S3 encryption enabled in the security configuration, ETL output data is stored in plaintext, potentially exposing sensitive information to unauthorized access.
@@ -28589,23 +28589,23 @@ queries:
       - uid: mondoo-aws-security-glue-security-config-cloudwatch-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-security-config-cloudwatch-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-cloudwatch-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-cloudwatch-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-cloudwatch-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue security configurations have CloudWatch log encryption enabled. Glue jobs and crawlers emit logs to CloudWatch during execution. Without CloudWatch encryption in the security configuration, these logs are stored unencrypted and may contain sensitive data excerpts, error details, or schema information.
@@ -28735,23 +28735,23 @@ queries:
       - uid: mondoo-aws-security-glue-security-config-bookmark-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-security-config-bookmark-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-bookmark-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-bookmark-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-security-config-bookmark-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue security configurations have job bookmark encryption enabled. Job bookmarks track the state of ETL job runs, allowing jobs to process only new or changed data. Without encryption, bookmark data is stored in plaintext and may reveal information about data processing patterns and state.
@@ -28881,23 +28881,23 @@ queries:
       - uid: mondoo-aws-security-glue-job-supported-version-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-job-supported-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-supported-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-supported-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-glue-job-supported-version-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Glue ETL jobs are configured to use a supported Glue version (3.0 or later). Older Glue versions may contain unpatched vulnerabilities and lack security features available in newer releases. AWS Security Hub control Glue.4 recommends running jobs on supported versions.
@@ -29015,23 +29015,23 @@ queries:
       - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Elastic Beanstalk environments have enhanced health reporting enabled. Enhanced health reporting goes beyond basic green/yellow/red status by evaluating application logs, instance metrics, and OS-level data to surface detailed health descriptors that are critical for security monitoring.
@@ -29158,23 +29158,23 @@ queries:
       - uid: mondoo-aws-security-rds-proxy-tls-required-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-proxy-tls-required-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-tls-required-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-tls-required-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-tls-required-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS Proxy instances are configured to require TLS encryption for all client connections. Without TLS enforcement, database connections through the proxy may transmit credentials and query data in plaintext, exposing sensitive information to network-based attacks.
@@ -29304,23 +29304,23 @@ queries:
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS Proxy instances do not have debug logging enabled. When debug logging is active, detailed information about SQL statements, connection parameters, and query data is written to CloudWatch Logs. This debug output may include sensitive data such as query parameters, database schemas, and application logic.
@@ -29442,7 +29442,7 @@ queries:
       - uid: mondoo-aws-security-documentdb-snapshot-encrypted-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon DocumentDB cluster snapshots are encrypted at rest. Snapshots contain a complete backup of cluster data and, if unencrypted, could expose sensitive document data if the snapshot is shared, copied to another region, or accessed by unauthorized users.
@@ -29544,19 +29544,19 @@ queries:
       - uid: mondoo-aws-security-memorydb-snapshot-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-memorydb-snapshot-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-snapshot-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-snapshot-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon MemoryDB snapshots are encrypted with a customer-managed KMS key rather than the default AWS-managed key. Customer-managed keys provide greater control over the encryption lifecycle, including key rotation, access policies, and audit capabilities.
@@ -29664,23 +29664,23 @@ queries:
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that MemoryDB clusters are not using the default "open-access" ACL. The open-access ACL grants all commands and all keys to any authenticated user, effectively bypassing access control. Clusters should use custom ACLs with properly scoped user permissions.
@@ -29812,23 +29812,23 @@ queries:
       - uid: mondoo-aws-security-sns-subscription-https-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sns-subscription-https-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-subscription-https-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-subscription-https-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sns-subscription-https-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SNS topic subscriptions delivering to HTTP/HTTPS endpoints use the HTTPS protocol rather than plaintext HTTP. SNS notifications may contain sensitive data, and using HTTP transmits this data unencrypted across the network.
@@ -29946,23 +29946,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker models have network isolation enabled. When network isolation is enabled, the container cannot make any outbound network calls, even to other AWS services. This prevents potential data exfiltration from ML models.
@@ -30078,23 +30078,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker models are deployed within a VPC. Deploying models in a VPC allows you to control network traffic using security groups and network ACLs, and ensures that data does not traverse the public internet.
@@ -30220,7 +30220,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-training-job-network-isolation-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker training jobs have network isolation enabled. When network isolation is enabled, training containers cannot make outbound network calls, preventing potential data exfiltration of training data and model artifacts.
@@ -30313,7 +30313,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-training-job-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker training jobs have inter-container traffic encryption enabled. When enabled, traffic between training containers in distributed training is encrypted using TLS 1.2.
@@ -30406,7 +30406,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker training jobs are deployed within a VPC. Running training jobs in a VPC enables network-level access controls and keeps data transfer within the AWS private network.
@@ -30503,7 +30503,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker processing jobs have network isolation enabled. Processing jobs handle data transformation, feature engineering, and model evaluation. When network isolation is enabled, containers cannot make outbound network calls.
@@ -30593,7 +30593,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-processing-job-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker processing jobs have inter-container traffic encryption enabled. When enabled, traffic between processing containers in distributed processing is encrypted using TLS 1.2.
@@ -30682,7 +30682,7 @@ queries:
       - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon SageMaker processing jobs are deployed within a VPC. Running processing jobs in a VPC provides network-level access controls and keeps data transfer within the AWS private network.
@@ -30775,23 +30775,23 @@ queries:
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SageMaker domains are configured with a KMS key for encrypting the EFS volume that stores user data. SageMaker domains use an EFS file system to store notebooks, data, and artifacts for all users in the domain.
@@ -30926,23 +30926,23 @@ queries:
       - uid: mondoo-aws-security-mq-audit-logging-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-mq-audit-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-audit-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-audit-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-audit-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MQ ActiveMQ brokers have audit logging enabled. Audit logs capture administrative actions such as broker creation, modification, and deletion, providing a detailed record of who performed which operations and when. Note: This check only applies to ActiveMQ engine types, as RabbitMQ brokers on Amazon MQ do not support audit logging.
@@ -31061,23 +31061,23 @@ queries:
       - uid: mondoo-aws-security-mq-general-logging-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-mq-general-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-general-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-general-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-general-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MQ brokers have general logging enabled. General logs capture broker-level events such as connections, disconnections, message delivery failures, and broker lifecycle events, providing operational visibility into broker activity.
@@ -31196,23 +31196,23 @@ queries:
       - uid: mondoo-aws-security-mq-no-public-access-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-mq-no-public-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-no-public-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-no-public-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-mq-no-public-access-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MQ brokers are not publicly accessible over the internet. Publicly accessible brokers expose their management console and messaging endpoints to the public internet, significantly increasing the attack surface for unauthorized access and denial-of-service attacks.
@@ -31334,23 +31334,23 @@ queries:
       - uid: mondoo-aws-security-msk-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-msk-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MSK (Managed Streaming for Apache Kafka) clusters are configured to use a customer-managed AWS KMS key for encryption of data at rest. By default, MSK encrypts data at rest using an AWS-managed key, but using a customer-managed key (CMK) provides greater control over key lifecycle and access policies.
@@ -31475,23 +31475,23 @@ queries:
       - uid: mondoo-aws-security-msk-encryption-in-transit-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-msk-encryption-in-transit-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-in-transit-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-in-transit-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-encryption-in-transit-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MSK clusters are configured to require TLS encryption for all client-to-broker communication. MSK supports three modes for client-broker encryption in transit: TLS only, plaintext only, or TLS preferred (allows both). Only the TLS-only setting prevents unencrypted data from traversing the network.
@@ -31620,23 +31620,23 @@ queries:
       - uid: mondoo-aws-security-msk-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-msk-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-msk-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon MSK clusters have broker logging enabled to at least one destination: Amazon CloudWatch Logs, Amazon S3, or Amazon Kinesis Data Firehose. Broker logs capture Kafka broker events including connection events, topic activity, and error conditions.
@@ -31770,7 +31770,7 @@ queries:
       - uid: mondoo-aws-security-cloudtrail-s3-bucket-not-public-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that the Amazon S3 bucket used to store AWS CloudTrail log files is not publicly accessible. CloudTrail logs contain a complete record of API calls made in your AWS account, including caller identity, source IP addresses, and request parameters. Exposing this data publicly is a critical security risk.
@@ -31870,7 +31870,7 @@ queries:
       - uid: mondoo-aws-security-cloudtrail-s3-bucket-logging-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that the Amazon S3 bucket used to store CloudTrail logs has S3 server access logging enabled. S3 access logging records detailed information about every request made to the CloudTrail bucket, providing a second layer of audit data that captures who accessed or attempted to access the log files themselves.
@@ -31967,23 +31967,23 @@ queries:
       - uid: mondoo-aws-security-dynamodb-pitr-enabled-aws
         tags:
           mondoo.com/filter-title: AWS DynamoDB Table
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dynamodb-pitr-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-pitr-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-pitr-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-pitr-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DynamoDB tables have Point-in-Time Recovery (PITR) enabled. PITR provides continuous backups of DynamoDB table data, allowing you to restore a table to any point in time within the last 35 days. This protects against accidental writes, deletes, and application bugs that corrupt or destroy data.
@@ -32103,23 +32103,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-unauthorized-api-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-unauthorized-api-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-unauthorized-api-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-unauthorized-api-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-unauthorized-api-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect unauthorized API calls within your AWS environment. Unauthorized API calls may indicate an attacker probing your environment or attempting to exploit misconfigured IAM permissions.
@@ -32273,23 +32273,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect AWS Management Console sign-ins that occur without multi-factor authentication (MFA). Console logins without MFA represent an elevated risk since accounts protected only by passwords are more susceptible to compromise.
@@ -32443,23 +32443,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-root-usage-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-root-usage-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-root-usage-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-root-usage-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-root-usage-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect usage of the AWS root account. The root account has unrestricted access to all resources and should be used only for tasks that specifically require root credentials, such as initial account setup.
@@ -32613,23 +32613,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to IAM policies. IAM policy changes, such as creating, modifying, or deleting policies, can significantly alter the access control landscape of your AWS environment.
@@ -32783,23 +32783,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS CloudTrail configuration. CloudTrail is the primary audit log for AWS API activity, and any modifications to its configuration could indicate an attempt to disable or circumvent logging.
@@ -32953,23 +32953,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect failed console authentication attempts. Repeated authentication failures may indicate a brute force attack or credential stuffing attempt targeting your AWS Management Console.
@@ -33123,23 +33123,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect disabling or scheduled deletion of customer-managed KMS keys (CMKs). CMKs protect encrypted data across many AWS services, and their unauthorized deletion or disabling can render encrypted data permanently inaccessible.
@@ -33293,23 +33293,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Amazon S3 bucket policies and ACLs. S3 buckets frequently contain sensitive data, and unintended changes to bucket policies or ACLs can inadvertently expose that data publicly.
@@ -33463,23 +33463,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-config-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-config-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-config-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-config-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-config-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS Config configuration. AWS Config provides continuous compliance monitoring and resource configuration tracking, and any modifications to its configuration could undermine your compliance posture.
@@ -33633,23 +33633,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to VPC security groups. Security groups act as virtual firewalls controlling inbound and outbound traffic to AWS resources, and unauthorized changes could expose systems to attack.
@@ -33803,23 +33803,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Network Access Control Lists (NACLs). NACLs provide subnet-level traffic filtering in VPCs, and unauthorized changes could weaken your network perimeter defenses.
@@ -33973,23 +33973,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to network gateways including internet gateways, customer gateways, and virtual private gateways. Network gateways control traffic flow between your VPCs and external networks, and unauthorized changes could expose internal resources.
@@ -34143,23 +34143,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to VPC route tables. Route tables control the routing of traffic within and between VPCs, and unauthorized modifications could redirect traffic to malicious destinations or disrupt network connectivity.
@@ -34313,23 +34313,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Virtual Private Clouds (VPCs). VPCs form the foundational network isolation layer in AWS, and changes to VPC configuration can have broad security implications across all resources within the VPC.
@@ -34483,23 +34483,23 @@ queries:
       - uid: mondoo-aws-security-cloudwatch-org-change-alarm-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudwatch-org-change-alarm-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-org-change-alarm-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-org-change-alarm-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudwatch-org-change-alarm-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS Organizations configuration. AWS Organizations allows central governance of multiple AWS accounts, and unauthorized changes to organizational structure or policies can have broad security implications across your entire AWS footprint.
@@ -34653,23 +34653,23 @@ queries:
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-aws
         tags:
           mondoo.com/filter-title: AWS Security Group
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         Security groups should restrict outbound traffic to only necessary destinations and ports. Unrestricted egress (0.0.0.0/0 on all ports) allows compromised instances to communicate with any external host, facilitating data exfiltration or command-and-control communication.
@@ -34813,7 +34813,7 @@ queries:
       - uid: mondoo-aws-security-iam-root-hardware-mfa-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         The AWS root account has unrestricted access to all resources in the account and cannot be limited by IAM policies. Protecting it with a hardware MFA device provides a significantly stronger authentication guarantee than a software (virtual) MFA token, which can be compromised if the device or seed material is stolen.
@@ -34899,7 +34899,7 @@ queries:
       - uid: mondoo-aws-security-iam-expired-certificates-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         SSL/TLS certificates stored in AWS IAM that have passed their expiration date should be removed promptly. Expired certificates can no longer be used to establish trusted TLS connections, and their continued presence in IAM increases the risk of accidental use or confusion during incident response.
@@ -34973,19 +34973,19 @@ queries:
       - uid: mondoo-aws-security-iam-support-role-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-iam-support-role-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-support-role-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-iam-support-role-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         AWS recommends creating a dedicated IAM role or group with the AWSSupportAccess managed policy attached to manage interactions with AWS Support. This ensures that support access is granted through a traceable, auditable IAM identity rather than relying on root account credentials.
@@ -35126,7 +35126,7 @@ queries:
       - uid: mondoo-aws-security-iam-unused-credentials-disabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check identifies IAM credentials (passwords and access keys) that pose a risk due to inactivity. It flags two cases: (a) credentials that have **never been used** (where `passwordLastUsed` or `accessKey1LastUsedDate` is null), indicating they may have been provisioned but never needed, and (b) credentials that have not been used within a defined threshold period. Credentials that remain active but unused increase the attack surface, as they may belong to former employees, deprecated service accounts, or forgotten automation keys that an attacker could compromise without detection.
@@ -35234,23 +35234,23 @@ queries:
       - uid: mondoo-aws-security-lambda-xray-tracing-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-xray-tracing-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-xray-tracing-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-xray-tracing-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-xray-tracing-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         AWS X-Ray provides distributed tracing for Lambda functions, enabling visibility into function execution, latency, and downstream service calls. Enabling active tracing helps security and operations teams detect anomalous behavior, unexpected latency spikes, and unauthorized invocations.
@@ -35389,23 +35389,23 @@ queries:
       - uid: mondoo-aws-security-lambda-source-arn-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-source-arn-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-source-arn-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-source-arn-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-source-arn-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         Lambda resource-based policy statements that grant Allow permissions to AWS services (such as S3, SNS, or EventBridge) should include a Condition that specifies a source ARN. Without this condition, any resource in the granting service's account can invoke the function, creating a confused deputy vulnerability.
@@ -35546,23 +35546,23 @@ queries:
       - uid: mondoo-aws-security-s3-mfa-delete-aws
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-s3-mfa-delete-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-mfa-delete-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-mfa-delete-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-s3-mfa-delete-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         MFA delete adds an additional layer of protection for versioned S3 objects by requiring multi-factor authentication before permanently deleting an object version or changing the versioning state of a bucket. This prevents accidental or malicious deletion of critical data even if AWS credentials are compromised.
@@ -35688,23 +35688,23 @@ queries:
       - uid: mondoo-aws-security-elasticsearch-enforce-https-aws
         tags:
           mondoo.com/filter-title: AWS ES Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticsearch-enforce-https-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-enforce-https-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-enforce-https-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-enforce-https-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elasticsearch Service domains are configured to require HTTPS for all traffic. When HTTPS is not enforced, communication between clients and the Elasticsearch domain occurs over plaintext HTTP, exposing query data and results to network-level interception.
@@ -35825,23 +35825,23 @@ queries:
       - uid: mondoo-aws-security-elasticsearch-tls-policy-aws
         tags:
           mondoo.com/filter-title: AWS ES Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticsearch-tls-policy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-tls-policy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-tls-policy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-tls-policy-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elasticsearch Service domains are configured with a TLS security policy that enforces TLS 1.2 or higher. Older TLS versions (1.0 and 1.1) have known vulnerabilities and should not be used for production workloads.
@@ -35964,23 +35964,23 @@ queries:
       - uid: mondoo-aws-security-elasticsearch-audit-logging-aws
         tags:
           mondoo.com/filter-title: AWS ES Domain
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticsearch-audit-logging-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-audit-logging-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-audit-logging-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticsearch-audit-logging-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Elasticsearch Service domains have audit logging enabled. Audit logs capture authentication attempts, access to indices, and query activity, providing visibility into who is accessing your Elasticsearch data and what operations they perform.
@@ -36104,23 +36104,23 @@ queries:
       - uid: mondoo-aws-security-emr-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EMR clusters have at-rest encryption enabled through a security configuration. At-rest encryption protects data stored on local disks and in Amazon S3 by EMR clusters, preventing unauthorized access to data at the storage layer.
@@ -36275,23 +36275,23 @@ queries:
       - uid: mondoo-aws-security-emr-encryption-in-transit-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-encryption-in-transit-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-in-transit-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-in-transit-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-encryption-in-transit-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EMR clusters have in-transit encryption enabled through a security configuration. In-transit encryption protects data moving between nodes in the cluster and between the cluster and S3, preventing interception of data on the network.
@@ -36432,23 +36432,23 @@ queries:
       - uid: mondoo-aws-security-emr-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EMR clusters have logging enabled by configuring an S3 log URI. EMR cluster logs include step logs, application logs, and bootstrap action logs that provide operational and security visibility into cluster activity.
@@ -36581,23 +36581,23 @@ queries:
       - uid: mondoo-aws-security-dax-encryption-at-rest-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dax-encryption-at-rest-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-at-rest-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-at-rest-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-at-rest-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DynamoDB Accelerator (DAX) clusters have server-side encryption (SSE) enabled. DAX is an in-memory cache for DynamoDB that stores copies of table data, and without encryption at rest, cached data is stored unencrypted in memory and on disk.
@@ -36725,23 +36725,23 @@ queries:
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon SQS queue access policies do not grant access to wildcard principals. A queue policy with `"Principal": "*"` or `"Principal": {"AWS": "*"}` without appropriate conditions allows any AWS account or unauthenticated user to perform actions on the queue.
@@ -36876,7 +36876,7 @@ queries:
       - uid: mondoo-aws-security-ecs-task-definition-no-plaintext-secrets-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon ECS task definitions do not contain plaintext secrets in container environment variables. Hardcoded secrets such as passwords, API keys, and access tokens in environment variables can be exposed through the ECS console, API calls, or container introspection.
@@ -36996,7 +36996,7 @@ queries:
       - uid: mondoo-aws-security-no-default-vpc-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that the default VPC is not present in the AWS account. Default VPCs are created automatically in each AWS region with permissive network configurations that are unsuitable for production workloads.
@@ -37062,23 +37062,23 @@ queries:
       - uid: mondoo-aws-security-emr-local-disk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-local-disk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-local-disk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-local-disk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-local-disk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon EMR clusters have local disk encryption enabled. Local disk encryption protects data stored on instance store volumes and EBS volumes attached to EMR cluster nodes using Linux Unified Key Setup (LUKS) or other encryption mechanisms.
@@ -37226,23 +37226,23 @@ queries:
       - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-aws
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS CloudTrail multi-region trails are configured to deliver logs to Amazon CloudWatch Logs. CloudWatch integration enables real-time monitoring, alerting, and automated responses to CloudTrail events.
@@ -37368,23 +37368,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-backup-retention-aws
         tags:
           mondoo.com/filter-title: AWS ElastiCache Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-backup-retention-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-backup-retention-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-backup-retention-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-backup-retention-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Redis ElastiCache clusters have automatic backup (snapshot) retention configured. Automatic backups protect against data loss and enable point-in-time recovery.
@@ -37499,23 +37499,23 @@ queries:
       - uid: mondoo-aws-security-rds-backup-retention-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-backup-retention-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-backup-retention-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-backup-retention-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-backup-retention-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS DB instances have automated backup retention configured. Automated backups allow point-in-time recovery and are essential for data protection and disaster recovery.
@@ -37628,23 +37628,23 @@ queries:
       - uid: mondoo-aws-security-rds-performance-insights-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-performance-insights-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-performance-insights-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-performance-insights-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-performance-insights-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS DB instances have Performance Insights enabled. Performance Insights helps monitor and troubleshoot database performance issues by providing a dashboard that visualizes database load and helps identify bottlenecks.
@@ -37761,23 +37761,23 @@ queries:
       - uid: mondoo-aws-security-rds-deletion-protection-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-deletion-protection-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-deletion-protection-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-deletion-protection-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-deletion-protection-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS DB instances have deletion protection enabled. Deletion protection prevents accidental or unauthorized deletion of RDS instances, which could result in permanent data loss.
@@ -37890,23 +37890,23 @@ queries:
       - uid: mondoo-aws-security-rds-cluster-deletion-protection-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-cluster-deletion-protection-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-deletion-protection-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-deletion-protection-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-deletion-protection-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon RDS DB clusters (Aurora) have deletion protection enabled. Deletion protection prevents accidental or unauthorized deletion of Aurora clusters, which could result in permanent data loss.
@@ -38021,23 +38021,23 @@ queries:
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon ECR repositories are configured to use AWS KMS encryption instead of the default AES-256 encryption. Customer-managed KMS encryption provides additional control over the encryption keys used to protect container images at rest.
@@ -38152,23 +38152,23 @@ queries:
       - uid: mondoo-aws-security-neptune-cluster-log-export-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-cluster-log-export-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-log-export-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-log-export-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-cluster-log-export-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune DB clusters have audit log export to CloudWatch Logs enabled. Exporting Neptune audit logs to CloudWatch enables centralized monitoring, analysis, and alerting on database activities.
@@ -38277,23 +38277,23 @@ queries:
       - uid: mondoo-aws-security-documentdb-cluster-log-export-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-cluster-log-export-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-log-export-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-log-export-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-cluster-log-export-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DocumentDB clusters have audit log export to CloudWatch Logs enabled. Exporting audit logs to CloudWatch enables centralized monitoring, analysis, and alerting on DocumentDB operations.
@@ -38415,23 +38415,23 @@ queries:
       - uid: mondoo-aws-security-config-aggregator-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-config-aggregator-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that an AWS Config aggregator is configured to collect configuration and compliance data across all AWS accounts and regions. Without an aggregator, Config data is siloed per region, making it difficult to maintain a centralized view of resource compliance.
@@ -38534,23 +38534,23 @@ queries:
       - uid: mondoo-aws-security-config-aggregator-all-regions-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-config-aggregator-all-regions-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-all-regions-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-all-regions-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-config-aggregator-all-regions-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Config aggregators are configured to collect data from all AWS regions. An aggregator that only covers specific regions leaves blind spots where resource misconfigurations and compliance violations may go undetected.
@@ -38670,7 +38670,7 @@ queries:
       - uid: mondoo-aws-security-ecr-no-public-access-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that Amazon ECR private repository access policies do not grant public access. A repository policy that allows the `*` principal enables any AWS account or unauthenticated user to pull container images, potentially exposing proprietary code, configuration, and embedded secrets.
@@ -38786,7 +38786,7 @@ queries:
       - uid: mondoo-aws-security-ec2-launch-template-no-secrets-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that EC2 launch template user data does not contain hard-coded secrets such as AWS access keys, private keys, passwords, or API tokens. Launch template user data is visible to anyone with EC2 describe permissions and is stored in plaintext, making it an insecure location for sensitive credentials.
@@ -38891,7 +38891,7 @@ queries:
       - uid: mondoo-aws-security-cloudtrail-is-logging-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that all multi-region AWS CloudTrail trails have logging actively enabled. The check scopes to multi-region trails because these provide the broadest visibility across all AWS regions, making them the most critical trails to keep active. A trail that exists but has logging stopped provides no visibility into API activity, creating a dangerous blind spot in your security monitoring.
@@ -38976,7 +38976,7 @@ queries:
       - uid: mondoo-aws-security-ec2-snapshot-not-public-aws
         tags:
           mondoo.com/filter-title: AWS EBS Snapshot
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that EBS snapshots are not publicly shared. Public snapshots expose volume data to any AWS account, potentially leaking sensitive information such as application data, credentials, or encryption keys stored on the volume.
@@ -39066,23 +39066,23 @@ queries:
       - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that all EBS volumes defined in EC2 launch configurations are encrypted. Launch configurations are a legacy Auto Scaling mechanism, but many environments still use them. Unencrypted EBS volumes in launch configurations mean every instance launched by the associated Auto Scaling group will have unencrypted root or data volumes.
@@ -39213,23 +39213,23 @@ queries:
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 launch configurations do not automatically assign public IP addresses to instances. Instances with public IPs are directly reachable from the internet, increasing the attack surface.
@@ -39335,23 +39335,23 @@ queries:
       - uid: mondoo-aws-security-ec2-launch-config-imdsv2-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ec2-launch-config-imdsv2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-imdsv2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-imdsv2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ec2-launch-config-imdsv2-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EC2 launch configurations require IMDSv2 (Instance Metadata Service Version 2) by setting `httpTokens` to `required`. IMDSv1 is vulnerable to SSRF attacks that can extract instance credentials.
@@ -39470,23 +39470,23 @@ queries:
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Instance
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that RDS database instances are encrypted using customer-managed KMS keys (CMK) rather than the default AWS-managed encryption. Customer-managed keys provide full control over key lifecycle, rotation policies, and access auditing.
@@ -39612,23 +39612,23 @@ queries:
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS RDS DB Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that RDS clusters are encrypted using customer-managed KMS keys (CMK). Customer-managed keys provide full control over key lifecycle, rotation policies, and access auditing for cluster data.
@@ -39755,7 +39755,7 @@ queries:
       - uid: mondoo-aws-security-rds-snapshot-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS RDS Snapshot
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
     docs:
       desc: |
         This check ensures that RDS snapshots are encrypted using customer-managed KMS keys (CMK). Snapshots may be shared across accounts or retained long-term, making encryption key control especially important.
@@ -39848,23 +39848,23 @@ queries:
       - uid: mondoo-aws-security-emr-not-publicly-accessible-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-not-publicly-accessible-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check verifies that EMR cluster master nodes do not have a public DNS name assigned. A master node with a public DNS name is directly reachable from the internet, exposing sensitive data processing infrastructure and creating a significant attack surface.
@@ -39988,23 +39988,23 @@ queries:
       - uid: mondoo-aws-security-emr-log-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-log-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-log-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-log-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-emr-log-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that EMR clusters with logging enabled use a customer-managed KMS key (CMK) to encrypt log data. For Terraform deployments, the check verifies that a security configuration is attached to the cluster, as the security configuration is where CMK encryption settings for logs are defined. EMR logs may contain sensitive information including query results, application output, and debugging data.
@@ -40152,23 +40152,23 @@ queries:
       - uid: mondoo-aws-security-neptune-no-default-security-groups-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-neptune-no-default-security-groups-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-no-default-security-groups-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-no-default-security-groups-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-neptune-no-default-security-groups-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Neptune database clusters do not use the default VPC security group. Default security groups often have overly permissive inbound and outbound rules that do not follow the principle of least privilege.
@@ -40281,23 +40281,23 @@ queries:
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon DocumentDB clusters do not use the default VPC security group. Default security groups often have overly permissive rules that violate the principle of least privilege.
@@ -40414,23 +40414,23 @@ queries:
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
         tags:
           mondoo.com/filter-title: AWS Redshift Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that when Redshift clusters use AWS Secrets Manager to manage the master password, the associated KMS key is a customer-managed key (CMK). This check only applies when Secrets Manager manages the Redshift master password.
@@ -40546,19 +40546,19 @@ queries:
       - uid: mondoo-aws-security-cloudfront-sni-only-aws
         tags:
           mondoo.com/filter-title: AWS CloudFront Distribution
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-sni-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-sni-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-sni-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that CloudFront distributions use SNI-only (Server Name Indication) for SSL/TLS certificate serving rather than dedicated IP SSL. SNI-only is the modern, recommended approach for HTTPS on CloudFront.
@@ -40670,23 +40670,23 @@ queries:
       - uid: mondoo-aws-security-cloudfront-access-logging-enabled-aws
         tags:
           mondoo.com/filter-title: AWS CloudFront Distribution
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-access-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-access-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-access-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-cloudfront-access-logging-enabled-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon CloudFront distributions have access logging enabled. Access logs contain detailed information about every request received by the distribution, including the requester IP, request path, response code, and edge location.
@@ -40793,23 +40793,23 @@ queries:
       - uid: mondoo-aws-security-dax-encryption-in-transit-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dax-encryption-in-transit-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-in-transit-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-in-transit-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dax-encryption-in-transit-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that DynamoDB Accelerator (DAX) clusters enforce TLS encryption for data in transit. Without encryption in transit, cached data transmitted between DAX nodes and clients is vulnerable to network-level interception.
@@ -40923,19 +40923,19 @@ queries:
       - uid: mondoo-aws-security-ecs-init-process-enabled-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecs-init-process-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-init-process-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecs-init-process-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that ECS task definitions configure containers with the init process enabled. Without an init process, PID 1 does not properly reap zombie processes, signal handling is unreliable, and container stops may hang until the timeout is reached.
@@ -41048,23 +41048,23 @@ queries:
       - uid: mondoo-aws-security-lambda-in-vpc-aws
         tags:
           mondoo.com/filter-title: AWS Lambda Function
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-lambda-in-vpc-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-in-vpc-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-in-vpc-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-lambda-in-vpc-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that AWS Lambda functions are deployed within a VPC. Lambda functions outside a VPC cannot leverage network-level security controls such as security groups, NACLs, or private subnets.
@@ -41189,19 +41189,19 @@ queries:
       - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon ECR repository policies do not grant overly permissive access through wildcard principals without conditions. ECR policies with unconditional wildcard principals allow any AWS account to pull or push images.
@@ -41332,23 +41332,23 @@ queries:
       - uid: mondoo-aws-security-elasticache-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS ElastiCache Cluster
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticache-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-elasticache-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that ElastiCache replication groups are encrypted using customer-managed KMS keys (CMK). CMKs provide full control over key lifecycle, rotation policies, and access auditing for cached data.
@@ -41467,23 +41467,23 @@ queries:
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-aws
         tags:
           mondoo.com/filter-title: AWS Account
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that Amazon Kinesis Data Streams are encrypted using customer-managed KMS keys (CMK).
@@ -41601,23 +41601,23 @@ queries:
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-aws
         tags:
           mondoo.com/filter-title: AWS DynamoDB Table
-          mondoo.com/icon: aws
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-cloudformation
         tags:
           mondoo.com/filter-title: CloudFormation
-          mondoo.com/icon: cloudformation
+          mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
         This check ensures that DynamoDB tables are encrypted using customer-managed KMS keys (CMK). CMKs provide full control over key lifecycle, rotation policies, and access auditing for DynamoDB table data.

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -273,19 +273,19 @@ queries:
       - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Machine
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OS disks for Azure virtual machines are encrypted, which is critical for securing boot volumes from unauthorized access and data breaches. The use of Customer Managed Keys (CMK) offers enhanced control over the encryption and decryption processes, allowing organizations to manage their own keys via Azure Key Vault. This approach not only meets compliance requirements but also provides a higher level of security by enabling key rotation and revocation capabilities. Encrypting OS disks ensures that the data is unreadable to unauthorized users, protecting it from both external attacks and insider threats. Customer managed keys can be either Azure Disk Encryption (ADE) or server-side encryption (SSE).
@@ -521,19 +521,19 @@ queries:
       - uid: mondoo-azure-security-ssh-access-restricted-from-internet-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ssh-access-restricted-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ssh-access-restricted-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ssh-access-restricted-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     props:
       - uid: mondooAzureSecurityDisallowedPortsSSH
         title: A list of disallowed TCP ports, by default SSH listens only on TCP port 22. Add more ports as needed.
@@ -728,19 +728,19 @@ queries:
       - uid: mondoo-azure-security-rdp-access-restricted-from-internet-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-rdp-access-restricted-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rdp-access-restricted-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rdp-access-restricted-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     props:
       - uid: mondooAzureSecurityDisallowedPortsRDP
         title: a list of disallowed TCP ports, by default RDP listens only on TCP port 3389. Add more ports as needed.
@@ -934,19 +934,19 @@ queries:
       - uid: mondoo-azure-security-vnc-access-restricted-from-internet-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-vnc-access-restricted-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vnc-access-restricted-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vnc-access-restricted-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     props:
       - uid: mondooAzureSecurityDisallowedPortsVNC
         title: a list of disallowed TCP ports, by default VNC listens only on TCP port 5900. Add more ports as needed.
@@ -1140,19 +1140,19 @@ queries:
       - uid: mondoo-azure-security-secure-transfer-required-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-secure-transfer-required-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-secure-transfer-required-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-secure-transfer-required-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that "Secure transfer required" is enabled. This setting enforces the use of HTTPS for data operations, ensuring that data transmitted to and from Azure storage accounts is secured.
@@ -1276,19 +1276,19 @@ queries:
       - uid: mondoo-azure-security-public-access-level-private-blob-containers-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-public-access-level-private-blob-containers-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-public-access-level-private-blob-containers-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-public-access-level-private-blob-containers-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that anonymous access to blob containers is disabled and public access on storage accounts is disabled.
@@ -1444,19 +1444,19 @@ queries:
       - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure storage accounts have their default network access rule set to "Deny". This configuration is critical for enhancing security by ensuring that only explicitly allowed networks can access the storage accounts.
@@ -1608,19 +1608,19 @@ queries:
       - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that "Trusted Microsoft Services" is enabled for storage account access.
@@ -1762,19 +1762,19 @@ queries:
       - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure SQL servers have an audit log retention policy set to at least 30 days.
@@ -1885,27 +1885,27 @@ queries:
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-single-azuresql
         tags:
           mondoo.com/filter-title: Azure SQL Database
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-single-postgresql-flexible
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-single-mysql-flexible
         tags:
           mondoo.com/filter-title: Azure MySQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SQL databases across various platforms (Azure SQL, PostgreSQL, MySQL) do not permit unrestricted network access by blocking ingress from the IP address range "0.0.0.0/0".
@@ -2073,19 +2073,19 @@ queries:
       - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Managed Identities are enabled for Azure App Services to securely authenticate with Microsoft Entra ID.
@@ -2247,19 +2247,19 @@ queries:
       - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Key Vaults are configured with purge protection to prevent accidental or malicious deletion of key vaults and their contents.
@@ -2364,19 +2364,19 @@ queries:
       - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Services use the latest available version of TLS encryption for secure Web App connections.
@@ -2535,19 +2535,19 @@ queries:
       - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that expiration dates are set for all keys and secrets in Azure Key Vaults to enforce proper key rotation and prevent the use of expired cryptographic materials.
@@ -2715,19 +2715,19 @@ queries:
       - uid: mondoo-azure-security-ensure-logging-enabled-kv-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-logging-enabled-kv-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-logging-enabled-kv-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-logging-enabled-kv-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all operations in Azure Key Vault are logged to provide a comprehensive audit trail for security and compliance purposes.
@@ -2904,19 +2904,19 @@ queries:
       - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that activity log alerts are configured for the creation, update, and deletion of network security groups to monitor changes and detect suspicious activities.
@@ -3132,19 +3132,19 @@ queries:
       - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that security alert email notifications are enabled to promptly inform administrators of potential security issues.
@@ -3303,19 +3303,19 @@ queries:
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SSL/TLS is enforced for all connections to PostgreSQL database servers to safeguard data in transit.
@@ -3441,19 +3441,19 @@ queries:
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-azure
         tags:
           mondoo.com/filter-title: Azure MySQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SSL connections are enforced for MySQL database servers to safeguard data in transit and that the latest supported TLS version is used to mitigate vulnerabilities associated with older versions.
@@ -3572,19 +3572,19 @@ queries:
       - uid: mondoo-azure-security-ensure-disabled-public-access-sql-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-ensure-disabled-public-access-sql-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-disabled-public-access-sql-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-ensure-disabled-public-access-sql-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access for Azure SQL servers is either disabled or limited to specific networks, significantly reducing exposure to potential attacks.
@@ -3697,19 +3697,19 @@ queries:
       - uid: mondoo-azure-security-keyvault-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-keyvault-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access to Azure Key Vault is either disabled or restricted to selected networks, significantly reducing exposure to potential attacks.
@@ -3829,19 +3829,19 @@ queries:
       - uid: mondoo-azure-security-sql-server-audit-on-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-server-audit-on-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-audit-on-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-audit-on-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that auditing is enabled for every database or server in your Azure deployment to monitor and log activities for security and compliance purposes.
@@ -3964,19 +3964,19 @@ queries:
       - uid: mondoo-azure-security-sql-server-tde-on-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-server-tde-on-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-tde-on-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-tde-on-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Transparent Data Encryption (TDE) is enabled for SQL Server databases to encrypt data at rest and protect sensitive information.
@@ -4087,19 +4087,19 @@ queries:
       - uid: mondoo-azure-security-diagnostic-settings-exist-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-diagnostic-settings-exist-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-diagnostic-settings-exist-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-diagnostic-settings-exist-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that diagnostic settings are configured for Azure resources to collect essential logs and metrics, enabling effective monitoring and security analysis.
@@ -4266,19 +4266,19 @@ queries:
       - uid: mondoo-azure-security-diagnostic-settings-essential-categories-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-diagnostic-settings-essential-categories-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-diagnostic-settings-essential-categories-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-diagnostic-settings-essential-categories-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that diagnostic settings collect essential security categories such as Administrative, Security, Alert, and Policy logs to provide comprehensive monitoring and security insights.
@@ -4491,19 +4491,19 @@ queries:
       - uid: mondoo-azure-security-disable-udp-virtualmachines-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-disable-udp-virtualmachines-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-disable-udp-virtualmachines-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-disable-udp-virtualmachines-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     props:
       - uid: mondooAzureSecurityDisallowedPortsUDP
         title: A list of disallowed UDP ports, by default covering common UDP services. Add more as needed.
@@ -4733,19 +4733,19 @@ queries:
       - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that blob soft delete is enabled for Azure Storage accounts to protect against accidental or malicious deletion of blob data.
@@ -4870,19 +4870,19 @@ queries:
       - uid: mondoo-azure-security-storage-container-soft-delete-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-container-soft-delete-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-container-soft-delete-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-container-soft-delete-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that container soft delete is enabled for Azure Storage accounts to protect against accidental or malicious deletion of storage containers and their contents.
@@ -5007,19 +5007,19 @@ queries:
       - uid: mondoo-azure-security-storage-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Storage accounts enforce a minimum TLS version of 1.2 for all connections, preventing the use of older, vulnerable TLS versions.
@@ -5135,19 +5135,19 @@ queries:
       - uid: mondoo-azure-security-sql-threat-detection-enabled-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-threat-detection-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-detection-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-detection-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Advanced Threat Protection (threat detection) is enabled on Azure SQL servers to detect anomalous database activities and potential security threats.
@@ -5234,19 +5234,19 @@ queries:
       - uid: mondoo-azure-security-sql-ad-admin-configured-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-ad-admin-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-ad-admin-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-ad-admin-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that an Azure Active Directory (Azure AD) administrator is configured for Azure SQL servers, enabling centralized identity management and stronger authentication.
@@ -5341,19 +5341,19 @@ queries:
       - uid: mondoo-azure-security-keyvault-rbac-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-keyvault-rbac-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-rbac-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-rbac-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Key Vault uses Role-Based Access Control (RBAC) for authorization instead of vault access policies, providing more granular and manageable access control.
@@ -5443,19 +5443,19 @@ queries:
       - uid: mondoo-azure-security-keyvault-key-auto-rotation-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-keyvault-key-auto-rotation-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-key-auto-rotation-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-key-auto-rotation-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all enabled keys in Azure Key Vault have automatic rotation configured, reducing the risk of using long-lived cryptographic keys.
@@ -5576,19 +5576,19 @@ queries:
       - uid: mondoo-azure-security-keyvault-private-endpoints-azure
         tags:
           mondoo.com/filter-title: Azure Key Vault
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-keyvault-private-endpoints-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-private-endpoints-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-keyvault-private-endpoints-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Key Vault instances have at least one private endpoint connection configured, enabling secure access through private network connectivity.
@@ -5706,19 +5706,19 @@ queries:
       - uid: mondoo-azure-security-compute-data-disks-encrypted-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Machine
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-data-disks-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-data-disks-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-data-disks-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that data disks attached to Azure virtual machines are encrypted with Customer Managed Keys (CMK), protecting stored data from unauthorized access.
@@ -5840,19 +5840,19 @@ queries:
       - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Network Watcher flow logs are enabled to capture and record network traffic data for security analysis and monitoring.
@@ -5980,19 +5980,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-servers-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-servers-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-servers-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-servers-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Servers is enabled to provide advanced threat protection for Azure virtual machines and on-premises servers connected to Azure.
@@ -6102,19 +6102,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-app-services-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-app-services-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-app-services-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-app-services-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for App Service is enabled to detect threats targeting applications hosted on Azure App Service.
@@ -6223,19 +6223,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-sql-databases-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-sql-databases-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-sql-databases-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-sql-databases-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Azure SQL Databases is enabled to provide advanced threat detection for Azure SQL Database instances.
@@ -6344,19 +6344,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-storage-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-storage-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-storage-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-storage-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Storage is enabled to detect unusual and potentially harmful attempts to access or exploit Azure Storage accounts.
@@ -6465,19 +6465,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-keyvault-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-keyvault-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-keyvault-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-keyvault-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Key Vault is enabled to detect unusual and potentially harmful attempts to access or exploit Azure Key Vault resources.
@@ -6586,19 +6586,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-containers-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-containers-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-containers-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-containers-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Containers is enabled to provide threat protection for Azure Kubernetes Service (AKS) clusters and container workloads.
@@ -6707,19 +6707,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-resource-manager-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-resource-manager-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-resource-manager-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-resource-manager-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Resource Manager is enabled to monitor Azure management operations and detect suspicious resource management activities.
@@ -6828,19 +6828,19 @@ queries:
       - uid: mondoo-azure-security-defender-auto-provisioning-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-auto-provisioning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-auto-provisioning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-auto-provisioning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that auto-provisioning of the monitoring agent is enabled so that all new and existing virtual machines are automatically configured for security data collection.
@@ -6947,19 +6947,19 @@ queries:
       - uid: mondoo-azure-security-aks-rbac-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-rbac-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-rbac-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-rbac-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Role-Based Access Control (RBAC) is enabled on all Azure Kubernetes Service (AKS) clusters to enforce proper access control for Kubernetes resources.
@@ -7083,19 +7083,19 @@ queries:
       - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that non-private AKS clusters have API server authorized IP ranges configured to restrict access to the Kubernetes API server from known, trusted networks. Private clusters are excluded from this check as they use private endpoints for API server access, which provides stronger network isolation.
@@ -7231,19 +7231,19 @@ queries:
       - uid: mondoo-azure-security-aks-network-policy-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-network-policy-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-network-policy-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-network-policy-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have a network policy configured (such as Azure Network Policy or Calico) to control traffic flow between pods.
@@ -7376,19 +7376,19 @@ queries:
       - uid: mondoo-azure-security-app-service-https-only-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-https-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-https-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-https-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service web applications are configured to enforce HTTPS-only access, automatically redirecting HTTP requests to HTTPS.
@@ -7517,19 +7517,19 @@ queries:
       - uid: mondoo-azure-security-app-service-ftp-disabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-ftp-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ftp-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ftp-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that basic authentication for FTP publishing is disabled on Azure App Service web apps, preventing the use of username/password credentials for file deployment.
@@ -7660,19 +7660,19 @@ queries:
       - uid: mondoo-azure-security-app-service-scm-disabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-scm-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-scm-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-scm-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that basic authentication for SCM (Kudu) site publishing is disabled on Azure App Service web apps, preventing the use of username/password credentials for deployment via the SCM endpoint.
@@ -7803,19 +7803,19 @@ queries:
       - uid: mondoo-azure-security-redis-ssl-only-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-ssl-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-ssl-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-ssl-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the non-SSL port (6379) is disabled on Azure Cache for Redis instances, requiring all connections to use TLS-encrypted communication.
@@ -7914,19 +7914,19 @@ queries:
       - uid: mondoo-azure-security-redis-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Cache for Redis instances, requiring connections to go through private endpoints.
@@ -8024,19 +8024,19 @@ queries:
       - uid: mondoo-azure-security-aks-private-cluster-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-private-cluster-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-private-cluster-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-private-cluster-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Kubernetes Service (AKS) clusters are configured as private clusters, making the API server accessible only through private endpoints within the virtual network.
@@ -8174,19 +8174,19 @@ queries:
       - uid: mondoo-azure-security-aks-run-command-disabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-run-command-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-run-command-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-run-command-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the run command feature is disabled on Azure Kubernetes Service (AKS) clusters, preventing remote command execution through the Azure API.
@@ -8324,19 +8324,19 @@ queries:
       - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the Azure Policy add-on is enabled on Azure Kubernetes Service (AKS) clusters, allowing organizations to enforce governance and compliance policies at the cluster level.
@@ -8477,19 +8477,19 @@ queries:
       - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that private AKS clusters do not expose a public fully qualified domain name (FQDN), preventing DNS resolution of the API server from outside the private network.
@@ -8630,19 +8630,19 @@ queries:
       - uid: mondoo-azure-security-aks-defender-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-defender-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-defender-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-defender-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Containers is enabled on Azure Kubernetes Service (AKS) clusters, providing cloud-native Kubernetes security including environment hardening, workload protection, and runtime threat detection.
@@ -8762,19 +8762,19 @@ queries:
       - uid: mondoo-azure-security-aks-image-cleaner-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-image-cleaner-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-image-cleaner-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-image-cleaner-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the Image Cleaner feature is enabled on AKS clusters, automatically detecting and removing stale, unused, and potentially vulnerable container images cached on nodes.
@@ -8890,19 +8890,19 @@ queries:
       - uid: mondoo-azure-security-aks-workload-identity-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-workload-identity-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-workload-identity-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-workload-identity-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that workload identity is enabled on AKS clusters, allowing pods to authenticate to Azure services using Azure AD federated credentials instead of storing secrets in the cluster.
@@ -9021,19 +9021,19 @@ queries:
       - uid: mondoo-azure-security-aks-encryption-at-host-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-encryption-at-host-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-encryption-at-host-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-encryption-at-host-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that host-based encryption is enabled on all agent pool nodes in AKS clusters, providing end-to-end encryption for temporary disks, OS disks, and cached data.
@@ -9164,19 +9164,19 @@ queries:
       - uid: mondoo-azure-security-aks-no-kubenet-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-no-kubenet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-no-kubenet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-no-kubenet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters do not use the kubenet network plugin, which has limited security capabilities compared to Azure CNI or Azure CNI Overlay.
@@ -9288,19 +9288,19 @@ queries:
       - uid: mondoo-azure-security-aks-container-insights-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-container-insights-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-container-insights-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-container-insights-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Container Insights (via the OMS agent add-on) is enabled on AKS clusters, collecting container logs, performance metrics, and Kubernetes events for Azure Monitor.
@@ -9415,19 +9415,19 @@ queries:
       - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the Azure Key Vault Secrets Provider (Secrets Store CSI Driver) is enabled on AKS clusters, enabling pods to retrieve secrets directly from Azure Key Vault.
@@ -9541,19 +9541,19 @@ queries:
       - uid: mondoo-azure-security-app-service-client-cert-enabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-client-cert-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-client-cert-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-client-cert-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that client certificate authentication (mutual TLS) is enabled for Azure App Service web applications, requiring clients to present a valid certificate to establish a connection.
@@ -9697,19 +9697,19 @@ queries:
       - uid: mondoo-azure-security-app-service-remote-debugging-disabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-remote-debugging-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-remote-debugging-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-remote-debugging-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that remote debugging is disabled for Azure App Service web applications, preventing the exposure of debugging ports and interfaces to the network.
@@ -9856,19 +9856,19 @@ queries:
       - uid: mondoo-azure-security-app-service-http20-enabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-http20-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-http20-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-http20-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that HTTP 2.0 is enabled for Azure App Service web applications, providing improved performance and security features over HTTP 1.1.
@@ -10015,19 +10015,19 @@ queries:
       - uid: mondoo-azure-security-app-service-ftps-required-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-ftps-required-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ftps-required-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ftps-required-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service apps do not allow unencrypted FTP connections for file deployment, requiring either FTPS (FTP over TLS) or disabling FTP entirely.
@@ -10161,19 +10161,19 @@ queries:
       - uid: mondoo-azure-security-app-service-cors-no-wildcard-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-cors-no-wildcard-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-cors-no-wildcard-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-cors-no-wildcard-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service apps do not have Cross-Origin Resource Sharing (CORS) configured with a wildcard (`*`) origin, which would allow any website to make cross-origin requests to the application.
@@ -10319,19 +10319,19 @@ queries:
       - uid: mondoo-azure-security-function-app-authentication-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Function App
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-function-app-authentication-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-function-app-authentication-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-function-app-authentication-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Function apps have App Service Authentication (Easy Auth) enabled, requiring callers to authenticate before reaching the function endpoints.
@@ -10476,19 +10476,19 @@ queries:
       - uid: mondoo-azure-security-function-app-private-endpoints-azure
         tags:
           mondoo.com/filter-title: Azure Function App
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-function-app-private-endpoints-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-function-app-private-endpoints-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-function-app-private-endpoints-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Function apps are configured with private endpoints, restricting network access to only traffic from within the virtual network.
@@ -10624,19 +10624,19 @@ queries:
       - uid: mondoo-azure-security-redis-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are configured to require a minimum TLS version of 1.2 for all connections, preventing the use of older, vulnerable TLS versions.
@@ -10746,19 +10746,19 @@ queries:
       - uid: mondoo-azure-security-redis-latest-version-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-latest-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-latest-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-latest-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are running a supported version (version 6 or later), as older versions may lack important security patches and features.
@@ -10869,19 +10869,19 @@ queries:
       - uid: mondoo-azure-security-redis-auth-required-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-auth-required-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-auth-required-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-auth-required-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances require authentication for all connections, preventing unauthorized access to cached data.
@@ -10981,19 +10981,19 @@ queries:
       - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that cross-tenant replication is disabled for Azure Storage accounts, preventing data from being replicated to storage accounts in different Microsoft Entra ID tenants.
@@ -11123,19 +11123,19 @@ queries:
       - uid: mondoo-azure-security-storage-sftp-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-sftp-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-sftp-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-sftp-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SFTP (SSH File Transfer Protocol) is disabled on Azure Storage accounts unless there is a specific business requirement for it, reducing the attack surface.
@@ -11265,19 +11265,19 @@ queries:
       - uid: mondoo-azure-security-storage-shared-key-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-shared-key-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-shared-key-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-shared-key-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that shared key access is disabled for Azure Storage accounts, requiring all requests to be authorized using Microsoft Entra ID.
@@ -11407,19 +11407,19 @@ queries:
       - uid: mondoo-azure-security-compute-vm-no-public-ip-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Machine
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-vm-no-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-vm-no-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-vm-no-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure virtual machines do not have public IP addresses directly attached, reducing the exposure of compute resources to the public internet.
@@ -11588,19 +11588,19 @@ queries:
       - uid: mondoo-azure-security-compute-managed-disks-only-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Machine
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-managed-disks-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-managed-disks-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-managed-disks-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure virtual machines use managed disks instead of unmanaged disks, providing improved reliability, security, and simplified management.
@@ -11771,19 +11771,19 @@ queries:
       - uid: mondoo-azure-security-compute-unattached-disks-encrypted-azure
         tags:
           mondoo.com/filter-title: Azure Managed Disk
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-unattached-disks-encrypted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-unattached-disks-encrypted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-unattached-disks-encrypted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that unattached Azure managed disks are encrypted with Customer Managed Keys (CMK), protecting data at rest even when disks are not attached to any virtual machine.
@@ -11924,19 +11924,19 @@ queries:
       - uid: mondoo-azure-security-network-ddos-protection-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Network
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-ddos-protection-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-ddos-protection-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-ddos-protection-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure DDoS Protection is enabled on all virtual networks to defend against distributed denial-of-service attacks.
@@ -12092,19 +12092,19 @@ queries:
       - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Network
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VM protection is enabled on all Azure virtual networks to help prevent unauthorized traffic from reaching virtual machines.
@@ -12236,19 +12236,19 @@ queries:
       - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Virtual Network
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that default outbound access is disabled on all subnets within Azure virtual networks, enforcing explicit outbound connectivity configurations.
@@ -12379,19 +12379,19 @@ queries:
       - uid: mondoo-azure-security-network-database-ports-restricted-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-database-ports-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-database-ports-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-database-ports-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     props:
       - uid: mondooAzureSecurityDisallowedPortsDB
         title: A list of disallowed TCP database ports. Add more ports as needed.
@@ -12594,19 +12594,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Cosmos DB is enabled to detect threats targeting Azure Cosmos DB accounts.
@@ -12728,19 +12728,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for open-source relational databases is enabled to provide threat protection for Azure Database for MySQL and PostgreSQL.
@@ -12862,19 +12862,19 @@ queries:
       - uid: mondoo-azure-security-defender-cspm-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-cspm-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-cspm-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-cspm-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender Cloud Security Posture Management (CSPM) is enabled to provide advanced security posture capabilities beyond the foundational CSPM features.
@@ -12998,19 +12998,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Cosmos DB accounts, requiring all connections to go through private endpoints or approved virtual networks.
@@ -13137,19 +13137,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that local authentication (key-based access) is disabled on Azure Cosmos DB accounts, requiring the use of Microsoft Entra ID (formerly Azure Active Directory) for authentication.
@@ -13276,19 +13276,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that virtual network filtering is enabled on Azure Cosmos DB accounts, restricting access to traffic from approved virtual networks and subnets.
@@ -13427,19 +13427,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that key-based metadata write access is disabled on Azure Cosmos DB accounts, preventing clients using account keys from modifying databases, containers, and throughput settings.
@@ -13565,19 +13565,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that automatic failover is enabled on Azure Cosmos DB accounts, providing high availability by automatically failing over to a secondary region during an outage.
@@ -13714,19 +13714,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured to require a minimum TLS version of 1.2 for all connections, rejecting clients that attempt to connect using older, insecure TLS versions.
@@ -13852,19 +13852,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts have the network ACL bypass set to `None`, preventing Azure services from bypassing firewall rules.
@@ -13990,19 +13990,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with customer-managed keys (CMK) via Azure Key Vault for data-at-rest encryption, rather than relying on the default Microsoft-managed keys.
@@ -14129,19 +14129,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts with public network access enabled have IP firewall rules configured, restricting which IP addresses can connect to the account.
@@ -14260,19 +14260,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-private-endpoints-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-private-endpoints-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-private-endpoints-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-private-endpoints-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts have private endpoint connections configured, providing network-level isolation through the Azure private network.
@@ -14402,19 +14402,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts do not have Cross-Origin Resource Sharing (CORS) configured with a wildcard (`*`) origin, which would allow any website to make cross-origin requests.
@@ -14540,19 +14540,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-continuous-backup-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-continuous-backup-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-continuous-backup-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-continuous-backup-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with a continuous backup policy, providing point-in-time restore capabilities with fine-grained recovery points.
@@ -14669,19 +14669,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-multi-region-write-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-multi-region-write-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-multi-region-write-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-multi-region-write-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts distributed across multiple regions have multi-region write enabled, reducing write latency and improving availability.
@@ -14805,19 +14805,19 @@ queries:
       - uid: mondoo-azure-security-cosmosdb-strong-consistency-azure
         tags:
           mondoo.com/filter-title: Azure Cosmos DB Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cosmosdb-strong-consistency-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-strong-consistency-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-cosmosdb-strong-consistency-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with strong or bounded staleness consistency, providing stronger data integrity guarantees for security-sensitive workloads.
@@ -14934,19 +14934,19 @@ queries:
       - uid: mondoo-azure-security-firewall-threat-intel-deny-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-firewall-threat-intel-deny-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-threat-intel-deny-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-threat-intel-deny-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Firewall threat intelligence-based filtering is set to Deny mode, actively blocking traffic from and to known malicious IP addresses and domains.
@@ -15079,19 +15079,19 @@ queries:
       - uid: mondoo-azure-security-firewall-premium-sku-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-firewall-premium-sku-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-premium-sku-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-premium-sku-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Firewall instances use the Premium SKU, which provides advanced threat protection capabilities beyond what the Standard SKU offers.
@@ -15220,19 +15220,19 @@ queries:
       - uid: mondoo-azure-security-firewall-policy-configured-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-firewall-policy-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-policy-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-policy-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Firewall instances have a firewall policy attached, providing centralized rule management and consistent security posture across firewalls.
@@ -15384,19 +15384,19 @@ queries:
       - uid: mondoo-azure-security-firewall-idps-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-firewall-idps-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-idps-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-firewall-idps-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Firewall Policy has Intrusion Detection and Prevention System (IDPS) set to Deny mode, providing signature-based detection and active blocking of known attack patterns. Alert-only mode logs threats but does not prevent them from reaching protected resources.
@@ -15537,19 +15537,19 @@ queries:
       - uid: mondoo-azure-security-batch-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-batch-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Batch accounts, requiring all connections to go through private endpoints.
@@ -15675,19 +15675,19 @@ queries:
       - uid: mondoo-azure-security-batch-aad-auth-only-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-batch-aad-auth-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-aad-auth-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-aad-auth-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Batch accounts do not allow Shared Key authentication, requiring the use of Entra ID (Azure Active Directory) for all authentication operations.
@@ -15824,19 +15824,19 @@ queries:
       - uid: mondoo-azure-security-batch-encryption-configured-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-batch-encryption-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-encryption-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-encryption-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Batch accounts have encryption configured, protecting data at rest with either platform-managed or customer-managed encryption keys.
@@ -15983,7 +15983,7 @@ queries:
       - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
     docs:
       desc: |
         This check ensures that diagnostic settings are enabled on Azure Batch accounts, providing visibility into service operations, errors, and security events through centralized logging.
@@ -16104,19 +16104,19 @@ queries:
       - uid: mondoo-azure-security-batch-private-endpoints-configured-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-batch-private-endpoints-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-private-endpoints-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-private-endpoints-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Batch accounts have at least one private endpoint connection configured, enabling secure access through private network connectivity.
@@ -16263,19 +16263,19 @@ queries:
       - uid: mondoo-azure-security-batch-pool-disk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Batch Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-batch-pool-disk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-pool-disk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-batch-pool-disk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Batch pool compute nodes have disk encryption configured, protecting data at rest on OS and temporary disks.
@@ -16426,19 +16426,19 @@ queries:
       - uid: mondoo-azure-security-sql-server-min-tls-12-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-server-min-tls-12-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-min-tls-12-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-server-min-tls-12-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure SQL servers enforce a minimum TLS version of 1.2 for all connections, preventing the use of older, less secure TLS versions.
@@ -16523,19 +16523,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for PostgreSQL flexible servers, restricting connections to private endpoints only.
@@ -16622,19 +16622,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys, providing additional control over encryption keys.
@@ -16734,19 +16734,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-server-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-server-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-server-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-server-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL single servers enforce a minimum TLS version of 1.2 for all connections.
@@ -16827,19 +16827,19 @@ queries:
       - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure MySQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for MySQL flexible servers, restricting connections to private endpoints only.
@@ -16927,19 +16927,19 @@ queries:
       - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-azure
         tags:
           mondoo.com/filter-title: Azure MySQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for MySQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys, providing additional control over encryption keys.
@@ -17039,19 +17039,19 @@ queries:
       - uid: mondoo-azure-security-mysql-server-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure MySQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-mysql-server-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-server-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-server-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for MySQL single servers enforce a minimum TLS version of 1.2 for all connections.
@@ -17132,19 +17132,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for SQL Servers on Machines is enabled to provide advanced threat detection for SQL Server instances running on Azure VMs, on-premises, and in hybrid environments.
@@ -17243,19 +17243,19 @@ queries:
       - uid: mondoo-azure-security-aks-disk-encryption-set-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-disk-encryption-set-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-disk-encryption-set-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-disk-encryption-set-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have the disk CSI driver enabled in the storage profile. The disk CSI driver enables advanced disk features including customer-managed key encryption, Azure Disk encryption sets, and dynamic provisioning with encryption for cluster nodes.
@@ -17375,19 +17375,19 @@ queries:
       - uid: mondoo-azure-security-appgw-ssl-policy-tls12-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-appgw-ssl-policy-tls12-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-ssl-policy-tls12-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-ssl-policy-tls12-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all Azure Application Gateways have an SSL policy configured that enforces TLS 1.2 or higher as the minimum protocol version, preventing the use of deprecated TLS versions.
@@ -17525,19 +17525,19 @@ queries:
       - uid: mondoo-azure-security-vpn-gateway-ikev2-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-vpn-gateway-ikev2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vpn-gateway-ikev2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vpn-gateway-ikev2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure VPN gateways use the route-based VPN type, which supports the IKEv2 protocol. Policy-based VPN gateways only support IKEv1, which has known security limitations.
@@ -17666,19 +17666,19 @@ queries:
       - uid: mondoo-azure-security-databricks-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-databricks-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-databricks-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-databricks-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Databricks workspaces have public network access disabled, restricting connectivity to private endpoints only.
@@ -17793,19 +17793,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-endpoint-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-endpoint-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-endpoint-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-endpoint-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for Endpoint (WDATP) integration is enabled in Microsoft Defender for Cloud, providing endpoint detection and response (EDR) capabilities for Azure resources.
@@ -17913,19 +17913,19 @@ queries:
       - uid: mondoo-azure-security-defender-for-apis-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-defender-for-apis-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-apis-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-defender-for-apis-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Microsoft Defender for APIs is enabled to provide threat protection for APIs published through Azure API Management.
@@ -18030,19 +18030,19 @@ queries:
       - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service web applications are configured with a strong minimum TLS cipher suite, specifically TLS_AES_256_GCM_SHA384, which provides the highest level of encryption strength.
@@ -18172,19 +18172,19 @@ queries:
       - uid: mondoo-azure-security-app-service-e2e-encryption-enabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-e2e-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-e2e-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-e2e-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that end-to-end TLS encryption is enabled for Azure App Service web applications, encrypting traffic between the Azure front-end load balancer and the application worker process.
@@ -18321,19 +18321,19 @@ queries:
       - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have node OS auto-upgrade enabled, which automatically applies security patches to the underlying node operating system images.
@@ -18452,19 +18452,19 @@ queries:
       - uid: mondoo-azure-security-aks-local-accounts-disabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-local-accounts-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-local-accounts-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-local-accounts-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that local accounts are disabled on Azure Kubernetes Service (AKS) clusters, requiring all authentication to go through Microsoft Entra ID (Azure Active Directory).
@@ -18597,19 +18597,19 @@ queries:
       - uid: mondoo-azure-security-aks-public-network-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-public-network-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-public-network-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-public-network-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Kubernetes Service (AKS) clusters, restricting API server access to private networks only.
@@ -18749,19 +18749,19 @@ queries:
       - uid: mondoo-azure-security-aks-auto-upgrade-enabled-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-auto-upgrade-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-auto-upgrade-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-auto-upgrade-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have auto-upgrade enabled to automatically receive Kubernetes version updates, including security patches and bug fixes.
@@ -18876,19 +18876,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that password-based authentication is disabled on Azure Database for PostgreSQL flexible servers, enforcing Microsoft Entra ID (Azure Active Directory) as the sole authentication method.
@@ -18976,19 +18976,19 @@ queries:
       - uid: mondoo-azure-security-storage-smb-versions-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-smb-versions-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-smb-versions-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-smb-versions-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Storage accounts restrict SMB file share access to SMB 3.0 and later versions only, blocking older protocol versions that have known security vulnerabilities.
@@ -19111,19 +19111,19 @@ queries:
       - uid: mondoo-azure-security-storage-smb-channel-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-smb-channel-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-smb-channel-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-smb-channel-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Storage accounts are configured to use strong SMB channel encryption, specifically requiring AES-256-GCM support for file share connections.
@@ -19246,19 +19246,19 @@ queries:
       - uid: mondoo-azure-security-vpn-gateway-generation2-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-vpn-gateway-generation2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vpn-gateway-generation2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-vpn-gateway-generation2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure VPN gateways use the Generation2 SKU, which supports higher throughput, more tunnels, and stronger cryptographic standards compared to Generation1 gateways.
@@ -19389,19 +19389,19 @@ queries:
       - uid: mondoo-azure-security-compute-disk-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Managed Disk
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-disk-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-disk-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-disk-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that public network access is disabled for all Azure managed disks, preventing disk data from being accessed over the public internet during export or upload operations.
@@ -20250,19 +20250,19 @@ queries:
       - uid: mondoo-azure-security-aks-node-resource-group-restricted-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-node-resource-group-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-node-resource-group-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-node-resource-group-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have node resource group access restricted to read-only, preventing direct modification of managed infrastructure resources in the node resource group.
@@ -20367,7 +20367,7 @@ queries:
       - uid: mondoo-azure-security-aks-wireguard-transit-encryption-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
     docs:
       desc: |
         This check ensures that AKS clusters have WireGuard-based transit encryption enabled for pod-to-pod communication, protecting network traffic between nodes.
@@ -20440,19 +20440,19 @@ queries:
       - uid: mondoo-azure-security-aks-etcd-kms-encryption-azure
         tags:
           mondoo.com/filter-title: Azure AKS Cluster
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-aks-etcd-kms-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-etcd-kms-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-aks-etcd-kms-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AKS clusters have Azure Key Vault KMS encryption configured for etcd, providing envelope encryption for Kubernetes secrets at rest.
@@ -20555,7 +20555,7 @@ queries:
       - uid: mondoo-azure-security-app-service-ssh-disabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
     docs:
       desc: |
         This check ensures that Azure App Service instances have SSH access disabled, reducing the attack surface of production web applications.
@@ -20611,19 +20611,19 @@ queries:
       - uid: mondoo-azure-security-app-service-public-network-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-public-network-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-public-network-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-public-network-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service instances have public network access disabled, requiring all traffic to flow through private endpoints or VNet integration.
@@ -20718,19 +20718,19 @@ queries:
       - uid: mondoo-azure-security-app-service-scm-min-tls-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-scm-min-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-scm-min-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-scm-min-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the SCM (Kudu) endpoint for Azure App Service uses TLS 1.2 or higher, preventing credential interception during deployment operations.
@@ -20829,19 +20829,19 @@ queries:
       - uid: mondoo-azure-security-app-service-vnet-route-all-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-vnet-route-all-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-vnet-route-all-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-vnet-route-all-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service instances route all outbound traffic through VNet integration, subjecting it to network security controls such as NSGs and Azure Firewall.
@@ -20944,19 +20944,19 @@ queries:
       - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-azure
         tags:
           mondoo.com/filter-title: Azure App Service
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure App Service instances have IP restriction default action set to deny, blocking traffic from any IP address that is not explicitly allowed.
@@ -21076,19 +21076,19 @@ queries:
       - uid: mondoo-azure-security-storage-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Storage accounts use customer-managed keys (CMK) for encryption, providing key lifecycle control beyond the default Microsoft-managed encryption.
@@ -21209,19 +21209,19 @@ queries:
       - uid: mondoo-azure-security-sql-ad-only-authentication-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-ad-only-authentication-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-ad-only-authentication-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-ad-only-authentication-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure SQL Server is configured with Microsoft Entra ID (formerly Azure AD) only authentication, disabling SQL authentication entirely.
@@ -21326,19 +21326,19 @@ queries:
       - uid: mondoo-azure-security-sql-tde-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-tde-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-tde-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-tde-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure SQL Server Transparent Data Encryption (TDE) uses customer-managed keys stored in Azure Key Vault, providing key lifecycle control for data-at-rest encryption.
@@ -21428,19 +21428,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL Flexible Server uses customer-managed keys for data encryption, providing customer-controlled encryption for data at rest. By default, Azure manages encryption with service-managed keys for PostgreSQL Flexible Server, but customer-managed keys provide additional control over the encryption lifecycle.
@@ -21550,19 +21550,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-flexible-geo-backup-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-flexible-geo-backup-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-geo-backup-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-flexible-geo-backup-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL Flexible Server has geo-redundant backup enabled, protecting data against regional outages.
@@ -21659,19 +21659,19 @@ queries:
       - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure MySQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Database for MySQL Flexible Server uses customer-managed keys for data encryption, providing customer-controlled encryption for data at rest. By default, Azure manages encryption with service-managed keys for MySQL Flexible Server, but customer-managed keys provide additional control over the encryption lifecycle.
@@ -21781,19 +21781,19 @@ queries:
       - uid: mondoo-azure-security-redis-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-redis-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Cache for Redis uses customer-managed keys for encryption, providing key lifecycle control for cached data at rest.
@@ -21926,19 +21926,19 @@ queries:
       - uid: mondoo-azure-security-appgw-min-tls-version-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-appgw-min-tls-version-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-min-tls-version-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-min-tls-version-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all Azure Application Gateways enforce TLS 1.2 or higher as the minimum protocol version for SSL connections.
@@ -22051,19 +22051,19 @@ queries:
       - uid: mondoo-azure-security-appgw-no-weak-ciphers-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-appgw-no-weak-ciphers-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-no-weak-ciphers-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-appgw-no-weak-ciphers-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Application Gateways do not use weak SSL cipher suites such as RC4, 3DES, NULL, or EXPORT ciphers that allow decryption of intercepted traffic.
@@ -22186,19 +22186,19 @@ queries:
       - uid: mondoo-azure-security-public-ip-ddos-protection-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-public-ip-ddos-protection-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-public-ip-ddos-protection-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-public-ip-ddos-protection-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all Azure public IP addresses have DDoS protection enabled, either through a DDoS Protection plan or inherited from the virtual network.
@@ -22313,19 +22313,19 @@ queries:
       - uid: mondoo-azure-security-nsg-no-unrestricted-egress-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-nsg-no-unrestricted-egress-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-nsg-no-unrestricted-egress-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-nsg-no-unrestricted-egress-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that network security group rules do not allow unrestricted outbound traffic to the internet on all ports and protocols. Unrestricted egress rules allow compromised resources to exfiltrate data, establish command-and-control channels, or participate in attacks against external targets without network-level controls.
@@ -22480,19 +22480,19 @@ queries:
       - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure network interfaces do not have IP forwarding enabled unless explicitly required. IP forwarding allows a network interface to send and receive traffic not destined for its own IP address, which is typically only needed for network virtual appliances (firewalls, load balancers).
@@ -22600,19 +22600,19 @@ queries:
       - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-azure
         tags:
           mondoo.com/filter-title: Azure Network Security Group
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that network security groups do not expose sensitive management and database ports (Telnet/23, SMB/445, RPC/135, MSSQL/1433, MySQL/3306, PostgreSQL/5432) to the internet. The check identifies inbound allow rules with a source of `*` or `Internet`, which permit traffic from any internet source to reach these sensitive ports.
@@ -22774,19 +22774,19 @@ queries:
       - uid: mondoo-azure-security-compute-vm-password-auth-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Compute VM
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-compute-vm-password-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-vm-password-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-compute-vm-password-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Linux virtual machines have password authentication disabled in favor of SSH key-based authentication. Password authentication is vulnerable to brute-force attacks, credential stuffing, and password spraying.
@@ -22907,19 +22907,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-log-connections-enabled-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-log-connections-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-log-connections-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-log-connections-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `log_connections` server parameter is set to `ON` for Azure Database for PostgreSQL. When enabled, each attempted connection to the server is logged, including successful and failed authentication attempts.
@@ -23007,19 +23007,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `log_checkpoints` server parameter is set to `ON` for Azure Database for PostgreSQL. Checkpoint logging records when checkpoints occur, which is primarily a compliance and operational visibility requirement.
@@ -23107,19 +23107,19 @@ queries:
       - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-azure
         tags:
           mondoo.com/filter-title: Azure PostgreSQL Flexible Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `connection_throttle.enable` server parameter is set to `ON` for Azure Database for PostgreSQL Flexible Server. Connection throttling temporarily blocks connections from IP addresses that have too many failed login attempts, providing protection against brute-force attacks.
@@ -23207,19 +23207,19 @@ queries:
       - uid: mondoo-azure-security-sql-audit-retention-90-days-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-audit-retention-90-days-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-audit-retention-90-days-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-audit-retention-90-days-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure SQL Server audit log retention is configured for at least 90 days. While the existing 30-day check establishes a baseline, 90 days provides sufficient history for thorough security investigations, compliance audits, and trend analysis.
@@ -23314,19 +23314,19 @@ queries:
       - uid: mondoo-azure-security-sql-threat-alert-emails-configured-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-threat-alert-emails-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-alert-emails-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-alert-emails-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that at least one email address is configured to receive SQL threat detection alerts. Without notification recipients, threat detection alerts are generated but never seen by security teams.
@@ -23422,19 +23422,19 @@ queries:
       - uid: mondoo-azure-security-sql-threat-detection-types-configured-azure
         tags:
           mondoo.com/filter-title: Azure SQL Server
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-sql-threat-detection-types-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-detection-types-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-sql-threat-detection-types-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all SQL threat detection alert types are enabled and none have been disabled. Azure SQL threat detection monitors for SQL injection, SQL injection vulnerabilities, anomalous client login, access from unusual locations, and other threat patterns.
@@ -23526,19 +23526,19 @@ queries:
       - uid: mondoo-azure-security-activity-log-retention-365-days-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-activity-log-retention-365-days-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-activity-log-retention-365-days-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-activity-log-retention-365-days-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles retain activity logs for at least 365 days. Activity logs record control plane operations across the subscription and are critical for long-term security investigations and compliance audits.
@@ -23657,19 +23657,19 @@ queries:
       - uid: mondoo-azure-security-log-profile-all-locations-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-log-profile-all-locations-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-log-profile-all-locations-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-log-profile-all-locations-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles capture activity log events from all Azure locations, including the special `global` category. Without capturing all locations, activity logs may miss events from certain regions.
@@ -23785,19 +23785,19 @@ queries:
       - uid: mondoo-azure-security-log-profile-all-categories-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-log-profile-all-categories-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-log-profile-all-categories-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-log-profile-all-categories-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles capture all activity log categories: Administrative, Security, ServiceHealth, Alert, Recommendation, Policy, Autoscale, and ResourceHealth. Missing any category creates blind spots in the audit trail. Note that legacy log profiles use the category names Write, Delete, and Action, which map to the modern category names.
@@ -23916,19 +23916,19 @@ queries:
       - uid: mondoo-azure-security-security-contact-emails-configured-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-security-contact-emails-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-security-contact-emails-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-security-contact-emails-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that at least one security contact has email addresses configured for receiving security alert notifications. Without configured email recipients, Defender for Cloud alerts go unnoticed.
@@ -24021,19 +24021,19 @@ queries:
       - uid: mondoo-azure-security-security-contact-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-security-contact-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-security-contact-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-security-contact-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that at least one security contact is enabled in Microsoft Defender for Cloud. A disabled security contact means no one receives notifications about security findings, even if email addresses are configured.
@@ -24125,19 +24125,19 @@ queries:
       - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that custom RBAC role definitions do not grant wildcard (`*`) action permissions. Custom roles with `*` actions provide the same level of access as built-in Owner/Contributor roles, defeating the purpose of creating a custom role with specific permissions.
@@ -24261,19 +24261,19 @@ queries:
       - uid: mondoo-azure-security-rbac-no-custom-role-creation-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-rbac-no-custom-role-creation-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rbac-no-custom-role-creation-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-rbac-no-custom-role-creation-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that custom RBAC role definitions do not include the `Microsoft.Authorization/roleDefinitions/write` permission, which allows creating new custom roles. Granting this permission to custom roles enables privilege escalation by allowing users to create roles with arbitrary permissions.
@@ -24395,19 +24395,19 @@ queries:
       - uid: mondoo-azure-security-storage-queue-logging-enabled-azure
         tags:
           mondoo.com/filter-title: Azure Storage Account
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-queue-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-queue-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-storage-queue-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Storage account Queue Services have analytics logging enabled for read, write, and delete operations. Queue storage logging provides an audit trail of all operations performed on queues.
@@ -24528,19 +24528,19 @@ queries:
       - uid: mondoo-azure-security-datafactory-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Data Factory instances have public network access disabled.
@@ -24645,19 +24645,19 @@ queries:
       - uid: mondoo-azure-security-datafactory-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Data Factory instances are configured with customer-managed key (CMK) encryption.
@@ -24780,19 +24780,19 @@ queries:
       - uid: mondoo-azure-security-datafactory-managed-identity-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-managed-identity-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-managed-identity-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-datafactory-managed-identity-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Data Factory instances are configured with a managed identity.
@@ -24901,19 +24901,19 @@ queries:
       - uid: mondoo-azure-security-synapse-public-access-disabled-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-public-access-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-public-access-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-public-access-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces have public network access disabled.
@@ -25029,19 +25029,19 @@ queries:
       - uid: mondoo-azure-security-synapse-managed-vnet-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-managed-vnet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-managed-vnet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-managed-vnet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured with a managed virtual network.
@@ -25163,19 +25163,19 @@ queries:
       - uid: mondoo-azure-security-synapse-aad-only-auth-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-aad-only-auth-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-aad-only-auth-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-aad-only-auth-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured to use Azure Active Directory (Azure AD) only authentication, disabling local SQL authentication.
@@ -25305,19 +25305,19 @@ queries:
       - uid: mondoo-azure-security-synapse-cmk-encryption-azure
         tags:
           mondoo.com/filter-title: Azure Subscription
-          mondoo.com/icon: azure
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-cmk-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-azure-security-synapse-cmk-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured with customer-managed key (CMK) encryption.

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -296,19 +296,19 @@ queries:
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud Compute Engine instances are not configured to use the default service account (-compute@developer.gserviceaccount.com). Instead, instances should use custom service accounts with only the permissions required for their specific function, adhering to the principle of least privilege.
@@ -447,19 +447,19 @@ queries:
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud Compute Engine instances are not provisioned to use the default service account with full access to all Google Cloud APIs. Instead, instances should be assigned custom service accounts with narrowly scoped permissions, adhering to the principle of least privilege.
@@ -611,19 +611,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OS Login is enabled on Google Cloud Platform (GCP) Compute Engine instances to manage SSH access through IAM roles rather than relying on SSH keys stored in project or instance metadata. OS Login improves access control, auditability, and security by centralizing identity-based SSH authentication.
@@ -754,19 +754,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Storage Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud Storage buckets do not have IAM bindings or ACLs that grant access to the allUsers or allAuthenticatedUsers principals. These principals represent unauthenticated and broadly authenticated public access, which significantly increases the risk of unintentional data exposure.
@@ -883,19 +883,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Storage Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Cloud Storage offers two systems for granting users permission to access your buckets and objects: IAM and Access Control Lists (ACLs). These systems act in parallel - in order for a user to access a Cloud Storage resource, only one of the systems needs to grant the user permission. IAM is used throughout Google Cloud and allows you to grant a variety of permissions at the bucket and project levels. ACLs are used only by Cloud Storage and have limited permission options, but they allow you to grant permissions on a per-object basis.
@@ -976,19 +976,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Storage Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Public access prevention protects Cloud Storage buckets from being accidentally exposed to the public. When you enforce public access prevention on a bucket, it prevents all public access to the bucket and its objects, regardless of existing IAM policies or ACLs.
@@ -1075,19 +1075,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Storage Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         By default, Google Cloud Storage encrypts all data at rest using Google-managed encryption keys. While this provides a baseline level of encryption, using customer-managed encryption keys (CMEK) through Cloud KMS gives organizations greater control over their encryption keys and meets compliance requirements that mandate customer-controlled key management.
@@ -1193,19 +1193,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Storage Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         A retention policy on a Cloud Storage bucket ensures that objects stored in the bucket cannot be deleted or overwritten for a specified duration. Locking the retention policy makes it irreversible, preventing anyone (including bucket owners) from reducing the retention period or removing the policy.
@@ -1311,19 +1311,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery datasets can be configured with access controls that grant permissions to specific users, groups, domains, or special groups. Granting access to `allUsers` or `allAuthenticatedUsers` makes the dataset publicly accessible, exposing potentially sensitive data to anyone on the internet or any authenticated Google user.
@@ -1458,19 +1458,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery encrypts all data at rest by default using Google-managed encryption keys. However, for organizations that require greater control over their encryption keys, BigQuery supports customer-managed encryption keys (CMEK) through Cloud KMS. Configuring a default CMEK on a dataset ensures that all new tables created within the dataset are automatically encrypted with the specified key.
@@ -1578,19 +1578,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery tables can be individually encrypted with customer-managed encryption keys (CMEK) through Cloud KMS. While setting a default CMEK on the dataset ensures new tables inherit encryption, individual tables may have been created before the default was set or may have been explicitly configured with a different key. Verifying that all tables within a dataset use CMEK ensures comprehensive encryption coverage.
@@ -1715,19 +1715,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery ML models can contain sensitive training data and proprietary algorithms. Like tables and datasets, models support encryption with customer-managed encryption keys (CMEK) through Cloud KMS. Ensuring all models use CMEK provides consistent encryption coverage across all BigQuery resources.
@@ -1835,19 +1835,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery supports two SQL dialects: GoogleSQL (standard SQL) and Legacy SQL. Legacy SQL is a non-standard SQL dialect that lacks many modern features and security capabilities available in GoogleSQL. Views created with Legacy SQL cannot leverage column-level security, row-level security, or data masking features.
@@ -1954,19 +1954,19 @@ queries:
       - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-gcp
         tags:
           mondoo.com/filter-title: GCP BigQuery Dataset
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         BigQuery datasets can grant access to an entire Google Workspace or Cloud Identity domain using domain-type access entries. While this may seem convenient, it grants access to every user in the domain, including contractors, temporary employees, and service accounts, which violates the principle of least privilege.
@@ -2078,19 +2078,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Assigning public IP addresses to Cloud SQL MySQL instances expands the potential attack surface, making databases accessible from the public internet and increasing security risks.
@@ -2217,19 +2217,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Requiring SSL/TLS for connections to Cloud SQL MySQL instances encrypts data in transit between the client and the database server. This prevents potential eavesdropping and man-in-the-middle attacks, protecting sensitive data from unauthorized access during transmission.
@@ -2368,19 +2368,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         **Why this matters**
@@ -2516,19 +2516,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         **Why this matters**
@@ -2666,19 +2666,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         **Why this matters**
@@ -2827,19 +2827,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         **Why this matters**
@@ -2978,19 +2978,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         **Why this matters**
@@ -3134,19 +3134,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Virtual machine (VM) instances within Google Cloud Compute Engine should not be configured with public, external IP addresses.
@@ -3302,19 +3302,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         VM instances should be configured to use dedicated service accounts instead of the default Compute Engine service account.
@@ -3486,19 +3486,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Configure VM instances to block project-wide SSH keys, favoring instance-specific keys for access.
@@ -3630,19 +3630,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enable the Confidential VM service for applicable Compute Engine VM instances to enhance data security during processing.
@@ -3806,19 +3806,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enable Secure Boot, a feature of Shielded VMs, on Compute Engine instances to enhance platform security and integrity.
@@ -3983,19 +3983,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enable the virtual Trusted Platform Module (vTPM), a feature of Shielded VMs, on Compute Engine instances to support Measured Boot and enhance integrity verification.
@@ -4162,19 +4162,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enable Integrity Monitoring, a feature of Shielded VMs, on Compute Engine instances to detect potentially malicious modifications to the boot sequence.
@@ -4347,19 +4347,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Assigning public IP addresses to Cloud SQL PostgreSQL instances expands the potential attack surface, making databases accessible from the public internet and increasing security risks.
@@ -4500,19 +4500,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instances-not-publicly-exposed-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Assigning public IP addresses to Cloud SQL for SQL Server instances expands the potential attack surface, making databases accessible from the public internet and increasing security risks.
@@ -4648,19 +4648,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Requiring SSL/TLS for connections to Cloud SQL PostgreSQL instances encrypts data in transit between the client and the database server. This prevents potential eavesdropping and man-in-the-middle attacks, protecting sensitive data from unauthorized access during transmission.
@@ -4800,19 +4800,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Requiring SSL/TLS for connections to Cloud SQL for SQL Server instances encrypts data in transit between the client and the database server. This prevents potential eavesdropping and man-in-the-middle attacks, protecting sensitive data from unauthorized access during transmission.
@@ -4952,19 +4952,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud KMS Keyring
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         It is recommended to restrict anonymous and/or public access in the Cloud Key Management Service (KMS) Cryptokeys Identity and Access Management (IAM) policy.
@@ -5123,19 +5123,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud KMS Keyring
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Google Cloud Key Management Service (KMS) stores cryptographic keys hierarchically with robust access control. Configure a key rotation period and start time to ensure regular updates, enhancing security for data encrypted by these keys. The gcloud CLI requires the next rotation time in ISO or RFC3339 format, and the rotation period as INTEGER[UNIT] (s, m, h, or d). Note that after rotation, the older key version is still required to decrypt data encrypted with it.
@@ -5250,19 +5250,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud KMS Keyring
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud KMS crypto keys have a destroy scheduled duration of at least 24 hours. When a crypto key version is scheduled for destruction, the destroy scheduled duration determines how long it remains in the DESTROY_SCHEDULED state before being permanently destroyed. A minimum of 24 hours provides a safety window to recover keys that were accidentally scheduled for destruction.
@@ -5372,19 +5372,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud KMS Keyring
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud KMS keyrings are created in a specific regional location rather than the 'global' location. Using regional locations for keyrings helps meet data residency requirements and provides better control over where cryptographic operations are performed.
@@ -5495,19 +5495,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud KMS Keyring
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Google Cloud KMS crypto keys with the ENCRYPT_DECRYPT purpose have automatic rotation configured. Automatic key rotation creates new key versions on a regular schedule, ensuring that data encryption uses current key material without requiring manual intervention.
@@ -5632,19 +5632,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud DNS Managed Zone
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Cloud DNS with DNSSEC provides a secure, reliable, and cost-effective domain name system. DNSSEC protects domains from hijacking and man-in-the-middle attacks by cryptographically signing DNS records, ensuring the authenticity of DNS responses. This prevents attackers from redirecting users to malicious sites through fake DNS lookups.
@@ -5761,19 +5761,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud DNS Managed Zone
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         When configuring DNSSEC for a managed zone, choose strong, recommended algorithms for key signing and denial-of-existence. While various DNSSEC algorithms are available, some are better suited for zone signing or transaction security. Note that SHA1 is deprecated by Google and requires a Google Cloud support contract and allowlisting for use. To modify DNSSEC settings on an enabled zone, disable and then re-enable it with the new configuration.
@@ -5912,19 +5912,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud DNS Managed Zone
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         DNSSEC algorithm numbers in this registry may be used in CERT RRs. Zone-signing is used for authenticating DNS zone data. Using a weak algorithm like RSASHA1 for zone signing undermines the security guarantees of DNSSEC. SHA-1 is considered cryptographically weak and is deprecated by Google, requiring a support contract and allowlisting for use. Stronger alternatives such as RSASHA256, RSASHA512, ECDSAP256SHA256, or ECDSAP384SHA384 should be used for zone-signing keys.
@@ -6061,19 +6061,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud DNS Managed Zone
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         DNSSEC provides authenticated denial-of-existence responses to prove that a queried domain name does not exist. Two mechanisms are available: NSEC and NSEC3. NSEC exposes all zone record names in plaintext, which allows attackers to enumerate every record in the zone by walking the NSEC chain. This reveals the full zone contents, including internal hostnames, service records, and other sensitive infrastructure details.
@@ -6211,19 +6211,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules do not allow unrestricted SSH access (TCP port 22) from the entire internet (0.0.0.0/0 or ::/0). Firewall rules should restrict SSH access to specific trusted IP ranges to minimize the attack surface.
@@ -6368,19 +6368,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules do not allow unrestricted RDP access (TCP port 3389) from the entire internet (0.0.0.0/0 or ::/0). Firewall rules should restrict RDP access to specific trusted IP ranges to minimize exposure of Windows instances.
@@ -6508,19 +6508,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules do not allow unrestricted ingress traffic on all protocols and ports from the entire internet (0.0.0.0/0 or ::/0). Firewall rules that allow all traffic from any source create the broadest possible network exposure and should never be used in production environments.
@@ -6655,19 +6655,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules do not allow unrestricted ingress to common database ports from the entire internet (0.0.0.0/0 or ::/0). Database services should never be directly exposed to the internet, as they contain sensitive data and are frequent targets for automated attacks.
@@ -6804,19 +6804,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules which allow ingress from the entire internet (0.0.0.0/0 or ::/0) specify explicit port restrictions. Firewall rules that allow traffic from the internet should always be scoped to the minimum required set of ports rather than leaving ports unrestricted.
@@ -6948,19 +6948,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Attribute-Based Access Control (ABAC) is a legacy authorization mechanism in Kubernetes that has been superseded by Role-Based Access Control (RBAC). Legacy ABAC grants broad access permissions based on simple attribute matching, making it difficult to implement fine-grained access control.
@@ -7052,19 +7052,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Master authorized networks restrict access to the GKE cluster's Kubernetes API server to specific trusted CIDR ranges. Without this configuration, the API server is accessible from any IP address, increasing the attack surface.
@@ -7161,19 +7161,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         GKE clusters should use Cloud Logging (formerly Stackdriver Logging) for centralized log management. When properly configured, the logging service captures system and workload logs from the cluster, providing visibility into cluster operations and security events.
@@ -7264,19 +7264,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Kubernetes network policies control traffic flow between pods and between pods and external endpoints. Without network policies, all pods in a cluster can communicate freely with each other, which violates the principle of least privilege and increases the blast radius of a compromised pod.
@@ -7379,19 +7379,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Kubernetes alpha features are experimental and may change or be removed in future releases. Alpha clusters are not covered by GKE SLA, cannot be upgraded, and will be automatically deleted after 30 days. Enabling alpha features on production clusters introduces instability and security risks.
@@ -7482,19 +7482,19 @@ queries:
       - uid: mondoo-gcp-security-gke-workload-identity-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-workload-identity-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-workload-identity-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-workload-identity-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Workload Identity is enabled on Google Kubernetes Engine (GKE) clusters. Workload Identity is the recommended way for workloads running on GKE to access Google Cloud services securely, replacing the need for node-level service account keys or metadata server access.
@@ -7595,19 +7595,19 @@ queries:
       - uid: mondoo-gcp-security-gke-private-cluster-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-private-cluster-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-private-cluster-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-private-cluster-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE clusters are configured as private clusters, where nodes only have internal IP addresses and are isolated from the public internet. Private clusters reduce the attack surface by preventing direct internet access to cluster nodes.
@@ -7710,19 +7710,19 @@ queries:
       - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Shielded GKE Nodes are enabled on GKE clusters. Shielded Nodes provide verifiable node identity and integrity, protecting against boot-level and kernel-level attacks on cluster nodes.
@@ -7833,19 +7833,19 @@ queries:
       - uid: mondoo-gcp-security-gke-release-channel-configured-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-release-channel-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-release-channel-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-release-channel-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE clusters are subscribed to a release channel (Regular, Rapid, or Stable) for automated version management. Release channels ensure clusters receive automatic upgrades with security patches and bug fixes.
@@ -7949,19 +7949,19 @@ queries:
       - uid: mondoo-gcp-security-compute-network-not-legacy-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Network
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-network-not-legacy-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-not-legacy-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-not-legacy-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Legacy networks are a single, flat network that spans the entire project and do not support subnets. Legacy networks lack modern networking features including VPC Flow Logs, Private Google Access, and fine-grained firewall rules that operate at the subnet level.
@@ -8056,19 +8056,19 @@ queries:
       - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Subnetwork
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         VPC Flow Logs record a sample of network flows sent from and received by VM instances, including traffic between VMs in the same VPC. Flow logs can be used for network monitoring, forensic analysis, real-time security analysis, and expense optimization.
@@ -8167,19 +8167,19 @@ queries:
       - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Subnetwork
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Private Google Access enables VM instances on a subnet to reach Google APIs and services using an internal IP address rather than an external IP address. This allows VMs without external IPs to access services like Cloud Storage, BigQuery, and other Google Cloud APIs.
@@ -8272,19 +8272,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-auth-enabled-memorystore-redis
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-auth-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-auth-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-auth-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Redis AUTH is enabled on Cloud Memorystore for Redis instances. Redis AUTH requires clients to authenticate with a password before executing commands, providing an additional layer of security beyond network-level access controls.
@@ -8382,23 +8382,23 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-redis
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-rediscluster
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Memorystore for Redis instances are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK gives organizations full control over the encryption key lifecycle, including rotation, access policies, and the ability to revoke access by disabling or destroying keys.
@@ -8524,19 +8524,19 @@ queries:
       - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-gcp
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that user-managed service account keys are not created in the Google Cloud project. User-managed keys are a significant security risk because they can be leaked, are difficult to track, and do not expire by default. Google-managed keys or Workload Identity Federation should be used instead.
@@ -8654,7 +8654,7 @@ queries:
       - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that default Compute Engine and App Engine service accounts are disabled when not needed. Default service accounts are automatically created with overly broad permissions (Editor role) and should be disabled or replaced with custom service accounts following the principle of least privilege.
@@ -8756,7 +8756,7 @@ queries:
       - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-gcp
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that user-managed service account keys are rotated at least every 90 days. Long-lived credentials that are not regularly rotated increase the window of opportunity for an attacker to use compromised credentials without detection.
@@ -8856,7 +8856,7 @@ queries:
       - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-gcp
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that disabled service account keys are deleted rather than left in a disabled state. Disabled keys represent unnecessary credential material that can be re-enabled and should be fully removed to reduce the attack surface.
@@ -8942,19 +8942,19 @@ queries:
       - uid: mondoo-gcp-security-logging-bucket-retention-30-days-gcp
         tags:
           mondoo.com/filter-title: GCP Logging Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-bucket-retention-30-days-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-retention-30-days-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-retention-30-days-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Logging log buckets have a retention period of at least 30 days. Adequate log retention is essential for incident response, forensic investigation, and compliance with regulatory frameworks.
@@ -9051,19 +9051,19 @@ queries:
       - uid: mondoo-gcp-security-logging-bucket-locked-gcp
         tags:
           mondoo.com/filter-title: GCP Logging Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-bucket-locked-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-locked-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-locked-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Logging log buckets (excluding system-managed _Default and _Required buckets) are locked to prevent modification or deletion. Locked buckets guarantee that log data cannot be tampered with, which is critical for forensic integrity and compliance.
@@ -9168,19 +9168,19 @@ queries:
       - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Logging Bucket
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Logging log buckets are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with control over the encryption key lifecycle for log data at rest.
@@ -9282,19 +9282,19 @@ queries:
       - uid: mondoo-gcp-security-logging-sinks-configured-gcp
         tags:
           mondoo.com/filter-title: GCP
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-sinks-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-sinks-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-logging-sinks-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that at least one Cloud Logging sink is configured in the project to export logs to an external destination. Log sinks enable long-term retention, centralized analysis, and security monitoring by routing logs to Cloud Storage, BigQuery, Pub/Sub, or external SIEM systems.
@@ -9385,19 +9385,19 @@ queries:
       - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Pub/Sub Topic
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Pub/Sub topics are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with full control over the encryption key lifecycle for message data at rest.
@@ -9490,19 +9490,19 @@ queries:
       - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Pub/Sub Subscription
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Pub/Sub subscriptions have an expiration policy configured to prevent orphaned subscriptions from accumulating indefinitely. Subscriptions without expiration policies can persist after their consumers are decommissioned, creating unnecessary resource overhead and potential data access points.
@@ -9593,15 +9593,15 @@ queries:
       - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Pub/Sub topics do not have IAM bindings that grant access to `allUsers` or `allAuthenticatedUsers`. These principals represent unauthenticated internet access and any Google-authenticated user access respectively, which can expose topic data to unauthorized parties.
@@ -9710,15 +9710,15 @@ queries:
       - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Pub/Sub subscriptions do not have IAM bindings that grant access to `allUsers` or `allAuthenticatedUsers`. These principals represent unauthenticated internet access and any Google-authenticated user access respectively, which can expose subscription data to unauthorized parties.
@@ -9827,19 +9827,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Functions do not have their ingress settings configured to allow all traffic (ALLOW_ALL). Functions should restrict ingress to internal traffic only or internal traffic plus Cloud Load Balancing to minimize their attack surface.
@@ -9940,19 +9940,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Functions are not configured to use the default Compute Engine or App Engine service account. Default service accounts have overly broad permissions and should be replaced with custom service accounts following the principle of least privilege.
@@ -10062,19 +10062,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Functions have a VPC connector configured to enable secure communication with resources in a VPC network. Without a VPC connector, functions can only reach internal resources through public internet paths, increasing exposure and latency.
@@ -10177,19 +10177,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Functions are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with control over the encryption key lifecycle for function source code and data at rest.
@@ -10290,19 +10290,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-ingress-restricted-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Service
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-ingress-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-ingress-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-ingress-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run services are not configured with ingress set to INGRESS_TRAFFIC_ALL, which allows traffic from the public internet. Services should restrict ingress to internal traffic or internal traffic with Cloud Load Balancing to reduce the attack surface.
@@ -10405,19 +10405,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Service
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run services are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with control over the encryption key lifecycle for container images and data at rest.
@@ -10518,19 +10518,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Service
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-no-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-no-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-no-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run services are not using the default Compute Engine service account. Default service accounts have overly broad permissions (Editor role) and should be replaced with custom service accounts scoped to only the permissions required by the service.
@@ -10653,19 +10653,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Service
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run services have VPC access configured to enable secure communication with resources in a VPC network. Without VPC access, services can only reach internal resources through public internet paths, increasing exposure and latency.
@@ -10770,19 +10770,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Job
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run jobs are not using the default Compute Engine service account. Default service accounts have overly broad permissions (Editor role) and should be replaced with custom service accounts scoped to only the permissions required by the job.
@@ -10915,19 +10915,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Run Job
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run jobs are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with control over the encryption key lifecycle for job container images and data at rest.
@@ -11032,19 +11032,19 @@ queries:
       - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Dataproc Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Dataproc clusters use customer-managed encryption keys (CMEK) to encrypt persistent disks. CMEK provides control over the encryption key lifecycle for data at rest on cluster nodes, enabling organizations to manage key rotation, access policies, and revocation.
@@ -11144,19 +11144,19 @@ queries:
       - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-gcp
         tags:
           mondoo.com/filter-title: GCP Dataproc Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Dataproc clusters are configured with internal IP addresses only, preventing cluster nodes from being directly accessible from the public internet.
@@ -11263,19 +11263,19 @@ queries:
       - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-gcp
         tags:
           mondoo.com/filter-title: GCP Dataproc Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Dataproc clusters have Shielded VM features enabled, including Secure Boot, vTPM, and integrity monitoring. Shielded VMs provide verifiable integrity of cluster instances, protecting against rootkits and bootkits.
@@ -11408,19 +11408,19 @@ queries:
       - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Dataproc Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Dataproc clusters are not configured to use the default Compute Engine service account. Default service accounts have overly broad permissions and should be replaced with custom service accounts following the principle of least privilege.
@@ -11540,19 +11540,19 @@ queries:
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-gcp
         tags:
           mondoo.com/filter-title: GCP Binary Authorization Policy
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the Binary Authorization default admission rule is not set to ALWAYS_ALLOW. When set to ALWAYS_ALLOW, any container image can be deployed without attestation, completely bypassing the image verification controls that Binary Authorization is designed to enforce.
@@ -11663,19 +11663,19 @@ queries:
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Binary Authorization Policy
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Binary Authorization global policy evaluation is enabled. Global policy evaluation applies Google-maintained system policies to evaluate common system-level images, providing a baseline level of trust verification without requiring explicit allowlisting of every system image.
@@ -11773,19 +11773,19 @@ queries:
       - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-gcp
         tags:
           mondoo.com/filter-title: GCP API Key
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that API keys have API target restrictions configured, limiting which Google Cloud APIs the key can be used to call. Without API restrictions, a compromised key can be used to call any enabled API in the project.
@@ -11893,19 +11893,19 @@ queries:
       - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-gcp
         tags:
           mondoo.com/filter-title: GCP API Key
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that API keys have at least one type of application restriction configured (HTTP referrer, IP address, Android app, or iOS app). Application restrictions limit where the key can be used from, preventing unauthorized use if the key is leaked.
@@ -12035,7 +12035,7 @@ queries:
       - uid: mondoo-gcp-security-api-keys-not-stale-gcp
         tags:
           mondoo.com/filter-title: GCP API Key
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that API keys have been created or updated within the last 90 days. Stale API keys that have not been rotated increase the window of opportunity for credential misuse and should be regularly rotated or replaced.
@@ -12123,19 +12123,19 @@ queries:
       - uid: mondoo-gcp-security-compute-network-default-deleted-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Network
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-network-default-deleted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-default-deleted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-default-deleted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the default VPC network has been deleted from the project. The default network is automatically created with permissive firewall rules that allow SSH and RDP from anywhere, and should be replaced with custom networks following least-privilege networking principles.
@@ -12249,19 +12249,19 @@ queries:
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that DNS logging is enabled through Cloud DNS policies for VPC networks. DNS logging captures DNS queries made by resources within a VPC, providing critical data for threat detection, forensic investigation, and monitoring for data exfiltration via DNS tunneling.
@@ -12361,19 +12361,19 @@ queries:
       - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Subnetwork
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPC subnetworks do not use overly broad IP CIDR ranges (/15 or larger, i.e. broader than /16). Excessively large subnets reduce the effectiveness of network segmentation and make it harder to contain the blast radius of security incidents.
@@ -12475,23 +12475,23 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-memorystore-redis
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-memorystore-rediscluster
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that in-transit encryption (TLS) is enabled on Cloud Memorystore for Redis instances and clusters. In-transit encryption encrypts all data transmitted between the client application and the Redis instance, preventing eavesdropping and man-in-the-middle attacks.
@@ -12603,19 +12603,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-memorystore-redis
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Memorystore for Redis instances are using the Standard HA tier, which provides automatic failover and replication for high availability and data durability.
@@ -12706,19 +12706,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-memorystore-rediscluster
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that IAM authentication is enabled on Cloud Memorystore for Redis Cluster instances. IAM authentication integrates Redis Cluster with Google Cloud's Identity and Access Management, replacing open or password-based access with identity-based access control.
@@ -12818,19 +12818,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-memorystore-rediscluster
         tags:
           mondoo.com/filter-title: GCP Memorystore Redis Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that deletion protection is enabled on Cloud Memorystore for Redis Cluster instances. Deletion protection prevents accidental or malicious deletion of the cluster, safeguarding data availability and service continuity.
@@ -12927,19 +12927,19 @@ queries:
       - uid: mondoo-gcp-security-secretmanager-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Secret Manager Secret
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-secretmanager-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Secret Manager secrets are encrypted using customer-managed encryption keys (CMEK) rather than default Google-managed keys. CMEK provides organizations with full control over the encryption key lifecycle for secret data at rest.
@@ -13080,19 +13080,19 @@ queries:
       - uid: mondoo-gcp-security-secretmanager-rotation-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Secret Manager Secret
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-secretmanager-rotation-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-rotation-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-rotation-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Secret Manager secrets have a rotation policy configured. Secret rotation limits the window of exposure if a secret is compromised and ensures that credentials are regularly refreshed.
@@ -13215,19 +13215,19 @@ queries:
       - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-gcp
         tags:
           mondoo.com/filter-title: GCP Secret Manager Secret
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Secret Manager secrets do not have IAM bindings that grant access to `allUsers` or `allAuthenticatedUsers`. These principals represent unauthenticated and broadly authenticated public access, which would expose sensitive credentials to the internet.
@@ -13371,19 +13371,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that IP forwarding is not enabled on Google Compute Engine instances unless the instance specifically serves as a network gateway, NAT device, or router.
@@ -13484,19 +13484,19 @@ queries:
       - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that interactive serial port access is disabled on Google Compute Engine instances. The serial console can be used for troubleshooting but should not be left enabled in production environments.
@@ -13613,19 +13613,19 @@ queries:
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Compute Engine persistent disks are encrypted using customer-managed encryption keys (CMEK) through Cloud KMS rather than the default Google-managed encryption keys.
@@ -13728,19 +13728,19 @@ queries:
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-gcp
         tags:
           mondoo.com/filter-title: GCP
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that external-facing forwarding rules do not forward traffic on all ports. Forwarding all ports to a backend exposes every service listening on the target to the internet, significantly increasing the attack surface.
@@ -13842,27 +13842,27 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-mysql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-postgresql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-sqlserver
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud SQL instances do not have authorized networks configured with overly permissive CIDR ranges such as `0.0.0.0/0` or `::/0`, which would allow connections from any IP address on the internet.
@@ -13998,27 +13998,27 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-gcp-mysql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-gcp-postgresql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-gcp-sqlserver
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud SQL instances have a password validation policy enabled to enforce minimum password complexity and strength requirements for database user accounts.
@@ -14140,27 +14140,27 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-gcp-mysql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-gcp-postgresql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-gcp-sqlserver
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud SQL instances are encrypted using customer-managed encryption keys (CMEK) through Cloud KMS rather than default Google-managed encryption.
@@ -14265,19 +14265,19 @@ queries:
       - uid: mondoo-gcp-security-gke-database-encryption-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-database-encryption-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-database-encryption-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-database-encryption-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that application-layer secrets encryption is enabled on GKE clusters, providing an additional layer of encryption for Kubernetes Secrets stored in etcd using a Cloud KMS key.
@@ -14377,19 +14377,19 @@ queries:
       - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Secure Boot is enabled on all GKE cluster node pools. While the existing shielded nodes check verifies the cluster-level configuration, this check validates that each individual node pool has Secure Boot enabled in its shielded instance configuration.
@@ -14514,19 +14514,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check identifies Cloud Functions that may contain secrets stored as plaintext environment variables by detecting environment variable keys with common secret-related naming patterns. Secrets should be stored in Secret Manager and referenced using Cloud Functions secret environment variable or secret volume support.
@@ -14672,19 +14672,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Function
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Functions are configured to use a user-managed Artifact Registry repository for storing built container images, rather than the default Google-managed repository.
@@ -14788,19 +14788,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Armor
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Armor security policy rules are not configured in preview mode. When a rule is in preview mode, it logs matching requests but does not enforce the configured action, leaving services unprotected against the threats the rule was designed to block.
@@ -14904,19 +14904,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud Armor
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Armor security policies do not have a default rule that allows all traffic. The default rule (priority 2147483647) is the catch-all rule that applies to any request not matching a higher-priority rule. If the default rule action is "allow", all unmatched traffic passes through, effectively bypassing the security policy.
@@ -15040,19 +15040,19 @@ queries:
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-gcp
         tags:
           mondoo.com/filter-title: GCP SSL Policy
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SSL policies configured for Google Cloud load balancers enforce a minimum TLS version of 1.2. TLS 1.0 and 1.1 have known vulnerabilities and are deprecated by major standards bodies including IETF (RFC 8996), PCI DSS, and NIST.
@@ -15141,19 +15141,19 @@ queries:
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-gcp
         tags:
           mondoo.com/filter-title: GCP SSL Policy
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SSL policies use the MODERN or RESTRICTED profile rather than the COMPATIBLE or CUSTOM profile. The profile determines which cipher suites are available for TLS negotiation.
@@ -15239,7 +15239,7 @@ queries:
       - uid: mondoo-gcp-security-ssl-certificate-not-expired-gcp
         tags:
           mondoo.com/filter-title: GCP SSL Certificate
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that self-managed SSL certificates registered with Google Cloud are not expired or nearing expiration (within 30 days). Expired certificates cause service outages and security warnings for users. This check applies only to self-managed certificates, as Google-managed certificates are automatically renewed.
@@ -15337,19 +15337,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud NAT
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud NAT gateways do not have endpoint-independent mapping enabled. Endpoint-independent mapping causes the NAT gateway to use the same external IP and port for all connections from a given internal IP and port, regardless of the destination. This behavior can expose internal services to certain reflection and amplification attacks.
@@ -15445,19 +15445,19 @@ queries:
       - uid: mondoo-gcp-security-audit-logging-enabled-all-services-gcp
         tags:
           mondoo.com/filter-title: GCP Project
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-audit-logging-enabled-all-services-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-audit-logging-enabled-all-services-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-audit-logging-enabled-all-services-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that audit logging is configured for all services in the GCP project with at least ADMIN_READ log type enabled. Audit logs record administrative actions and data access events, providing critical visibility for security monitoring, incident response, and compliance.
@@ -15576,19 +15576,19 @@ queries:
       - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-gcp
         tags:
           mondoo.com/filter-title: GCP Project
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `constraints/compute.vmExternalIpAccess` organization policy is configured to restrict which VM instances can have external IP addresses. This constraint limits the set of Compute Engine instances that are allowed to use external IP addresses, reducing the attack surface by preventing unnecessary internet exposure.
@@ -15705,19 +15705,19 @@ queries:
       - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Project
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-org-policy-serial-port-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-serial-port-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-serial-port-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `constraints/compute.disableSerialPortAccess` organization policy is enforced. When enforced, this constraint prevents interactive serial console access on all VM instances in the project, providing an organization-wide preventive control that supplements instance-level metadata checks.
@@ -15821,19 +15821,19 @@ queries:
       - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-gcp
         tags:
           mondoo.com/filter-title: GCP Project
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `constraints/storage.uniformBucketLevelAccess` organization policy is enforced. When enabled, this constraint requires all new and existing Cloud Storage buckets to use uniform bucket-level access (IAM) instead of fine-grained ACLs, simplifying access management and reducing the risk of misconfiguration.
@@ -15937,19 +15937,19 @@ queries:
       - uid: mondoo-gcp-security-firestore-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Firestore
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firestore-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firestore-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firestore-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Firestore databases are encrypted using customer-managed encryption keys (CMEK) rather than Google-managed keys. CMEK provides organizations with full control over the encryption key lifecycle, including rotation, access policies, and the ability to revoke access by disabling or destroying keys.
@@ -16047,19 +16047,19 @@ queries:
       - uid: mondoo-gcp-security-spanner-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Spanner
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-spanner-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-spanner-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-spanner-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Spanner databases are encrypted using customer-managed encryption keys (CMEK). CMEK provides full control over the encryption key lifecycle and meets compliance requirements for customer-controlled key management.
@@ -16153,19 +16153,19 @@ queries:
       - uid: mondoo-gcp-security-bigtable-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Bigtable
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-bigtable-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigtable-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-bigtable-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Bigtable clusters are encrypted using customer-managed encryption keys (CMEK). CMEK is configured at the cluster level in Bigtable, and all data stored in the cluster is encrypted with the specified Cloud KMS key.
@@ -16263,19 +16263,19 @@ queries:
       - uid: mondoo-gcp-security-alloydb-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP AlloyDB
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-alloydb-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-alloydb-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-alloydb-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AlloyDB clusters are encrypted using customer-managed encryption keys (CMEK). AlloyDB is a fully managed PostgreSQL-compatible database, and CMEK provides organizations with full control over the encryption key lifecycle.
@@ -16374,19 +16374,19 @@ queries:
       - uid: mondoo-gcp-security-alloydb-no-public-ip-gcp
         tags:
           mondoo.com/filter-title: GCP AlloyDB
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-alloydb-no-public-ip-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-alloydb-no-public-ip-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-alloydb-no-public-ip-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AlloyDB instances do not have public IP addresses assigned. AlloyDB instances with public IPs are directly reachable from the internet, significantly increasing their exposure to brute-force attacks, SQL injection, and unauthorized access.
@@ -16486,19 +16486,19 @@ queries:
       - uid: mondoo-gcp-security-gke-security-posture-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-security-posture-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-security-posture-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-security-posture-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE clusters have Security Posture enabled with vulnerability scanning. GKE Security Posture provides automated security health analysis of your clusters, including vulnerability scanning of container workloads to detect known vulnerabilities in your container images.
@@ -16606,19 +16606,19 @@ queries:
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
         tags:
           mondoo.com/filter-title: GCP VPN Tunnel
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud VPN tunnels use IKE (Internet Key Exchange) version 2 instead of version 1. IKEv2 provides significant security and reliability improvements over IKEv1, including stronger cryptographic negotiation, built-in NAT traversal, and improved resilience against denial-of-service attacks.
@@ -16717,19 +16717,19 @@ queries:
       - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE cluster node pools have an upgrade strategy explicitly configured. An upgrade strategy (such as SURGE or BLUE_GREEN) controls how node pool upgrades are performed, ensuring that workloads remain available during the upgrade process and that security patches are applied safely.
@@ -16874,27 +16874,27 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-gcp-mysql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for MySQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-gcp-postgresql
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for PostgreSQL
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-gcp-sqlserver
         tags:
           mondoo.com/filter-title: GCP Cloud SQL for SQL Server
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud SQL instances have connector enforcement set to REQUIRED, forcing all connections to use the Cloud SQL Auth Proxy, Cloud SQL Language Connectors, or equivalent secure connection methods. When connector enforcement is enabled, direct IP-based connections are rejected, ensuring all database connections are authenticated and encrypted through Google's managed infrastructure.
@@ -17013,19 +17013,19 @@ queries:
       - uid: mondoo-gcp-security-backupdr-vault-access-restricted-gcp
         tags:
           mondoo.com/filter-title: GCP Backup & DR
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-backupdr-vault-access-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-backupdr-vault-access-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-backupdr-vault-access-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Backup & DR backup vaults have access restrictions configured. Access restrictions control which projects and regions can store backups in the vault, limiting the blast radius of compromised credentials.
@@ -17120,19 +17120,19 @@ queries:
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Vertex AI endpoints are encrypted using customer-managed encryption keys (CMEK). Vertex AI endpoints serve model predictions and may process sensitive data that requires encryption with keys you control.
@@ -17238,19 +17238,19 @@ queries:
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Vertex AI endpoints have Private Service Connect enabled. Private Service Connect provides private connectivity to Vertex AI endpoints without exposing traffic to the public internet.
@@ -17353,7 +17353,7 @@ queries:
       - uid: mondoo-gcp-security-vertexai-model-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that Vertex AI models are encrypted using customer-managed encryption keys (CMEK). Vertex AI models contain trained machine learning artifacts that may encode sensitive patterns from training data.
@@ -17432,19 +17432,19 @@ queries:
       - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Vertex AI datasets are encrypted using customer-managed encryption keys (CMEK). Vertex AI datasets store training and evaluation data that often contains sensitive information.
@@ -17559,7 +17559,7 @@ queries:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that Vertex AI pipeline jobs are encrypted using customer-managed encryption keys (CMEK). Pipeline jobs orchestrate ML workflows including training, evaluation, and deployment steps that process sensitive data.
@@ -17662,7 +17662,7 @@ queries:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-vpc-network-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that Vertex AI pipeline jobs are configured to run within a VPC network. Without VPC peering, pipeline jobs may communicate over the public internet, increasing the risk of data exposure.
@@ -17755,7 +17755,7 @@ queries:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-no-default-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
     docs:
       desc: |
         This check ensures that Vertex AI pipeline jobs are not using the default Compute Engine service account. Default service accounts have overly broad permissions and should be replaced with custom service accounts scoped to only the permissions required by the pipeline.
@@ -17858,19 +17858,19 @@ queries:
       - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Vertex AI
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Vertex AI feature online stores are encrypted using customer-managed encryption keys (CMEK). Feature online stores serve precomputed feature values for real-time predictions and may contain sensitive data.
@@ -17980,19 +17980,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules do not allow unrestricted egress traffic to all destinations (0.0.0.0/0 or ::/0) on all protocols. Unrestricted egress rules allow compromised instances to communicate with any external host, enabling data exfiltration, command-and-control callbacks, and lateral movement to external targets.
@@ -18102,19 +18102,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-egress-all-ports-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-egress-all-ports-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-egress-all-ports-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-egress-all-ports-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP egress firewall rules that target the entire internet specify explicit port restrictions rather than allowing all ports. Rules that permit outbound traffic on all ports to 0.0.0.0/0 give compromised workloads maximum flexibility to exfiltrate data or reach attacker infrastructure on any port.
@@ -18229,19 +18229,19 @@ queries:
       - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the legacy instance metadata API endpoint (v0.1 and v1beta1) is disabled on all GKE node pools. The legacy metadata endpoint does not enforce metadata concealment and can be accessed by any pod running on the node, potentially exposing the node's service account credentials.
@@ -18327,19 +18327,19 @@ queries:
       - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE clusters do not use legacy authentication methods: static passwords (basic authentication) and client certificates. These methods provide cluster-wide, non-auditable, permanent credentials that cannot be revoked without rotating the cluster master.
@@ -18438,19 +18438,19 @@ queries:
       - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE node pools have automatic upgrade enabled. Node auto-upgrade keeps nodes on a supported, patched Kubernetes version, reducing the window of exposure to known vulnerabilities.
@@ -18534,19 +18534,19 @@ queries:
       - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE node pools have automatic repair enabled. Node auto-repair monitors node health and automatically recreates unhealthy nodes, improving cluster reliability and security posture.
@@ -18630,19 +18630,19 @@ queries:
       - uid: mondoo-gcp-security-gke-dedicated-service-account-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-dedicated-service-account-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-dedicated-service-account-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-dedicated-service-account-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE node pools use a dedicated service account rather than the Compute Engine default service account. The default service account has broad project-level permissions that far exceed what GKE nodes require.
@@ -18736,19 +18736,19 @@ queries:
       - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE clusters use VPC-native mode (IP aliasing) rather than routes-based networking. VPC-native clusters assign pod IPs from the VPC network, enabling native integration with VPC firewall rules, Cloud NAT, and other network services.
@@ -18830,19 +18830,19 @@ queries:
       - uid: mondoo-gcp-security-gke-cos-node-image-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-cos-node-image-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cos-node-image-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-cos-node-image-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE node pools use Container-Optimized OS (COS) as their node image. COS is a Google-maintained, minimal operating system designed specifically for running containers with a reduced attack surface.
@@ -18935,19 +18935,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud SQL instances have automated backups enabled. Automated backups provide point-in-time recovery capability, protecting against data loss from accidental deletion, corruption, or ransomware.
@@ -19041,19 +19041,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL SQL Server Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `cross db ownership chaining` database flag is set to `off` for Cloud SQL for SQL Server instances. When enabled, this setting allows a stored procedure in one database to access objects in another database without the caller having explicit permissions.
@@ -19155,19 +19155,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL SQL Server Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `contained database authentication` flag is set to `off` for Cloud SQL for SQL Server instances. Contained databases store user credentials inside the database itself rather than in the master database, which introduces authentication bypass risks.
@@ -19270,19 +19270,19 @@ queries:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP Cloud SQL PostgreSQL Instance
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the `log_lock_waits` database flag is set to `on` for Cloud SQL PostgreSQL instances. When enabled, this setting logs a message whenever a session waits longer than `deadlock_timeout` to acquire a lock, providing visibility into lock contention issues.
@@ -19383,19 +19383,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-no-large-port-range-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-no-large-port-range-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-large-port-range-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-no-large-port-range-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GCP firewall rules that allow ingress from the internet do not open port ranges covering nearly all ports (ranges ending at ports 65530-65535, such as `0-65535`, `1-65535`, or `1024-65535`). Rules that expose all or nearly all ports make every service on the instance reachable from the internet.
@@ -19505,19 +19505,19 @@ queries:
       - uid: mondoo-gcp-security-firewall-default-rules-restricted-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Firewall
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-firewall-default-rules-restricted-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-default-rules-restricted-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-firewall-default-rules-restricted-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the auto-created default firewall rules in a VPC network are disabled or have been replaced with more restrictive rules. When a default VPC network is created, GCP auto-generates permissive firewall rules (e.g., `default-allow-internal`, `default-allow-ssh`, `default-allow-rdp`, `default-allow-icmp`) that allow broad access patterns.
@@ -19625,19 +19625,19 @@ queries:
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-gcp
         tags:
           mondoo.com/filter-title: GCP Compute Disk
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Compute Engine persistent disks are encrypted with Customer-Supplied Encryption Keys (CSEK). With CSEK, Google does not retain the encryption key; the customer provides it at the time of each disk operation. This provides the strongest level of customer control over encryption keys.
@@ -19729,19 +19729,19 @@ queries:
       - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that GKE node pools use the GKE Metadata Server to conceal node metadata from workloads. When the workload metadata mode is set to `GKE_METADATA`, pods access a GKE-specific metadata server that prevents them from querying the underlying Compute Engine instance metadata, including the node's service account credentials.
@@ -19844,19 +19844,19 @@ queries:
       - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-gcp
         tags:
           mondoo.com/filter-title: GCP GKE Cluster
-          mondoo.com/icon: gcp
+          mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the GKE cluster control plane (API server) is accessible only via a private endpoint within the VPC, not through a public IP address. When the control plane has a public endpoint, it is reachable from the internet, increasing the risk of brute-force attacks, credential stuffing, and exploitation of API server vulnerabilities.

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -5388,15 +5388,15 @@ queries:
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-debian
         tags:
           mondoo.com/filter-title: Debian Linux
-          mondoo.com/icon: linux
+          mondoo.com/filter-icon: linux
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
         tags:
           mondoo.com/filter-title: Red Hat Linux
-          mondoo.com/icon: linux
+          mondoo.com/filter-icon: linux
       - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
         tags:
           mondoo.com/filter-title: Other Linux
-          mondoo.com/icon: linux
+          mondoo.com/filter-icon: linux
     docs:
       desc: |
         This check verifies that auditd is configured to monitor login and logout events. The parameters in this section track changes to the files associated with login and logout events. The file `/var/log/lastlog` tracks the last login of each user. The file `/var/log/tallylog` tracks failed login attempts. The file `/var/run/faillock` is used by the `pam_faillock` module to track failed authentication attempts. All audit records will be tagged with the identifier "logins."
@@ -6001,11 +6001,11 @@ queries:
       - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-debian-rhel
         tags:
           mondoo.com/filter-title: Debian/Red Hat Linux
-          mondoo.com/icon: linux
+          mondoo.com/filter-icon: linux
       - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-other
         tags:
           mondoo.com/filter-title: Other Linux
-          mondoo.com/icon: linux
+          mondoo.com/filter-icon: linux
     docs:
       desc: |
         This check verifies that the audit system is configured to record changes to key network configuration files and system identity settings by monitoring specific system calls and file paths.

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -171,19 +171,19 @@ queries:
       - uid: mondoo-oci-security-iam-no-overly-permissive-policies-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-iam-no-overly-permissive-policies-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-iam-no-overly-permissive-policies-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-iam-no-overly-permissive-policies-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that no IAM policies grant the `manage all-resources in tenancy` permission, which gives unrestricted administrative access to all resources in the entire tenancy.
@@ -411,19 +411,19 @@ queries:
       - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OCI Object Storage buckets do not allow public access. Public buckets can be accessed by anyone on the internet, which significantly increases the risk of data exposure.
@@ -513,19 +513,19 @@ queries:
       - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that object versioning is enabled on OCI Object Storage buckets. Versioning preserves, retrieves, and restores every version of every object in a bucket, providing protection against accidental deletion or overwriting.
@@ -615,19 +615,19 @@ queries:
       - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that object event logging is enabled on OCI Object Storage buckets. Event logging emits events when objects are created, updated, or deleted, enabling audit trails and automated responses.
@@ -717,19 +717,19 @@ queries:
       - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OCI Object Storage buckets are encrypted using customer-managed keys from the OCI Vault service (KMS) rather than Oracle-managed default encryption keys. Customer-managed keys provide greater control over the encryption lifecycle.
@@ -834,19 +834,19 @@ queries:
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OCI VCN security lists do not contain ingress rules that allow all traffic (all protocols) from any source (0.0.0.0/0). Such rules effectively disable network-level access control for inbound traffic.
@@ -950,19 +950,19 @@ queries:
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OCI VCN security lists do not contain TCP ingress rules from 0.0.0.0/0 that allow all TCP ports. When a TCP ingress rule has no port restrictions, every TCP service on the instance is accessible from the internet.
@@ -1080,19 +1080,19 @@ queries:
       - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-oci
         tags:
           mondoo.com/filter-title: OCI
-          mondoo.com/icon: oci
+          mondoo.com/filter-icon: oci
       - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that OCI VCN security lists do not contain egress rules that allow all outbound traffic to any destination. Unrestricted egress rules can facilitate data exfiltration and command-and-control communications from compromised instances.

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -159,7 +159,7 @@ queries:
       - uid: mondoo-okta-security-limit-super-admins-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         Admin roles allow you to control user access to a range of Okta functions. You can assign more than one role to an individual admin if their job requires them to perform actions that span multiple roles. This role can create other admins, assign or remove permissions, and perform all other admin activities. The super admin has the highest permissions of all admin roles.
@@ -214,19 +214,19 @@ queries:
       - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         Configure network blocklisting to deny access from known malicious IP addresses or locations from your Okta org.
@@ -353,19 +353,19 @@ queries:
       - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enable strong MFA factors to improve resistance to phishing and man-in-the-middle attacks.
@@ -540,19 +540,19 @@ queries:
       - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Okta Verify is a multifactor authentication (MFA) app developed by Okta. It lets users verify their identity when they sign in to Okta and makes it less likely that someone pretending to be the user can gain access to the account.
@@ -694,7 +694,7 @@ queries:
       - uid: mondoo-okta-security-okta-mfa-access-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         Enabling at least one required factor for your org ensures that end users assigned to a given policy are enrolled in MFA.
@@ -777,7 +777,7 @@ queries:
       - uid: mondoo-okta-security-okta-enforce-session-lifetime-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         The session lifetime determines the maximum idle time of a user's Okta session, and when the session expires.
@@ -841,15 +841,15 @@ queries:
       - uid: mondoo-okta-security-okta-auth-openid-saml-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-okta-auth-openid-saml-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-okta-auth-openid-saml-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         SAML and OIDC are authentication protocols that reduce reliance on password-based authentication.
@@ -1019,19 +1019,19 @@ queries:
       - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         When a user reports suspicious activity, admins can enable specific actions and System Log events to obtain further details about the activity.
@@ -1144,19 +1144,19 @@ queries:
       - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         When enabled, this email notification notifies end users of any sign-in activity. The email contains user sign-on details such as the web browser, operating system used to sign in, and time and location of authentication.
@@ -1255,19 +1255,19 @@ queries:
       - uid: mondoo-okta-security-factor-enrollment-notifications-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Factor enrollment notifications for end users notifies end users of any activity on their account related to multifactor authentication (MFA) factor enrollment.
@@ -1363,19 +1363,19 @@ queries:
       - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         When enabled, end users are sent an email notification to inform them that one or more factors have been reset for their account.
@@ -1471,19 +1471,19 @@ queries:
       - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         When enabled, end users are sent an email notification to inform them that the password for their account has changed. This email contains details such as the time and location of the password change.
@@ -1582,19 +1582,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-minimum-length-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-minimum-length-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-minimum-length-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-minimum-length-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify a minimum password length of at least eight characters. Longer passwords provide greater protection against brute force attacks.
@@ -1660,19 +1660,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-max-lockout-attempts-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-max-lockout-attempts-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-max-lockout-attempts-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-max-lockout-attempts-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify the maximum number of invalid password attempts before locking the user's account. This provides protection against brute-force password attacks.
@@ -1721,19 +1721,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-min-lowercase-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-min-lowercase-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-lowercase-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-lowercase-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify the minimum number of lowercase characters in a password. Complex passwords increase the security of your users' accounts.
@@ -1774,19 +1774,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-min-number-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-min-number-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-number-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-number-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify the minimum number of numeric characters in a password. Complex passwords increase the security of your users' accounts.
@@ -1827,19 +1827,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-min-symbols-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-min-symbols-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-symbols-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-symbols-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify the minimum number of symbol characters in a password. Complex passwords increase the security of your users' accounts.
@@ -1881,19 +1881,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-min-age-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-min-age-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-age-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-min-age-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Specify the minimum time interval in minutes between password changes. Setting the minimum password interval protects against brute force attacks.
@@ -1935,19 +1935,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-exclude-username-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-exclude-username-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-username-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-username-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check enforces whether the username must be excluded from the password. Complex passwords increase the security of your users' accounts.
@@ -1989,19 +1989,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-exclude-first-name-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-exclude-first-name-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-first-name-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-first-name-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check enforces whether the user's first name must be excluded from the password. Complex passwords increase the security of your users' accounts.
@@ -2043,19 +2043,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-exclude-last-name-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-exclude-last-name-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-last-name-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-exclude-last-name-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check enforces whether the user's last name must be excluded from the password. Complex passwords increase the security of your users' accounts.
@@ -2097,19 +2097,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-dictionary-lookup-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-dictionary-lookup-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-dictionary-lookup-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-dictionary-lookup-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks passwords against a common password dictionary. Complex passwords increase the security of your users' accounts.
@@ -2151,19 +2151,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-max-age-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-max-age-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-max-age-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-max-age-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks the length in days a password is valid before expiry. Rotating passwords increases the security of your users' accounts.
@@ -2205,19 +2205,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-expire-warning-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-expire-warning-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-expire-warning-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-expire-warning-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks the length in days a user will be warned before password expiry. Rotating passwords increases the security of your users' accounts.
@@ -2259,19 +2259,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-history-count-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-history-count-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-history-count-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-history-count-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks the number of distinct passwords that must be created before they can be reused. Rotating passwords increases the security of your users' accounts.
@@ -2313,19 +2313,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-auto-unlock-minutes-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-auto-unlock-minutes-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-auto-unlock-minutes-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-auto-unlock-minutes-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks the number of minutes before a locked account is unlocked.
@@ -2367,19 +2367,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-show-lockout-failures-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-show-lockout-failures-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-show-lockout-failures-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-show-lockout-failures-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks whether a user should be informed when their account is locked.
@@ -2421,19 +2421,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-email-recovery-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-email-recovery-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-email-recovery-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-email-recovery-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks whether email password recovery is enabled or disabled.
@@ -2475,19 +2475,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-sms-recovery-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-sms-recovery-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-sms-recovery-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-sms-recovery-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks whether sms password recovery is enabled or disabled.
@@ -2529,19 +2529,19 @@ queries:
       - uid: mondoo-okta-security-password-settings-question-recovery-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
       - uid: mondoo-okta-security-password-settings-question-recovery-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-question-recovery-terraform-plan
         tags:
           mondoo.com/filter-title: Terraform Plan
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
       - uid: mondoo-okta-security-password-settings-question-recovery-terraform-state
         tags:
           mondoo.com/filter-title: Terraform State
-          mondoo.com/icon: terraform
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This checks whether question password recovery is enabled or disabled.
@@ -2579,7 +2579,7 @@ queries:
       - uid: mondoo-okta-security-threatinsight-action-block-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         This check ensures that Okta ThreatInsight is configured to actively block suspicious login attempts rather than only auditing or ignoring them.
@@ -2640,7 +2640,7 @@ queries:
       - uid: mondoo-okta-security-trusted-origins-https-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         This check ensures that all active trusted origins in Okta are configured to use HTTPS rather than HTTP.
@@ -2697,7 +2697,7 @@ queries:
       - uid: mondoo-okta-security-signon-requires-mfa-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         This check ensures that active sign-on policy rules require multi-factor authentication (MFA) for user sign-in.
@@ -2766,7 +2766,7 @@ queries:
       - uid: mondoo-okta-security-limit-org-admins-api
         tags:
           mondoo.com/filter-title: Okta Organization
-          mondoo.com/icon: okta
+          mondoo.com/filter-icon: okta
     docs:
       desc: |
         This check ensures that the number of users with the Organization Administrator (ORG_ADMIN) role does not exceed a safe threshold.

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -67,11 +67,11 @@ queries:
       - uid: mondoo-tailscale-security-devices-authorized-device
         tags:
           mondoo.com/filter-title: Tailscale Device
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
       - uid: mondoo-tailscale-security-devices-authorized-tailnet
         tags:
           mondoo.com/filter-title: Tailscale Tailnet
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
     docs:
       desc: |
         This check ensures that all devices connected to the Tailscale tailnet are explicitly authorized. Unauthorized devices may have been added without proper review and could pose a security risk to the network.
@@ -124,11 +124,11 @@ queries:
       - uid: mondoo-tailscale-security-devices-key-expiry-enabled-device
         tags:
           mondoo.com/filter-title: Tailscale Device
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
       - uid: mondoo-tailscale-security-devices-key-expiry-enabled-tailnet
         tags:
           mondoo.com/filter-title: Tailscale Tailnet
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
     docs:
       desc: |
         This check ensures that key expiry is not disabled on Tailscale devices. Key expiry forces devices to periodically re-authenticate, which limits the window of exposure if a device key is compromised.
@@ -191,11 +191,11 @@ queries:
       - uid: mondoo-tailscale-security-devices-client-up-to-date-device
         tags:
           mondoo.com/filter-title: Tailscale Device
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
       - uid: mondoo-tailscale-security-devices-client-up-to-date-tailnet
         tags:
           mondoo.com/filter-title: Tailscale Tailnet
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
     docs:
       desc: |
         This check ensures that Tailscale devices are running the latest available client software. Outdated clients may contain security vulnerabilities or lack important security features.
@@ -258,11 +258,11 @@ queries:
       - uid: mondoo-tailscale-security-devices-no-tailnet-lock-errors-device
         tags:
           mondoo.com/filter-title: Tailscale Device
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
       - uid: mondoo-tailscale-security-devices-no-tailnet-lock-errors-tailnet
         tags:
           mondoo.com/filter-title: Tailscale Tailnet
-          mondoo.com/icon: tailscale
+          mondoo.com/filter-icon: tailscale
     docs:
       desc: |
         This check ensures that no devices in the tailnet have tailnet lock signature errors. Tailnet lock errors indicate that a device's node key has not been properly signed, which may prevent it from functioning correctly in a locked tailnet or may indicate a compromised device.

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -4462,11 +4462,11 @@ queries:
       - uid: mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none-dc
         tags:
           mondoo.com/filter-title: "Windows Domain Controller"
-          mondoo.com/icon: "windows"
+          mondoo.com/filter-icon: "windows"
       - uid: mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none-ms
         tags:
           mondoo.com/filter-title: "Windows Member Server"
-          mondoo.com/icon: "windows"
+          mondoo.com/filter-icon: "windows"
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies


### PR DESCRIPTION
## Summary
- Renames `mondoo.com/icon` to `mondoo.com/filter-icon` in variant filter tags across all security policies
- Affects 8 policy files: AWS, Azure, GCP, Linux, OCI, Okta, Tailscale, and Windows
- No functional changes beyond the tag key rename

## Test plan
- [ ] `cnspec policy lint` passes on all modified files
- [ ] Variant filter icons render correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)