### PR TITLE
🌱 Add Terraform variants to 3 GCP security checks (batch 1)

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -20565,7 +20565,6 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled
     title: Ensure Cloud Storage buckets have soft delete retention enabled
     impact: 75
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
@@ -20574,12 +20573,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/soc2-2017: false
-    mql: |
-      gcp.project.storageService.buckets.all(
-        softDeletePolicy != null &&
-        softDeletePolicy['retentionDurationSeconds'] != null &&
-        softDeletePolicy['retentionDurationSeconds'].to_int > 0
-      )
+    variants:
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud Storage
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Cloud Storage bucket has soft delete retention configured. Soft delete retains deleted objects for a configurable period during which they can be restored, providing a recovery window against ransomware, malicious insiders, and accidental deletion.
@@ -20629,6 +20639,38 @@ queries:
     refs:
       - url: https://cloud.google.com/storage/docs/soft-delete
         title: Cloud Storage - Soft delete
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.storageService.buckets.all(
+        softDeletePolicy != null &&
+        softDeletePolicy['retentionDurationSeconds'] != null &&
+        softDeletePolicy['retentionDurationSeconds'].to_int > 0
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_storage_bucket')
+    mql: |
+      terraform.resources('google_storage_bucket').all(
+        blocks.where(type == 'soft_delete_policy') != empty &&
+        blocks.where(type == 'soft_delete_policy').all(arguments.retention_duration_seconds > 0)
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_storage_bucket').all(
+        change.after['soft_delete_policy'] != empty &&
+        change.after['soft_delete_policy'].any(_['retention_duration_seconds'] > 0)
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.state.resources.where(type == 'google_storage_bucket').all(
+        values['soft_delete_policy'] != empty &&
+        values['soft_delete_policy'].any(_['retention_duration_seconds'] > 0)
+      )
   - uid: mondoo-gcp-security-cloud-storage-bucket-object-retention-locked
     title: Ensure Cloud Storage buckets with object retention have it locked
     impact: 75
@@ -21003,7 +21045,6 @@ queries:
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy
     title: Ensure Target SSL proxies have an explicit SSL policy attached
     impact: 70
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
@@ -21012,8 +21053,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/soc2-2017: soc2-control-cc6-7-2
-    mql: |
-      gcp.project.computeService.targetSslProxies.all(sslPolicyUrl != "")
+    variants:
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
+        tags:
+          mondoo.com/filter-title: GCP Compute (Target SSL Proxy)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Target SSL Proxy has an explicit SSL policy attached. Target SSL proxies without an attached SSL policy fall back to GCP's default `COMPATIBLE` profile, which permits TLS 1.0 and 1.1. The existing checks on SSL policies (`ssl-policy-min-tls-1-2`, `ssl-policy-modern-or-restricted-profile`) only inspect *defined* SSL policies — they do not catch proxies that have no policy at all and therefore inherit the weak default.
@@ -21068,6 +21124,31 @@ queries:
     refs:
       - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: GCP - SSL policies
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.targetSslProxies.all(sslPolicyUrl != "")
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.resources('google_compute_target_ssl_proxy').all(
+        arguments['ssl_policy'] != null && arguments['ssl_policy'] != ""
+      )
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_target_ssl_proxy').all(
+        change.after['ssl_policy'] != null && change.after['ssl_policy'] != ""
+      )
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_target_ssl_proxy').all(
+        values['ssl_policy'] != null && values['ssl_policy'] != ""
+      )
   - uid: mondoo-gcp-security-gke-network-policy-provider-specified
     title: Ensure GKE network policy has a provider specified
     impact: 70
@@ -21460,7 +21541,6 @@ queries:
   - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr
     title: Ensure IAP tunnel destination groups do not use overly broad CIDR ranges
     impact: 75
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
@@ -21469,10 +21549,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-3-3
-    mql: |
-      gcp.project.iapService.tunnelDestGroups.all(
-        cidrs.none(_ == /\/([0-9]|1[0-5])$/)
-      )
+    variants:
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
+        tags:
+          mondoo.com/filter-title: GCP IAP (Tunnel destination groups)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no Identity-Aware Proxy (IAP) tunnel destination group carries a CIDR of `/15` or larger (fewer bits than `/16`). IAP tunnels let an authorized user reach internal resources via a bastion-like path; a tunnel destination group with a `/8` or `/10` CIDR authorizes that user to reach an entire wide range of private IPs, well beyond the specific hosts any individual workflow should need.
@@ -21526,6 +21619,33 @@ queries:
     refs:
       - url: https://cloud.google.com/iap/docs/tcp-by-host
         title: IAP - TCP forwarding with destination groups
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.iapService.tunnelDestGroups.all(
+        cidrs.none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.resources('google_iap_tunnel_dest_group').all(
+        arguments['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_iap_tunnel_dest_group').all(
+        change.after['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.state.resources.where(type == 'google_iap_tunnel_dest_group').all(
+        values['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
   - uid: mondoo-gcp-security-dlp-job-trigger-healthy
     title: Ensure Cloud DLP job triggers are healthy and not stale
     impact: 70


### PR DESCRIPTION
## Summary

Companion follow-up to #2418. Adds Terraform HCL/plan/state variants to three GCP-runtime-only checks that map cleanly to single Terraform attributes:

- `mondoo-gcp-security-target-ssl-proxy-has-explicit-policy` — `google_compute_target_ssl_proxy.ssl_policy` non-empty
- `mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr` — `google_iap_tunnel_dest_group.cidrs[]` rejects `/0`-`/15`
- `mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled` — `google_storage_bucket.soft_delete_policy` block present with `retention_duration_seconds > 0`

Pattern follows the `memorystore-iam-auth-enabled` reference variant block.

## Test plan

- [x] `cnspec policy lint content/mondoo-gcp-security.mql.yaml` passes
- [x] `python3 content/validation/validate_remediation_commands.py gcp` reports 0 failures
- [ ] Spot-check each new variant against a sample Terraform HCL/plan/state asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)