### PR TITLE
✨ Add Hetzner Cloud security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -145,7 +145,6 @@ deactivateduser
 deanonymize
 deauth
 debconf
-decomp
 devtmpfs
 DGAs
 dhe
@@ -238,10 +237,12 @@ grundschutz
 GTK
 gunicorn
 hbdev
+hcloud
 HDFS
 healthinsights
 healthreporting
 Helpdesk
+hetzner
 Hostbased
 hostpath
 hotlink
@@ -258,7 +259,6 @@ igmp
 iis
 ikev
 Imds
-inplace
 insertafter
 intransit
 iommu
@@ -358,7 +358,6 @@ nodepool
 nonarm
 nopasswd
 noreply
-norestart
 notconnect
 nrg
 nsg
@@ -389,7 +388,6 @@ openresty
 opensearch
 openssh
 openssl
-opensuse
 oper
 opscode
 ospf
@@ -419,7 +417,6 @@ PMTU
 poap
 posix
 postgre
-prebuilt
 pricings
 privs
 PROJECTID
@@ -434,17 +431,16 @@ PVEVM
 querypack
 qwen
 rai
-RClient
 rdp
 rebrands
 Redir
 rediraccept
+reissuance
 remoteadministrator
 removexattr
 renameat
 reprovisioned
 restrictremotesam
-revertto
 rexec
 rfc
 Rfi
@@ -499,7 +495,6 @@ showcerts
 siem
 Signin
 skype
-slp
 sntrup
 socketfilterfw
 softwareupdate

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -1,0 +1,538 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-hetzner-security
+    name: Mondoo Hetzner Cloud Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: hetzner,cloud
+    require:
+      - provider: hetzner
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Secure Hetzner Cloud servers, firewalls, load balancers, certificates, and IP addresses
+    docs:
+      desc: |
+        The Mondoo Hetzner Cloud Security policy identifies critical misconfigurations that could leave your Hetzner Cloud project vulnerable to attackers. The policy focuses on security-relevant controls only — hardening against unauthorized network access, data exposure in transit, weak cryptography, and exposure to known CVEs through end-of-life software.
+
+        This policy provides security checks across the following Hetzner Cloud resources:
+
+        - Cloud Servers
+        - Firewalls
+        - Load Balancers
+        - TLS Certificates
+        - Floating IPs and Primary IPs
+
+        ## Scan a Hetzner Cloud project
+
+        ```bash
+        cnspec scan hetzner --token <your-api-token>
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Servers
+        filters: asset.platform == "hetzner-project"
+        checks:
+          - uid: mondoo-hetzner-security-server-in-private-network
+          - uid: mondoo-hetzner-security-server-has-firewall
+          - uid: mondoo-hetzner-security-server-image-not-deprecated
+      - title: Firewalls
+        filters: asset.platform == "hetzner-project"
+        checks:
+          - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh
+          - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp
+          - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports
+          - uid: mondoo-hetzner-security-firewall-no-all-ports-open
+      - title: Load Balancers
+        filters: asset.platform == "hetzner-project"
+        checks:
+          - uid: mondoo-hetzner-security-lb-http-redirected-to-https
+          - uid: mondoo-hetzner-security-lb-https-service-has-certificate
+      - title: TLS Certificates
+        filters: asset.platform == "hetzner-project"
+        checks:
+          - uid: mondoo-hetzner-security-cert-not-expired
+      - title: IP Addresses
+        filters: asset.platform == "hetzner-project"
+        checks:
+          - uid: mondoo-hetzner-security-floating-ip-not-blocked
+          - uid: mondoo-hetzner-security-primary-ip-not-blocked
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-hetzner-security-server-in-private-network
+    title: Ensure servers are attached to a private network
+    impact: 70
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.servers.all(privateNet != empty)
+    docs:
+      desc: |
+        This check ensures that every Hetzner Cloud server is attached to at least one private network.
+
+        **Why this matters**
+
+        A Hetzner server with no private network attachment can only reach other resources over the public internet, even resources in the same project. Without network-level segmentation, an attacker who compromises one server has broader reach across the project, and lateral movement is harder to contain. Private networks also reduce unnecessary internet exposure by allowing private-only traffic between resources in the same network.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Networks** and create a network if one does not already exist.
+        2. Open the affected server and go to **Networking**.
+        3. Click **Attach to Network** and select the target network.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud server attach-to-network <server> --network <network>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/networks/overview/
+        title: Hetzner Cloud Networks overview
+
+  - uid: mondoo-hetzner-security-server-has-firewall
+    title: Ensure servers have at least one firewall applied
+    impact: 90
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.servers.all(firewalls != empty)
+    docs:
+      desc: |
+        This check ensures that every Hetzner Cloud server has at least one Hetzner Cloud Firewall applied.
+
+        **Why this matters**
+
+        Hetzner Cloud servers do not have a default-deny firewall posture — a server with no Cloud Firewall attached exposes every listening port on its public interfaces to the entire internet. Any service unintentionally bound to `0.0.0.0` (a debug port, an internal admin tool, a misconfigured database) is reachable by every host on the network. Applying a Cloud Firewall ensures only the explicitly allowed ports are reachable, even if the OS-level firewall is misconfigured or disabled.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Firewalls** and create a firewall with rules appropriate for the server's role.
+        2. Open the firewall and go to **Apply to**.
+        3. Add the affected server (or a label selector that matches it).
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud firewall apply-to-resource <firewall> --type server --server <server>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-server-image-not-deprecated
+    title: Ensure servers do not run a deprecated OS image
+    impact: 70
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/soc2-2017: soc2-control-cc7-1-5
+    mql: |
+      hetzner.servers.where(image != null).all(image.deprecated == null || image.deprecated > time.now)
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud server was created from a system image that Hetzner has marked deprecated and whose deprecation date has passed.
+
+        **Why this matters**
+
+        Hetzner marks system images deprecated when the upstream operating system reaches end of life or when Hetzner is preparing to remove the image. A server still running a deprecated image is no longer guaranteed to receive vendor security patches; known-exploited CVEs accumulate without remediation. Rebuilding the server from a current image keeps the workload on a supported and patched base.
+      remediation: |
+        Hetzner does not support changing the base image of a running server in place. To remediate, build a new server from a supported image and migrate the workload.
+
+        **From the Hetzner Cloud Console**
+
+        1. Note the affected server's configuration (type, location, network, firewall, SSH keys).
+        2. Provision a replacement server using a current OS image.
+        3. Migrate data and configuration to the new server.
+        4. Update DNS, monitoring, and dependent services to point at the new server.
+        5. Delete the original server.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud server create \
+          --name <new-name> \
+          --type <server-type> \
+          --image <current-image> \
+          --location <location> \
+          --network <network> \
+          --firewall <firewall> \
+          --ssh-key <ssh-key>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/servers/faq/#what-does-it-mean-when-an-image-is-deprecated
+        title: Hetzner image deprecation policy
+
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh
+    title: Ensure no firewall allows unrestricted inbound SSH (port 22)
+    impact: 100
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.firewalls.all(
+        rules.none(
+          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("0.0.0.0/0")
+        )
+      )
+      hetzner.firewalls.all(
+        rules.none(
+          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("::/0")
+        )
+      )
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud Firewall has an inbound rule that allows TCP traffic on port 22 from the public internet (`0.0.0.0/0` or `::/0`).
+
+        **Why this matters**
+
+        SSH exposed to the entire internet is a primary target for credential stuffing, brute-force login attempts, and exploitation of any future SSH server CVE. Even with key-based authentication, open SSH exposes the SSH daemon itself as an attack surface. SSH access should be restricted to a known trusted CIDR range, a bastion host, or a VPN.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Firewalls** and open the affected firewall.
+        2. Edit the offending inbound rule for SSH and change the source from `Any IPv4`/`Any IPv6` to a specific trusted CIDR.
+        3. Save the firewall.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud firewall delete-rule <firewall> \
+          --direction in --protocol tcp --port 22 --source-ips 0.0.0.0/0
+        hcloud firewall add-rule <firewall> \
+          --direction in --protocol tcp --port 22 --source-ips <your-trusted-cidr>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp
+    title: Ensure no firewall allows unrestricted inbound RDP (port 3389)
+    impact: 100
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.firewalls.all(
+        rules.none(
+          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("0.0.0.0/0")
+        )
+      )
+      hetzner.firewalls.all(
+        rules.none(
+          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("::/0")
+        )
+      )
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud Firewall has an inbound rule that allows TCP traffic on port 3389 from the public internet (`0.0.0.0/0` or `::/0`).
+
+        **Why this matters**
+
+        RDP is a long-standing target of ransomware deployment and has been involved in repeated high-impact breaches. The RDP protocol itself has had multiple critical pre-authentication RCE CVEs (for example BlueKeep). Exposing RDP to the internet should be treated as an immediate security incident.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Firewalls** and open the affected firewall.
+        2. Remove the RDP rule entirely, or restrict the source to a specific trusted CIDR.
+        3. Save the firewall.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud firewall delete-rule <firewall> \
+          --direction in --protocol tcp --port 3389 --source-ips 0.0.0.0/0
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports
+    title: Ensure no firewall allows unrestricted inbound on common database ports
+    impact: 90
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("::/0")))
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud Firewall allows inbound traffic from the public internet to common database ports: MySQL (3306), PostgreSQL (5432), MongoDB (27017), Redis (6379), Kafka (9092), Elasticsearch/OpenSearch (9200), and SQL Server (1433).
+
+        **Why this matters**
+
+        Databases exposed directly to the internet are routinely scanned and compromised — credential brute force, unauthenticated misconfiguration exploitation, and ransom-style data extortion are all well-documented outcomes. Database traffic should only traverse private networks; applications needing external access should reach the database through a bastion or through the application tier, not directly.
+      remediation: |
+        Remove or restrict the offending inbound rule so the source is a trusted CIDR.
+
+        ```bash
+        hcloud firewall delete-rule <firewall> \
+          --direction in --protocol tcp --port 5432 --source-ips 0.0.0.0/0
+        ```
+
+        Repeat for each offending port. Prefer placing databases on a Hetzner private network and reaching them only from within that network.
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-firewall-no-all-ports-open
+    title: Ensure no firewall allows unrestricted inbound on all ports
+    impact: 100
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    mql: |
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("::/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("0.0.0.0/0")))
+      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("::/0")))
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud Firewall has an inbound rule that allows the full port range (`any`, `1-65535`, or `0-65535`) from the public internet.
+
+        **Why this matters**
+
+        An "allow all ports from anywhere" rule is functionally equivalent to having no firewall. It exposes every service running on the server — intended or unintended, known or forgotten — to every host on the internet. This is the highest-severity network misconfiguration.
+      remediation: |
+        Remove the wide-open rule and replace it with narrow rules that expose only the specific ports required by the workload, scoped to trusted source CIDRs.
+
+        ```bash
+        hcloud firewall delete-rule <firewall> \
+          --direction in --protocol tcp --port any --source-ips 0.0.0.0/0
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-lb-http-redirected-to-https
+    title: Ensure load balancers redirect HTTP traffic to HTTPS
+    impact: 80
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/soc2-2017: soc2-control-cc6-7-2
+    mql: |
+      hetzner.loadBalancers.all(
+        services.where(protocol == "http").all(http["redirect_http"] == true)
+      )
+    docs:
+      desc: |
+        This check ensures that any load balancer accepting HTTP traffic also has the HTTP-to-HTTPS redirect enabled, so HTTP requests are 301-redirected to HTTPS.
+
+        **Why this matters**
+
+        A load balancer that accepts plaintext HTTP and serves the response in plaintext exposes every request to interception and modification — credentials, session cookies, API keys, and response content are all readable by any host on the network path. Redirecting HTTP to HTTPS forces subsequent requests over TLS, closing the window where a downgrade or sidejacking attack can succeed.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Load Balancers** and open the affected load balancer.
+        2. Go to **Services** and edit the HTTP service.
+        3. Enable **Redirect HTTP to HTTPS**. Confirm that an HTTPS service and TLS certificate are configured.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud load-balancer update-service <lb> \
+          --listen-port 80 --http-redirect-http
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+        title: Hetzner Cloud Load Balancers overview
+
+  - uid: mondoo-hetzner-security-lb-https-service-has-certificate
+    title: Ensure HTTPS load balancer services have a TLS certificate attached
+    impact: 90
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/soc2-2017: soc2-control-cc6-7-2
+    mql: |
+      hetzner.loadBalancers.all(
+        services.where(protocol == "https").all(certificates != empty)
+      )
+    docs:
+      desc: |
+        This check ensures that every load balancer service configured for HTTPS has at least one TLS certificate attached.
+
+        **Why this matters**
+
+        An HTTPS listener with no certificate cannot terminate TLS for the listening domain — clients either hit certificate warnings, fall back to HTTP, or fail to connect entirely. Either outcome exposes user traffic to interception, content injection, and credential theft, and a "fail open to HTTP" path is a classic downgrade-attack surface.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Load Balancers** and open the affected load balancer.
+        2. Go to **Services** and edit the HTTPS service.
+        3. Under **Certificates**, attach an existing certificate or create a Hetzner-managed certificate for the domain.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud load-balancer add-service <lb> \
+          --protocol https --listen-port 443 \
+          --destination-port 80 \
+          --http-certificates <certificate>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+        title: Hetzner Cloud Load Balancers overview
+
+  - uid: mondoo-hetzner-security-cert-not-expired
+    title: Ensure TLS certificates are not expired
+    impact: 100
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/soc2-2017: soc2-control-cc6-7-2
+    mql: |
+      hetzner.certificates.all(notValidAfter > time.now)
+    docs:
+      desc: |
+        This check ensures that no TLS certificate managed in Hetzner Cloud has passed its `notValidAfter` expiration date.
+
+        **Why this matters**
+
+        An expired TLS certificate breaks the trust chain clients rely on. Users see certificate warnings and are trained to click through — which normalizes certificate bypass and gives real man-in-the-middle attempts cover. API clients often fail closed and take down dependent services, so an expired certificate is both a security failure and an availability incident.
+      remediation: |
+        **From the Hetzner Cloud Console**
+
+        1. Navigate to **Certificates**.
+        2. Identify the expired certificate. For Hetzner-managed certificates, deletion and re-creation will trigger reissuance through Let's Encrypt; for uploaded certificates, upload a renewed version.
+        3. Update any load balancers referencing the old certificate to use the renewed certificate.
+
+        **From `hcloud`**
+
+        ```bash
+        hcloud certificate create \
+          --type managed \
+          --name <new-name> \
+          --domain <domain>
+        ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/certificates/overview/
+        title: Hetzner Cloud Certificates overview
+
+  - uid: mondoo-hetzner-security-floating-ip-not-blocked
+    title: Ensure floating IPs are not blocked by Hetzner abuse
+    impact: 70
+    tags:
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: false
+    mql: |
+      hetzner.floatingIps.all(blocked == false)
+    docs:
+      desc: |
+        This check ensures that no floating IP in the project is in a `blocked` state.
+
+        **Why this matters**
+
+        Hetzner sets the `blocked` flag on a floating IP when its abuse team has determined the IP is involved in malicious activity (outbound attack traffic, spam, scanning, hosting malware). A blocked IP that is still attached to a server is a strong indicator that the underlying workload is compromised or being misused, and warrants investigation rather than re-enabling the IP.
+      remediation: |
+        Investigate before unblocking.
+
+        1. Identify the server the floating IP is attached to and review recent logs, outbound traffic, and authentication events for signs of compromise.
+        2. If the workload is compromised, rebuild the server from a known-good image and rotate any credentials it held.
+        3. Contact Hetzner support to discuss the abuse case and request unblocking once the underlying issue is remediated.
+    refs:
+      - url: https://docs.hetzner.com/cloud/floating-ips/overview/
+        title: Hetzner Cloud Floating IPs overview
+
+  - uid: mondoo-hetzner-security-primary-ip-not-blocked
+    title: Ensure primary IPs are not blocked by Hetzner abuse
+    impact: 70
+    tags:
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/soc2-2017: false
+    mql: |
+      hetzner.primaryIps.all(blocked == false)
+    docs:
+      desc: |
+        This check ensures that no primary IP in the project is in a `blocked` state.
+
+        **Why this matters**
+
+        Hetzner sets the `blocked` flag on a primary IP when its abuse team has determined the IP is involved in malicious activity originating from the assigned server. A blocked primary IP is a strong indicator that the server is compromised or misconfigured to emit abusive traffic, and warrants investigation rather than re-enabling the IP.
+      remediation: |
+        Investigate before unblocking.
+
+        1. Identify the server the primary IP is assigned to and review recent logs, outbound traffic, and authentication events for signs of compromise.
+        2. If the workload is compromised, rebuild the server from a known-good image and rotate any credentials it held.
+        3. Contact Hetzner support to discuss the abuse case and request unblocking once the underlying issue is remediated.
+    refs:
+      - url: https://docs.hetzner.com/cloud/primary-ips/overview/
+        title: Hetzner Cloud Primary IPs overview


### PR DESCRIPTION
## Summary

- Adds `content/mondoo-hetzner-security.mql.yaml`, a baseline security policy for Hetzner Cloud projects.
- Twelve checks across Servers, Firewalls, Load Balancers, TLS Certificates, and IP Addresses.
- Requires the new `hetzner` provider from [mondoohq/mql#7369](https://github.com/mondoohq/mql/pull/7369); will not run until that ships in a cnquery release.

## Checks

**Servers**
- Servers attached to a private network
- Servers have at least one Cloud Firewall applied
- Servers do not run a deprecated OS image

**Firewalls** (no inbound rule from `0.0.0.0/0` or `::/0`)
- Port 22 (SSH)
- Port 3389 (RDP)
- Common database ports (3306, 5432, 27017, 6379, 9092, 9200, 1433)
- All-ports rules (`any`, `1-65535`, `0-65535`)

**Load Balancers**
- HTTP services redirect to HTTPS
- HTTPS services have a TLS certificate attached

**TLS Certificates**
- Certificates are not expired

**IP Addresses**
- Floating IPs are not Hetzner-abuse-blocked
- Primary IPs are not Hetzner-abuse-blocked

## Compliance tags

Mappings for the network/crypto/vulnerability checks were verified against the framework YAMLs in `cnspec-enterprise-policies/frameworks/` (A.8.20 Networks security, A.8.22 Segregation of networks, A.8.24 Use of cryptography, A.8.8 Vulnerability mgmt; SC-7/8/12, SI-2). The two abuse-blocked-IP checks are tagged `false` across all frameworks since they're a detection signal, not a misconfiguration.

## Test plan

- [x] `cnspec policy lint ./content/mondoo-hetzner-security.mql.yaml`
- [ ] Live scan against a Hetzner Cloud project once the `hetzner` provider lands in a cnquery release. Specifically verify:
  - The `http["redirect_http"]` dict key in the LB redirect check matches what the provider serializes (alternative could be `redirectHttp`)
  - `hcloud` CLI flags shown in remediation steps (`--http-redirect-http`, `--http-certificates`, etc.) are valid against the current `hcloud` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)