### PR TITLE
:star: Add vLLM security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -170,6 +170,7 @@ deanonymize
 deauth
 debconf
 decryptable
+detokenize
 devtmpfs
 DGAs
 dhe
@@ -647,6 +648,7 @@ vhost
 virtio
 Virtualisation
 vlans
+vllm
 vmbr
 vmid
 vnc

--- a/content/README.md
+++ b/content/README.md
@@ -95,6 +95,7 @@ Our comprehensive collection of security policies covers major platforms and ser
 - **Chef Infra Client** - `mondoo-chef-infra-client.mql.yaml` - Chef Infra Client security configuration
 - **Chef Infra Server** - `mondoo-chef-infra-server.mql.yaml` - Chef Infra Server security configuration
 - **MCP** - `mondoo-mcp-security.mql.yaml` - Model Context Protocol server security assessment
+- **vLLM** - `mondoo-vllm-security.mql.yaml` - vLLM inference server HTTP exposure and endpoint hardening
 - **Phoenix PLCnext** - `mondoo-phoenix-plcnext-security.mql.yaml` - Industrial automation security
 - **EDR** - `mondoo-edr-policy.mql.yaml` - Endpoint Detection and Response validation
 

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -1,0 +1,311 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+policies:
+  - summary: Secure vLLM inference server HTTP exposure and operational endpoints
+    uid: mondoo-vllm-security
+    name: Mondoo vLLM Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: vllm,ai
+    require:
+      - provider: vllm
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    docs:
+      desc: |
+        The Mondoo vLLM Security policy assesses the externally observable HTTP posture of vLLM inference servers. It focuses on the surfaces that a remote scanner can verify truthfully: API authentication behavior, exposed documentation and metadata endpoints, CORS behavior, operational control routes, development and profiler routes, and unauthenticated metrics or load data.
+
+        This policy intentionally avoids host-local checks such as command-line flags, environment variables, LoRA resolver configuration, model revision pinning, media allowlists, and internode transport controls. Those settings require local process or deployment inspection and are outside the remote vLLM provider scope.
+
+        ## Scan a vLLM server
+
+        ```bash
+        cnspec scan vllm https://vllm.example.com -f mondoo-vllm-security.mql.yaml
+        ```
+
+        To compare anonymous and authenticated route behavior, provide a bearer token:
+
+        ```bash
+        cnspec scan vllm https://vllm.example.com --api-key <token> -f mondoo-vllm-security.mql.yaml
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Transport and Browser Exposure
+        filters: asset.family.contains("vllm")
+        checks:
+          - uid: mondoo-vllm-security-use-tls
+          - uid: mondoo-vllm-security-cors-not-wide-open
+      - title: API Authentication
+        filters: asset.family.contains("vllm")
+        checks:
+          - uid: mondoo-vllm-security-openai-routes-require-authentication
+          - uid: mondoo-vllm-security-custom-inference-routes-not-anonymous
+          - uid: mondoo-vllm-security-operational-control-routes-not-anonymous
+          - uid: mondoo-vllm-security-tokenization-routes-not-anonymous
+      - title: Information and Operational Exposure
+        filters: asset.family.contains("vllm")
+        checks:
+          - uid: mondoo-vllm-security-docs-not-exposed
+          - uid: mondoo-vllm-security-openapi-not-exposed
+          - uid: mondoo-vllm-security-version-not-exposed
+          - uid: mondoo-vllm-security-tokenizer-info-not-exposed
+          - uid: mondoo-vllm-security-metrics-not-exposed
+          - uid: mondoo-vllm-security-load-not-exposed
+      - title: Development and Debug Surfaces
+        filters: asset.family.contains("vllm")
+        checks:
+          - uid: mondoo-vllm-security-development-routes-not-exposed
+          - uid: mondoo-vllm-security-profiler-routes-not-exposed
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-vllm-security-cors-not-wide-open
+    title: Ensure CORS does not allow arbitrary origins
+    impact: 70
+    mql: |
+      vllm.server.corsConfigured == false || vllm.server.corsAllowsAnyOrigin == false
+    docs:
+      desc: |
+        This check verifies that the vLLM endpoint does not accept arbitrary browser origins during CORS preflight probing.
+
+        **Why this matters**
+
+        Wide-open CORS allows browser-based applications from untrusted origins to interact with the vLLM API from a user's browser context. When combined with permissive network access or weak authentication controls, this expands the attack surface for prompt abuse, data exposure, and unintended model consumption.
+      remediation: |
+        Restrict CORS to the exact origins that are allowed to call the vLLM API. When vLLM is exposed through a reverse proxy or API gateway, enforce CORS policy there and avoid wildcard origins.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+        title: vLLM OpenAI-Compatible Server
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+        title: MDN Web Docs CORS
+  - uid: mondoo-vllm-security-custom-inference-routes-not-anonymous
+    title: Ensure non-v1 inference routes are not anonymously accessible
+    impact: 100
+    mql: |
+      vllm.endpoints.where(category == "custom-inference").none(anonymousAccessible == true)
+    docs:
+      desc: |
+        This check verifies that non-`/v1` inference routes such as `/invocations`, `/inference/v1/generate`, `/pooling`, `/classify`, `/score`, and `/rerank` are not anonymously accessible.
+
+        **Why this matters**
+
+        vLLM API-key authentication is scoped to OpenAI-compatible `/v1/*` routes. Non-`/v1` inference endpoints can remain reachable unless protected by an upstream control. Leaving these routes anonymous can bypass the intended API authentication boundary and allow unauthorized model use.
+      remediation: |
+        Restrict non-`/v1` inference routes at a reverse proxy, API gateway, ingress controller, or firewall. If these routes are not required, deny them entirely. If they are required, enforce authentication and authorization before forwarding requests to vLLM.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+      - url: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+        title: OWASP Top 10 for LLM Applications
+  - uid: mondoo-vllm-security-development-routes-not-exposed
+    title: Ensure development routes are not exposed
+    impact: 90
+    mql: |
+      vllm.server.devEndpointsExposed == false
+    docs:
+      desc: |
+        This check verifies that development-oriented routes such as `/server_info`, cache reset routes, sleep and wake routes, and collective RPC routes are not anonymously exposed.
+
+        **Why this matters**
+
+        Development endpoints can expose sensitive runtime details or alter server behavior. These routes are not needed for normal inference clients and should not be reachable from untrusted networks.
+      remediation: |
+        Disable development routes when possible and block them at the reverse proxy, API gateway, ingress controller, or firewall. Expose administrative or debug routes only on trusted internal networks.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-docs-not-exposed
+    title: Ensure FastAPI documentation is not exposed
+    impact: 60
+    mql: |
+      vllm.server.docsExposed == false
+    docs:
+      desc: |
+        This check verifies that the FastAPI `/docs` interface is not anonymously exposed.
+
+        **Why this matters**
+
+        Interactive API documentation makes endpoint discovery easier for attackers. It can reveal available routes, request shapes, and operational surfaces that help an attacker plan unauthorized access or abuse.
+      remediation: |
+        Disable FastAPI documentation in vLLM when it is not explicitly required. If documentation must remain available, restrict it to trusted networks or authenticated administrative users through a proxy or gateway.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-load-not-exposed
+    title: Ensure load tracking is not anonymously exposed
+    impact: 60
+    mql: |
+      vllm.metrics.loadEndpointExposed == false
+    docs:
+      desc: |
+        This check verifies that `/load` is not anonymously exposed.
+
+        **Why this matters**
+
+        Load data can reveal operational state and utilization patterns. Attackers can use this information to time abuse, infer tenant activity, or identify periods when denial-of-service attempts are more likely to succeed.
+      remediation: |
+        Block `/load` for untrusted clients. If load data is required for autoscaling or monitoring, expose it only to trusted infrastructure components over an authenticated or private path.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-metrics-not-exposed
+    title: Ensure Prometheus metrics are not anonymously exposed
+    impact: 70
+    mql: |
+      vllm.metrics.prometheusExposed == false
+    docs:
+      desc: |
+        This check verifies that `/metrics` is not anonymously exposed.
+
+        **Why this matters**
+
+        Metrics can reveal model activity, request pressure, cache behavior, deployment capacity, and runtime characteristics. Anonymous access gives attackers operational intelligence that can support denial-of-service timing, capacity abuse, or targeted exploitation.
+      remediation: |
+        Restrict `/metrics` to the monitoring system only. Enforce network allow-lists, mTLS, authentication, or a private monitoring path before forwarding metrics requests to vLLM.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-openai-routes-require-authentication
+    title: Ensure OpenAI-compatible routes require authentication
+    impact: 100
+    mql: |
+      vllm.endpoints.where(category == "openai" && present == true).all(requiresAuth == true)
+    docs:
+      desc: |
+        This check verifies that observed OpenAI-compatible vLLM routes reject anonymous requests with an authentication-like response.
+
+        **Why this matters**
+
+        OpenAI-compatible routes expose the primary model inference surface. Anonymous access allows anyone who can reach the endpoint to submit prompts, generate completions, consume GPU capacity, and potentially extract sensitive model behavior or data returned by connected application workflows.
+      remediation: |
+        Configure vLLM API-key authentication and place the server behind an authenticated gateway or reverse proxy. Verify that all externally reachable `/v1/*` routes reject anonymous requests and that the token is only distributed to trusted clients.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+        title: vLLM OpenAI-Compatible Server
+  - uid: mondoo-vllm-security-openapi-not-exposed
+    title: Ensure the OpenAPI specification is not exposed
+    impact: 60
+    mql: |
+      vllm.server.openapiExposed == false
+    docs:
+      desc: |
+        This check verifies that `/openapi.json` is not anonymously exposed.
+
+        **Why this matters**
+
+        OpenAPI documents provide machine-readable route details that speed up reconnaissance and automated attack tooling. Exposing the specification can reveal optional endpoints or operational capabilities that are otherwise harder to enumerate.
+      remediation: |
+        Disable or block `/openapi.json` for untrusted clients. Serve API specifications only from an authenticated internal documentation system if they are needed by developers or operators.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-operational-control-routes-not-anonymous
+    title: Ensure operational control routes are not anonymously accessible
+    impact: 90
+    mql: |
+      vllm.endpoints.where(category == "operational-control").none(anonymousAccessible == true)
+    docs:
+      desc: |
+        This check verifies that operational control routes such as `/pause`, `/resume`, and `/scale_elastic_ep` are not anonymously accessible.
+
+        **Why this matters**
+
+        Operational control endpoints can affect availability and runtime behavior. Anonymous access could let an attacker disrupt service, manipulate serving capacity, or trigger state changes outside the normal administration path.
+      remediation: |
+        Block operational control routes from untrusted networks. If operational routes are required, expose them only through an authenticated administrative plane and restrict access to trusted operators or automation.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-profiler-routes-not-exposed
+    title: Ensure profiler routes are not exposed
+    impact: 90
+    mql: |
+      vllm.server.profilerEndpointsExposed == false
+    docs:
+      desc: |
+        This check verifies that profiler routes such as `/start_profile` and `/stop_profile` are not anonymously exposed.
+
+        **Why this matters**
+
+        Profiling endpoints can expose runtime internals, degrade service performance, and create an administrative control surface for attackers. They should never be available to ordinary inference clients.
+      remediation: |
+        Disable profiler routes outside controlled diagnostics windows. Restrict any required profiling access to authenticated operators on trusted administrative networks.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-tokenization-routes-not-anonymous
+    title: Ensure tokenization routes are not anonymously accessible
+    impact: 70
+    mql: |
+      vllm.endpoints.where(path == "/tokenize" || path == "/detokenize").none(anonymousAccessible == true)
+    docs:
+      desc: |
+        This check verifies that `/tokenize` and `/detokenize` are not anonymously accessible.
+
+        **Why this matters**
+
+        Tokenization endpoints can reveal tokenizer behavior and consume service resources without invoking the primary completion API. In exposed deployments, anonymous tokenization access broadens the unauthenticated API surface and can support reconnaissance or abuse workflows.
+      remediation: |
+        Restrict `/tokenize` and `/detokenize` at the reverse proxy, gateway, ingress, or firewall. If client applications need these routes, require authentication before forwarding requests to vLLM.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-tokenizer-info-not-exposed
+    title: Ensure tokenizer information is not exposed
+    impact: 50
+    mql: |
+      vllm.server.tokenizerInfoExposed == false
+    docs:
+      desc: |
+        This check verifies that `/tokenizer_info` is not anonymously exposed.
+
+        **Why this matters**
+
+        Tokenizer metadata can reveal details about the deployed model family and serving configuration. This information supports reconnaissance and can help attackers tune prompts or payloads for the target model.
+      remediation: |
+        Disable tokenizer information exposure unless a trusted client explicitly requires it. If the endpoint is required, restrict it with authentication and network controls.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+  - uid: mondoo-vllm-security-use-tls
+    title: Ensure the vLLM API is served over TLS
+    impact: 80
+    mql: |
+      vllm.server.usesTls == true
+    docs:
+      desc: |
+        This check verifies that the scanned vLLM endpoint uses HTTPS.
+
+        **Why this matters**
+
+        vLLM APIs process prompts, completions, embeddings, and operational metadata. Plain HTTP allows network observers or intermediate systems to read or modify requests and responses, including prompts that may contain proprietary source code, customer data, credentials, or other sensitive context.
+      remediation: |
+        Terminate TLS in front of the vLLM server with a reverse proxy, load balancer, API gateway, or service mesh. Expose only the HTTPS endpoint to clients and restrict direct access to the backend vLLM HTTP listener.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security
+      - url: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+        title: OWASP Top 10 for LLM Applications
+  - uid: mondoo-vllm-security-version-not-exposed
+    title: Ensure the vLLM version endpoint is not exposed
+    impact: 50
+    mql: |
+      vllm.server.version == empty
+    docs:
+      desc: |
+        This check verifies that the `/version` endpoint does not disclose the vLLM software version to anonymous clients.
+
+        **Why this matters**
+
+        Version disclosure helps attackers fingerprint deployments and quickly match them to known vulnerabilities. vLLM has had high-impact vulnerabilities in its serving and model-loading surfaces, so exposing exact version data increases targeting precision.
+      remediation: |
+        Block `/version` from untrusted clients at the reverse proxy, gateway, ingress, or firewall. Keep version inventory in internal asset management rather than exposing it through the public serving API.
+    refs:
+      - url: https://docs.vllm.ai/en/latest/serving/security.html
+        title: vLLM Security

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -1,9 +1,7 @@
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
-
 policies:
-  - summary: Secure vLLM inference server HTTP exposure and operational endpoints
-    uid: mondoo-vllm-security
+  - uid: mondoo-vllm-security
     name: Mondoo vLLM Security
     version: 1.0.0
     license: BUSL-1.1
@@ -15,6 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
+    summary: Secure vLLM inference server HTTP exposure and operational endpoints
     docs:
       desc: |
         The Mondoo vLLM Security policy assesses the externally observable HTTP posture of vLLM inference servers. It focuses on the surfaces that a remote scanner can verify truthfully: API authentication behavior, exposed documentation and metadata endpoints, CORS behavior, operational control routes, development and profiler routes, and unauthenticated metrics or load data.
@@ -66,6 +65,20 @@ queries:
   - uid: mondoo-vllm-security-cors-not-wide-open
     title: Ensure CORS does not allow arbitrary origins
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.corsConfigured == false || vllm.server.corsAllowsAnyOrigin == false
     docs:
@@ -85,6 +98,20 @@ queries:
   - uid: mondoo-vllm-security-custom-inference-routes-not-anonymous
     title: Ensure non-v1 inference routes are not anonymously accessible
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.endpoints.where(category == "custom-inference").none(anonymousAccessible == true)
     docs:
@@ -104,6 +131,20 @@ queries:
   - uid: mondoo-vllm-security-development-routes-not-exposed
     title: Ensure development routes are not exposed
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-31
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-7
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.devEndpointsExposed == false
     docs:
@@ -121,6 +162,20 @@ queries:
   - uid: mondoo-vllm-security-docs-not-exposed
     title: Ensure FastAPI documentation is not exposed
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.docsExposed == false
     docs:
@@ -138,6 +193,20 @@ queries:
   - uid: mondoo-vllm-security-load-not-exposed
     title: Ensure load tracking is not anonymously exposed
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.metrics.loadEndpointExposed == false
     docs:
@@ -155,6 +224,20 @@ queries:
   - uid: mondoo-vllm-security-metrics-not-exposed
     title: Ensure Prometheus metrics are not anonymously exposed
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.metrics.prometheusExposed == false
     docs:
@@ -172,6 +255,20 @@ queries:
   - uid: mondoo-vllm-security-openai-routes-require-authentication
     title: Ensure OpenAI-compatible routes require authentication
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.endpoints.where(category == "openai" && present == true).all(requiresAuth == true)
     docs:
@@ -191,6 +288,20 @@ queries:
   - uid: mondoo-vllm-security-openapi-not-exposed
     title: Ensure the OpenAPI specification is not exposed
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.openapiExposed == false
     docs:
@@ -208,6 +319,20 @@ queries:
   - uid: mondoo-vllm-security-operational-control-routes-not-anonymous
     title: Ensure operational control routes are not anonymously accessible
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-15
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.endpoints.where(category == "operational-control").none(anonymousAccessible == true)
     docs:
@@ -225,6 +350,20 @@ queries:
   - uid: mondoo-vllm-security-profiler-routes-not-exposed
     title: Ensure profiler routes are not exposed
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.profilerEndpointsExposed == false
     docs:
@@ -242,6 +381,20 @@ queries:
   - uid: mondoo-vllm-security-tokenization-routes-not-anonymous
     title: Ensure tokenization routes are not anonymously accessible
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.endpoints.where(path == "/tokenize" || path == "/detokenize").none(anonymousAccessible == true)
     docs:
@@ -259,6 +412,20 @@ queries:
   - uid: mondoo-vllm-security-tokenizer-info-not-exposed
     title: Ensure tokenizer information is not exposed
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.tokenizerInfoExposed == false
     docs:
@@ -276,6 +443,20 @@ queries:
   - uid: mondoo-vllm-security-use-tls
     title: Ensure the vLLM API is served over TLS
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.usesTls == true
     docs:
@@ -295,6 +476,20 @@ queries:
   - uid: mondoo-vllm-security-version-not-exposed
     title: Ensure the vLLM version endpoint is not exposed
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: "false"
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: "false"
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: "false"
     mql: |
       vllm.server.version == empty
     docs:


### PR DESCRIPTION
## Summary
- add an open-source Mondoo vLLM Security policy
- cover the remote HTTP posture exposed by the new `vllm` provider: TLS, CORS, OpenAI-compatible route auth, non-`/v1` inference routes, operational control routes, tokenization routes, docs/OpenAPI/version exposure, metrics/load exposure, and dev/profiler routes
- document that host-local checks such as CLI flags, LoRA state, model revision pinning, media allowlists, and internode controls are out of scope for the remote provider
- add the policy to the content README

## Upstream dependency
- Depends on mondoohq/mql#7446 for the `vllm` provider and resources.
- This PR is draft until cnspec depends on an MQL build that includes that provider.

## Validation
- `git diff --check`
- YAML parsed with `yq`
- verified 4 policy groups and 14 queries
- verified every group check UID has a matching query UID and no duplicate group check UIDs
- `cnspec --auto-update=false policy fmt content/mondoo-vllm-security.mql.yaml --sort`

## Known blocker
- `cnspec --auto-update=false policy lint content/mondoo-vllm-security.mql.yaml` currently fails with `cannot find resource for identifier 'vllm'` because the provider is not available in this checkout's MQL dependency yet.