### PR TITLE
Reduce maxConnections from 50 to 40

### DIFF
--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	maxConnections = 50 // max assets connected (with runtimes open) at a time
+	maxConnections = 40 // max assets connected (with runtimes open) at a time
 	syncBatchSize  = 5  // how many assets to batch for upstream sync calls
 )
 


### PR DESCRIPTION
## Summary
- Lower the `maxConnections` cap in `policy/scan/scan_pipeline.go` from 50 to 40.
- Reduces the maximum number of concurrently open provider runtimes during a scan, which fan out into upstream `SynchronizeAssets` calls in batches.

## Motivation
Intermittent errors have been observed at the current cap of 50. Dropping to 40 gives a bit of headroom under load while keeping scans well-parallelized.

## Test plan
- [ ] Run a scan that previously hit the errors and confirm it no longer reproduces
- [ ] Confirm no regression in scan throughput on a clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)