### PR TITLE
Refine platform tags for policy targeting

### DIFF
--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
-      mondoo.com/platform: linux,docker
+      mondoo.com/platform: dockerfile
     require:
       - provider: os
     authors:

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,docker
+      mondoo.com/platform: dockerfile
     require:
       - provider: os
     authors:

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -9,7 +9,7 @@ policies:
       benchmark: Mondoo Phoenix PLCnext
       date: "2023-02-11"
       mondoo.com/category: security
-      mondoo.com/platform: linux,plc
+      mondoo.com/platform: plcnext
       profile: PLCnext base security
     require:
       - provider: os

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: tailscale,network
+      mondoo.com/platform: tailscale,saas
     require:
       - provider: tailscale
     authors:

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: unifi,network
+      mondoo.com/platform: unifi,networkdevice
     require:
       - provider: unifi
     authors:

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.2.0
     tags:
       mondoo.com/category: best-practices
-      mondoo.com/platform: windows
+      mondoo.com/platform: windows:10
     require:
       - provider: os
     authors:

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: windows
+      mondoo.com/platform: windows:10,windows:11
     require:
       - provider: os
     authors:


### PR DESCRIPTION
## Summary
- Narrow `mondoo.com/platform` tags on eight policies to match the platforms each policy actually targets
- Replaces broader umbrella terms (e.g. `linux,docker`, `windows`) with specific platform identifiers (`dockerfile`, `windows:10`, `windows:10, windows:11`, `plcnext`, `saas`, `networkdevice`)

## Test plan
- [ ] `cnspec policy lint` passes for each modified policy
- [ ] Policies still resolve against intended assets in downstream scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)