### PR TITLE
feat: add GetResource and StreamResources to scan data store

### DIFF
--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-proxmox-security

--- a/policy/errors.go
+++ b/policy/errors.go
@@ -6,3 +6,4 @@ package policy
 import "github.com/cockroachdb/errors"
 
 var ErrRiskNotFound = errors.New("risk not found")
+var ErrResourceNotFound = errors.New("resource not found")

--- a/policy/scandb/scan_data_store.go
+++ b/policy/scandb/scan_data_store.go
@@ -36,11 +36,13 @@ type ScanDataStoreReader interface {
 	StreamScores(ctx context.Context, callback func(*policy.Score) error) error
 	StreamData(ctx context.Context, callback func(string, *llx.Result) error) error
 	StreamRisks(ctx context.Context, callback func(*policy.ScoredRiskFactor) error) error
+	StreamResources(ctx context.Context, callback func(*llx.ResourceRecording) error) error
 
 	// Reader methods for specific items
 	GetScore(ctx context.Context, qrId string) (*policy.Score, error)
 	GetData(ctx context.Context, codeId string) (*llx.Result, error)
 	GetRisk(ctx context.Context, mrn string) (*policy.ScoredRiskFactor, error)
+	GetResource(ctx context.Context, resource string, id string) (*llx.ResourceRecording, error)
 	Close() error
 }
 
@@ -403,6 +405,48 @@ func (s *SqliteScanDataStore) StreamRisks(ctx context.Context, callback func(*po
 
 		if err := callback(risk); err != nil {
 			return fmt.Errorf("callback error for risk %s: %w", risk.Mrn, err)
+		}
+	}
+
+	return nil
+}
+
+// GetResource retrieves a specific resource by name and ID
+func (s *SqliteScanDataStore) GetResource(ctx context.Context, resource string, id string) (*llx.ResourceRecording, error) {
+	data, err := s.queries.GetResource(ctx, sqlc.GetResourceParams{
+		Name: resource,
+		ID:   id,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, policy.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	result := &llx.ResourceRecording{}
+	if err := proto.Unmarshal(data, result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal resource %s/%s: %w", resource, id, err)
+	}
+
+	return result, nil
+}
+
+// StreamResources reads all resources with a callback function for memory-efficient processing
+func (s *SqliteScanDataStore) StreamResources(ctx context.Context, callback func(*llx.ResourceRecording) error) error {
+	resourceRows, err := s.queries.StreamResources(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to query resources: %w", err)
+	}
+
+	for _, row := range resourceRows {
+		result := &llx.ResourceRecording{}
+		if err := proto.Unmarshal(row.Data, result); err != nil {
+			return fmt.Errorf("failed to unmarshal resource %s/%s: %w", row.Name, row.ID, err)
+		}
+
+		if err := callback(result); err != nil {
+			return fmt.Errorf("callback error for resource %s/%s: %w", row.Name, row.ID, err)
 		}
 	}
 

--- a/policy/scandb/scan_data_store_test.go
+++ b/policy/scandb/scan_data_store_test.go
@@ -839,4 +839,84 @@ func TestSqliteScanDataStore_InsertResource(t *testing.T) {
 	// Write initial resource
 	err = store.WriteResource(ctx, initialResource)
 	require.NoError(t, err)
+
+	// Verify we can read it back
+	retrieved, err := store.GetResource(ctx, "upsert-resource-1", "res-1")
+	require.NoError(t, err)
+	assert.Equal(t, "upsert-resource-1", retrieved.Resource)
+	assert.Equal(t, "res-1", retrieved.Id)
+	require.NotNil(t, retrieved.Fields)
+	assert.Equal(t, llx.StringPrimitive("initial value"), retrieved.Fields["field1"].Data)
+
+	// Test not found
+	_, err = store.GetResource(ctx, "nonexistent", "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource not found")
+}
+
+func TestSqliteScanDataStore_StreamResources(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test_stream_resources.db")
+
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	assetMrn := "//assets.api.mondoo.com/spaces/test-space/assets/stream-resource-test"
+	store, err := NewSqliteScanDataStore(dbPath, assetMrn)
+	require.NoError(t, err)
+	defer store.Close()
+
+	ctx := context.Background()
+
+	resources := []*llx.ResourceRecording{
+		{
+			Resource: "alpha-resource",
+			Id:       "id-1",
+			Fields: map[string]*llx.Result{
+				"name": {CodeId: "name", Data: llx.StringPrimitive("alpha")},
+			},
+		},
+		{
+			Resource: "alpha-resource",
+			Id:       "id-2",
+			Fields: map[string]*llx.Result{
+				"name": {CodeId: "name", Data: llx.StringPrimitive("alpha-2")},
+			},
+		},
+		{
+			Resource: "beta-resource",
+			Id:       "id-1",
+			Fields: map[string]*llx.Result{
+				"name": {CodeId: "name", Data: llx.StringPrimitive("beta")},
+			},
+		},
+	}
+
+	for _, r := range resources {
+		err := store.WriteResource(ctx, r)
+		require.NoError(t, err)
+	}
+
+	// Stream all resources
+	var streamed []*llx.ResourceRecording
+	err = store.StreamResources(ctx, func(r *llx.ResourceRecording) error {
+		streamed = append(streamed, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, streamed, 3)
+
+	// Results are ordered by name, id
+	assert.Equal(t, "alpha-resource", streamed[0].Resource)
+	assert.Equal(t, "id-1", streamed[0].Id)
+	assert.Equal(t, "alpha-resource", streamed[1].Resource)
+	assert.Equal(t, "id-2", streamed[1].Id)
+	assert.Equal(t, "beta-resource", streamed[2].Resource)
+	assert.Equal(t, "id-1", streamed[2].Id)
+
+	// Verify individual gets still work
+	got, err := store.GetResource(ctx, "beta-resource", "id-1")
+	require.NoError(t, err)
+	assert.Equal(t, llx.StringPrimitive("beta"), got.Fields["name"].Data)
 }

--- a/policy/scandb/scan_data_store_wrapper.go
+++ b/policy/scandb/scan_data_store_wrapper.go
@@ -102,6 +102,24 @@ func (w *ScanDataStoreWrapper) GetRisk(ctx context.Context, assetMrn string, ris
 	return w.store.GetRisk(ctx, riskID)
 }
 
+func (w *ScanDataStoreWrapper) GetResource(ctx context.Context, assetMrn string, resource string, id string) (*llx.ResourceRecording, error) {
+	if err := w.validate(assetMrn); err != nil {
+		return nil, err
+	}
+
+	return w.store.GetResource(ctx, resource, id)
+}
+
+func (w *ScanDataStoreWrapper) StreamResources(ctx context.Context, assetMrn string, f func(resource *llx.ResourceRecording) error) error {
+	if err := w.validate(assetMrn); err != nil {
+		return err
+	}
+
+	return w.store.StreamResources(ctx, func(resource *llx.ResourceRecording) error {
+		return f(resource)
+	})
+}
+
 func (w *ScanDataStoreWrapper) StreamRisks(ctx context.Context, assetMrn string, f func(risk *policy.ScoredRiskFactor) error) error {
 	if err := w.validate(assetMrn); err != nil {
 		return err

--- a/policy/scandb/scan_data_store_wrapper.go
+++ b/policy/scandb/scan_data_store_wrapper.go
@@ -115,9 +115,7 @@ func (w *ScanDataStoreWrapper) StreamResources(ctx context.Context, assetMrn str
 		return err
 	}
 
-	return w.store.StreamResources(ctx, func(resource *llx.ResourceRecording) error {
-		return f(resource)
-	})
+	return w.store.StreamResources(ctx, f)
 }
 
 func (w *ScanDataStoreWrapper) StreamRisks(ctx context.Context, assetMrn string, f func(risk *policy.ScoredRiskFactor) error) error {

--- a/policy/scandb/scan_data_store_wrapper_test.go
+++ b/policy/scandb/scan_data_store_wrapper_test.go
@@ -116,6 +116,68 @@ func TestScanDataStoreWrapper(t *testing.T) {
 		assert.Contains(t, err.Error(), "data not found")
 	})
 
+	// Test resource methods
+	testResource := &llx.ResourceRecording{
+		Resource: "wrapper-resource",
+		Id:       "res-1",
+		Fields: map[string]*llx.Result{
+			"field1": {CodeId: "field1", Data: llx.StringPrimitive("wrapper resource data")},
+		},
+	}
+
+	t.Run("WriteResource with correct asset MRN", func(t *testing.T) {
+		err := wrapper.WriteResource(ctx, assetMrn, testResource)
+		require.NoError(t, err)
+	})
+
+	t.Run("WriteResource with incorrect asset MRN", func(t *testing.T) {
+		wrongAssetMrn := "//assets.api.mondoo.com/spaces/wrong/assets/wrong"
+		err := wrapper.WriteResource(ctx, wrongAssetMrn, testResource)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "asset MRN mismatch")
+	})
+
+	t.Run("GetResource with correct asset MRN", func(t *testing.T) {
+		resource, err := wrapper.GetResource(ctx, assetMrn, "wrapper-resource", "res-1")
+		require.NoError(t, err)
+		assert.Equal(t, "wrapper-resource", resource.Resource)
+		assert.Equal(t, "res-1", resource.Id)
+		assert.Equal(t, llx.StringPrimitive("wrapper resource data"), resource.Fields["field1"].Data)
+	})
+
+	t.Run("GetResource with incorrect asset MRN", func(t *testing.T) {
+		wrongAssetMrn := "//assets.api.mondoo.com/spaces/wrong/assets/wrong"
+		_, err := wrapper.GetResource(ctx, wrongAssetMrn, "wrapper-resource", "res-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "asset MRN mismatch")
+	})
+
+	t.Run("GetResource for non-existent resource", func(t *testing.T) {
+		_, err := wrapper.GetResource(ctx, assetMrn, "nonexistent", "nope")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resource not found")
+	})
+
+	t.Run("StreamResources with correct asset MRN", func(t *testing.T) {
+		var resources []*llx.ResourceRecording
+		err := wrapper.StreamResources(ctx, assetMrn, func(r *llx.ResourceRecording) error {
+			resources = append(resources, r)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assert.Equal(t, "wrapper-resource", resources[0].Resource)
+	})
+
+	t.Run("StreamResources with incorrect asset MRN", func(t *testing.T) {
+		wrongAssetMrn := "//assets.api.mondoo.com/spaces/wrong/assets/wrong"
+		err := wrapper.StreamResources(ctx, wrongAssetMrn, func(r *llx.ResourceRecording) error {
+			return nil
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "asset MRN mismatch")
+	})
+
 	t.Run("Finalize database", func(t *testing.T) {
 		path, err := wrapper.Finalize()
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Add `GetResource` and `StreamResources` reader methods to `ScanDataStoreReader` interface, matching the existing pattern for scores, data, and risk factors
- Implement both methods on `SqliteScanDataStore` using the already-defined sqlc queries
- Add corresponding wrapper methods on `ScanDataStoreWrapper` with asset MRN validation
- Add `ErrResourceNotFound` sentinel error
- Add tests for all new methods including round-trip, not-found, streaming order, and wrapper MRN validation

## Test plan
- [x] `TestSqliteScanDataStore_InsertResource` — verifies write + GetResource round-trip and not-found error
- [x] `TestSqliteScanDataStore_StreamResources` — verifies streaming multiple resources with correct ordering
- [x] `TestScanDataStoreWrapper` — verifies GetResource/StreamResources/WriteResource with correct and incorrect MRN, plus not-found
- [x] Full `go test ./policy/scandb/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)