### PR TITLE
🧹 Bump mql to v13.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260410121724-8588298e53e3
-	go.mondoo.com/mql/v13 v13.5.0
+	go.mondoo.com/mql/v13 v13.5.1
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.45.0
 	golang.org/x/sync v0.20.0
@@ -310,6 +310,7 @@ require (
 	github.com/sqlc-dev/sqlc v1.30.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
 	github.com/tliron/commonlog v0.2.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1042,6 +1042,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=
 github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
@@ -1097,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260410121724-8588298e53e3 h1:ArartArNQh/gZS8V1u1iKhaTq4AiDhJUpN8oMHPK2QI=
 go.mondoo.com/mondoo-go v0.0.0-20260410121724-8588298e53e3/go.mod h1:71ONiTX5I/jMdghOaeovcexBvxPvD1WcZqAEzz4RGOs=
-go.mondoo.com/mql/v13 v13.5.0 h1:LE8ORA1V/RiedmvOtjpuXIm/a5+ELBqDb5F9NOkdBq0=
-go.mondoo.com/mql/v13 v13.5.0/go.mod h1:B1cSIcnrRjRzdcRvOl+B13UDzSg+2GLJVSLkPbeiBnU=
+go.mondoo.com/mql/v13 v13.5.1 h1:WpXdy7h6y28npvUYg2YaLa++8CbVjCGQoDiL+IwXbc8=
+go.mondoo.com/mql/v13 v13.5.1/go.mod h1:fZ2CbY2dmjBBiLIKJDuW9HqEGFfzsR/n0kxIRRw6zik=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
## Summary

Bumps `go.mondoo.com/mql/v13` from v13.5.0 to v13.5.1.

This pulls in [mondoohq/cnquery#7197](https://github.com/mondoohq/cnquery/pull/7197), which adds JSON output and schema browsing subcommands to the `providers` CLI:

```
cnspec providers list --json
cnspec providers info <provider> [<provider>...] [--json]
cnspec providers resources <provider> [<resource>] [--json]
```

These are designed to make cnspec ergonomic for AI agents in local workflows without requiring the MCP server, and are already referenced by the [`mondoo-mql`](https://github.com/mondoohq/skills/blob/main/skills/mondoo-mql/SKILL.md) skill in mondoohq/skills. Without this bump, the skill documents CLI surface that no released `cnspec` binary exposes.

## Test plan

- [x] `go mod tidy` is clean
- [x] `go build ./apps/cnspec/` succeeds
- [x] `cnspec providers --help` lists the new `info` and `resources` subcommands
- [x] `cnspec providers list --json` returns structured JSON
- [x] `cnspec providers resources os --json` returns resource summaries
- [ ] CI green