### PR TITLE
fix: restore copyright_year to 2024 for dual-date headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -3,7 +3,7 @@ schema_version = 1
 project {
   license          = "BUSL-1.1"
   copyright_holder = "Mondoo, Inc."
-  copyright_year   = 2026
+  copyright_year   = 2024
 
   # (OPTIONAL) A list of globs that should not have copyright/license headers.
   # Supports doublestar glob patterns for more flexibility in defining which

--- a/.github/.golangci.yaml
+++ b/.github/.golangci.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 version: "2"

--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 ---

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 ---

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 version: "2"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 ARG VERSION

--- a/apps/cnspec/cmd/backgroundjob/background.go
+++ b/apps/cnspec/cmd/backgroundjob/background.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package backgroundjob

--- a/apps/cnspec/cmd/backgroundjob/checkin.go
+++ b/apps/cnspec/cmd/backgroundjob/checkin.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package backgroundjob

--- a/apps/cnspec/cmd/backgroundjob/checkin_pinger.go
+++ b/apps/cnspec/cmd/backgroundjob/checkin_pinger.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package backgroundjob

--- a/apps/cnspec/cmd/backgroundjob/serve_unix.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_unix.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux || darwin || netbsd || openbsd || freebsd

--- a/apps/cnspec/cmd/backgroundjob/serve_windows.go
+++ b/apps/cnspec/cmd/backgroundjob/serve_windows.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build windows

--- a/apps/cnspec/cmd/bundle.go
+++ b/apps/cnspec/cmd/bundle.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/config/config.go
+++ b/apps/cnspec/cmd/config/config.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package config

--- a/apps/cnspec/cmd/config/config_test.go
+++ b/apps/cnspec/cmd/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package config

--- a/apps/cnspec/cmd/framework.go
+++ b/apps/cnspec/cmd/framework.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/integrate.go
+++ b/apps/cnspec/cmd/integrate.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/login.go
+++ b/apps/cnspec/cmd/login.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/logout.go
+++ b/apps/cnspec/cmd/logout.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/lsp.go
+++ b/apps/cnspec/cmd/lsp.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/migrate.go
+++ b/apps/cnspec/cmd/migrate.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/policy.go
+++ b/apps/cnspec/cmd/policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/providers.go
+++ b/apps/cnspec/cmd/providers.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/report.go
+++ b/apps/cnspec/cmd/report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/root.go
+++ b/apps/cnspec/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/run.go
+++ b/apps/cnspec/cmd/run.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/sbom.go
+++ b/apps/cnspec/cmd/sbom.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/shell.go
+++ b/apps/cnspec/cmd/shell.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/status.go
+++ b/apps/cnspec/cmd/status.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/vault.go
+++ b/apps/cnspec/cmd/vault.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/version.go
+++ b/apps/cnspec/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cnspec.go
+++ b/apps/cnspec/cnspec.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package main

--- a/apps/gen-docs/main.go
+++ b/apps/gen-docs/main.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package main

--- a/cli/components/_examples/distributions/main.go
+++ b/cli/components/_examples/distributions/main.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package main

--- a/cli/components/advisories/report.go
+++ b/cli/components/advisories/report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package advisories

--- a/cli/components/advisories/report_test.go
+++ b/cli/components/advisories/report_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package advisories

--- a/cli/components/advisory_results.go
+++ b/cli/components/advisory_results.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/advisory_results_test.go
+++ b/cli/components/advisory_results_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/barchart.go
+++ b/cli/components/barchart.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/components.go
+++ b/cli/components/components.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/cvss_indicator.go
+++ b/cli/components/cvss_indicator.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/distributions.go
+++ b/cli/components/distributions.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/paper.go
+++ b/cli/components/paper.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/question.go
+++ b/cli/components/question.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/rating.go
+++ b/cli/components/rating.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/report.go
+++ b/cli/components/report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/scorecard.go
+++ b/cli/components/scorecard.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/stackbar.go
+++ b/cli/components/stackbar.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/components/stackbar_test.go
+++ b/cli/components/stackbar_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package components

--- a/cli/progress/progress.go
+++ b/cli/progress/progress.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package progress

--- a/cli/progress/todolist.go
+++ b/cli/progress/todolist.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package progress

--- a/cli/progress/todolist_test.go
+++ b/cli/progress/todolist_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package progress

--- a/cli/reporter/aws_sqs_handler.go
+++ b/cli/reporter/aws_sqs_handler.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/azure_service_bus_handler.go
+++ b/cli/reporter/azure_service_bus_handler.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/cli_reporter_test.go
+++ b/cli/reporter/cli_reporter_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/cnspec_report.go
+++ b/cli/reporter/cnspec_report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/cnspec_report.proto
+++ b/cli/reporter/cnspec_report.proto
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 syntax = "proto3";

--- a/cli/reporter/cnspec_report_compare.go
+++ b/cli/reporter/cnspec_report_compare.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/cnspec_report_compare_test.go
+++ b/cli/reporter/cnspec_report_compare_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/csv_vuln.go
+++ b/cli/reporter/csv_vuln.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/csv_vuln_test.go
+++ b/cli/reporter/csv_vuln_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/file_handler.go
+++ b/cli/reporter/file_handler.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/file_handler_test.go
+++ b/cli/reporter/file_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/json.go
+++ b/cli/reporter/json.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/json_test.go
+++ b/cli/reporter/json_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/json_vuln.go
+++ b/cli/reporter/json_vuln.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/json_vuln_test.go
+++ b/cli/reporter/json_vuln_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/junit_test.go
+++ b/cli/reporter/junit_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/output_handler.go
+++ b/cli/reporter/output_handler.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/output_handler_test.go
+++ b/cli/reporter/output_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_darwin.go
+++ b/cli/reporter/print_darwin.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_linux.go
+++ b/cli/reporter/print_linux.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_report.go
+++ b/cli/reporter/print_report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_test.go
+++ b/cli/reporter/print_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_vuln.go
+++ b/cli/reporter/print_vuln.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/print_windows.go
+++ b/cli/reporter/print_windows.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/proto.go
+++ b/cli/reporter/proto.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/proto_test.go
+++ b/cli/reporter/proto_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/render_advisory_policy.go
+++ b/cli/reporter/render_advisory_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/render_asset_overview.go
+++ b/cli/reporter/render_asset_overview.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/render_meta_policy.go
+++ b/cli/reporter/render_meta_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/render_policy.go
+++ b/cli/reporter/render_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cli/reporter/summary.go
+++ b/cli/reporter/summary.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reporter

--- a/cnspec.go
+++ b/cnspec.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cnspec

--- a/content/bundles_test.go
+++ b/content/bundles_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package content

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-arista-eos-security

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-aws-security

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-azure-security

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-bigip-security

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: chef-infra-client

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: chef-infra-server

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-cloudflare-security

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-dns-security

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-docker-best-practices

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-docker-security

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-edr-policy

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-email-security

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-freebsd-security

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-gcp-security

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-github-repository-best-practices

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-github-organization-security

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-gitlab-security

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-google-workspace-security

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-http-security

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-junos-security

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-kubernetes-best-practices

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-kubernetes-security

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: linux-operational-policy

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-linux-security

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: linux-snmp-policy

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-linux-workstation-security

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-m365-security

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-macos-security

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-mcp-security

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-oci-security

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-okta-security

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-panos-security

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: phoenix-plcnext

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-slack-security

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-snowflake-security

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-tailscale-security

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-tls-security

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-unifi-security

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-windows-11-compatibility

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-windows-security

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-windows-workstation-security

--- a/content/querypacks/mondoo-asset-count.mql.yaml
+++ b/content/querypacks/mondoo-asset-count.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-aws-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-aws-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-azure-inventory.mql.yaml
+++ b/content/querypacks/mondoo-azure-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-dns-inventory.mql.yaml
+++ b/content/querypacks/mondoo-dns-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-gcp-inventory.mql.yaml
+++ b/content/querypacks/mondoo-gcp-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-github-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-github-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-github-inventory.mql.yaml
+++ b/content/querypacks/mondoo-github-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-linux-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-linux-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-m365-inventory.mql.yaml
+++ b/content/querypacks/mondoo-m365-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-macos-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-macos-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-okta-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-okta-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-openssl-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-openssl-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-shodan-inventory.mql.yaml
+++ b/content/querypacks/mondoo-shodan-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-slack-inventory.mql.yaml
+++ b/content/querypacks/mondoo-slack-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-terraform-inventory.mql.yaml
+++ b/content/querypacks/mondoo-terraform-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-vmware-inventory.mql.yaml
+++ b/content/querypacks/mondoo-vmware-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-windows-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-windows-incident-response.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: terraform-deprecations

--- a/content/validation/dump_aws_commands.py
+++ b/content/validation/dump_aws_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Dumps all valid AWS CLI subcommands and their flags for services used in

--- a/content/validation/dump_azure_commands.py
+++ b/content/validation/dump_azure_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Dumps all valid Azure CLI commands and their flags.

--- a/content/validation/dump_gcloud_commands.py
+++ b/content/validation/dump_gcloud_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Dumps all valid gcloud CLI subcommands and their flags for services used

--- a/content/validation/dump_oci_commands.py
+++ b/content/validation/dump_oci_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Dumps all valid OCI CLI subcommands and their flags for services used in

--- a/content/validation/validate_ansible_remediation.py
+++ b/content/validation/validate_ansible_remediation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Validates Ansible playbook code blocks found in remediation sections of

--- a/content/validation/validate_bash_remediation.py
+++ b/content/validation/validate_bash_remediation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Validates Bash script code blocks found in remediation sections of cnspec

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Validates CLI commands found in remediation sections of cnspec policies

--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Validates Terraform HCL code blocks found in remediation sections of cnspec

--- a/content/vulnerabilities/mondoo-macos-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-macos-vulnerability.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-macos-vulnerability

--- a/content/vulnerabilities/mondoo-microsoft-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-microsoft-vulnerability.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-microsoft-vulnerability

--- a/content/vulnerabilities/mondoo-openssl-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-openssl-vulnerability.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-openssl-vulnerability

--- a/content/vulnerabilities/mondoo-vmware-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-vmware-vulnerability.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-vmware-vulnerability

--- a/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-xz-vulnerability-policy

--- a/examples/complex.mql.yaml
+++ b/examples/complex.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: example1

--- a/examples/compliance.mql.yaml
+++ b/examples/compliance.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: ssh-policy

--- a/examples/directory/example1.mql.yaml
+++ b/examples/directory/example1.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: example1

--- a/examples/directory/example2.mql.yaml
+++ b/examples/directory/example2.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: example2

--- a/examples/directory/queries/linux-1.mql.yaml
+++ b/examples/directory/queries/linux-1.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 queries:

--- a/examples/directory/queries/sshd-01.mql.yaml
+++ b/examples/directory/queries/sshd-01.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 queries:

--- a/examples/directory/queries/sshd-02.mql.yaml
+++ b/examples/directory/queries/sshd-02.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 queries:

--- a/examples/directory/queries/sshd-03.mql.yaml
+++ b/examples/directory/queries/sshd-03.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 queries:

--- a/examples/directory/queries/sshd-d-1.mql.yaml
+++ b/examples/directory/queries/sshd-d-1.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 queries:

--- a/examples/example.mql.yaml
+++ b/examples/example.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 # To run this file:

--- a/examples/lint_test.go
+++ b/examples/lint_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package examples

--- a/examples/props.mql.yaml
+++ b/examples/props.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 # This bundle contains two policies

--- a/examples/risk.mql.yaml
+++ b/examples/risk.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: example1

--- a/internal/bundle/bundle_ext.go
+++ b/internal/bundle/bundle_ext.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/fmt.go
+++ b/internal/bundle/fmt.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/fmt_test.go
+++ b/internal/bundle/fmt_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_results_cli.go
+++ b/internal/bundle/lint_results_cli.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_results_sarif.go
+++ b/internal/bundle/lint_results_sarif.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_rules_bundle.go
+++ b/internal/bundle/lint_rules_bundle.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_rules_bundle_migrations.go
+++ b/internal/bundle/lint_rules_bundle_migrations.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_rules_policy.go
+++ b/internal/bundle/lint_rules_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_rules_queries.go
+++ b/internal/bundle/lint_rules_queries.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package bundle

--- a/internal/bundle/yacit/main.go
+++ b/internal/bundle/yacit/main.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package main

--- a/internal/datalakes/inmemory/assets.go
+++ b/internal/datalakes/inmemory/assets.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/inmemory/inmemory.go
+++ b/internal/datalakes/inmemory/inmemory.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/inmemory/kiss.go
+++ b/internal/datalakes/inmemory/kiss.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/inmemory/policyhub.go
+++ b/internal/datalakes/inmemory/policyhub.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/inmemory/policyresolver.go
+++ b/internal/datalakes/inmemory/policyresolver.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/inmemory/resolved_policy_cache.go
+++ b/internal/datalakes/inmemory/resolved_policy_cache.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package inmemory

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sqlite

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package lsp

--- a/internal/lsp/lsp_yaml.go
+++ b/internal/lsp/lsp_yaml.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package lsp

--- a/internal/lsp/lsp_yaml_columns_test.go
+++ b/internal/lsp/lsp_yaml_columns_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package lsp

--- a/internal/lsp/lsp_yaml_test.go
+++ b/internal/lsp/lsp_yaml_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package lsp

--- a/internal/onboarding/aws.go
+++ b/internal/onboarding/aws.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding

--- a/internal/onboarding/aws_test.go
+++ b/internal/onboarding/aws_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding_test

--- a/internal/onboarding/azure.go
+++ b/internal/onboarding/azure.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding_test

--- a/internal/onboarding/constants.go
+++ b/internal/onboarding/constants.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding

--- a/internal/onboarding/exec.go
+++ b/internal/onboarding/exec.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 // A package that executes onboarding code.

--- a/internal/onboarding/exec_test.go
+++ b/internal/onboarding/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding_test

--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package onboarding_test

--- a/internal/sbom/cnspec_bom.go
+++ b/internal/sbom/cnspec_bom.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/cnspec_sbom.proto
+++ b/internal/sbom/cnspec_sbom.proto
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 syntax = "proto3";

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/formats.go
+++ b/internal/sbom/formats.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/generator/generator.go
+++ b/internal/sbom/generator/generator.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package generator

--- a/internal/sbom/generator/report_collection.go
+++ b/internal/sbom/generator/report_collection.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package generator

--- a/internal/sbom/multi_decoder.go
+++ b/internal/sbom/multi_decoder.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/pack/pack.go
+++ b/internal/sbom/pack/pack.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package pack

--- a/internal/sbom/pack/pack_test.go
+++ b/internal/sbom/pack/pack_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package pack

--- a/internal/sbom/pack/sbom.mql.yaml
+++ b/internal/sbom/pack/sbom.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 packs:

--- a/internal/sbom/protobom.go
+++ b/internal/sbom/protobom.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/sbom/textlist.go
+++ b/internal/sbom/textlist.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sbom

--- a/internal/tfgen/hcl.go
+++ b/internal/tfgen/hcl.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 // A package that generates Terraform deployment code.

--- a/internal/tfgen/hcl_internal_test.go
+++ b/internal/tfgen/hcl_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package tfgen

--- a/internal/tfgen/hcl_test.go
+++ b/internal/tfgen/hcl_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package tfgen_test

--- a/internal/yac-it/yac-it.go
+++ b/internal/yac-it/yac-it.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package yacit

--- a/policy/assessment.go
+++ b/policy/assessment.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_file_resolver.go
+++ b/policy/bundle_file_resolver.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_http_resolver.go
+++ b/policy/bundle_http_resolver.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_http_resolver_test.go
+++ b/policy/bundle_http_resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/bundle_map.go
+++ b/policy/bundle_map.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_migrations.go
+++ b/policy/bundle_migrations.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_require.go
+++ b/policy/bundle_require.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_s3_resolver.go
+++ b/policy/bundle_s3_resolver.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 syntax = "proto3";

--- a/policy/collectorjob.go
+++ b/policy/collectorjob.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/collectorjob_test.go
+++ b/policy/collectorjob_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/datalake.go
+++ b/policy/datalake.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/errors.go
+++ b/policy/errors.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/evidence.go
+++ b/policy/evidence.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/evidence_test.go
+++ b/policy/evidence_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/executor/executor.go
+++ b/policy/executor/executor.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package executor

--- a/policy/executor/executor_test.go
+++ b/policy/executor/executor_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package executor

--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package executor

--- a/policy/executor/internal/builder.go
+++ b/policy/executor/internal/builder.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/builder_test.go
+++ b/policy/executor/internal/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/nodes_test.go
+++ b/policy/executor/internal/nodes_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/queue.go
+++ b/policy/executor/internal/queue.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/waitgroup.go
+++ b/policy/executor/internal/waitgroup.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/waitgroup_test.go
+++ b/policy/executor/internal/waitgroup_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/explorer_errors.go
+++ b/policy/explorer_errors.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/explorer_filters.go
+++ b/policy/explorer_filters.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/explorer_human_time.go
+++ b/policy/explorer_human_time.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/explorer_impact.go
+++ b/policy/explorer_impact.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/explorer_mquery.go
+++ b/policy/explorer_mquery.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/explorer_property.go
+++ b/policy/explorer_property.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/fmt/fmt.go
+++ b/policy/fmt/fmt.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package fmt

--- a/policy/framework.go
+++ b/policy/framework.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/frameworks_test.go
+++ b/policy/frameworks_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/hub_test.go
+++ b/policy/hub_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/mquery.go
+++ b/policy/mquery.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/mquery_test.go
+++ b/policy/mquery_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/rating.go
+++ b/policy/rating.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/report.go
+++ b/policy/report.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/report_test.go
+++ b/policy/report_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/reportingjob.go
+++ b/policy/reportingjob.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/resolved_policy.go
+++ b/policy/resolved_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/resolved_policy_builder.go
+++ b/policy/resolved_policy_builder.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/resolver_test.go
+++ b/policy/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/resolver_v2_test.go
+++ b/policy/resolver_v2_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy_test

--- a/policy/risk_factor.go
+++ b/policy/risk_factor.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/risk_factor_test.go
+++ b/policy/risk_factor_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/scan/benchmark/benchmark_test.go
+++ b/policy/scan/benchmark/benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package benchmark

--- a/policy/scan/disk_queue.go
+++ b/policy/scan/disk_queue.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/disk_queue_test.go
+++ b/policy/scan/disk_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/fetcher.go
+++ b/policy/scan/fetcher.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/pdque/queue.go
+++ b/policy/scan/pdque/queue.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package pdque

--- a/policy/scan/pdque/queue_test.go
+++ b/policy/scan/pdque/queue_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package pdque

--- a/policy/scan/reporter.go
+++ b/policy/scan/reporter.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/reporter_aggregate.go
+++ b/policy/scan/reporter_aggregate.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/reporter_aggregate_test.go
+++ b/policy/scan/reporter_aggregate_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/reporter_error.go
+++ b/policy/scan/reporter_error.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/reporter_noop.go
+++ b/policy/scan/reporter_noop.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/scan.go
+++ b/policy/scan/scan.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scan

--- a/policy/scan/scan.proto
+++ b/policy/scan/scan.proto
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 syntax = "proto3";

--- a/policy/scandb/query.sql
+++ b/policy/scandb/query.sql
@@ -1,4 +1,4 @@
--- Copyright Mondoo, Inc. 2026
+-- Copyright Mondoo, Inc. 2024, 2026
 -- SPDX-License-Identifier: BUSL-1.1
 
 -- Metadata operations

--- a/policy/scandb/scan_data_store.go
+++ b/policy/scandb/scan_data_store.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:generate go tool sqlc generate ./

--- a/policy/scandb/scan_data_store_test.go
+++ b/policy/scandb/scan_data_store_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scandb

--- a/policy/scandb/scan_data_store_wrapper.go
+++ b/policy/scandb/scan_data_store_wrapper.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scandb

--- a/policy/scandb/scan_data_store_wrapper_test.go
+++ b/policy/scandb/scan_data_store_wrapper_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scandb

--- a/policy/scandb/scan_db.sql
+++ b/policy/scandb/scan_db.sql
@@ -1,4 +1,4 @@
--- Copyright Mondoo, Inc. 2026
+-- Copyright Mondoo, Inc. 2024, 2026
 -- SPDX-License-Identifier: BUSL-1.1
 
 -- SQLite schema for cnspec policy upload files

--- a/policy/scandb/sqlc.yaml
+++ b/policy/scandb/sqlc.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 version: "2"
 sql:

--- a/policy/score.go
+++ b/policy/score.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/score_stats.go
+++ b/policy/score_stats.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/score_stats_test.go
+++ b/policy/score_stats_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/services.go
+++ b/policy/services.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package policy

--- a/policy/tooling/tooling.go
+++ b/policy/tooling/tooling.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package tooling

--- a/policy/tooling/tooling_test.go
+++ b/policy/tooling/tooling_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package tooling

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 # See https://prometheus.io/docs/prometheus/latest/configuration/configuration/ for configuration options

--- a/scripts/pkg/debian/postinstall.sh
+++ b/scripts/pkg/debian/postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/scripts/pkg/debian/preinstall.sh
+++ b/scripts/pkg/debian/preinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/scripts/pkg/debian/preremove.sh
+++ b/scripts/pkg/debian/preremove.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/scripts/pkg/linux/postinstall.sh
+++ b/scripts/pkg/linux/postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/scripts/pkg/linux/preinstall.sh
+++ b/scripts/pkg/linux/preinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/scripts/pkg/linux/preremove.sh
+++ b/scripts/pkg/linux/preremove.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 

--- a/test/cli/cli_test.go
+++ b/test/cli/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cli

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package providers

--- a/test/providers/scan_flags_test.go
+++ b/test/providers/scan_flags_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package providers

--- a/test/providers/setup_test.go
+++ b/test/providers/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package providers

--- a/test/sbom/sbom_test.go
+++ b/test/sbom/sbom_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build debugtest

--- a/test/serve/serve_test.go
+++ b/test/serve/serve_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package serve

--- a/upstream/framework.gql.go
+++ b/upstream/framework.gql.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package upstream

--- a/upstream/gql.go
+++ b/upstream/gql.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package upstream


### PR DESCRIPTION
## Summary
- Reverts `copyright_year` from `2026` back to `2024` in `.copywrite.hcl` (fixes misconfiguration from #2304)
- Re-runs `make license/headers/apply` so all 344 tracked files now show `Copyright Mondoo, Inc. 2024, 2026` instead of just `2026`

## Test plan
- [x] `make license/headers/apply` runs cleanly
- [ ] License CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)