### PR TITLE
Remove SentinelStaticEngine checks from Windows EDR policy

### DIFF
--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -242,8 +242,6 @@ queries:
     mql: |
       services.where(name == /SentinelAgent/).any(running == true)
       services.where(name == /SentinelAgent/).any(enabled == true)
-      services.where(name == /SentinelStaticEngine/).any(running == true)
-      services.where(name == /SentinelStaticEngine/).any(enabled == true)
   - uid: mondoo-edr-policy-ensure-eset-agent-is-running-macos
     filters: |
       asset.platform == 'macos'


### PR DESCRIPTION
Starting with Windows SentinelOne Agent Version 25.2 the SentinelStaticEngine is integrated into the SentinelAgent service and no longer a standalone service. This PR removes the failing check.