### PR TITLE
Add Slack check for unconfirmed user email addresses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ When adding or changing compliance tags, follow this process for **each** framew
 5. **Cite the control you chose.** When you present tags to the user, include the control title and a short quote from the control description so the user can verify.
 
 Known high-value anchors (verify before using):
-- Identity proofing / email verification: `iso-27001-2022-a-5-16` (Identity management), `nist-csf-2-pr-aa-02` ("Identities are proofed and bound to credentials"), `nist-sp-800-53-rev5-ia-12` (Identity Proofing). No direct equivalent in NIST CSF 1.x, NIST 800-171 rev2, NIS 2 Article 21(2), or SOC 2 2017.
+- Identity proofing / email verification: `iso-27001-2022-a-5-16` (Identity management), `nist-csf-2-pr-aa-02` ("Identities are proofed and bound to credentials"), `nist-sp-800-53-rev5-ia-12` (Identity Proofing). No direct equivalent in NIST CSF 1.x, NIST 800-171 rev2, NIS2 Article 21(2), or SOC 2 2017.
 - Authenticator / MFA strength: `iso-27001-2022-a-8-5`, `nist-csf-2-pr-aa-03`, `nist-sp-800-53-rev5-ia-2`, `soc2-control-cc6-1-4`. Do **not** reuse these for identity-proofing checks.
 
 Test policy files:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ policies:
 
 When adding or changing compliance tags, follow this process for **each** framework the policy already tags:
 
-1. **Read the authoritative control text.** Open the framework definition for each framework (`<framework>.mql.yaml`, e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where the framework definitions live if you don't already know; if they're not available, stop and tell the user — do not guess.
+1. **Read the authoritative control text.** Open the framework definition in `cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where their clone lives if you don't already know; if the files aren't available, stop and tell the user — do not guess.
 2. **State in one sentence what the check actually enforces.** If the check is about identity proofing, say so; if it's about encryption-at-rest, say so. Do not let the check's *title* mislead you — read the MQL.
 3. **Find the single best-matching control** by scanning control titles and descriptions for language that covers the enforced behavior. Strict fit only: MFA, password policy, and session-timeout controls are *not* acceptable stand-ins for identity-proofing, encryption, network-isolation, etc.
 4. **If no control fits, tag it `false`.** This is an established pattern in this repo (grep for `compliance/.*: false`). A missing mapping is strictly better than a wrong one — wrong mappings get caught in compliance audits and create trust debt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,22 @@ policies:
 - Check `title` fields must be 75 characters or fewer.
 - When writing CLI commands in remediation steps, verify that the subcommands and flags you use are valid by checking the reference data in `content/validation/cmd_data/` (e.g., `aws_commands.json`, `azure_commands.json`). Read the relevant JSON file and confirm the command and its flags exist before including them in remediation content.
 
+#### Compliance tags (`compliance/<framework>: <control-uid>`)
+
+**Never copy compliance tags from a neighboring check.** The nearby check was mapped for a different control objective; reusing its tags propagates a wrong mapping and misleads auditors. Two checks that both "relate to identity" can map to different controls.
+
+When adding or changing compliance tags, follow this process for **each** framework the policy already tags:
+
+1. **Read the authoritative control text.** Open the framework definition in `~/dev/cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. If the repo is not on disk, tell the user and stop — do not guess.
+2. **State in one sentence what the check actually enforces.** If the check is about identity proofing, say so; if it's about encryption-at-rest, say so. Do not let the check's *title* mislead you — read the MQL.
+3. **Find the single best-matching control** by scanning control titles and descriptions for language that covers the enforced behavior. Strict fit only: MFA, password policy, and session-timeout controls are *not* acceptable stand-ins for identity-proofing, encryption, network-isolation, etc.
+4. **If no control fits, tag it `false`.** This is an established pattern in this repo (grep for `compliance/.*: false`). A missing mapping is strictly better than a wrong one — wrong mappings get caught in compliance audits and create trust debt.
+5. **Cite the control you chose.** When you present tags to the user, include the control title and a short quote from the control description so the user can verify.
+
+Known high-value anchors (verify before using):
+- Identity proofing / email verification: `iso-27001-2022-a-5-16` (Identity management), `nist-csf-2-pr-aa-02` ("Identities are proofed and bound to credentials"), `nist-sp-800-53-rev5-ia-12` (Identity Proofing). No direct equivalent in NIST CSF 1.x, NIST 800-171 rev2, NIS 2 Article 21(2), or SOC 2 2017.
+- Authenticator / MFA strength: `iso-27001-2022-a-8-5`, `nist-csf-2-pr-aa-03`, `nist-sp-800-53-rev5-ia-2`, `soc2-control-cc6-1-4`. Do **not** reuse these for identity-proofing checks.
+
 Test policy files:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ policies:
 
 When adding or changing compliance tags, follow this process for **each** framework the policy already tags:
 
-1. **Read the authoritative control text.** Open the framework definition in `~/dev/cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. If the repo is not on disk, tell the user and stop — do not guess.
+1. **Read the authoritative control text.** Open the framework definition for each framework (`<framework>.mql.yaml`, e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where the framework definitions live if you don't already know; if they're not available, stop and tell the user — do not guess.
 2. **State in one sentence what the check actually enforces.** If the check is about identity proofing, say so; if it's about encryption-at-rest, say so. Do not let the check's *title* mislead you — read the MQL.
 3. **Find the single best-matching control** by scanning control titles and descriptions for language that covers the enforced behavior. Strict fit only: MFA, password policy, and session-timeout controls are *not* acceptable stand-ins for identity-proofing, encryption, network-isolation, etc.
 4. **If no control fits, tag it `false`.** This is an established pattern in this repo (grep for `compliance/.*: false`). A missing mapping is strictly better than a wrong one — wrong mappings get caught in compliance audits and create trust debt.

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -378,7 +378,13 @@ queries:
       compliance/soc2-2017: false
     mql: |
       slack.users.members
-        .where(name != /deactivateduser/ && isInvitedUser == false && id != "USLACKBOT")
+        .where(
+          deleted == false &&
+          isInvitedUser == false &&
+          isConnectorBot == false &&
+          isWorkflowBot == false &&
+          id != "USLACKBOT"
+        )
         .all(isEmailConfirmed == true)
     docs:
       desc: |

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -369,13 +369,13 @@ queries:
     title: Ensure all active users have confirmed their email address
     impact: 60
     tags:
-      compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-j
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
-      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/iso-27001-2022: iso-27001-2022-a-5-16
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: nist-csf-2-pr-aa-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-12
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: false
     mql: |
       slack.users.members
         .where(name != /deactivateduser/ && isInvitedUser == false && id != "USLACKBOT")

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -381,6 +381,7 @@ queries:
         .where(
           deleted == false &&
           isInvitedUser == false &&
+          isBot == false &&
           isConnectorBot == false &&
           isWorkflowBot == false &&
           id != "USLACKBOT"

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.4.1
+    version: 1.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -90,6 +90,7 @@ policies:
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel
           - uid: mondoo-slack-security-at-least-one-workspace-internal-channel-no-ext-members
           - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
+          - uid: mondoo-slack-security-users-email-confirmed
 queries:
   - uid: mondoo-slack-security-limit-admin-accounts
     title: Ensure that between 2 and 4 users have admin permissions
@@ -364,3 +365,47 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/help/articles/203772216
         title: Slack Single Sign-On
+  - uid: mondoo-slack-security-users-email-confirmed
+    title: Ensure all active users have confirmed their email address
+    impact: 60
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
+    mql: |
+      slack.users.members
+        .where(name != /deactivateduser/ && isInvitedUser == false && id != "USLACKBOT")
+        .all(isEmailConfirmed == true)
+    docs:
+      desc: |
+        This check verifies that every active (non-bot, non-deactivated, non-pending-invite) member of the Slack workspace has a confirmed email address.
+
+        **Why this matters**
+
+        An unconfirmed email address means Slack has not verified that the person using the account actually controls the email it was registered with. That breaks a core assumption most downstream security controls depend on:
+
+          - **Account takeover via typo-squatting**: Attackers can register accounts with look-alike domains (`acme-co.com` vs. `acme.co`) and never need to prove ownership to participate in channels and DMs.
+          - **Identity spoofing**: Unconfirmed accounts can impersonate employees, partners, or executives in phishing and social-engineering attacks without being caught by email-domain controls.
+          - **Password reset pivot**: If the email was never verified, a recovery flow that emails a reset link may deliver it to an address the real user cannot access — enabling silent hijack.
+          - **Bypassing SSO / domain allowlists**: Workspaces that rely on domain-based allowlisting assume the email is real; an unconfirmed address means the allowlist is protecting a string, not a verified identity.
+          - **Audit trail integrity**: Messages, file uploads, and channel joins attributed to an unconfirmed user cannot be reliably traced back to a human.
+
+        Review every flagged account and require the user to confirm their email address, or deactivate the account if it cannot be verified.
+      remediation: |
+        Investigate each flagged user:
+
+        1. Confirm whether the account belongs to a real, current member of your organization.
+        2. For legitimate users, have them complete the email confirmation flow. Slack sends a confirmation link when the email is added or changed — users can request a new link from their [account settings](https://slack.com/account/settings).
+        3. For accounts you cannot attribute to a known person, deactivate them immediately. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
+        4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/115005206006) in the Slack documentation.
+    refs:
+      - url: https://slack.com/help/articles/360004635551
+        title: Slack Workspace Administration Guide
+      - url: https://slack.com/help/articles/213185747
+        title: Deactivate a member
+      - url: https://slack.com/help/articles/115005206006
+        title: Manage sign-in options


### PR DESCRIPTION
## Summary
- Adds `mondoo-slack-security-users-email-confirmed` to the Mondoo Slack Team Security policy
- Flags any active member (non-bot, non-deactivated, not pending invite, not Slackbot) whose `isEmailConfirmed` is `false`
- Uses the new `slack.user.isEmailConfirmed` field shipped in the slack provider 13.0.6

## Why this is a real security signal
An unconfirmed email means Slack never verified that the account holder actually controls the address the account was registered with. That breaks several controls at once:
- Identity spoofing via lookalike domains (`acme-co.com` vs `acme.co`) that can join channels and DMs without proving ownership
- Password-reset links delivered to an address the real user cannot access
- Domain allowlisting that protects a string rather than a verified identity
- Audit trail integrity — messages attributed to an unconfirmed user can't be traced to a human

Bumps policy version to `1.5.0`.

## Test plan
- [x] `cnspec policy lint ./content/mondoo-slack-security.mql.yaml` passes
- [ ] Verified against a Slack workspace with at least one user whose email has not been confirmed (requires slack provider ≥ 13.0.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)