### PR TITLE
🐛 fix batching bug for todo list 

### DIFF
--- a/cli/progress/progress.go
+++ b/cli/progress/progress.go
@@ -27,6 +27,8 @@ func (n Noop) Completed()          {}
 // Tasks can be added dynamically via AddTask at any point after Open.
 type MultiProgress interface {
 	Open() error
+	Discovered(count int)
+	Filtered(count int)
 	AddTask(index string, asset *inventory.Asset)
 	OnProgress(index string, percent float64)
 	Score(index string, score string)
@@ -40,6 +42,8 @@ type MultiProgress interface {
 type NoopMultiProgress struct{}
 
 func (n NoopMultiProgress) Open() error                      { return nil }
+func (n NoopMultiProgress) Discovered(int)                   {}
+func (n NoopMultiProgress) Filtered(int)                     {}
 func (n NoopMultiProgress) AddTask(string, *inventory.Asset) {}
 func (n NoopMultiProgress) OnProgress(string, float64)       {}
 func (n NoopMultiProgress) Score(string, string)             {}

--- a/cli/progress/todolist.go
+++ b/cli/progress/todolist.go
@@ -79,6 +79,9 @@ type msgNotApplicable struct {
 
 type msgTick time.Time
 
+type msgDiscovered struct{ count int }
+type msgFiltered struct{ count int }
+
 // modelTodoList is the bubbletea model for the TODO-list progress UI.
 type modelTodoList struct {
 	tasks        []*task
@@ -87,6 +90,8 @@ type modelTodoList struct {
 	startTime    time.Time
 	includeScore bool
 	spinner      spinner.Model
+	discovered   int
+	filtered     int
 }
 
 func newTodoListModel(opts ...Option) *modelTodoList {
@@ -125,6 +130,18 @@ func (m *modelTodoList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.WindowSizeMsg:
+		return m, nil
+
+	case msgDiscovered:
+		m.lock.Lock()
+		m.discovered += msg.count
+		m.lock.Unlock()
+		return m, nil
+
+	case msgFiltered:
+		m.lock.Lock()
+		m.filtered += msg.count
+		m.lock.Unlock()
 		return m, nil
 
 	case msgAddTask:
@@ -309,11 +326,20 @@ func (m *modelTodoList) View() string {
 	// Footer: completion stats with elapsed time.
 	// All terminal states (completed, errored, n/a) count as "done" tasks.
 	total := len(m.tasks)
-	if total > 0 {
+	if total > 0 || m.discovered > 0 {
 		done := len(finished)
 		elapsed := time.Since(m.startTime).Truncate(time.Second)
 		b.WriteString("\n")
-		footer := fmt.Sprintf("  %d/%d completed", done, total)
+
+		var footer string
+		if m.discovered > 0 {
+			footer = fmt.Sprintf("  %d discovered · %d scanned", m.discovered, done)
+			if m.filtered > 0 {
+				footer += styleDim.Render(fmt.Sprintf(" · %d filtered", m.filtered))
+			}
+		} else {
+			footer = fmt.Sprintf("  %d/%d completed", done, total)
+		}
 		if errored > 0 {
 			footer += styleError.Render(fmt.Sprintf(" · %d errored", errored))
 		}
@@ -433,6 +459,14 @@ func (t *todoListProgress) Open() error {
 		return err
 	}
 	return nil
+}
+
+func (t *todoListProgress) Discovered(count int) {
+	t.program.Send(msgDiscovered{count: count})
+}
+
+func (t *todoListProgress) Filtered(count int) {
+	t.program.Send(msgFiltered{count: count})
 }
 
 func (t *todoListProgress) AddTask(index string, asset *inventory.Asset) {

--- a/cli/progress/todolist_test.go
+++ b/cli/progress/todolist_test.go
@@ -285,3 +285,29 @@ func TestTodoListMultiBatch(t *testing.T) {
 	assert.Contains(t, output, "batch2-b")
 	assert.Contains(t, output, "5/5 completed")
 }
+
+func TestTodoListDiscoveredAndSkipped(t *testing.T) {
+	var in bytes.Buffer
+	var buf bytes.Buffer
+
+	tl, err := newTodoListProgram(&in, &buf)
+	require.NoError(t, err)
+
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		tl.Discovered(100)
+		tl.AddTask("1", testAsset("scannable1", "linux"))
+		tl.AddTask("2", testAsset("scannable2", "linux"))
+		tl.Filtered(3)
+		tl.Completed("1")
+		tl.Completed("2")
+		tl.Close()
+	}()
+	err = tl.Open()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "100 discovered")
+	assert.Contains(t, output, "2 scanned")
+	assert.Contains(t, output, "3 filtered")
+}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -459,6 +459,10 @@ type scanContext struct {
 // After all children are handled, the node itself is scanned (if it has
 // platform IDs) and then closed.
 func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedAsset) error {
+	if len(node.Children) > 0 {
+		sc.multiprogress.Discovered(len(node.Children))
+	}
+
 	var leafBatch []*discovery.TrackedAsset
 
 	for _, child := range node.Children {
@@ -497,6 +501,7 @@ func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedA
 		// Leaf node — skip if it has no platform IDs (not scannable)
 		if len(connected.Asset.PlatformIds) == 0 {
 			log.Debug().Str("name", connected.Asset.Name).Msg("asset has no platform IDs, skipping")
+			sc.multiprogress.Filtered(1)
 			if err := sc.explorer.CloseAsset(connected); err != nil {
 				log.Error().Err(err).Str("asset", connected.Asset.Name).Msg("failed to close asset")
 			}
@@ -528,6 +533,7 @@ func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedA
 			return err
 		}
 	} else {
+		sc.multiprogress.Filtered(1)
 		if err := sc.explorer.CloseAsset(node); err != nil {
 			log.Error().Err(err).Str("asset", node.Asset.Name).Msg("failed to close asset")
 		}


### PR DESCRIPTION
Instead of showing multiples of the batch size in our to do list, actually display what has been discovered and filtered out. The new list looks like this:
<img width="1206" height="502" alt="image" src="https://github.com/user-attachments/assets/d91d0389-5765-4b03-b6cc-1c41622e3fd8" />
