### PR TITLE
Trim Cisco IOS-XR and NX-OS policy summaries

### DIFF
--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure Cisco IOS-XR routers and network devices
+    summary: Secure Cisco IOS-XR routers
     docs:
       desc: |-
         The Mondoo Cisco IOS-XR Security policy provides comprehensive security checks for Cisco IOS-XR routers and network devices. This policy helps ensure your Cisco IOS-XR infrastructure is properly configured, hardened, and maintained according to security best practices.

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure Cisco NX-OS switches and network devices
+    summary: Secure Cisco NX-OS switches
     docs:
       desc: |-
         The Mondoo Cisco NX-OS Security policy provides comprehensive security checks for Cisco NX-OS switches and data center network devices. This policy helps ensure your Cisco Nexus infrastructure is properly configured, hardened, and maintained according to security best practices.


### PR DESCRIPTION
## Summary
- Shorten the Cisco IOS-XR policy summary to "Secure Cisco IOS-XR routers"
- Shorten the Cisco NX-OS policy summary to "Secure Cisco NX-OS switches"

## Test plan
- [ ] `cnspec policy lint content/mondoo-cisco-iosxr-security.mql.yaml`
- [ ] `cnspec policy lint content/mondoo-cisco-nxos-security.mql.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)