### PR TITLE
fix: auditd MAC policy check uses bare keyname causing null propagation

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -6315,7 +6315,7 @@ queries:
       appArmorConfigured = appArmorPaths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "MAC-policy"
+          && f.keyname == "MAC-policy"
         )
       )
 
@@ -6323,7 +6323,7 @@ queries:
       seLinuxConfigured = seLinuxPaths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "MAC-policy"
+          && f.keyname == "MAC-policy"
         )
       )
 


### PR DESCRIPTION
Fixes #2375

In the `mondoo-linux-security-events-that-modify-the-systems-mandatory-access-controls-are-collected` check, `keyname` inside `contains(f: ...)` nested inside `all(p: ...)` resolves to null in the outer String context because it lacks the `f.` prefix. This causes null propagation, returning `?` instead of `true`/`false` when auditd rules are present.

Changed `keyname == "MAC-policy"` → `f.keyname == "MAC-policy"` in both the AppArmor and SELinux sections.