### PR TITLE
Change checks for running systemd sockets to only happen if socket exists

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3428,13 +3428,11 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-
-
-      systemd.sockets.where(name == "telnet").all(
+      sockets = ["telnet"]
+      systemd.sockets.where(name.in(sockets)).all(
         running == false &&
         enabled == false
       )
-
     docs:
       desc: |-
         This check verifies that the Telnet server service (telnet.socket) is not running and is disabled on the system.
@@ -3510,13 +3508,11 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-
-
-      systemd.sockets.where(name == "tftp").all(
+      sockets = ["tftp"]
+      systemd.sockets.where(name.in(sockets)).all(
         running == false &&
         enabled == false
       )
-
     docs:
       desc: |
         This check verifies that the Trivial File Transfer Protocol (TFTP) server service (tftp.socket) is not running and is disabled on the system.

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3333,13 +3333,11 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-
       sockets = ["rsh", "rlogin", "rexec"]
       systemd.sockets.where(name.in(sockets)).all(
         running == false &&
         enabled == false
       )
-
     docs:
       desc: |
         This check verifies that the Remote Shell (rsh) server services—specifically rsh.socket, rlogin.socket, and rexec.socket—are not running and are disabled on the system.
@@ -3508,8 +3506,7 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      sockets = ["tftp"]
-      systemd.sockets.where(name.in(sockets)).all(
+      systemd.sockets.where(name == "tftp").all(
         running == false &&
         enabled == false
       )

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3426,8 +3426,7 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      sockets = ["telnet"]
-      systemd.sockets.where(name.in(sockets)).all(
+      systemd.sockets.where(name == "telnet").all(
         running == false &&
         enabled == false
       )

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3333,12 +3333,12 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      systemd.socket("rsh").enabled == false
-      systemd.socket("rlogin").enabled == false
-      systemd.socket("rexec").enabled == false
-      systemd.socket("rsh").running == false
-      systemd.socket("rlogin").running == false
-      systemd.socket("rexec").running == false
+      service("rsh").enabled == false
+      service("rlogin").enabled == false
+      service("rexec").enabled == false
+      service("rsh").running == false
+      service("rlogin").running == false
+      service("rexec").running == false
     docs:
       desc: |
         This check verifies that the Remote Shell (rsh) server services—specifically rsh.socket, rlogin.socket, and rexec.socket—are not running and are disabled on the system.
@@ -3427,8 +3427,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      systemd.socket("telnet").enabled == false
-      systemd.socket("telnet").running == false
+      service("telnet").enabled == false
+      service("telnet").running == false
     docs:
       desc: |-
         This check verifies that the Telnet server service (telnet.socket) is not running and is disabled on the system.
@@ -3504,8 +3504,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      systemd.socket("tftp").enabled == false
-      systemd.socket("tftp").running == false
+      service("tftp").enabled == false
+      service("tftp").running == false
     docs:
       desc: |
         This check verifies that the Trivial File Transfer Protocol (TFTP) server service (tftp.socket) is not running and is disabled on the system.

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3333,12 +3333,13 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("rsh").enabled == false
-      service("rlogin").enabled == false
-      service("rexec").enabled == false
-      service("rsh").running == false
-      service("rlogin").running == false
-      service("rexec").running == false
+
+      sockets = ["rsh", "rlogin", "rexec"]
+      systemd.sockets.where(name.in(sockets)).all(
+        running == false &&
+        enabled == false
+      )
+
     docs:
       desc: |
         This check verifies that the Remote Shell (rsh) server services—specifically rsh.socket, rlogin.socket, and rexec.socket—are not running and are disabled on the system.
@@ -3427,8 +3428,13 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("telnet").enabled == false
-      service("telnet").running == false
+
+
+      systemd.sockets.where(name == "telnet").all(
+        running == false &&
+        enabled == false
+      )
+
     docs:
       desc: |-
         This check verifies that the Telnet server service (telnet.socket) is not running and is disabled on the system.
@@ -3504,8 +3510,13 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      service("tftp").enabled == false
-      service("tftp").running == false
+
+
+      systemd.sockets.where(name == "tftp").all(
+        running == false &&
+        enabled == false
+      )
+
     docs:
       desc: |
         This check verifies that the Trivial File Transfer Protocol (TFTP) server service (tftp.socket) is not running and is disabled on the system.


### PR DESCRIPTION
Fixes https://github.com/mondoo-community/customer-issues/issues/139

The `systemd.socket` resource does not return a null type unlike `services` for sockets that don't exist, which causes any checks looking if the sockets are running/enabled to fail.