### PR TITLE
:star: Add Terraform variants to 8 GCP security checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,46 @@ cnspec policy lint ./content/your-policy.mql.yaml
 cnspec scan local -f ./content/your-policy.mql.yaml
 ```
 
+#### Terraform variants for cloud policies
+
+When you add or modify a check in a cloud policy (`mondoo-aws-security`, `mondoo-azure-security`, `mondoo-gcp-security`, `mondoo-oci-security`, `mondoo-kubernetes-security`, etc.), the check should run against both the live cloud runtime **and** any Terraform asset that configures the same resource. Convert single-platform checks to a `variants:` block with up to four children:
+
+- `<uid>-<cloud>` — runtime check (`asset.platform == 'gcp'`, `'aws'`, …)
+- `<uid>-terraform-hcl` — `terraform.resources(...)` against HCL source
+- `<uid>-terraform-plan` — `terraform.plan.resourceChanges` against `terraform plan` JSON
+- `<uid>-terraform-state` — `terraform.state.resources` against `terraform.tfstate`
+
+Reference patterns in this repo:
+
+- GCP: `mondoo-gcp-security-memorystore-iam-auth-enabled` in `content/mondoo-gcp-security.mql.yaml`
+- HCL nested-block fanout: `mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-*` (database_flags)
+- Plan/state list-of-objects shape: `mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-terraform-*`
+
+**When a Terraform variant is not possible, leave a YAML comment above the parent check explaining why** so future passes don't re-investigate. Common reasons:
+
+- The runtime check evaluates operational telemetry (job state, latest execution status, observed traffic) that has no configuration analog.
+- The cloud resource is managed only via SDK / CLI / console and has no Terraform resource (e.g., short-lived imperative API calls like Vertex AI custom jobs).
+- The runtime check depends on cross-resource correlation (e.g., "every cluster has a backup plan that points at it") that the runtime check itself does not yet implement correctly — in which case fix the runtime first.
+- The runtime check inspects a field whose Terraform analog is a different feature (don't paper over the mismatch with a vacuous variant).
+
+Comment format (inserted on the line before `- uid:`):
+
+```yaml
+# No Terraform variants: <one-sentence reason>. <Optional: when this could be revisited>.
+- uid: mondoo-<cloud>-security-...
+```
+
+The comment must explain the technical limitation, not just say "skip". Keep it to a few lines.
+
+After every batch of variant additions, both must pass:
+
+```bash
+cnspec policy lint content/mondoo-<cloud>-security.mql.yaml
+python3 content/validation/validate_remediation_commands.py <cloud>
+```
+
+**MQL gotcha for Terraform variants:** the parser rejects `.all((expr) || ...)` — a parenthesized clause as the first token inside `.all(`. Rely on `&&` binding tighter than `||` instead of writing leading parentheses.
+
 ### MQL Development
 
 MQL (Mondoo Query Language) syntax examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ cnspec policy lint content/mondoo-<cloud>-security.mql.yaml
 python3 content/validation/validate_remediation_commands.py <cloud>
 ```
 
-**MQL gotcha for Terraform variants:** the parser rejects `.all((expr) || ...)` — a parenthesized clause as the first token inside `.all(`. Rely on `&&` binding tighter than `||` instead of writing leading parentheses.
+**MQL parser quirk for Terraform variants:** the parser rejects `.all((expr) || ...)` — a parenthesized clause as the first token inside `.all(`. Rely on `&&` binding tighter than `||` instead of writing leading parentheses.
 
 ### MQL Development
 

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -20872,7 +20872,6 @@ queries:
   - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets
     title: Ensure no custom routes send 0.0.0.0/0 to the default internet gateway
     impact: 70
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
@@ -20881,10 +20880,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-    mql: |
-      gcp.project.computeService.routes.where(destRange == "0.0.0.0/0").all(
-        nextHopGateway == "" || nextHopGateway == null
-      )
+    variants:
+      - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
+        tags:
+          mondoo.com/filter-title: GCP VPC Routes
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check flags custom routes in any VPC that send `0.0.0.0/0` traffic to the `default-internet-gateway` next hop. Default internet gateway routes are created automatically on every VPC; additional *custom* `0.0.0.0/0 → default-internet-gateway` routes are typically a configuration mistake or a deliberate egress bypass that attackers plant to exfiltrate data around NAT / Cloud NAT logging.
@@ -20949,10 +20961,36 @@ queries:
     refs:
       - url: https://cloud.google.com/vpc/docs/routes
         title: GCP VPC Routes
+  - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.routes.where(destRange == "0.0.0.0/0").all(
+        nextHopGateway == "" || nextHopGateway == null
+      )
+  - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_route')
+    mql: |
+      terraform.resources('google_compute_route').where(arguments['dest_range'] == "0.0.0.0/0").all(
+        arguments['next_hop_gateway'] == null || arguments['next_hop_gateway'] == ""
+      )
+  - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_route')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_route' && change.after['dest_range'] == "0.0.0.0/0").all(
+        change.after['next_hop_gateway'] == null || change.after['next_hop_gateway'] == ""
+      )
+  - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_route')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_route' && values['dest_range'] == "0.0.0.0/0").all(
+        values['next_hop_gateway'] == null || values['next_hop_gateway'] == ""
+      )
   - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed
     title: Ensure PSC service attachments do not accept connections automatically
     impact: 80
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
@@ -20961,11 +20999,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-3-3
-    mql: |
-      gcp.project.computeService.serviceAttachments.all(
-        connectionPreference == "ACCEPT_MANUAL" ||
-        consumerAcceptLists.length > 0
-      )
+    variants:
+      - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
+        tags:
+          mondoo.com/filter-title: GCP Private Service Connect
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Private Service Connect (PSC) service attachment either requires manual connection approval (`connectionPreference == "ACCEPT_MANUAL"`) or restricts the consumers who can attach via an explicit `consumerAcceptLists`. A service attachment that automatically accepts connections with no consumer allowlist is reachable by any consumer project in the GCP organization — effectively a public-on-GCP endpoint for the backing service.
@@ -21021,10 +21071,46 @@ queries:
     refs:
       - url: https://cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect
+  - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.serviceAttachments.all(
+        connectionPreference == "ACCEPT_MANUAL" ||
+        consumerAcceptLists.length > 0
+      )
+  - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_service_attachment')
+    mql: |
+      terraform.resources('google_compute_service_attachment').all(
+        arguments['connection_preference'] == "ACCEPT_MANUAL" ||
+        blocks.where(type == 'consumer_accept_lists') != empty
+      )
+  - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_service_attachment')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_service_attachment').all(
+        change.after['connection_preference'] == "ACCEPT_MANUAL" ||
+        change.after['consumer_accept_lists'] != empty
+      )
+  - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_service_attachment')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_service_attachment').all(
+        values['connection_preference'] == "ACCEPT_MANUAL" ||
+        values['consumer_accept_lists'] != empty
+      )
+  # Terraform variants intentionally check google_sql_user resources directly without
+  # filtering by parent instance database_version. The runtime check exempts "sqlserver"
+  # as a system user; Cloud SQL Server does not support CLOUD_IAM_* user types, so any
+  # custom users on SQL Server instances are unavoidably BUILT_IN and will fail the
+  # Terraform variants. This matches the runtime check's behavior for non-system
+  # SQL Server users.
   - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth
     title: Ensure Cloud SQL users authenticate via Cloud IAM, not built-in passwords
     impact: 70
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: false
@@ -21033,10 +21119,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc6-1-9
-    mql: |
-      gcp.project.sqlService.instances.all(
-        users.all(type != "BUILT_IN" || name == "root" || name == "postgres" || name == "sqlserver")
-      )
+    variants:
+      - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud SQL
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that Cloud SQL instance user accounts authenticate via Cloud IAM (`CLOUD_IAM_USER`, `CLOUD_IAM_SERVICE_ACCOUNT`, `CLOUD_IAM_GROUP_*`) rather than with built-in password authentication. The check permits the engine-managed system accounts (`root`, `postgres`, `sqlserver`) to remain built-in since they exist by default, but any additional user accounts should be created as IAM-backed.
@@ -21095,6 +21194,42 @@ queries:
     refs:
       - url: https://cloud.google.com/sql/docs/mysql/iam-authentication
         title: Cloud SQL - IAM database authentication
+  - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.sqlService.instances.all(
+        users.all(type != "BUILT_IN" || name == "root" || name == "postgres" || name == "sqlserver")
+      )
+  - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_sql_user')
+    mql: |
+      terraform.resources('google_sql_user').all(
+        arguments['type'] != null && arguments['type'] != "BUILT_IN" ||
+        arguments['name'] == "root" ||
+        arguments['name'] == "postgres" ||
+        arguments['name'] == "sqlserver"
+      )
+  - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_sql_user')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_sql_user').all(
+        change.after['type'] != null && change.after['type'] != "BUILT_IN" ||
+        change.after['name'] == "root" ||
+        change.after['name'] == "postgres" ||
+        change.after['name'] == "sqlserver"
+      )
+  - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_sql_user')
+    mql: |
+      terraform.state.resources.where(type == 'google_sql_user').all(
+        values['type'] != null && values['type'] != "BUILT_IN" ||
+        values['name'] == "root" ||
+        values['name'] == "postgres" ||
+        values['name'] == "sqlserver"
+      )
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy
     title: Ensure Target SSL proxies have an explicit SSL policy attached
     impact: 70
@@ -21355,6 +21490,11 @@ queries:
     refs:
       - url: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-notifications
         title: GKE - Cluster notifications
+  # No Terraform variants: the runtime check confirms presence of any active
+  # google_gke_backup_backup_plan but does not correlate plans to specific clusters.
+  # A Terraform variant would silently inherit that gap (a plan in any project would
+  # satisfy a check on any cluster). Resolve the per-cluster correlation in the
+  # runtime check before shipping a Terraform variant.
   - uid: mondoo-gcp-security-gke-backup-plan-exists
     title: Ensure every GKE cluster is protected by at least one backup plan
     impact: 75
@@ -21443,7 +21583,6 @@ queries:
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public
     title: Ensure Vertex AI index endpoints are not publicly accessible
     impact: 85
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
@@ -21452,10 +21591,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-    mql: |
-      gcp.project.vertexaiService.indexEndpoints.all(
-        publicEndpointEnabled == false
-      )
+    variants:
+      - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Vertex AI index endpoint has its public endpoint disabled. Vertex AI Matching Engine / Vector Search index endpoints hold the embedding-based search index of whatever text, image, or multimodal content the organization has loaded — exposing one publicly makes that entire embedding space queryable by anyone on the internet.
@@ -21508,6 +21660,37 @@ queries:
     refs:
       - url: https://cloud.google.com/vertex-ai/docs/vector-search/setup/setup-index-endpoint
         title: Vertex AI - Setup index endpoint
+  - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.vertexaiService.indexEndpoints.all(
+        publicEndpointEnabled == false
+      )
+  - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.resources('google_vertex_ai_index_endpoint').all(
+        arguments['public_endpoint_enabled'] != true
+      )
+  - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_index_endpoint').all(
+        change.after['public_endpoint_enabled'] != true
+      )
+  - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.state.resources.where(type == 'google_vertex_ai_index_endpoint').all(
+        values['public_endpoint_enabled'] != true
+      )
+  # No Terraform variants: Vertex AI custom jobs are short-lived imperative API calls
+  # invoked via the Python/JS SDKs or `gcloud ai custom-jobs create`. The Terraform
+  # provider does not expose a google_vertex_ai_custom_job resource, so there is
+  # nothing in HCL/plan/state to evaluate.
   - uid: mondoo-gcp-security-vertexai-custom-job-has-explicit-service-account
     title: Ensure Vertex AI custom jobs run under an explicit service account
     impact: 80
@@ -21699,6 +21882,10 @@ queries:
       terraform.state.resources.where(type == 'google_iap_tunnel_dest_group').all(
         values['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
       )
+  # No Terraform variants: this check evaluates the runtime status of the most
+  # recent job execution (latestJobs[].state == "DONE"), which is operational
+  # telemetry returned by the API at runtime, not configuration. Job execution
+  # state is not expressible in HCL/plan/state.
   - uid: mondoo-gcp-security-dlp-job-trigger-healthy
     title: Ensure Cloud DLP job triggers are healthy and not stale
     impact: 70

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -20671,6 +20671,12 @@ queries:
         values['soft_delete_policy'] != empty &&
         values['soft_delete_policy'].any(_['retention_duration_seconds'] > 0)
       )
+  # No Terraform variants: the runtime check inspects bucket-level objectRetentionMode
+  # (per-object retention feature). Terraform only exposes enable_object_retention (bool)
+  # at bucket creation; per-object lock state is set via the API/CLI after upload and is
+  # not expressible in HCL/plan/state. The bucket-level retention_policy.is_locked
+  # behavior is a separate feature and already covered by
+  # mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked.
   - uid: mondoo-gcp-security-cloud-storage-bucket-object-retention-locked
     title: Ensure Cloud Storage buckets with object retention have it locked
     impact: 75
@@ -20742,7 +20748,6 @@ queries:
   - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict
     title: Ensure KMS key access justifications exclude customer-initiated support
     impact: 65
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: false
@@ -20751,14 +20756,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: false
       compliance/soc2-2017: soc2-control-cc6-1-9
-    mql: |
-      gcp.project.kmsService.keyrings.all(
-        cryptokeys.all(
-          keyAccessJustificationsPolicy == null ||
-          keyAccessJustificationsPolicy['allowedAccessReasons'] == null ||
-          keyAccessJustificationsPolicy['allowedAccessReasons'].none(_ == "CUSTOMER_INITIATED_SUPPORT")
-        )
-      )
+    variants:
+      - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud KMS
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no KMS crypto key allows `CUSTOMER_INITIATED_SUPPORT` in its Key Access Justifications (KAJ) policy. KAJ requires every access to a key to be tagged with a business reason; including `CUSTOMER_INITIATED_SUPPORT` means Google support staff can access keyed data when the customer has opened a support case, without a more specific per-request justification.
@@ -20816,6 +20830,45 @@ queries:
     refs:
       - url: https://cloud.google.com/kms/docs/key-access-justifications
         title: Cloud KMS - Key Access Justifications
+  - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.kmsService.keyrings.all(
+        cryptokeys.all(
+          keyAccessJustificationsPolicy == null ||
+          keyAccessJustificationsPolicy['allowedAccessReasons'] == null ||
+          keyAccessJustificationsPolicy['allowedAccessReasons'].none(_ == "CUSTOMER_INITIATED_SUPPORT")
+        )
+      )
+  - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_kms_crypto_key')
+    mql: |
+      terraform.resources('google_kms_crypto_key').all(
+        blocks.where(type == 'key_access_justifications_policy').all(
+          arguments['allowed_access_reasons'].none(_ == "CUSTOMER_INITIATED_SUPPORT")
+        )
+      )
+  - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_kms_crypto_key')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_kms_crypto_key').all(
+        change.after['key_access_justifications_policy'] == null ||
+        change.after['key_access_justifications_policy'].all(
+          _['allowed_access_reasons'].none(_ == "CUSTOMER_INITIATED_SUPPORT")
+        )
+      )
+  - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_kms_crypto_key')
+    mql: |
+      terraform.state.resources.where(type == 'google_kms_crypto_key').all(
+        values['key_access_justifications_policy'] == null ||
+        values['key_access_justifications_policy'].all(
+          _['allowed_access_reasons'].none(_ == "CUSTOMER_INITIATED_SUPPORT")
+        )
+      )
   - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets
     title: Ensure no custom routes send 0.0.0.0/0 to the default internet gateway
     impact: 70
@@ -21747,7 +21800,6 @@ queries:
   - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types
     title: Ensure DLP inspect templates include common credential info types
     impact: 70
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-12
       compliance/nis-2: false
@@ -21756,15 +21808,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
       compliance/soc2-2017: false
-    mql: |
-      gcp.project.dlpService.inspectTemplates.all(
-        inspectConfig != null &&
-        inspectConfig['infoTypes'] != null &&
-        inspectConfig['infoTypes'].any(_['name'] == "AWS_CREDENTIALS") &&
-        inspectConfig['infoTypes'].any(_['name'] == "GCP_CREDENTIALS") &&
-        inspectConfig['infoTypes'].any(_['name'] == "JSON_WEB_TOKEN") &&
-        inspectConfig['infoTypes'].any(_['name'] == "BASIC_AUTH_HEADER")
-      )
+    variants:
+      - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
+        tags:
+          mondoo.com/filter-title: GCP DLP (Sensitive Data Protection)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Cloud DLP inspect template includes the common credential detectors: `AWS_CREDENTIALS`, `GCP_CREDENTIALS`, `JSON_WEB_TOKEN`, and `BASIC_AUTH_HEADER`. DLP templates that scan for PII but omit these credential detectors miss the single highest-impact class of sensitive data — live secrets that grant attackers immediate access.
@@ -21843,6 +21903,56 @@ queries:
     refs:
       - url: https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference
         title: DLP - InfoTypes reference
+  - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.dlpService.inspectTemplates.all(
+        inspectConfig != null &&
+        inspectConfig['infoTypes'] != null &&
+        inspectConfig['infoTypes'].any(_['name'] == "AWS_CREDENTIALS") &&
+        inspectConfig['infoTypes'].any(_['name'] == "GCP_CREDENTIALS") &&
+        inspectConfig['infoTypes'].any(_['name'] == "JSON_WEB_TOKEN") &&
+        inspectConfig['infoTypes'].any(_['name'] == "BASIC_AUTH_HEADER")
+      )
+  - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_data_loss_prevention_inspect_template')
+    mql: |
+      terraform.resources('google_data_loss_prevention_inspect_template').all(
+        blocks.where(type == 'inspect_config') != empty &&
+        blocks.where(type == 'inspect_config').all(
+          blocks.where(type == 'info_types').any(arguments['name'] == "AWS_CREDENTIALS") &&
+          blocks.where(type == 'info_types').any(arguments['name'] == "GCP_CREDENTIALS") &&
+          blocks.where(type == 'info_types').any(arguments['name'] == "JSON_WEB_TOKEN") &&
+          blocks.where(type == 'info_types').any(arguments['name'] == "BASIC_AUTH_HEADER")
+        )
+      )
+  - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_data_loss_prevention_inspect_template')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_data_loss_prevention_inspect_template').all(
+        change.after['inspect_config'] != empty &&
+        change.after['inspect_config'].all(
+          _['info_types'].any(name == "AWS_CREDENTIALS") &&
+          _['info_types'].any(name == "GCP_CREDENTIALS") &&
+          _['info_types'].any(name == "JSON_WEB_TOKEN") &&
+          _['info_types'].any(name == "BASIC_AUTH_HEADER")
+        )
+      )
+  - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_data_loss_prevention_inspect_template')
+    mql: |
+      terraform.state.resources.where(type == 'google_data_loss_prevention_inspect_template').all(
+        values['inspect_config'] != empty &&
+        values['inspect_config'].all(
+          _['info_types'].any(name == "AWS_CREDENTIALS") &&
+          _['info_types'].any(name == "GCP_CREDENTIALS") &&
+          _['info_types'].any(name == "JSON_WEB_TOKEN") &&
+          _['info_types'].any(name == "BASIC_AUTH_HEADER")
+        )
+      )
   - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter
     title: Ensure Model Armor templates enable prompt injection filtering
     impact: 90

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -20565,7 +20565,6 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled
     title: Ensure Cloud Storage buckets have soft delete retention enabled
     impact: 75
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
@@ -20574,12 +20573,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/soc2-2017: false
-    mql: |
-      gcp.project.storageService.buckets.all(
-        softDeletePolicy != null &&
-        softDeletePolicy['retentionDurationSeconds'] != null &&
-        softDeletePolicy['retentionDurationSeconds'].to_int > 0
-      )
+    variants:
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud Storage
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Cloud Storage bucket has soft delete retention configured. Soft delete retains deleted objects for a configurable period during which they can be restored, providing a recovery window against ransomware, malicious insiders, and accidental deletion.
@@ -20629,6 +20639,38 @@ queries:
     refs:
       - url: https://cloud.google.com/storage/docs/soft-delete
         title: Cloud Storage - Soft delete
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.storageService.buckets.all(
+        softDeletePolicy != null &&
+        softDeletePolicy['retentionDurationSeconds'] != null &&
+        softDeletePolicy['retentionDurationSeconds'].to_int > 0
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_storage_bucket')
+    mql: |
+      terraform.resources('google_storage_bucket').all(
+        blocks.where(type == 'soft_delete_policy') != empty &&
+        blocks.where(type == 'soft_delete_policy').all(arguments.retention_duration_seconds > 0)
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_storage_bucket').all(
+        change.after['soft_delete_policy'] != empty &&
+        change.after['soft_delete_policy'].any(_['retention_duration_seconds'] > 0)
+      )
+  - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.state.resources.where(type == 'google_storage_bucket').all(
+        values['soft_delete_policy'] != empty &&
+        values['soft_delete_policy'].any(_['retention_duration_seconds'] > 0)
+      )
   - uid: mondoo-gcp-security-cloud-storage-bucket-object-retention-locked
     title: Ensure Cloud Storage buckets with object retention have it locked
     impact: 75
@@ -21003,7 +21045,6 @@ queries:
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy
     title: Ensure Target SSL proxies have an explicit SSL policy attached
     impact: 70
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
@@ -21012,8 +21053,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/soc2-2017: soc2-control-cc6-7-2
-    mql: |
-      gcp.project.computeService.targetSslProxies.all(sslPolicyUrl != "")
+    variants:
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
+        tags:
+          mondoo.com/filter-title: GCP Compute (Target SSL Proxy)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Target SSL Proxy has an explicit SSL policy attached. Target SSL proxies without an attached SSL policy fall back to GCP's default `COMPATIBLE` profile, which permits TLS 1.0 and 1.1. The existing checks on SSL policies (`ssl-policy-min-tls-1-2`, `ssl-policy-modern-or-restricted-profile`) only inspect *defined* SSL policies — they do not catch proxies that have no policy at all and therefore inherit the weak default.
@@ -21068,6 +21124,31 @@ queries:
     refs:
       - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: GCP - SSL policies
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.targetSslProxies.all(sslPolicyUrl != "")
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.resources('google_compute_target_ssl_proxy').all(
+        arguments['ssl_policy'] != null && arguments['ssl_policy'] != ""
+      )
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_target_ssl_proxy').all(
+        change.after['ssl_policy'] != null && change.after['ssl_policy'] != ""
+      )
+  - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_target_ssl_proxy')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_target_ssl_proxy').all(
+        values['ssl_policy'] != null && values['ssl_policy'] != ""
+      )
   - uid: mondoo-gcp-security-gke-network-policy-provider-specified
     title: Ensure GKE network policy has a provider specified
     impact: 70
@@ -21460,7 +21541,6 @@ queries:
   - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr
     title: Ensure IAP tunnel destination groups do not use overly broad CIDR ranges
     impact: 75
-    filters: asset.platform == 'gcp'
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
@@ -21469,10 +21549,23 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-3-3
-    mql: |
-      gcp.project.iapService.tunnelDestGroups.all(
-        cidrs.none(_ == /\/([0-9]|1[0-5])$/)
-      )
+    variants:
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
+        tags:
+          mondoo.com/filter-title: GCP IAP (Tunnel destination groups)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no Identity-Aware Proxy (IAP) tunnel destination group carries a CIDR of `/15` or larger (fewer bits than `/16`). IAP tunnels let an authorized user reach internal resources via a bastion-like path; a tunnel destination group with a `/8` or `/10` CIDR authorizes that user to reach an entire wide range of private IPs, well beyond the specific hosts any individual workflow should need.
@@ -21526,6 +21619,33 @@ queries:
     refs:
       - url: https://cloud.google.com/iap/docs/tcp-by-host
         title: IAP - TCP forwarding with destination groups
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.iapService.tunnelDestGroups.all(
+        cidrs.none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.resources('google_iap_tunnel_dest_group').all(
+        arguments['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_iap_tunnel_dest_group').all(
+        change.after['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
+  - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_iap_tunnel_dest_group')
+    mql: |
+      terraform.state.resources.where(type == 'google_iap_tunnel_dest_group').all(
+        values['cidrs'].none(_ == /\/([0-9]|1[0-5])$/)
+      )
   - uid: mondoo-gcp-security-dlp-job-trigger-healthy
     title: Ensure Cloud DLP job triggers are healthy and not stale
     impact: 70


### PR DESCRIPTION
## Summary

Companion follow-up to #2418. Converts eight single-platform GCP runtime checks into multi-variant checks so they also run against Terraform HCL, plan, and state assets. Adds explanatory comments for four runtime-only or blocked checks so future passes do not re-investigate.

### New Terraform variants

| Check | Resource | Field |
|---|---|---|
| `target-ssl-proxy-has-explicit-policy` | `google_compute_target_ssl_proxy` | `ssl_policy` non-empty |
| `iap-tunnel-dest-group-no-broad-cidr` | `google_iap_tunnel_dest_group` | `cidrs[]` rejects `/0`-`/15` |
| `cloud-storage-bucket-soft-delete-enabled` | `google_storage_bucket` | `soft_delete_policy.retention_duration_seconds > 0` |
| `cloud-kms-key-access-justifications-strict` | `google_kms_crypto_key` | `key_access_justifications_policy.allowed_access_reasons` excludes `CUSTOMER_INITIATED_SUPPORT` |
| `dlp-inspect-template-covers-credential-info-types` | `google_data_loss_prevention_inspect_template` | `inspect_config.info_types[].name` covers AWS/GCP creds, JWT, basic auth |
| `cloud-sql-users-use-iam-auth` | `google_sql_user` | `type` is non-`BUILT_IN` (root/postgres/sqlserver exempt) |
| `vertexai-index-endpoint-not-public` | `google_vertex_ai_index_endpoint` | `public_endpoint_enabled != true` |
| `compute-route-no-internet-gateway-to-sensitive-subnets` | `google_compute_route` | `dest_range == "0.0.0.0/0"` ⇒ `next_hop_gateway` unset |
| `compute-service-attachment-consumer-reviewed` | `google_compute_service_attachment` | `connection_preference == "ACCEPT_MANUAL"` or non-empty `consumer_accept_lists` |

### YAML comments documenting why no variant

- `cloud-storage-bucket-object-retention-locked` — per-object retention lock state isn't expressible in HCL/plan/state. (The plan author's proposed `retention_policy.is_locked` mapping is a different feature, already covered by `mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked`.)
- `gke-backup-plan-exists` — blocked on a runtime bug: the check doesn't correlate plans to specific clusters; a Terraform variant would inherit the same gap.
- `vertexai-custom-job-has-explicit-service-account` — no `google_vertex_ai_custom_job` resource exists in Terraform.
- `dlp-job-trigger-healthy` — `latestJobs[].state` is operational telemetry, not configuration.

### CLAUDE.md updates

Adds a "Terraform variants for cloud policies" subsection covering: when to add variants, when to leave a limitation comment, the reference patterns to mirror, and an MQL parser quirk (`.all((expr) || ...)` is rejected — rely on `&&` binding tighter than `||` rather than leading parentheses).

## Notes for reviewers

This supersedes the closed batch PRs #2434 and #2435.

## Test plan

- [x] `cnspec policy lint content/mondoo-gcp-security.mql.yaml` passes
- [x] `python3 content/validation/validate_remediation_commands.py gcp` reports 0 failures
- [ ] Spot-check each new variant against a sample Terraform HCL/plan/state asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)