### PR TITLE
:bug: DynamoDB KMS encryption check using null sseDescription dict

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3613,8 +3613,7 @@ queries:
   - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-aws
     filters: asset.platform == "aws-dynamodb-table"
     mql: |
-      aws.dynamodb.table.sseDescription.SSEType == "KMS"
-      aws.dynamodb.table.sseDescription.Status == "ENABLED"
+      aws.dynamodb.table.sseType == "KMS"
   - uid: mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dynamodb_table")
     mql: |


### PR DESCRIPTION
## Summary
- The `mondoo-aws-security-dynamodb-table-encrypted-kms-aws` check queried `aws.dynamodb.table.sseDescription.SSEType == "KMS"` and `sseDescription.Status == "ENABLED"`, but when a DynamoDB table uses default AWS-owned encryption, the API returns nil for `SSEDescription`, so both fields evaluate to `_` (undefined)
- Switched to the dedicated `sseType` field which returns `""` for default encryption and `"KMS"` for KMS encryption
- The `Status == "ENABLED"` check is redundant — `sseType == "KMS"` can only be true when encryption is active

## Test plan
- [x] Scan a DynamoDB table with default encryption — check should fail with `actual: ""` instead of `actual: _`
- [x] Scan a DynamoDB table with KMS encryption — check should pass
- [x] Verify no regressions in other DynamoDB checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)