### PR TITLE
✨ Add GetScanParameters RPC for server-controlled scan parameters

### DIFF
--- a/policy/cnspec_policy.pb.go
+++ b/policy/cnspec_policy.pb.go
@@ -863,7 +863,7 @@ func (x Source_Vendor) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Source_Vendor.Descriptor instead.
 func (Source_Vendor) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{99, 0}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{101, 0}
 }
 
 type ImpactValue struct {
@@ -8449,6 +8449,94 @@ func (x *SynchronizeAssetsResp) GetDetails() map[string]*SynchronizeAssetsRespAs
 	return nil
 }
 
+type GetScanParametersReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ScopeMrn      string                 `protobuf:"bytes,1,opt,name=scope_mrn,json=scopeMrn,proto3" json:"scope_mrn,omitempty"` // space or org MRN
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetScanParametersReq) Reset() {
+	*x = GetScanParametersReq{}
+	mi := &file_cnspec_policy_proto_msgTypes[95]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetScanParametersReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetScanParametersReq) ProtoMessage() {}
+
+func (x *GetScanParametersReq) ProtoReflect() protoreflect.Message {
+	mi := &file_cnspec_policy_proto_msgTypes[95]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetScanParametersReq.ProtoReflect.Descriptor instead.
+func (*GetScanParametersReq) Descriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{95}
+}
+
+func (x *GetScanParametersReq) GetScopeMrn() string {
+	if x != nil {
+		return x.ScopeMrn
+	}
+	return ""
+}
+
+type ScanParameters struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	EnabledFeatures []string               `protobuf:"bytes,1,rep,name=enabled_features,json=enabledFeatures,proto3" json:"enabled_features,omitempty"` // mql feature names enabled by server
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ScanParameters) Reset() {
+	*x = ScanParameters{}
+	mi := &file_cnspec_policy_proto_msgTypes[96]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScanParameters) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScanParameters) ProtoMessage() {}
+
+func (x *ScanParameters) ProtoReflect() protoreflect.Message {
+	mi := &file_cnspec_policy_proto_msgTypes[96]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScanParameters.ProtoReflect.Descriptor instead.
+func (*ScanParameters) Descriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{96}
+}
+
+func (x *ScanParameters) GetEnabledFeatures() []string {
+	if x != nil {
+		return x.EnabledFeatures
+	}
+	return nil
+}
+
 type PurgeAssetsRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	SpaceMrn        string                 `protobuf:"bytes,1,opt,name=spaceMrn,proto3" json:"spaceMrn,omitempty"`
@@ -8465,7 +8553,7 @@ type PurgeAssetsRequest struct {
 
 func (x *PurgeAssetsRequest) Reset() {
 	*x = PurgeAssetsRequest{}
-	mi := &file_cnspec_policy_proto_msgTypes[95]
+	mi := &file_cnspec_policy_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8477,7 +8565,7 @@ func (x *PurgeAssetsRequest) String() string {
 func (*PurgeAssetsRequest) ProtoMessage() {}
 
 func (x *PurgeAssetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[95]
+	mi := &file_cnspec_policy_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8490,7 +8578,7 @@ func (x *PurgeAssetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeAssetsRequest.ProtoReflect.Descriptor instead.
 func (*PurgeAssetsRequest) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{95}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *PurgeAssetsRequest) GetSpaceMrn() string {
@@ -8553,7 +8641,7 @@ type DateFilter struct {
 
 func (x *DateFilter) Reset() {
 	*x = DateFilter{}
-	mi := &file_cnspec_policy_proto_msgTypes[96]
+	mi := &file_cnspec_policy_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8565,7 +8653,7 @@ func (x *DateFilter) String() string {
 func (*DateFilter) ProtoMessage() {}
 
 func (x *DateFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[96]
+	mi := &file_cnspec_policy_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8578,7 +8666,7 @@ func (x *DateFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DateFilter.ProtoReflect.Descriptor instead.
 func (*DateFilter) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{96}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *DateFilter) GetTimestamp() string {
@@ -8612,7 +8700,7 @@ type PurgeAssetsConfirmation struct {
 
 func (x *PurgeAssetsConfirmation) Reset() {
 	*x = PurgeAssetsConfirmation{}
-	mi := &file_cnspec_policy_proto_msgTypes[97]
+	mi := &file_cnspec_policy_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8624,7 +8712,7 @@ func (x *PurgeAssetsConfirmation) String() string {
 func (*PurgeAssetsConfirmation) ProtoMessage() {}
 
 func (x *PurgeAssetsConfirmation) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[97]
+	mi := &file_cnspec_policy_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8637,7 +8725,7 @@ func (x *PurgeAssetsConfirmation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeAssetsConfirmation.ProtoReflect.Descriptor instead.
 func (*PurgeAssetsConfirmation) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{97}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *PurgeAssetsConfirmation) GetAssetMrns() []string {
@@ -8665,7 +8753,7 @@ type Sources struct {
 
 func (x *Sources) Reset() {
 	*x = Sources{}
-	mi := &file_cnspec_policy_proto_msgTypes[98]
+	mi := &file_cnspec_policy_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8677,7 +8765,7 @@ func (x *Sources) String() string {
 func (*Sources) ProtoMessage() {}
 
 func (x *Sources) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[98]
+	mi := &file_cnspec_policy_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8690,7 +8778,7 @@ func (x *Sources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sources.ProtoReflect.Descriptor instead.
 func (*Sources) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{98}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *Sources) GetItems() []*Source {
@@ -8723,7 +8811,7 @@ type Source struct {
 
 func (x *Source) Reset() {
 	*x = Source{}
-	mi := &file_cnspec_policy_proto_msgTypes[99]
+	mi := &file_cnspec_policy_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8735,7 +8823,7 @@ func (x *Source) String() string {
 func (*Source) ProtoMessage() {}
 
 func (x *Source) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[99]
+	mi := &file_cnspec_policy_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8748,7 +8836,7 @@ func (x *Source) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Source.ProtoReflect.Descriptor instead.
 func (*Source) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{99}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *Source) GetName() string {
@@ -9585,7 +9673,11 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\adetails\x18\x01 \x03(\v24.cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntryR\adetails\x1an\n" +
 	"\fDetailsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12H\n" +
-	"\x05value\x18\x02 \x01(\v22.cnspec.policy.v1.SynchronizeAssetsRespAssetDetailR\x05value:\x028\x01\"\xfa\x02\n" +
+	"\x05value\x18\x02 \x01(\v22.cnspec.policy.v1.SynchronizeAssetsRespAssetDetailR\x05value:\x028\x01\"3\n" +
+	"\x14GetScanParametersReq\x12\x1b\n" +
+	"\tscope_mrn\x18\x01 \x01(\tR\bscopeMrn\";\n" +
+	"\x0eScanParameters\x12)\n" +
+	"\x10enabled_features\x18\x01 \x03(\tR\x0fenabledFeatures\"\xfa\x02\n" +
 	"\x12PurgeAssetsRequest\x12\x1a\n" +
 	"\bspaceMrn\x18\x01 \x01(\tR\bspaceMrn\x12\x1d\n" +
 	"\n" +
@@ -9725,8 +9817,7 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x0fDefaultPolicies\x12$.cnspec.policy.v1.DefaultPoliciesReq\x1a\x16.cnspec.policy.v1.URLs\"\x00\x12D\n" +
 	"\fGetFramework\x12\x15.cnspec.policy.v1.Mrn\x1a\x1b.cnspec.policy.v1.Framework\"\x00\x12C\n" +
 	"\x0fDeleteFramework\x12\x15.cnspec.policy.v1.Mrn\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12K\n" +
-	"\x0eListFrameworks\x12\x19.cnspec.policy.v1.ListReq\x1a\x1c.cnspec.policy.v1.Frameworks\"\x002\xf3\n" +
-	"\n" +
+	"\x0eListFrameworks\x12\x19.cnspec.policy.v1.ListReq\x1a\x1c.cnspec.policy.v1.Frameworks\"\x002\xd4\v\n" +
 	"\x0ePolicyResolver\x12G\n" +
 	"\x06Assign\x12\".cnspec.policy.v1.PolicyAssignment\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12I\n" +
 	"\bUnassign\x12\".cnspec.policy.v1.PolicyAssignment\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12A\n" +
@@ -9743,7 +9834,8 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\bGetScore\x12 .cnspec.policy.v1.EntityScoreReq\x1a\x18.cnspec.policy.v1.Report\"\x00\x12t\n" +
 	"\x10GetResourcesData\x12..mql.providers.v1.recording.EntityResourcesReq\x1a..mql.providers.v1.recording.EntityResourcesRes\"\x00\x12f\n" +
 	"\x11SynchronizeAssets\x12&.cnspec.policy.v1.SynchronizeAssetsReq\x1a'.cnspec.policy.v1.SynchronizeAssetsResp\"\x00\x12`\n" +
-	"\vPurgeAssets\x12$.cnspec.policy.v1.PurgeAssetsRequest\x1a).cnspec.policy.v1.PurgeAssetsConfirmation\"\x00B!Z\x1fgo.mondoo.com/cnspec/v13/policyb\x06proto3"
+	"\vPurgeAssets\x12$.cnspec.policy.v1.PurgeAssetsRequest\x1a).cnspec.policy.v1.PurgeAssetsConfirmation\"\x00\x12_\n" +
+	"\x11GetScanParameters\x12&.cnspec.policy.v1.GetScanParametersReq\x1a .cnspec.policy.v1.ScanParameters\"\x00B!Z\x1fgo.mondoo.com/cnspec/v13/policyb\x06proto3"
 
 var (
 	file_cnspec_policy_proto_rawDescOnce sync.Once
@@ -9758,7 +9850,7 @@ func file_cnspec_policy_proto_rawDescGZIP() []byte {
 }
 
 var file_cnspec_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 14)
-var file_cnspec_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 138)
+var file_cnspec_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 140)
 var file_cnspec_policy_proto_goTypes = []any{
 	(Action)(0),            // 0: cnspec.policy.v1.Action
 	(ScoringSystem)(0),     // 1: cnspec.policy.v1.ScoringSystem
@@ -9869,74 +9961,76 @@ var file_cnspec_policy_proto_goTypes = []any{
 	(*SynchronizeAssetsReq)(nil),                // 106: cnspec.policy.v1.SynchronizeAssetsReq
 	(*SynchronizeAssetsRespAssetDetail)(nil),    // 107: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
 	(*SynchronizeAssetsResp)(nil),               // 108: cnspec.policy.v1.SynchronizeAssetsResp
-	(*PurgeAssetsRequest)(nil),                  // 109: cnspec.policy.v1.PurgeAssetsRequest
-	(*DateFilter)(nil),                          // 110: cnspec.policy.v1.DateFilter
-	(*PurgeAssetsConfirmation)(nil),             // 111: cnspec.policy.v1.PurgeAssetsConfirmation
-	(*Sources)(nil),                             // 112: cnspec.policy.v1.Sources
-	(*Source)(nil),                              // 113: cnspec.policy.v1.Source
-	nil,                                         // 114: cnspec.policy.v1.ObjectRef.TagsEntry
-	nil,                                         // 115: cnspec.policy.v1.TypedDoc.TagsEntry
-	nil,                                         // 116: cnspec.policy.v1.Filters.ItemsEntry
-	nil,                                         // 117: cnspec.policy.v1.Mquery.TagsEntry
-	nil,                                         // 118: cnspec.policy.v1.QueryPack.TagsEntry
-	nil,                                         // 119: cnspec.policy.v1.Policy.TagsEntry
-	nil,                                         // 120: cnspec.policy.v1.MigrationMetadata.LabelsEntry
-	nil,                                         // 121: cnspec.policy.v1.RiskFactor.TagsEntry
-	nil,                                         // 122: cnspec.policy.v1.Framework.TagsEntry
-	nil,                                         // 123: cnspec.policy.v1.Control.TagsEntry
-	nil,                                         // 124: cnspec.policy.v1.ExecutionJob.QueriesEntry
-	nil,                                         // 125: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	nil,                                         // 126: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	nil,                                         // 127: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	nil,                                         // 128: cnspec.policy.v1.CollectorJob.DatapointsEntry
-	nil,                                         // 129: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	nil,                                         // 130: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	nil,                                         // 131: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
-	nil,                                         // 132: cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
-	nil,                                         // 133: cnspec.policy.v1.ReportingJob.DatapointsEntry
-	nil,                                         // 134: cnspec.policy.v1.ReportingJob.ChildJobsEntry
-	nil,                                         // 135: cnspec.policy.v1.Report.ScoresEntry
-	nil,                                         // 136: cnspec.policy.v1.Report.DataEntry
-	nil,                                         // 137: cnspec.policy.v1.Report.CvssScoresEntry
-	nil,                                         // 138: cnspec.policy.v1.ReportCollection.AssetsEntry
-	nil,                                         // 139: cnspec.policy.v1.ReportCollection.ReportsEntry
-	nil,                                         // 140: cnspec.policy.v1.ReportCollection.ErrorsEntry
-	nil,                                         // 141: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	nil,                                         // 142: cnspec.policy.v1.ReportCollection.VulnReportsEntry
-	nil,                                         // 143: cnspec.policy.v1.ScoredRiskFactor.DataEntry
-	nil,                                         // 144: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
-	nil,                                         // 145: cnspec.policy.v1.StoreResultsReq.DataEntry
-	nil,                                         // 146: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
-	nil,                                         // 147: cnspec.policy.v1.UploadURL.HeadersEntry
-	nil,                                         // 148: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	nil,                                         // 149: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	nil,                                         // 150: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
-	nil,                                         // 151: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	(*timestamppb.Timestamp)(nil),               // 152: google.protobuf.Timestamp
-	(*inventory.Platform)(nil),                  // 153: cnquery.providers.v1.Platform
-	(*llx.CodeBundle)(nil),                      // 154: mql.llx.CodeBundle
-	(*inventory.Asset)(nil),                     // 155: cnquery.providers.v1.Asset
-	(*llx.Result)(nil),                          // 156: mql.llx.Result
-	(*mvd.VulnReport)(nil),                      // 157: mondoo.mvd.v1.VulnReport
-	(*llx.ResourceRecording)(nil),               // 158: mql.llx.ResourceRecording
-	(*recording.EntityResourcesReq)(nil),        // 159: mql.providers.v1.recording.EntityResourcesReq
-	(*recording.EntityResourcesRes)(nil),        // 160: mql.providers.v1.recording.EntityResourcesRes
+	(*GetScanParametersReq)(nil),                // 109: cnspec.policy.v1.GetScanParametersReq
+	(*ScanParameters)(nil),                      // 110: cnspec.policy.v1.ScanParameters
+	(*PurgeAssetsRequest)(nil),                  // 111: cnspec.policy.v1.PurgeAssetsRequest
+	(*DateFilter)(nil),                          // 112: cnspec.policy.v1.DateFilter
+	(*PurgeAssetsConfirmation)(nil),             // 113: cnspec.policy.v1.PurgeAssetsConfirmation
+	(*Sources)(nil),                             // 114: cnspec.policy.v1.Sources
+	(*Source)(nil),                              // 115: cnspec.policy.v1.Source
+	nil,                                         // 116: cnspec.policy.v1.ObjectRef.TagsEntry
+	nil,                                         // 117: cnspec.policy.v1.TypedDoc.TagsEntry
+	nil,                                         // 118: cnspec.policy.v1.Filters.ItemsEntry
+	nil,                                         // 119: cnspec.policy.v1.Mquery.TagsEntry
+	nil,                                         // 120: cnspec.policy.v1.QueryPack.TagsEntry
+	nil,                                         // 121: cnspec.policy.v1.Policy.TagsEntry
+	nil,                                         // 122: cnspec.policy.v1.MigrationMetadata.LabelsEntry
+	nil,                                         // 123: cnspec.policy.v1.RiskFactor.TagsEntry
+	nil,                                         // 124: cnspec.policy.v1.Framework.TagsEntry
+	nil,                                         // 125: cnspec.policy.v1.Control.TagsEntry
+	nil,                                         // 126: cnspec.policy.v1.ExecutionJob.QueriesEntry
+	nil,                                         // 127: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	nil,                                         // 128: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	nil,                                         // 129: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	nil,                                         // 130: cnspec.policy.v1.CollectorJob.DatapointsEntry
+	nil,                                         // 131: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	nil,                                         // 132: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	nil,                                         // 133: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
+	nil,                                         // 134: cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
+	nil,                                         // 135: cnspec.policy.v1.ReportingJob.DatapointsEntry
+	nil,                                         // 136: cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	nil,                                         // 137: cnspec.policy.v1.Report.ScoresEntry
+	nil,                                         // 138: cnspec.policy.v1.Report.DataEntry
+	nil,                                         // 139: cnspec.policy.v1.Report.CvssScoresEntry
+	nil,                                         // 140: cnspec.policy.v1.ReportCollection.AssetsEntry
+	nil,                                         // 141: cnspec.policy.v1.ReportCollection.ReportsEntry
+	nil,                                         // 142: cnspec.policy.v1.ReportCollection.ErrorsEntry
+	nil,                                         // 143: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	nil,                                         // 144: cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	nil,                                         // 145: cnspec.policy.v1.ScoredRiskFactor.DataEntry
+	nil,                                         // 146: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	nil,                                         // 147: cnspec.policy.v1.StoreResultsReq.DataEntry
+	nil,                                         // 148: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	nil,                                         // 149: cnspec.policy.v1.UploadURL.HeadersEntry
+	nil,                                         // 150: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	nil,                                         // 151: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	nil,                                         // 152: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	nil,                                         // 153: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	(*timestamppb.Timestamp)(nil),               // 154: google.protobuf.Timestamp
+	(*inventory.Platform)(nil),                  // 155: cnquery.providers.v1.Platform
+	(*llx.CodeBundle)(nil),                      // 156: mql.llx.CodeBundle
+	(*inventory.Asset)(nil),                     // 157: cnquery.providers.v1.Asset
+	(*llx.Result)(nil),                          // 158: mql.llx.Result
+	(*mvd.VulnReport)(nil),                      // 159: mondoo.mvd.v1.VulnReport
+	(*llx.ResourceRecording)(nil),               // 160: mql.llx.ResourceRecording
+	(*recording.EntityResourcesReq)(nil),        // 161: mql.providers.v1.recording.EntityResourcesReq
+	(*recording.EntityResourcesRes)(nil),        // 162: mql.providers.v1.recording.EntityResourcesRes
 }
 var file_cnspec_policy_proto_depIdxs = []int32{
 	14,  // 0: cnspec.policy.v1.Impact.value:type_name -> cnspec.policy.v1.ImpactValue
 	1,   // 1: cnspec.policy.v1.Impact.scoring:type_name -> cnspec.policy.v1.ScoringSystem
 	0,   // 2: cnspec.policy.v1.Impact.action:type_name -> cnspec.policy.v1.Action
-	114, // 3: cnspec.policy.v1.ObjectRef.tags:type_name -> cnspec.policy.v1.ObjectRef.TagsEntry
-	115, // 4: cnspec.policy.v1.TypedDoc.tags:type_name -> cnspec.policy.v1.TypedDoc.TagsEntry
+	116, // 3: cnspec.policy.v1.ObjectRef.tags:type_name -> cnspec.policy.v1.ObjectRef.TagsEntry
+	117, // 4: cnspec.policy.v1.TypedDoc.tags:type_name -> cnspec.policy.v1.TypedDoc.TagsEntry
 	20,  // 5: cnspec.policy.v1.Remediation.items:type_name -> cnspec.policy.v1.TypedDoc
 	18,  // 6: cnspec.policy.v1.MqueryDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
 	21,  // 7: cnspec.policy.v1.MqueryDocs.remediation:type_name -> cnspec.policy.v1.Remediation
-	116, // 8: cnspec.policy.v1.Filters.items:type_name -> cnspec.policy.v1.Filters.ItemsEntry
+	118, // 8: cnspec.policy.v1.Filters.items:type_name -> cnspec.policy.v1.Filters.ItemsEntry
 	16,  // 9: cnspec.policy.v1.Property.for:type_name -> cnspec.policy.v1.ObjectRef
 	18,  // 10: cnspec.policy.v1.Mquery.refs:type_name -> cnspec.policy.v1.MqueryRef
 	22,  // 11: cnspec.policy.v1.Mquery.docs:type_name -> cnspec.policy.v1.MqueryDocs
 	15,  // 12: cnspec.policy.v1.Mquery.impact:type_name -> cnspec.policy.v1.Impact
-	117, // 13: cnspec.policy.v1.Mquery.tags:type_name -> cnspec.policy.v1.Mquery.TagsEntry
+	119, // 13: cnspec.policy.v1.Mquery.tags:type_name -> cnspec.policy.v1.Mquery.TagsEntry
 	23,  // 14: cnspec.policy.v1.Mquery.filters:type_name -> cnspec.policy.v1.Filters
 	24,  // 15: cnspec.policy.v1.Mquery.props:type_name -> cnspec.policy.v1.Property
 	16,  // 16: cnspec.policy.v1.Mquery.variants:type_name -> cnspec.policy.v1.ObjectRef
@@ -9951,7 +10045,7 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	35,  // 25: cnspec.policy.v1.QueryPack.require:type_name -> cnspec.policy.v1.Requirement
 	26,  // 26: cnspec.policy.v1.QueryPack.docs:type_name -> cnspec.policy.v1.QueryPackDocs
 	17,  // 27: cnspec.policy.v1.QueryPack.authors:type_name -> cnspec.policy.v1.Author
-	118, // 28: cnspec.policy.v1.QueryPack.tags:type_name -> cnspec.policy.v1.QueryPack.TagsEntry
+	120, // 28: cnspec.policy.v1.QueryPack.tags:type_name -> cnspec.policy.v1.QueryPack.TagsEntry
 	24,  // 29: cnspec.policy.v1.PropsReq.props:type_name -> cnspec.policy.v1.Property
 	32,  // 30: cnspec.policy.v1.PolicyGroup.policies:type_name -> cnspec.policy.v1.PolicyRef
 	25,  // 31: cnspec.policy.v1.PolicyGroup.checks:type_name -> cnspec.policy.v1.Mquery
@@ -9972,7 +10066,7 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	52,  // 46: cnspec.policy.v1.Policy.docs:type_name -> cnspec.policy.v1.PolicyDocs
 	1,   // 47: cnspec.policy.v1.Policy.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
 	17,  // 48: cnspec.policy.v1.Policy.authors:type_name -> cnspec.policy.v1.Author
-	119, // 49: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
+	121, // 49: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
 	24,  // 50: cnspec.policy.v1.Policy.props:type_name -> cnspec.policy.v1.Property
 	49,  // 51: cnspec.policy.v1.Policy.risk_factors:type_name -> cnspec.policy.v1.RiskFactor
 	35,  // 52: cnspec.policy.v1.Policy.require:type_name -> cnspec.policy.v1.Requirement
@@ -9993,8 +10087,8 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	41,  // 67: cnspec.policy.v1.MigrationGroup.metadata:type_name -> cnspec.policy.v1.MigrationMetadata
 	38,  // 68: cnspec.policy.v1.MigrationConditions.source_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
 	38,  // 69: cnspec.policy.v1.MigrationConditions.target_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
-	152, // 70: cnspec.policy.v1.MigrationMetadata.created_at:type_name -> google.protobuf.Timestamp
-	120, // 71: cnspec.policy.v1.MigrationMetadata.labels:type_name -> cnspec.policy.v1.MigrationMetadata.LabelsEntry
+	154, // 70: cnspec.policy.v1.MigrationMetadata.created_at:type_name -> google.protobuf.Timestamp
+	122, // 71: cnspec.policy.v1.MigrationMetadata.labels:type_name -> cnspec.policy.v1.MigrationMetadata.LabelsEntry
 	43,  // 72: cnspec.policy.v1.MigrationStage.query_migrations:type_name -> cnspec.policy.v1.Migration
 	43,  // 73: cnspec.policy.v1.MigrationStage.policy_migrations:type_name -> cnspec.policy.v1.Migration
 	44,  // 74: cnspec.policy.v1.Migration.source:type_name -> cnspec.policy.v1.MigrationSource
@@ -10009,11 +10103,11 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	46,  // 83: cnspec.policy.v1.RiskFactor.software:type_name -> cnspec.policy.v1.SoftwareSelector
 	47,  // 84: cnspec.policy.v1.RiskFactor.resources:type_name -> cnspec.policy.v1.ResourceSelector
 	0,   // 85: cnspec.policy.v1.RiskFactor.action:type_name -> cnspec.policy.v1.Action
-	121, // 86: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
+	123, // 86: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
 	55,  // 87: cnspec.policy.v1.Framework.groups:type_name -> cnspec.policy.v1.FrameworkGroup
 	52,  // 88: cnspec.policy.v1.Framework.docs:type_name -> cnspec.policy.v1.PolicyDocs
 	17,  // 89: cnspec.policy.v1.Framework.authors:type_name -> cnspec.policy.v1.Author
-	122, // 90: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
+	124, // 90: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
 	56,  // 91: cnspec.policy.v1.Framework.dependencies:type_name -> cnspec.policy.v1.FrameworkRef
 	59,  // 92: cnspec.policy.v1.Framework.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
 	53,  // 93: cnspec.policy.v1.Frameworks.items:type_name -> cnspec.policy.v1.Framework
@@ -10028,7 +10122,7 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	25,  // 102: cnspec.policy.v1.Evidence.queries:type_name -> cnspec.policy.v1.Mquery
 	62,  // 103: cnspec.policy.v1.Evidence.controls:type_name -> cnspec.policy.v1.ControlRef
 	61,  // 104: cnspec.policy.v1.Control.docs:type_name -> cnspec.policy.v1.ControlDocs
-	123, // 105: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
+	125, // 105: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
 	0,   // 106: cnspec.policy.v1.Control.action:type_name -> cnspec.policy.v1.Action
 	57,  // 107: cnspec.policy.v1.Control.evidence:type_name -> cnspec.policy.v1.Evidence
 	16,  // 108: cnspec.policy.v1.FrameworkMap.framework_dependencies:type_name -> cnspec.policy.v1.ObjectRef
@@ -10042,49 +10136,49 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	62,  // 116: cnspec.policy.v1.ControlMap.queries:type_name -> cnspec.policy.v1.ControlRef
 	18,  // 117: cnspec.policy.v1.ControlDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
 	0,   // 118: cnspec.policy.v1.ControlRef.action:type_name -> cnspec.policy.v1.Action
-	153, // 119: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
+	155, // 119: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
 	65,  // 120: cnspec.policy.v1.ResolvedPolicy.execution_job:type_name -> cnspec.policy.v1.ExecutionJob
 	67,  // 121: cnspec.policy.v1.ResolvedPolicy.collector_job:type_name -> cnspec.policy.v1.CollectorJob
 	25,  // 122: cnspec.policy.v1.ResolvedPolicy.filters:type_name -> cnspec.policy.v1.Mquery
 	5,   // 123: cnspec.policy.v1.ResolvedPolicy.features:type_name -> cnspec.policy.v1.ServerFeature
-	124, // 124: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
-	125, // 125: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	154, // 126: cnspec.policy.v1.ExecutionQuery.code:type_name -> mql.llx.CodeBundle
-	126, // 127: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	127, // 128: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	128, // 129: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
-	129, // 130: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	130, // 131: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	131, // 132: cnspec.policy.v1.CollectorJob.risk_data_queries:type_name -> cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
-	132, // 133: cnspec.policy.v1.RiskDataInfo.datapoint_checksums:type_name -> cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
+	126, // 124: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
+	127, // 125: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	156, // 126: cnspec.policy.v1.ExecutionQuery.code:type_name -> mql.llx.CodeBundle
+	128, // 127: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	129, // 128: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	130, // 129: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
+	131, // 130: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	132, // 131: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	133, // 132: cnspec.policy.v1.CollectorJob.risk_data_queries:type_name -> cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
+	134, // 133: cnspec.policy.v1.RiskDataInfo.datapoint_checksums:type_name -> cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
 	1,   // 134: cnspec.policy.v1.ReportingJob.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	133, // 135: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
-	134, // 136: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	135, // 135: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
+	136, // 136: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
 	11,  // 137: cnspec.policy.v1.ReportingJob.type:type_name -> cnspec.policy.v1.ReportingJob.Type
 	79,  // 138: cnspec.policy.v1.Report.score:type_name -> cnspec.policy.v1.Score
-	135, // 139: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
-	136, // 140: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
+	137, // 139: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
+	138, // 140: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
 	85,  // 141: cnspec.policy.v1.Report.stats:type_name -> cnspec.policy.v1.Stats
 	82,  // 142: cnspec.policy.v1.Report.risks:type_name -> cnspec.policy.v1.ScoredRiskFactors
 	85,  // 143: cnspec.policy.v1.Report.ignored_stats:type_name -> cnspec.policy.v1.Stats
 	77,  // 144: cnspec.policy.v1.Report.cvss_score:type_name -> cnspec.policy.v1.Cvss
-	137, // 145: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
+	139, // 145: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
 	78,  // 146: cnspec.policy.v1.Report.cvss_stats:type_name -> cnspec.policy.v1.CvssStats
 	72,  // 147: cnspec.policy.v1.Reports.reports:type_name -> cnspec.policy.v1.Report
-	138, // 148: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
+	140, // 148: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
 	37,  // 149: cnspec.policy.v1.ReportCollection.bundle:type_name -> cnspec.policy.v1.Bundle
-	139, // 150: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
-	140, // 151: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
-	141, // 152: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	142, // 153: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	141, // 150: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
+	142, // 151: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
+	143, // 152: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	144, // 153: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
 	76,  // 154: cnspec.policy.v1.FrameworkReport.score:type_name -> cnspec.policy.v1.ControlScore
 	76,  // 155: cnspec.policy.v1.FrameworkReport.controls:type_name -> cnspec.policy.v1.ControlScore
 	76,  // 156: cnspec.policy.v1.ControlScore.assets:type_name -> cnspec.policy.v1.ControlScore
 	86,  // 157: cnspec.policy.v1.ControlScore.scores:type_name -> cnspec.policy.v1.ScoreDistribution
 	82,  // 158: cnspec.policy.v1.Score.risk_factors:type_name -> cnspec.policy.v1.ScoredRiskFactors
-	113, // 159: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
-	112, // 160: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
-	143, // 161: cnspec.policy.v1.ScoredRiskFactor.data:type_name -> cnspec.policy.v1.ScoredRiskFactor.DataEntry
+	115, // 159: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
+	114, // 160: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
+	145, // 161: cnspec.policy.v1.ScoredRiskFactor.data:type_name -> cnspec.policy.v1.ScoredRiskFactor.DataEntry
 	81,  // 162: cnspec.policy.v1.ScoredRiskFactors.items:type_name -> cnspec.policy.v1.ScoredRiskFactor
 	83,  // 163: cnspec.policy.v1.RiskFactorsStats.items:type_name -> cnspec.policy.v1.RiskFactorStats
 	86,  // 164: cnspec.policy.v1.Stats.failed:type_name -> cnspec.policy.v1.ScoreDistribution
@@ -10095,29 +10189,29 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	25,  // 169: cnspec.policy.v1.Mqueries.items:type_name -> cnspec.policy.v1.Mquery
 	0,   // 170: cnspec.policy.v1.PolicyAssignment.action:type_name -> cnspec.policy.v1.Action
 	1,   // 171: cnspec.policy.v1.PolicyAssignment.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	144, // 172: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	146, // 172: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
 	0,   // 173: cnspec.policy.v1.PolicyMutationDelta.action:type_name -> cnspec.policy.v1.Action
 	12,  // 174: cnspec.policy.v1.PolicyDelta.action:type_name -> cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
 	1,   // 175: cnspec.policy.v1.PolicyDelta.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
 	25,  // 176: cnspec.policy.v1.ResolveReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
 	25,  // 177: cnspec.policy.v1.UpdateAssetJobsReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
 	79,  // 178: cnspec.policy.v1.StoreResultsReq.scores:type_name -> cnspec.policy.v1.Score
-	145, // 179: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
-	146, // 180: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	147, // 179: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
+	148, // 180: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
 	81,  // 181: cnspec.policy.v1.StoreResultsReq.risks:type_name -> cnspec.policy.v1.ScoredRiskFactor
 	77,  // 182: cnspec.policy.v1.StoreResultsReq.cvssScores:type_name -> cnspec.policy.v1.Cvss
 	6,   // 183: cnspec.policy.v1.GetUploadURLReq.kind:type_name -> cnspec.policy.v1.UploadURLKind
 	103, // 184: cnspec.policy.v1.GetUploadURLResp.upload_url:type_name -> cnspec.policy.v1.UploadURL
-	147, // 185: cnspec.policy.v1.UploadURL.headers:type_name -> cnspec.policy.v1.UploadURL.HeadersEntry
-	155, // 186: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
-	148, // 187: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	149, // 188: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	110, // 189: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
-	150, // 190: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	149, // 185: cnspec.policy.v1.UploadURL.headers:type_name -> cnspec.policy.v1.UploadURL.HeadersEntry
+	157, // 186: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
+	150, // 187: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	151, // 188: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	112, // 189: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
+	152, // 190: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
 	8,   // 191: cnspec.policy.v1.DateFilter.comparison:type_name -> cnspec.policy.v1.Comparison
 	9,   // 192: cnspec.policy.v1.DateFilter.field:type_name -> cnspec.policy.v1.DateFilterField
-	151, // 193: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	113, // 194: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
+	153, // 193: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	115, // 194: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
 	13,  // 195: cnspec.policy.v1.Source.vendor:type_name -> cnspec.policy.v1.Source.Vendor
 	25,  // 196: cnspec.policy.v1.Filters.ItemsEntry.value:type_name -> cnspec.policy.v1.Mquery
 	66,  // 197: cnspec.policy.v1.ExecutionJob.QueriesEntry.value:type_name -> cnspec.policy.v1.ExecutionQuery
@@ -10129,16 +10223,16 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	68,  // 203: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry.value:type_name -> cnspec.policy.v1.RiskDataInfo
 	15,  // 204: cnspec.policy.v1.ReportingJob.ChildJobsEntry.value:type_name -> cnspec.policy.v1.Impact
 	79,  // 205: cnspec.policy.v1.Report.ScoresEntry.value:type_name -> cnspec.policy.v1.Score
-	156, // 206: cnspec.policy.v1.Report.DataEntry.value:type_name -> mql.llx.Result
+	158, // 206: cnspec.policy.v1.Report.DataEntry.value:type_name -> mql.llx.Result
 	77,  // 207: cnspec.policy.v1.Report.CvssScoresEntry.value:type_name -> cnspec.policy.v1.Cvss
-	155, // 208: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
+	157, // 208: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
 	72,  // 209: cnspec.policy.v1.ReportCollection.ReportsEntry.value:type_name -> cnspec.policy.v1.Report
 	64,  // 210: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry.value:type_name -> cnspec.policy.v1.ResolvedPolicy
-	157, // 211: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
-	156, // 212: cnspec.policy.v1.ScoredRiskFactor.DataEntry.value:type_name -> mql.llx.Result
+	159, // 211: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
+	158, // 212: cnspec.policy.v1.ScoredRiskFactor.DataEntry.value:type_name -> mql.llx.Result
 	97,  // 213: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry.value:type_name -> cnspec.policy.v1.PolicyDelta
-	156, // 214: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> mql.llx.Result
-	158, // 215: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> mql.llx.ResourceRecording
+	158, // 214: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> mql.llx.Result
+	160, // 215: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> mql.llx.ResourceRecording
 	107, // 216: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry.value:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
 	37,  // 217: cnspec.policy.v1.PolicyHub.SetBundle:input_type -> cnspec.policy.v1.Bundle
 	37,  // 218: cnspec.policy.v1.PolicyHub.ValidateBundle:input_type -> cnspec.policy.v1.Bundle
@@ -10164,38 +10258,40 @@ var file_cnspec_policy_proto_depIdxs = []int32{
 	105, // 238: cnspec.policy.v1.PolicyResolver.GetReport:input_type -> cnspec.policy.v1.EntityScoreReq
 	105, // 239: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:input_type -> cnspec.policy.v1.EntityScoreReq
 	105, // 240: cnspec.policy.v1.PolicyResolver.GetScore:input_type -> cnspec.policy.v1.EntityScoreReq
-	159, // 241: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> mql.providers.v1.recording.EntityResourcesReq
+	161, // 241: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> mql.providers.v1.recording.EntityResourcesReq
 	106, // 242: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:input_type -> cnspec.policy.v1.SynchronizeAssetsReq
-	109, // 243: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
-	89,  // 244: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
-	89,  // 245: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
-	37,  // 246: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
-	33,  // 247: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
-	89,  // 248: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
-	91,  // 249: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
-	34,  // 250: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
-	94,  // 251: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
-	53,  // 252: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
-	89,  // 253: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
-	54,  // 254: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
-	89,  // 255: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
-	89,  // 256: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
-	89,  // 257: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnspec.policy.v1.Empty
-	64,  // 258: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
-	89,  // 259: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
-	64,  // 260: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
-	64,  // 261: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
-	89,  // 262: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
-	102, // 263: cnspec.policy.v1.PolicyResolver.GetUploadURL:output_type -> cnspec.policy.v1.GetUploadURLResp
-	89,  // 264: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:output_type -> cnspec.policy.v1.Empty
-	72,  // 265: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
-	75,  // 266: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
-	72,  // 267: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
-	160, // 268: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> mql.providers.v1.recording.EntityResourcesRes
-	108, // 269: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
-	111, // 270: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
-	244, // [244:271] is the sub-list for method output_type
-	217, // [217:244] is the sub-list for method input_type
+	111, // 243: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
+	109, // 244: cnspec.policy.v1.PolicyResolver.GetScanParameters:input_type -> cnspec.policy.v1.GetScanParametersReq
+	89,  // 245: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
+	89,  // 246: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
+	37,  // 247: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
+	33,  // 248: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
+	89,  // 249: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
+	91,  // 250: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
+	34,  // 251: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
+	94,  // 252: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
+	53,  // 253: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
+	89,  // 254: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
+	54,  // 255: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
+	89,  // 256: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
+	89,  // 257: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
+	89,  // 258: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnspec.policy.v1.Empty
+	64,  // 259: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
+	89,  // 260: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
+	64,  // 261: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
+	64,  // 262: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
+	89,  // 263: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
+	102, // 264: cnspec.policy.v1.PolicyResolver.GetUploadURL:output_type -> cnspec.policy.v1.GetUploadURLResp
+	89,  // 265: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:output_type -> cnspec.policy.v1.Empty
+	72,  // 266: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
+	75,  // 267: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
+	72,  // 268: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
+	162, // 269: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> mql.providers.v1.recording.EntityResourcesRes
+	108, // 270: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
+	113, // 271: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
+	110, // 272: cnspec.policy.v1.PolicyResolver.GetScanParameters:output_type -> cnspec.policy.v1.ScanParameters
+	245, // [245:273] is the sub-list for method output_type
+	217, // [217:245] is the sub-list for method input_type
 	217, // [217:217] is the sub-list for extension type_name
 	217, // [217:217] is the sub-list for extension extendee
 	0,   // [0:217] is the sub-list for field type_name
@@ -10212,7 +10308,7 @@ func file_cnspec_policy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cnspec_policy_proto_rawDesc), len(file_cnspec_policy_proto_rawDesc)),
 			NumEnums:      14,
-			NumMessages:   138,
+			NumMessages:   140,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -1220,6 +1220,10 @@ service PolicyResolver {
 
   rpc SynchronizeAssets(SynchronizeAssetsReq) returns (SynchronizeAssetsResp) {}
   rpc PurgeAssets(PurgeAssetsRequest) returns (PurgeAssetsConfirmation) {}
+
+  // GetScanParameters returns server-controlled parameters for scans in the
+  // given scope (space or org MRN), such as client-side mql features to enable.
+  rpc GetScanParameters(GetScanParametersReq) returns (ScanParameters) {}
 }
 
 message PolicyAssignment {
@@ -1339,6 +1343,14 @@ message SynchronizeAssetsRespAssetDetail {
 
 message SynchronizeAssetsResp {
   map<string, SynchronizeAssetsRespAssetDetail> details = 1;
+}
+
+message GetScanParametersReq {
+  string scope_mrn = 1;  // space or org MRN
+}
+
+message ScanParameters {
+  repeated string enabled_features = 1;  // mql feature names enabled by server
 }
 
 message PurgeAssetsRequest {

--- a/policy/cnspec_policy.ranger.go
+++ b/policy/cnspec_policy.ranger.go
@@ -442,6 +442,7 @@ type PolicyResolver interface {
 	GetResourcesData(context.Context, *recording.EntityResourcesReq) (*recording.EntityResourcesRes, error)
 	SynchronizeAssets(context.Context, *SynchronizeAssetsReq) (*SynchronizeAssetsResp, error)
 	PurgeAssets(context.Context, *PurgeAssetsRequest) (*PurgeAssetsConfirmation, error)
+	GetScanParameters(context.Context, *GetScanParametersReq) (*ScanParameters, error)
 }
 
 // client implementation
@@ -550,6 +551,11 @@ func (c *PolicyResolverClient) PurgeAssets(ctx context.Context, in *PurgeAssetsR
 	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/PurgeAssets"}, ""), in, out)
 	return out, err
 }
+func (c *PolicyResolverClient) GetScanParameters(ctx context.Context, in *GetScanParametersReq) (*ScanParameters, error) {
+	out := new(ScanParameters)
+	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/GetScanParameters"}, ""), in, out)
+	return out, err
+}
 
 // server implementation
 
@@ -589,6 +595,7 @@ func NewPolicyResolverServer(handler PolicyResolver, opts ...PolicyResolverServe
 			"GetResourcesData":      srv.GetResourcesData,
 			"SynchronizeAssets":     srv.SynchronizeAssets,
 			"PurgeAssets":           srv.PurgeAssets,
+			"GetScanParameters":     srv.GetScanParameters,
 		},
 	}
 	return ranger.NewRPCServer(&service)
@@ -982,4 +989,28 @@ func (p *PolicyResolverServer) PurgeAssets(ctx context.Context, reqBytes *[]byte
 		return nil, err
 	}
 	return p.handler.PurgeAssets(ctx, &req)
+}
+func (p *PolicyResolverServer) GetScanParameters(ctx context.Context, reqBytes *[]byte) (pb.Message, error) {
+	var req GetScanParametersReq
+	var err error
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, errors.New("could not access header")
+	}
+
+	switch md.First("Content-Type") {
+	case "application/protobuf", "application/octet-stream", "application/grpc+proto":
+		err = pb.Unmarshal(*reqBytes, &req)
+	default:
+		// handle case of empty object
+		if len(*reqBytes) > 0 {
+			err = jsonpb.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(*reqBytes, &req)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return p.handler.GetScanParameters(ctx, &req)
 }

--- a/policy/cnspec_policy_vtproto.pb.go
+++ b/policy/cnspec_policy_vtproto.pb.go
@@ -2773,6 +2773,44 @@ func (m *SynchronizeAssetsResp) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *GetScanParametersReq) CloneVT() *GetScanParametersReq {
+	if m == nil {
+		return (*GetScanParametersReq)(nil)
+	}
+	r := new(GetScanParametersReq)
+	r.ScopeMrn = m.ScopeMrn
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetScanParametersReq) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ScanParameters) CloneVT() *ScanParameters {
+	if m == nil {
+		return (*ScanParameters)(nil)
+	}
+	r := new(ScanParameters)
+	if rhs := m.EnabledFeatures; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.EnabledFeatures = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ScanParameters) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *PurgeAssetsRequest) CloneVT() *PurgeAssetsRequest {
 	if m == nil {
 		return (*PurgeAssetsRequest)(nil)
@@ -10661,6 +10699,88 @@ func (m *SynchronizeAssetsResp) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 
+func (m *GetScanParametersReq) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetScanParametersReq) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetScanParametersReq) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ScopeMrn) > 0 {
+		i -= len(m.ScopeMrn)
+		copy(dAtA[i:], m.ScopeMrn)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ScopeMrn)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ScanParameters) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ScanParameters) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ScanParameters) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.EnabledFeatures) > 0 {
+		for iNdEx := len(m.EnabledFeatures) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EnabledFeatures[iNdEx])
+			copy(dAtA[i:], m.EnabledFeatures[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EnabledFeatures[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *PurgeAssetsRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -14221,6 +14341,36 @@ func (m *SynchronizeAssetsResp) SizeVT() (n int) {
 			l += 1 + protohelpers.SizeOfVarint(uint64(l))
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetScanParametersReq) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ScopeMrn)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ScanParameters) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.EnabledFeatures) > 0 {
+		for _, s := range m.EnabledFeatures {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -36880,6 +37030,172 @@ func (m *SynchronizeAssetsResp) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Details[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetScanParametersReq) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetScanParametersReq: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetScanParametersReq: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ScopeMrn", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ScopeMrn = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ScanParameters) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ScanParameters: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ScanParameters: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EnabledFeatures", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EnabledFeatures = append(m.EnabledFeatures, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -300,6 +300,11 @@ func (s *LocalServices) PurgeAssets(context.Context, *PurgeAssetsRequest) (*Purg
 	return nil, nil
 }
 
+// GetScanParameters is not required for local services (no server-side scan parameters)
+func (s *LocalServices) GetScanParameters(context.Context, *GetScanParametersReq) (*ScanParameters, error) {
+	return &ScanParameters{}, nil
+}
+
 // HELPER METHODS
 // =================
 

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -394,6 +394,24 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		if err != nil {
 			return nil, err
 		}
+
+		// Fetch server-controlled scan parameters before scanning. Server-enabled
+		// features are layered on top of any features already set on the context
+		// by local config — we never replace or disable what the user asked for.
+		resp, err := services.GetScanParameters(ctx, &policy.GetScanParametersReq{ScopeMrn: spaceMrn})
+		if err != nil {
+			log.Warn().Err(err).Msg("could not get server scan parameters")
+		} else if len(resp.EnabledFeatures) > 0 {
+			log.Info().Strs("features", resp.EnabledFeatures).Msg("server activated features")
+			for _, name := range resp.EnabledFeatures {
+				f, ok := mql.FeaturesValue[name]
+				if !ok {
+					log.Warn().Str("feature", name).Msg("unknown server feature, ignoring")
+					continue
+				}
+				ctx = mql.WithFeature(ctx, f)
+			}
+		}
 	}
 
 	parallelism := int(job.Parallelism)


### PR DESCRIPTION
## Summary
- Adds `GetScanParameters` RPC to the `PolicyResolver` service. The upstream platform returns a `ScanParameters` message describing server-controlled scan behavior for a given scope (space/org MRN).
- Initial parameter is `enabled_features` — a list of mql feature names the server wants active for the scan. Client calls the RPC once early in `distributeJob` (before `SynchronizeAssets`) and applies the features to the scan context via `mql.InitFeatures` + `mql.SetFeatures`.
- Adds a no-op stub on `LocalServices` for local/incognito mode.

## Extensibility
`ScanParameters` is intentionally a broad message. Future per-scope scan controls (parallelism, allowed detectors, etc.) can be added as new fields on the same message without needing another RPC.

## Backward compatibility
- Old clients never call the new RPC.
- Against an older platform that doesn't implement the RPC, the client logs a warning and continues with local defaults.

## Test plan
- [ ] `go build ./...` succeeds
- [ ] Manual: run a scan against a platform that enables a client feature, confirm the feature is active (`mql.GetFeatures(ctx).IsActive(...)`) during scan execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)