### PR TITLE
Use per-resource cloud platforms for OCI, GCP, and AWS checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -14461,8 +14461,8 @@ queries:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/security.html
         title: AWS Documentation - Security in Amazon Neptune
   - uid: mondoo-aws-security-neptune-cluster-encrypted-aws
-    filters: asset.platform == "aws"
-    mql: aws.neptune.clusters.all(storageEncrypted == true)
+    filters: asset.platform == "aws-neptune-cluster"
+    mql: aws.neptune.cluster.storageEncrypted == true
   - uid: mondoo-aws-security-neptune-cluster-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -18611,8 +18611,8 @@ queries:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/security.html
         title: AWS Documentation - Security in Amazon Neptune
   - uid: mondoo-aws-security-neptune-cluster-iam-authentication-aws
-    filters: asset.platform == "aws"
-    mql: aws.neptune.clusters.all(iamDatabaseAuthenticationEnabled == true)
+    filters: asset.platform == "aws-neptune-cluster"
+    mql: aws.neptune.cluster.iamDatabaseAuthenticationEnabled == true
   - uid: mondoo-aws-security-neptune-cluster-iam-authentication-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -22465,11 +22465,9 @@ queries:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/backup-restore-overview.html
         title: AWS Documentation - Neptune DB cluster snapshots
   - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-neptune-cluster"
     mql: |
-      aws.neptune.clusters.all(
-        snapshots.all(storageEncrypted == true)
-      )
+      aws.neptune.cluster.snapshots.all(storageEncrypted == true)
   - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -24385,8 +24383,8 @@ queries:
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
   - uid: mondoo-aws-security-documentdb-cluster-encrypted-aws
-    filters: asset.platform == "aws"
-    mql: aws.documentdb.clusters.all(storageEncrypted == true)
+    filters: asset.platform == "aws-documentdb-cluster"
+    mql: aws.documentdb.cluster.storageEncrypted == true
   - uid: mondoo-aws-security-documentdb-cluster-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster")
     mql: |
@@ -24527,8 +24525,8 @@ queries:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk
         title: AWS KMS Customer Managed Keys
   - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.documentdb.clusters.all(kmsKey { metadata.KeyManager == "CUSTOMER" })
+    filters: asset.platform == "aws-documentdb-cluster"
+    mql: aws.documentdb.cluster.kmsKey { metadata.KeyManager == "CUSTOMER" }
   - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster")
     mql: |
@@ -27434,8 +27432,8 @@ queries:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk
         title: AWS KMS Customer Managed Keys
   - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.neptune.clusters.all(kmsKey { metadata.KeyManager == "CUSTOMER" })
+    filters: asset.platform == "aws-neptune-cluster"
+    mql: aws.neptune.cluster.kmsKey { metadata.KeyManager == "CUSTOMER" }
   - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -36711,8 +36709,8 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/emr-controls.html
         title: AWS Security Hub - EMR controls reference
   - uid: mondoo-aws-security-emr-encryption-at-rest-aws
-    filters: asset.platform == "aws"
-    mql: aws.emr.clusters.all(encryptionConfiguration.atRestEnabled == true)
+    filters: asset.platform == "aws-emr-cluster"
+    mql: aws.emr.cluster.encryptionConfiguration.atRestEnabled == true
   - uid: mondoo-aws-security-emr-encryption-at-rest-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_security_configuration")
     mql: |
@@ -36868,8 +36866,8 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/emr-controls.html
         title: AWS Security Hub - EMR controls reference
   - uid: mondoo-aws-security-emr-encryption-in-transit-aws
-    filters: asset.platform == "aws"
-    mql: aws.emr.clusters.all(encryptionConfiguration.inTransitEnabled == true)
+    filters: asset.platform == "aws-emr-cluster"
+    mql: aws.emr.cluster.encryptionConfiguration.inTransitEnabled == true
   - uid: mondoo-aws-security-emr-encryption-in-transit-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_security_configuration")
     mql: |
@@ -37017,8 +37015,8 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/emr-controls.html
         title: AWS Security Hub - EMR controls reference
   - uid: mondoo-aws-security-emr-logging-enabled-aws
-    filters: asset.platform == "aws"
-    mql: aws.emr.clusters.all(logUri != empty)
+    filters: asset.platform == "aws-emr-cluster"
+    mql: aws.emr.cluster.logUri != empty
   - uid: mondoo-aws-security-emr-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_cluster")
     mql: |
@@ -37690,12 +37688,10 @@ queries:
       - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-data-encryption-options.html
         title: AWS Documentation - Encryption options for Amazon EMR
   - uid: mondoo-aws-security-emr-local-disk-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-emr-cluster"
     mql: |
-      aws.emr.clusters.all(
-        encryptionConfiguration.atRestEnabled == true &&
-        encryptionConfiguration.atRestConfiguration['LocalDiskEncryptionConfiguration'] != empty
-      )
+      aws.emr.cluster.encryptionConfiguration.atRestEnabled == true &&
+      aws.emr.cluster.encryptionConfiguration.atRestConfiguration['LocalDiskEncryptionConfiguration'] != empty
   - uid: mondoo-aws-security-emr-local-disk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_security_configuration")
     mql: |
@@ -38809,8 +38805,8 @@ queries:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/auditing.html
         title: AWS Documentation - Auditing Amazon Neptune
   - uid: mondoo-aws-security-neptune-cluster-log-export-aws
-    filters: asset.platform == "aws"
-    mql: aws.neptune.clusters.all( enabledCloudwatchLogsExports.contains("audit") )
+    filters: asset.platform == "aws-neptune-cluster"
+    mql: aws.neptune.cluster.enabledCloudwatchLogsExports.contains("audit")
   - uid: mondoo-aws-security-neptune-cluster-log-export-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -38955,8 +38951,8 @@ queries:
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html
         title: AWS Documentation - Auditing Amazon DocumentDB events
   - uid: mondoo-aws-security-documentdb-cluster-log-export-aws
-    filters: asset.platform == "aws"
-    mql: aws.documentdb.clusters.all( enabledCloudwatchLogsExports.contains("audit") )
+    filters: asset.platform == "aws-documentdb-cluster"
+    mql: aws.documentdb.cluster.enabledCloudwatchLogsExports.contains("audit")
   - uid: mondoo-aws-security-documentdb-cluster-log-export-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster")
     mql: |
@@ -40628,9 +40624,9 @@ queries:
       - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-security.html
         title: AWS Documentation - Security in Amazon EMR
   - uid: mondoo-aws-security-emr-not-publicly-accessible-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-emr-cluster"
     mql: |
-      aws.emr.clusters.all(masterPublicDnsName == "" || masterPublicDnsName == empty)
+      aws.emr.cluster.masterPublicDnsName == "" || aws.emr.cluster.masterPublicDnsName == empty
   - uid: mondoo-aws-security-emr-not-publicly-accessible-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_cluster")
     mql: |
@@ -40802,9 +40798,9 @@ queries:
       - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-debugging.html
         title: AWS Documentation - Configure logging and debugging
   - uid: mondoo-aws-security-emr-log-cmk-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-emr-cluster" && aws.emr.cluster.logUri != empty
     mql: |
-      aws.emr.clusters.where(logUri != empty).all(logEncryptionKmsKey != empty)
+      aws.emr.cluster.logEncryptionKmsKey != empty
   - uid: mondoo-aws-security-emr-log-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_cluster")
     mql: |
@@ -40940,9 +40936,9 @@ queries:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/default-security-group.html
         title: AWS Documentation - Default security groups
   - uid: mondoo-aws-security-neptune-no-default-security-groups-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-neptune-cluster"
     mql: |
-      aws.neptune.clusters.all(securityGroups.none(name == "default"))
+      aws.neptune.cluster.securityGroups.none(name == "default")
   - uid: mondoo-aws-security-neptune-no-default-security-groups-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster")
     mql: |
@@ -41081,9 +41077,9 @@ queries:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/default-security-group.html
         title: AWS Documentation - Default security groups
   - uid: mondoo-aws-security-documentdb-no-default-security-groups-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-documentdb-cluster"
     mql: |
-      aws.documentdb.clusters.all(securityGroups.none(name == "default"))
+      aws.documentdb.cluster.securityGroups.none(name == "default")
   - uid: mondoo-aws-security-documentdb-no-default-security-groups-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -16368,11 +16368,9 @@ queries:
       - url: https://cloud.google.com/alloydb/docs/cmek
         title: Customer-managed encryption keys (CMEK) for AlloyDB
   - uid: mondoo-gcp-security-alloydb-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-alloydb-cluster'
     mql: |
-      gcp.project.alloydb.clusters.all(
-        encryptionConfig != empty
-      )
+      gcp.project.alloydbService.cluster.encryptionConfig != empty
   - uid: mondoo-gcp-security-alloydb-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_alloydb_cluster')
@@ -16478,11 +16476,9 @@ queries:
       - url: https://cloud.google.com/alloydb/docs/connect-public-ip
         title: Connect using public IP
   - uid: mondoo-gcp-security-alloydb-no-public-ip-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-alloydb-cluster'
     mql: |
-      gcp.project.alloydb.clusters.all(
-        instances().all(publicIpAddress == "")
-      )
+      gcp.project.alloydbService.cluster.instances().all(publicIpAddress == "")
   - uid: mondoo-gcp-security-alloydb-no-public-ip-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_alloydb_instance')

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -105,7 +105,7 @@ queries:
   - uid: mondoo-oci-security-iam-mfa-enabled-for-active-users
     title: Ensure MFA is enabled for all active IAM users
     impact: 90
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
@@ -115,7 +115,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
       compliance/soc2-2017: soc2-control-cc6-1-4
     mql: |
-      oci.identity.users.where(state == "ACTIVE").all(mfaActivated == true)
+      oci.identity.user.mfaActivated == true
     docs:
       desc: |
         This check ensures that multi-factor authentication (MFA) is enabled for all active IAM users in the OCI tenancy. MFA adds an additional layer of security beyond passwords, requiring users to provide a second authentication factor when signing in.
@@ -161,7 +161,7 @@ queries:
   - uid: mondoo-oci-security-iam-user-emails-verified
     title: Ensure IAM user email addresses are verified
     impact: 60
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE" && oci.identity.user.email != ""
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
@@ -171,7 +171,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-8
     mql: |
-      oci.identity.users.where(state == "ACTIVE" && email != "").all(emailVerified == true)
+      oci.identity.user.emailVerified == true
     docs:
       desc: |
         This check ensures that all active IAM users with email addresses have verified their email. Unverified emails may indicate misconfigured accounts or accounts that were never properly set up.
@@ -312,11 +312,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/policies.htm
         title: CIS OCI Foundations Benchmark 1.1
   - uid: mondoo-oci-security-iam-no-overly-permissive-policies-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policies.none(
-        statements.any(_ == /allow.*manage\s+all-resources\s+in\s+tenancy/i)
-      )
+      oci.identity.policy.statements.none(_ == /allow.*manage\s+all-resources\s+in\s+tenancy/i)
   - uid: mondoo-oci-security-iam-no-overly-permissive-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -338,7 +336,7 @@ queries:
   - uid: mondoo-oci-security-iam-inactive-users-no-active-api-keys
     title: Ensure inactive users have no active API keys
     impact: 80
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user" && oci.identity.user.state != "ACTIVE"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
@@ -348,9 +346,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
       compliance/soc2-2017: soc2-control-cc6-2-2
     mql: |
-      oci.identity.users.where(state != "ACTIVE").all(
-        apiKeys.none(state == "ACTIVE")
-      )
+      oci.identity.user.apiKeys.none(state == "ACTIVE")
     docs:
       desc: |
         This check ensures that IAM users in an inactive state do not have active API keys. Active API keys on inactive accounts represent unused credentials that could be exploited if compromised.
@@ -394,7 +390,7 @@ queries:
   - uid: mondoo-oci-security-iam-inactive-users-no-active-auth-tokens
     title: Ensure inactive users have no active auth tokens
     impact: 80
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user" && oci.identity.user.state != "ACTIVE"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
@@ -404,9 +400,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
       compliance/soc2-2017: soc2-control-cc6-2-2
     mql: |
-      oci.identity.users.where(state != "ACTIVE").all(
-        authTokens.none(state == "ACTIVE")
-      )
+      oci.identity.user.authTokens.none(state == "ACTIVE")
     docs:
       desc: |
         This check ensures that IAM users in an inactive state do not have active authentication tokens. Active auth tokens on inactive accounts represent unused credentials that could be exploited if compromised.
@@ -528,9 +522,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingbuckets.htm
         title: CIS OCI Foundations Benchmark 4.1.1
   - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
-      oci.objectStorage.buckets.all(publicAccessType == "NoPublicAccess")
+      oci.objectStorage.bucket.publicAccessType == "NoPublicAccess"
   - uid: mondoo-oci-security-object-storage-buckets-not-publicly-accessible-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -630,9 +624,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingversioning.htm
         title: OCI Object Storage versioning documentation
   - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
-      oci.objectStorage.buckets.all(versioning == "Enabled")
+      oci.objectStorage.bucket.versioning == "Enabled"
   - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -732,9 +726,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingbuckets.htm
         title: OCI Object Storage events documentation
   - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
-      oci.objectStorage.buckets.all(objectEventsEnabled == true)
+      oci.objectStorage.bucket.objectEventsEnabled == true
   - uid: mondoo-oci-security-object-storage-buckets-event-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -849,9 +843,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingbuckets_topic-Server_Side_Encryption_SSE.htm
         title: CIS OCI Foundations Benchmark 4.1.2
   - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
-      oci.objectStorage.buckets.all(kmsKeyId != "")
+      oci.objectStorage.bucket.kmsKeyId != ""
   - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -963,10 +957,10 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: CIS OCI Foundations Benchmark 2.1
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.none(_['source'] == "0.0.0.0/0" && _['protocol'] == "all")
+      oci.network.securityList.ingressSecurityRules.none(
+        _['source'] == "0.0.0.0/0" && _['protocol'] == "all"
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -1091,11 +1085,11 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: CIS OCI Foundations Benchmark 2.2
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.where(_['source'] == "0.0.0.0/0" && _['protocol'] == "6").none(_['tcpOptions'] == empty)
-      )
+      oci.network.securityList.ingressSecurityRules.where(
+        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
+      ).none(_['tcpOptions'] == empty)
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -1205,10 +1199,10 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: OCI security list documentation
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        egressSecurityRules.none(_['destination'] == "0.0.0.0/0" && _['protocol'] == "all")
+      oci.network.securityList.egressSecurityRules.none(
+        _['destination'] == "0.0.0.0/0" && _['protocol'] == "all"
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -1231,7 +1225,7 @@ queries:
   - uid: mondoo-oci-security-iam-stale-active-users
     title: Ensure active IAM users have logged in within the last 90 days
     impact: 70
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE" && oci.identity.user.lastLogin != empty
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
@@ -1241,9 +1235,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
       compliance/soc2-2017: soc2-control-cc6-2-2
     mql: |
-      oci.identity.users.where(state == "ACTIVE" && lastLogin != empty).all(
-        lastLogin > time.now - 90 * time.day
-      )
+      oci.identity.user.lastLogin > time.now - 90 * time.day
     docs:
       desc: |
         This check ensures that all active IAM users have logged in within the last 90 days. Accounts that remain active but unused may indicate orphaned identities that increase the attack surface.
@@ -1384,11 +1376,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/policies.htm
         title: CIS OCI Foundations Benchmark 1.2
   - uid: mondoo-oci-security-iam-no-broad-compartment-policies-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policies.none(
-        statements.any(_ == /allow.*manage\s+all-resources\s+in\s+compartment/i)
-      )
+      oci.identity.policy.statements.none(_ == /allow.*manage\s+all-resources\s+in\s+compartment/i)
   - uid: mondoo-oci-security-iam-no-broad-compartment-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -1493,9 +1483,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingreplication.htm
         title: OCI Object Storage replication documentation
   - uid: mondoo-oci-security-object-storage-buckets-replication-enabled-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
-      oci.objectStorage.buckets.all(replicationEnabled == true)
+      oci.objectStorage.bucket.replicationEnabled == true
   - uid: mondoo-oci-security-object-storage-buckets-replication-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -1586,9 +1576,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingversioning.htm
         title: OCI Object Storage versioning documentation
   - uid: mondoo-oci-security-object-storage-archive-buckets-versioning-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket" && oci.objectStorage.bucket.storageTier == "Archive"
     mql: |
-      oci.objectStorage.buckets.where(storageTier == "Archive").all(versioning == "Enabled")
+      oci.objectStorage.bucket.versioning == "Enabled"
   - uid: mondoo-oci-security-object-storage-archive-buckets-versioning-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_objectstorage_bucket")
     mql: |
@@ -1702,12 +1692,12 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: CIS OCI Foundations Benchmark 2.3
   - uid: mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.where(_['source'] == "0.0.0.0/0" && _['protocol'] == "6").none(
-          _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 22 && _['tcpOptions']['destinationPortRange']['max'] >= 22
-        )
+      oci.network.securityList.ingressSecurityRules.where(
+        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
+      ).none(
+        _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 22 && _['tcpOptions']['destinationPortRange']['max'] >= 22
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -1836,12 +1826,12 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: CIS OCI Foundations Benchmark 2.4
   - uid: mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.where(_['source'] == "0.0.0.0/0" && _['protocol'] == "6").none(
-          _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 3389 && _['tcpOptions']['destinationPortRange']['max'] >= 3389
-        )
+      oci.network.securityList.ingressSecurityRules.where(
+        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
+      ).none(
+        _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 3389 && _['tcpOptions']['destinationPortRange']['max'] >= 3389
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -1970,11 +1960,11 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: CIS OCI Foundations Benchmark 2.5
   - uid: mondoo-oci-security-vcn-no-unrestricted-udp-ingress-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.where(_['source'] == "0.0.0.0/0" && _['protocol'] == "17").none(_['udpOptions'] == empty)
-      )
+      oci.network.securityList.ingressSecurityRules.where(
+        _['source'] == "0.0.0.0/0" && _['protocol'] == "17"
+      ).none(_['udpOptions'] == empty)
   - uid: mondoo-oci-security-vcn-no-unrestricted-udp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -2084,11 +2074,11 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: OCI security list documentation
   - uid: mondoo-oci-security-vcn-no-stateless-ingress-from-internet-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        ingressSecurityRules.where(_['source'] == "0.0.0.0/0").none(_['isStateless'] == true)
-      )
+      oci.network.securityList.ingressSecurityRules.where(
+        _['source'] == "0.0.0.0/0"
+      ).none(_['isStateless'] == true)
   - uid: mondoo-oci-security-vcn-no-stateless-ingress-from-internet-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -2196,11 +2186,11 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm
         title: OCI security list documentation
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-tcp-ports-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityLists.all(
-        egressSecurityRules.where(_['destination'] == "0.0.0.0/0" && _['protocol'] == "6").none(_['tcpOptions'] == empty)
-      )
+      oci.network.securityList.egressSecurityRules.where(
+        _['destination'] == "0.0.0.0/0" && _['protocol'] == "6"
+      ).none(_['tcpOptions'] == empty)
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-tcp-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -2299,7 +2289,7 @@ queries:
   - uid: mondoo-oci-security-iam-auth-tokens-short-lived
     title: Ensure IAM auth tokens have an expiry no more than 90 days after creation
     impact: 75
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-identity-user"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: false
@@ -2309,10 +2299,8 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc6-1-9
     mql: |
-      oci.identity.users.all(
-        authTokens.where(state == "ACTIVE").all(
-          expires != null && created != null && expires - created <= 90 * time.day
-        )
+      oci.identity.user.authTokens.where(state == "ACTIVE").all(
+        expires != null && created != null && expires - created <= 90 * time.day
       )
     docs:
       desc: |
@@ -3447,7 +3435,7 @@ queries:
   - uid: mondoo-oci-security-object-storage-retention-rules-locked
     title: Ensure object storage bucket retention rules are locked
     impact: 80
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
@@ -3457,8 +3445,8 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/soc2-2017: false
     mql: |
-      oci.objectStorage.buckets.all(
-        retentionRules.all(timeRuleLocked != null && timeRuleLocked <= time.now)
+      oci.objectStorage.bucket.retentionRules.all(
+        timeRuleLocked != null && timeRuleLocked <= time.now
       )
     docs:
       desc: |
@@ -3506,7 +3494,7 @@ queries:
   - uid: mondoo-oci-security-object-storage-retention-duration-meets-minimum
     title: Ensure object storage retention rules are at least 30 days
     impact: 65
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-objectstorage-bucket"
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
@@ -3516,11 +3504,9 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/soc2-2017: false
     mql: |
-      oci.objectStorage.buckets.all(
-        retentionRules.all(
-          durationTimeUnit == "DAYS" && durationAmount >= 30 ||
-          durationTimeUnit == "YEARS" && durationAmount >= 1
-        )
+      oci.objectStorage.bucket.retentionRules.all(
+        durationTimeUnit == "DAYS" && durationAmount >= 30 ||
+        durationTimeUnit == "YEARS" && durationAmount >= 1
       )
     docs:
       desc: |


### PR DESCRIPTION
## Summary

Rewrites security checks across OCI, GCP, and AWS policies to run against individual discovered resources instead of tenancy/account aggregates. Each check now filters on a specific resource platform (e.g. `oci-objectstorage-bucket`, `gcp-alloydb-cluster`, `aws-neptune-cluster`) and evaluates the singular resource, so findings attach to the offending resource and scale with discovery rather than collapsing into a single tenancy score.

Follows up on provider discovery work in:
- mondoohq/mql#7263 (OCI fine-grained discovery)
- mondoohq/mql#7261 (GCP AlloyDB cluster)
- mondoohq/mql#7264 (AWS Neptune / EMR / DocumentDB clusters)

### OCI
21 checks moved to `oci-identity-user`, `oci-identity-policy`, `oci-network-securitylist`, `oci-objectstorage-bucket`. Checks on non-discoverable resources (compute, NSG, LB, OKE, DB, Vault, Functions, Container Instances, groups) intentionally stay on the `oci` tenancy platform.

### GCP
2 AlloyDB cluster checks moved to `gcp-alloydb-cluster` querying `gcp.project.alloydbService.cluster`.

### AWS
16 Neptune / EMR / DocumentDB cluster checks moved to `aws-neptune-cluster`, `aws-emr-cluster`, `aws-documentdb-cluster`. Instance- and snapshot-level checks for those services stay on `aws` since discovery today only emits clusters.

Where the original check carried an inner \`.where()\` predicate (e.g. \`state == \"ACTIVE\"\`, \`storageTier == \"Archive\"\`, \`logUri != empty\`), the predicate is lifted into the filter so only the relevant discovered resources are scored.

## Test plan

- [x] \`cnspec policy lint content/mondoo-oci-security.mql.yaml\`
- [x] \`cnspec policy lint content/mondoo-gcp-security.mql.yaml\`
- [x] \`cnspec policy lint content/mondoo-aws-security.mql.yaml\`
- [ ] Scan an OCI tenancy with \`--discover auto\` and confirm per-resource checks run and findings attach to individual users / policies / security lists / buckets
- [ ] Scan a GCP project with AlloyDB clusters and confirm per-cluster findings
- [ ] Scan an AWS account with Neptune / EMR / DocumentDB clusters and confirm per-cluster findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)