### PR TITLE
fix: filter to hostPath volumes before checking socket path

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -1316,7 +1316,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
     mql: |
       k8s.pod {
-        podSpec['volumes'] == null || podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+        podSpec['volumes'] == null || podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
       }
     docs:
       desc: |
@@ -1379,7 +1379,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
     mql: |
       k8s.cronjob {
-        podSpec['volumes'] == null || podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+        podSpec['volumes'] == null || podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
       }
     docs:
       desc: |
@@ -1440,7 +1440,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1500,7 +1500,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1560,7 +1560,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1620,7 +1620,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1680,7 +1680,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
+    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1740,7 +1740,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1800,7 +1800,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1860,7 +1860,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1920,7 +1920,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers in Deployments do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -1980,7 +1980,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2040,7 +2040,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2100,7 +2100,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
+    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2160,7 +2160,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2220,7 +2220,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2280,7 +2280,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2340,7 +2340,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2400,7 +2400,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2460,7 +2460,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
@@ -2520,7 +2520,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
+    mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
         This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.


### PR DESCRIPTION
## Problem

The docker-socket, containerd-socket, and crio-socket checks for all K8s resource types (pod, cronjob, deployment, statefulset, job, replicaset, daemonset) evaluate `_['hostPath']['path']` on **every** volume entry. Non-hostPath volumes (configMap, emptyDir, secret, etc.) don't have a `hostPath` key, so the access produces null/empty and the `!=` comparison against the socket path behaves unpredictably — causing false positives on workloads that have no hostPath volumes at all.

## Fix

Add `.where(_['hostPath'] != empty)` before `.all()` to filter volumes to only those with a hostPath field before checking the path value. This is the same pattern already used by the `hostpath-readonly` checks in the same file.

**Before:**
```
podSpec['volumes'].all(_['hostPath']['path'] != '/var/run/docker.sock')
```

**After:**
```
podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
```

## Scope

21 checks fixed (7 resource types × 3 socket types: docker, containerd, crio) in `content/mondoo-kubernetes-security.mql.yaml`.