### PR TITLE
🐛 Add check-latest to setup-go for self-hosted runners

### DIFF
--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Bump mql
         env:

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: "Authenticate to Google Cloud"

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Check go mod
         run: |
@@ -44,6 +45,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -65,6 +67,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       # https://github.com/actions/cache/blob/main/examples.md#go---modules
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -175,6 +178,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Make provider dir


### PR DESCRIPTION
## Summary

- Added `check-latest: true` to all `actions/setup-go` steps across 6 workflow files
- Self-hosted runners cache the Go toolchain in a persistent tool cache directory. Without `check-latest: true`, `setup-go` uses the cached version even when a newer patch release is available that satisfies the version constraint
- Affected workflows: goreleaser-check, goreleaser, pr-test-lint (4 occurrences), cnquery-update, pr-extended-linting, goreleaser-edge

## Test plan

- [ ] Verify CI workflows run successfully with the new setting
- [ ] Confirm self-hosted runners fetch the latest Go patch version

🤖 Generated with [Claude Code](https://claude.com/claude-code)