### PR TITLE
🧹 Simplify Dockerfile policy MQL with empty operator

### DIFF
--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -452,7 +452,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/soc2-2017: soc2-control-cc7-1-1
     mql: |
-      docker.file.stages.all(from.tag != "")
+      docker.file.stages.all(from.tag != empty)
     docs:
       desc: |
         This check ensures that all FROM instructions in the Dockerfile specify an explicit image tag. When no tag is provided (e.g., `FROM python` instead of `FROM python:3.12`), Docker implicitly uses the `:latest` tag, which defeats the purpose of version pinning.
@@ -695,8 +695,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
       compliance/soc2-2017: soc2-control-cc6-1-1
     mql: |
-      docker.file.stages.last.labels["org.opencontainers.image.source"] != null
-      docker.file.stages.last.labels["org.opencontainers.image.source"] != ""
+      docker.file.stages.last.labels["org.opencontainers.image.source"] != empty
     docs:
       desc: |
         This check ensures that the final stage of the Dockerfile sets the `org.opencontainers.image.source` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the URL of the source code repository that produced the image, so any running container can be traced back to the repository it was built from.
@@ -750,8 +749,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
       compliance/soc2-2017: soc2-control-cc6-1-1
     mql: |
-      docker.file.stages.last.labels["org.opencontainers.image.authors"] != null
-      docker.file.stages.last.labels["org.opencontainers.image.authors"] != ""
+      docker.file.stages.last.labels["org.opencontainers.image.authors"] != empty
     docs:
       desc: |
         This check ensures that the final stage of the Dockerfile sets the `org.opencontainers.image.authors` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the contact information for the people or team responsible for the image, so any running container can be traced back to a clear owner.


### PR DESCRIPTION
## Summary
- Use `!= empty` for the explicit-tag check on Dockerfile FROM stages
- Collapse separate `!= null` / `!= \"\"` checks for the OCI `image.source` and `image.authors` labels into a single `!= empty` expression

## Test plan
- [ ] `cnspec policy lint content/mondoo-dockerfile-security.mql.yaml`
- [ ] Scan a Dockerfile with missing/blank tags and OCI labels and confirm the checks still fail as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)