### PR TITLE
Retag vulnerability policies with vulnerability category

### DIFF
--- a/content/vulnerabilities/mondoo-macos-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-macos-vulnerability.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.1.0
     license: BUSL-1.1
     tags:
-      mondoo.com/category: security
+      mondoo.com/category: vulnerability
       mondoo.com/platform: macos
     require:
       - provider: os

--- a/content/vulnerabilities/mondoo-microsoft-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-microsoft-vulnerability.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.1.0
     license: BUSL-1.1
     tags:
-      mondoo.com/category: security
+      mondoo.com/category: vulnerability
       mondoo.com/platform: windows
     require:
       - provider: os

--- a/content/vulnerabilities/mondoo-openssl-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-openssl-vulnerability.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.1.0
     license: BUSL-1.1
     tags:
-      mondoo.com/category: security
+      mondoo.com/category: vulnerability
       mondoo.com/platform: linux,unix
     require:
       - provider: os

--- a/content/vulnerabilities/mondoo-vmware-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-vmware-vulnerability.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.1.0
     license: BUSL-1.1
     tags:
-      mondoo.com/category: security
+      mondoo.com/category: vulnerability
       mondoo.com/platform: vmware,vmware-esxi
     require:
       - provider: vsphere

--- a/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
+++ b/content/vulnerabilities/mondoo-xz-vulnerability.mql.yaml
@@ -6,7 +6,7 @@ policies:
     version: 1.0.0
     license: BUSL-1.1
     tags:
-      mondoo.com/category: security
+      mondoo.com/category: vulnerability
       mondoo.com/platform: linux,unix
     require:
       - provider: os


### PR DESCRIPTION
## Summary
- Change `mondoo.com/category` from `security` to `vulnerability` on all five policies in `content/vulnerabilities/` (macOS, Microsoft, OpenSSL, VMware, xz).
- These CVE-focused policies now surface under their own category instead of being grouped with general security hardening policies.

## Test plan
- [ ] `cnspec policy lint content/vulnerabilities/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)