### PR TITLE
Rename GitHub Repository Security policy to include Mondoo prefix

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -88,7 +88,7 @@ policies:
           - uid: mondoo-github-organization-security-security-policy
     scoring_system: highest impact
   - uid: mondoo-github-repository-security
-    name: GitHub Repository Security
+    name: Mondoo GitHub Repository Security
     version: 1.7.0
     license: BUSL-1.1
     tags:


### PR DESCRIPTION
## Summary
- Rename `GitHub Repository Security` policy to `Mondoo GitHub Repository Security` for naming consistency with other Mondoo-prefixed policies

## Test plan
- [ ] `cnspec policy lint content/mondoo-github-security.mql.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)