### PR TITLE
Backfill missing compliance tags on AWS, Azure, and GCP checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -44481,7 +44481,7 @@ queries:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission-security
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
@@ -44560,7 +44560,7 @@ queries:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission-security
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
@@ -44715,7 +44715,7 @@ queries:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission-security
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
@@ -44867,7 +44867,7 @@ queries:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission-security
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
@@ -45309,7 +45309,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-ac-03
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -45363,7 +45363,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-ac-03
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -45415,7 +45415,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
-      compliance/nist-csf-2: nist-csf-2-pr-ac-03
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -45486,7 +45486,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-ac-03
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -45674,7 +45674,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-ac-03
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/soc2-2017: soc2-control-cc6-1-3

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -35588,6 +35588,7 @@ queries:
     impact: 50
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-18
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
@@ -45305,6 +45306,9 @@ queries:
     title: Ensure EC2 serial console access is disabled
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ac-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
@@ -45356,6 +45360,9 @@ queries:
     title: Ensure AMI block public access is enabled
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ac-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
@@ -45405,6 +45412,9 @@ queries:
     title: Ensure EC2 launch templates require IMDSv2
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-ac-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
@@ -45473,6 +45483,9 @@ queries:
     title: Ensure S3 buckets enforce bucket owner ownership
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ac-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
@@ -45534,8 +45547,13 @@ queries:
     title: Ensure CloudTrail Insights is enabled
     impact: 60
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-5
+      compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-aws-security-cloudtrail-insights-enabled-aws
         tags:
@@ -45600,8 +45618,13 @@ queries:
     title: Ensure Security Hub has standards enabled
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-8
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-12-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
     variants:
       - uid: mondoo-aws-security-securityhub-standards-enabled-aws
         tags:
@@ -45648,6 +45671,9 @@ queries:
     title: Ensure SNS topics do not allow public access
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ac-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
@@ -45709,6 +45735,9 @@ queries:
     title: Ensure DRS uses private IP for data replication
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
@@ -45761,6 +45790,9 @@ queries:
     title: Ensure DRS recovery instances have no public IPs
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -25111,6 +25111,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/soc2-2017: soc2-control-cc6-1-8
     variants:
       - uid: mondoo-azure-security-datafactory-managed-identity-azure
         tags:
@@ -25360,6 +25362,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
     variants:
       - uid: mondoo-azure-security-synapse-managed-vnet-azure
         tags:
@@ -26513,9 +26517,11 @@ queries:
     impact: 50
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-10
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ip-6
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-12
+      compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc6-5-1
     variants:
       - uid: mondoo-azure-security-acr-retention-policy-enabled-azure
@@ -28858,9 +28864,11 @@ queries:
     impact: 60
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-de-ae-5
       compliance/nist-csf-2: nist-csf-2-de-ae-08
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-azure
@@ -29027,9 +29035,11 @@ queries:
     impact: 70
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-de-ae-5
       compliance/nist-csf-2: nist-csf-2-de-ae-08
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-azure

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -346,7 +346,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-pt-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -394,7 +394,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-pt-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -438,7 +438,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-pt-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -487,7 +487,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-10
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
-      compliance/soc2-2017: soc2-control-a1-2-1
+      compliance/soc2-2017: soc2-control-cc9-1-1
     mql: fortios.system.ha.mode != "standalone"
     docs:
       desc: |
@@ -539,7 +539,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-10
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
-      compliance/soc2-2017: soc2-control-a1-2-1
+      compliance/soc2-2017: soc2-control-cc9-1-1
     mql: fortios.system.ha.mode == "standalone" || fortios.system.ha.sessionPickup == "enable"
     docs:
       desc: |
@@ -629,7 +629,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
-      compliance/nist-csf-2: nist-csf-2-pr-pt-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
       compliance/soc2-2017: soc2-control-cc7-2-1
@@ -682,7 +682,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
-      compliance/nist-csf-2: nist-csf-2-pr-pt-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
       compliance/soc2-2017: soc2-control-cc7-2-1
@@ -1130,7 +1130,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-d
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
-      compliance/nist-csf-2: nist-csf-2-pr-ip-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/soc2-2017: soc2-control-cc6-1-3
@@ -1588,7 +1588,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-10
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
-      compliance/soc2-2017: soc2-control-a1-2-1
+      compliance/soc2-2017: soc2-control-cc9-1-1
     mql: fortios.router.bgp.neighbors.length == 0 || fortios.router.bgp.gracefulRestart == "enable"
     docs:
       desc: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -21386,8 +21386,13 @@ queries:
     title: Ensure Model Armor templates enable prompt injection filtering
     impact: 90
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-26
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
     variants:
       - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-gcp
         tags:
@@ -21436,8 +21441,13 @@ queries:
     title: Ensure Model Armor templates enable malicious URI filtering
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-23
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/soc2-2017: soc2-control-cc6-8-4
     variants:
       - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-gcp
         tags:
@@ -21484,8 +21494,13 @@ queries:
     title: Ensure Model Armor templates have RAI filters configured
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-26
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-filters-gcp
         tags:
@@ -21534,8 +21549,13 @@ queries:
     title: Ensure Model Armor templates have Sensitive Data Protection
     impact: 80
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: soc2-control-cc6-7-1
     variants:
       - uid: mondoo-gcp-security-model-armor-sdp-enabled-gcp
         tags:
@@ -21583,8 +21603,13 @@ queries:
     title: Ensure Model Armor templates enforce blocking mode
     impact: 85
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-26
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
     variants:
       - uid: mondoo-gcp-security-model-armor-blocking-mode-gcp
         tags:
@@ -21622,8 +21647,13 @@ queries:
     title: Ensure Model Armor templates log sanitize operations
     impact: 50
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-gcp-security-model-armor-sanitize-logging-gcp
         tags:
@@ -21670,8 +21700,13 @@ queries:
     title: Ensure Model Armor RAI filters use adequate confidence
     impact: 60
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-26
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-confidence-gcp
         tags:
@@ -21723,8 +21758,13 @@ queries:
     title: Ensure SCC notification configs are configured
     impact: 70
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-5
+      compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-gcp-security-scc-notification-configs-gcp
         tags:
@@ -21772,8 +21812,13 @@ queries:
     title: Ensure SCC BigQuery exports are configured
     impact: 60
     tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
     variants:
       - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
         tags:


### PR DESCRIPTION
## Summary

- **Backfill:** 24 checks across the AWS, Azure, and GCP security policies were missing one or more of the standard framework tags (ISO 27001:2022, NIS 2, NIST CSF 1, NIST SP 800-171, SOC 2). This PR backfills those tags so every check references all seven standard frameworks.
- **Invalid-ID cleanup:** Additionally, 18 existing tag values referenced framework UIDs that do not exist in the corresponding framework YAML. Those are all remapped to valid, best-fit controls in this PR (see "Invalid-UID remapping" section below).
- Each mapping was picked against the framework control text, not by copying a neighboring check (per [CLAUDE.md](./CLAUDE.md) guidance). Where no control is a strict fit — AI/LLM-specific Model Armor checks, ACR image retention, and backup-job alerts — the tag is set to `false` rather than forced into a loosely-related control.
- OCI was already at 100% coverage and is unchanged.

### Checks touched (backfill)

**AWS (10):** ec2-serial-console-disabled, ec2-ami-block-public-access, ec2-launch-template-imdsv2, s3-ownership-controls-enforced, cloudtrail-insights-enabled, securityhub-standards-enabled, sns-no-public-access, drs-private-replication, drs-no-public-recovery-ip, iam-unused-credentials-disabled

**Azure (5):** datafactory-managed-identity, synapse-managed-vnet, acr-retention-policy-enabled, recovery-vault-job-failure-alerts, recovery-vault-critical-op-alerts

**GCP (9):** 7 Model Armor checks (pi-jailbreak-filter, malicious-uri-filter, rai-filters, sdp-enabled, blocking-mode, sanitize-logging, rai-confidence) and 2 Security Command Center checks (notification-configs, bigquery-exports)

After this PR, all four cloud policies have 100% coverage on the seven standard frameworks.

### Invalid-UID remapping

An audit of every `compliance/*` tag across `content/*.mql.yaml` against the authoritative framework YAMLs in `cnspec-enterprise-policies/frameworks/` found 18 tag values that referenced UIDs that do not exist. Each was remapped by reading the check's MQL intent, then picking the single strictest-fitting control from the actual framework text — never by copying a sibling check.

#### HIPAA (4 AWS checks): `hipaa-security-ss164-312-e-1-transmission-security` → `hipaa-security-ss164-312-e-1-transmission`

The real control in `hipaa.mql.yaml` has no trailing `-security`; the existing UID was a typo. Control text: "§164.312(e)(1) - Transmission Security — Implement technical security measures to guard against unauthorized access to electronic protected health information that is being transmitted over an electronic communications network." This is the correct fit for all four checks (`transfer-no-ftp`, `transfer-vpc-endpoint`, `transfer-security-policy`, `appmesh-egress-filter`), which all enforce encryption/network isolation of data in transit.

#### NIST CSF 2 (5 AWS checks): `nist-csf-2-pr-ac-03` does not exist

NIST CSF 2 uses the `PR.AA` (Identity Management, Authentication, and Access Control) and `PR.IR` (Technology Infrastructure Resilience) subcategories — the CSF 1 `PR.AC` family was renamed in CSF 2. Each check was remapped individually:

- **`ec2-serial-console-disabled`** → `nist-csf-2-pr-aa-05` ("Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"). The check restricts access to a management-plane channel (serial console); that's access-permission management.
- **`ec2-ami-block-public-access`** → `nist-csf-2-pr-aa-05`. The check prevents AMIs from being shared publicly — an access-permission decision for the image resource.
- **`ec2-launch-template-imdsv2`** → `nist-csf-2-pr-aa-03` ("Users, services, and hardware are authenticated"). Unlike the others, this check is specifically about **authentication strength**: IMDSv2 replaces anonymous IMDSv1 GETs with session-token-authenticated requests. PR.AA-03 is the strict fit; PR.AA-05 would have been a looser "access enforcement" fit.
- **`s3-ownership-controls-enforced`** → `nist-csf-2-pr-aa-05`. Enforcing BucketOwnerEnforced consolidates object access under IAM and bucket policies — an access-permission policy decision.
- **`sns-no-public-access`** → `nist-csf-2-pr-aa-05`. The check rejects wildcard principals on SNS topic policies — an access-permission control.

#### NIST CSF 2 (1 FortiOS check): `nist-csf-2-pr-ip-01` does not exist

CSF 2 has no `PR.IP` family; CSF 1 `PR.IP-1` (baseline configuration) maps to CSF 2 `PR.PS-01` ("Configuration management practices are established and applied").

- **`no-disabled-policies`** → `nist-csf-2-pr-ps-01`. The check enforces that no firewall rule is left in a disabled state (configuration hygiene). This aligns with the check's existing NIST 800-53 CM-6 and NIST 800-171 3.4.2 tags, which are also configuration-management controls.

#### NIST CSF 2 (5 FortiOS checks): `nist-csf-2-pr-pt-01` does not exist

CSF 2 has no `PR.PT` family; the CSF 1 `PR.PT` controls were redistributed. Each check was remapped by intent:

- **`admin-https-non-default-port`**, **`admin-ssh-non-default-port`**, **`admin-scp-disabled`** → `nist-csf-2-pr-ps-01`. These are CSF 1 PR.PT-3 (least functionality) checks — hardening the management plane by changing defaults or disabling unused protocols. CSF 2 folds "least functionality" into PR.PS-01 (configuration management). This also aligns with each check's existing NIST 800-53 CM-7 tag.
- **`ntp-sync-enabled`**, **`ntp-servers-configured`** → `nist-csf-2-pr-ps-04` ("Log records are generated and made available for continuous monitoring"). These are CSF 1 PR.PT-1 (audit records) checks whose role is to keep system time in sync so audit-log timestamps are trustworthy. This matches each check's existing NIST 800-53 AU-8 (Time Stamps) tag, which is in the Audit family.

#### SOC 2 (3 FortiOS checks): `soc2-control-a1-2-1` does not exist

The SOC 2 framework in `soc2-2017.mql.yaml` contains only the Common Criteria (CC) series — there are no Availability (A), Confidentiality (C), or Processing Integrity (PI) controls. The convention already used elsewhere in this repo for availability/resilience checks (12 existing pairings with `nist-csf-2-pr-ds-11`) is `soc2-control-cc9-1-1` ("Considers Mitigation of Risks of Business Disruption — Risk mitigation activities include the development of planned policies, procedures, communications, and **alternative processing solutions** to respond to, mitigate, and recover from security events that disrupt business operations").

- **`ha-enabled`**, **`ha-session-pickup`**, **`bgp-graceful-restart`** → `soc2-control-cc9-1-1`. All three implement "alternative processing solutions" (HA cluster, session continuity during failover, graceful BGP restart) — the exact language of CC9.1.1.

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml`
- [x] `cnspec policy lint content/mondoo-azure-security.mql.yaml`
- [x] `cnspec policy lint content/mondoo-gcp-security.mql.yaml`
- [x] `cnspec policy lint content/mondoo-fortios-security.mql.yaml`
- [x] Verify 100% tag coverage across the seven standard frameworks for each cloud policy
- [x] Verify zero references to UIDs that are not defined in `cnspec-enterprise-policies/frameworks/*.mql.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)