### PR TITLE
Disable slow query reporting

### DIFF
--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -180,21 +180,6 @@ func (em *executionManager) executeCodeBundle(codeBundle *llx.CodeBundle, props 
 			Str("qrid", codeID).
 			Dur("duration", time.Since(startTime)).
 			Msg("finished query execution")
-		if time.Since(startTime) > 5*time.Minute {
-			// if the query duration was more than 5 minutes, send an alert to platform
-			health.ReportSlowQuery(
-				"cnspec", cnspec.Version, cnspec.Build,
-				health.SlowQueryInfo{
-					CodeID:   codeID,
-					Query:    codeBundle.Source,
-					Duration: time.Since(startTime),
-				},
-				health.WithTags(map[string]string{
-					"client.runtime.os":   goruntime.GOOS,
-					"client.runtime.arch": goruntime.GOARCH,
-				}),
-			)
-		}
 	}()
 	// TODO(jaym): sendResult may not be correct. We may need to fill in the
 	// checksum


### PR DESCRIPTION
## Summary
- Remove the slow query reporting mechanism that sends alerts to the health platform when queries take longer than 5 minutes
- Debug logging for query execution duration is retained

## Test plan
- [ ] Verify build succeeds
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)