### PR TITLE
Fix Cisco platform tags to use canonical hyphenated names

### DIFF
--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: cisco-iosxe,networkdevice
+      mondoo.com/platform: cisco-ios-xe,networkdevice
     require:
       - provider: networkdevices
     authors:

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: cisco-iosxr,networkdevice
+      mondoo.com/platform: cisco-ios-xr,networkdevice
     require:
       - provider: networkdevices
     authors:

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -7,7 +7,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: cisco-nxos,networkdevice
+      mondoo.com/platform: cisco-nx-os,networkdevice
     require:
       - provider: networkdevices
     authors:


### PR DESCRIPTION
## Summary
- Update `mondoo.com/platform` tags for the Cisco IOS-XE, IOS-XR, and NX-OS security policies to `cisco-ios-xe`, `cisco-ios-xr`, and `cisco-nx-os` so policy targeting aligns with the canonical platform identifiers reported by the networkdevices provider.

## Test plan
- [ ] `cnspec policy lint content/mondoo-cisco-iosxe-security.mql.yaml content/mondoo-cisco-iosxr-security.mql.yaml content/mondoo-cisco-nxos-security.mql.yaml`
- [ ] Confirm policies resolve against Cisco IOS-XE / IOS-XR / NX-OS assets after the tag change

🤖 Generated with [Claude Code](https://claude.com/claude-code)