### PR TITLE
fix: skip Active Directory integration app in Okta SAML/OIDC check

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -879,10 +879,10 @@ queries:
   - uid: mondoo-okta-security-okta-auth-openid-saml-api
     filters: asset.platform == "okta-org"
     mql: |
-      okta.applications.where(signOnMode != "BOOKMARK" && status == "ACTIVE").all(_.signOnMode == "OPENID_CONNECT" || _.signOnMode == "SAML_2_0")
+      okta.applications.where(signOnMode != "BOOKMARK" && name != "active_directory" && status == "ACTIVE").all(_.signOnMode == "OPENID_CONNECT" || _.signOnMode == "SAML_2_0")
     docs:
       desc: |
-        This check explicitly skips Okta Bookmark apps.
+        This check explicitly skips Okta Bookmark apps and Active Directory integration apps, which cannot be configured with SAML or OIDC authentication by design.
       remediation:
         - id: console
           desc: |


### PR DESCRIPTION
## Problem

The check `mondoo-okta-security-okta-auth-openid-saml-api` fails for any Okta tenant that has the Active Directory integration app installed.

The Okta Active Directory integration app cannot be configured with SAML or OIDC authentication by design, so it never satisfies the `signOnMode == "OPENID_CONNECT" || signOnMode == "SAML_2_0"` predicate. The current `where` filter only excludes `BOOKMARK` apps, which causes the AD integration app to surface as a false-positive failure.

## Fix

Add `name != "active_directory"` to the `where` filter, mirroring the existing `BOOKMARK` exclusion pattern and keyed on the stable OIN app name field.

```diff
-okta.applications.where(signOnMode != "BOOKMARK" && status == "ACTIVE").all(...)
+okta.applications.where(signOnMode != "BOOKMARK" && name != "active_directory" && status == "ACTIVE").all(...)
```

The check description is updated to document both exclusions.

## Notes

- Originally opened against `cnspec-enterprise-policies` in mondoohq/cnspec-enterprise-policies#2142; moved here because the check definition lives in this repo.
- MQL compiles cleanly against the `okta` provider.
