### PR TITLE
✨ Add Malwarebytes to EDR policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -240,7 +240,6 @@ lsp
 lsws
 ltm
 lts
-Malwarebytes
 managedzone
 Mbeze
 mcp


### PR DESCRIPTION
## Summary
- Adds Malwarebytes Endpoint Agent detection to the EDR policy for macOS and Windows
- macOS install check uses file existence at `/Library/Application Support/Malwarebytes`; running check verifies Malwarebytes processes are active
- Windows install check uses `Malwarebytes Endpoint Agent` package; running check verifies `MBEndpointAgent` service
- Bumps policy version to 1.6.0

Closes https://github.com/mondoo-community/customer-issues/issues/136

## Test plan
- [ ] `cnspec policy lint content/mondoo-edr-policy.mql.yaml` passes (verified locally)
- [ ] Test on macOS host with Malwarebytes installed — install and running checks should pass
- [ ] Test on Windows host with Malwarebytes Endpoint Agent installed — install and running checks should pass
- [ ] Test on host without any EDR — both checks should fail as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)