### PR TITLE
:star: Add Terraform variants to AWS security checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -487,6 +487,7 @@ sdp
 secadmin
 secauth
 secboot
+secgroup
 secretbox
 SECRETID
 secretmanager
@@ -612,6 +613,7 @@ wpaeap
 wpapsk
 wtmp
 xlarge
+XLast
 xoxb
 xoxp
 xts

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -27904,19 +27904,19 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_redshift_cluster")
     mql: |
       terraform.resources.where(nameLabel == "aws_redshift_cluster").all(
-        arguments.maintenance_track_name == "Current"
+        arguments.maintenance_track_name == "Current" || arguments.maintenance_track_name == "current"
       )
   - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_redshift_cluster")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_redshift_cluster").all(
-        change.after["maintenance_track_name"] == "Current"
+        change.after["maintenance_track_name"] == "Current" || change.after["maintenance_track_name"] == "current"
       )
   - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_redshift_cluster")
     mql: |
       terraform.state.resources.where(type == "aws_redshift_cluster").all(
-        values["maintenance_track_name"] == "Current"
+        values["maintenance_track_name"] == "Current" || values["maintenance_track_name"] == "current"
       )
   - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption
     title: Ensure FSx file systems are encrypted with a customer-managed KMS key
@@ -31445,7 +31445,6 @@ queries:
         networkConfig.enableNetworkIsolation == true &&
         networkConfig.enableInterContainerTrafficEncryption == true
       )
-  # No Terraform variants: Verifying that the role does not attach `AdministratorAccess` requires resolving an IAM role and walking `aws_iam_role_policy_attachment` resources — a multi-resource correlation that the variant pattern does not express. Audit IAM role attachments via `iam-no-admin-policies` instead.
   - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_sagemaker_data_quality_job_definition" || nameLabel == "aws_sagemaker_model_quality_job_definition" || nameLabel == "aws_sagemaker_model_bias_job_definition" || nameLabel == "aws_sagemaker_model_explainability_job_definition") != empty
     mql: |
@@ -31515,6 +31514,7 @@ queries:
           _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
         )
       )
+  # No Terraform variants: Verifying that the role does not attach `AdministratorAccess` requires resolving an IAM role and walking `aws_iam_role_policy_attachment` resources — a multi-resource correlation that the variant pattern does not express. Audit IAM role attachments via `iam-no-admin-policies` instead.
   - uid: mondoo-aws-security-sagemaker-domain-default-role-not-admin
     title: Ensure SageMaker domain default execution role is not AdministratorAccess
     impact: 90
@@ -39873,14 +39873,15 @@ queries:
         userData != /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ &&
         userData != /(?i)(aws_secret_access_key|password|secret_key|api_key|apikey|access_token|auth_token)\s*[=:]\s*['"]?[A-Za-z0-9\/+=]{8,}/
       )
-  # No Terraform variants: `isLogging` is runtime state from `GetTrailStatus`; Terraform's `aws_cloudtrail` has `enable_logging` (default `true`) but the runtime check verifies the actual logging service is running, not the declared default.
   - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_launch_template")
     mql: |
       terraform.resources.where(nameLabel == "aws_launch_template").all(
         arguments.user_data == null ||
         arguments.user_data == "" ||
-        arguments.user_data != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+        arguments.user_data != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ &&
+        arguments.user_data != /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ &&
+        arguments.user_data != /(?i)(aws_secret_access_key|password|secret_key|api_key|apikey|access_token|auth_token)\s*[=:]\s*['"]?[A-Za-z0-9\/+=]{8,}/
       )
   - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_launch_template")
@@ -39888,7 +39889,9 @@ queries:
       terraform.plan.resourceChanges.where(type == "aws_launch_template").all(
         change.after["user_data"] == null ||
         change.after["user_data"] == "" ||
-        change.after["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+        change.after["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ &&
+        change.after["user_data"] != /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ &&
+        change.after["user_data"] != /(?i)(aws_secret_access_key|password|secret_key|api_key|apikey|access_token|auth_token)\s*[=:]\s*['"]?[A-Za-z0-9\/+=]{8,}/
       )
   - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_launch_template")
@@ -39896,8 +39899,11 @@ queries:
       terraform.state.resources.where(type == "aws_launch_template").all(
         values["user_data"] == null ||
         values["user_data"] == "" ||
-        values["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+        values["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ &&
+        values["user_data"] != /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ &&
+        values["user_data"] != /(?i)(aws_secret_access_key|password|secret_key|api_key|apikey|access_token|auth_token)\s*[=:]\s*['"]?[A-Za-z0-9\/+=]{8,}/
       )
+  # No Terraform variants: `isLogging` is runtime state from `GetTrailStatus`; Terraform's `aws_cloudtrail` has `enable_logging` (default `true`) but the runtime check verifies the actual logging service is running, not the declared default.
   - uid: mondoo-aws-security-cloudtrail-is-logging
     title: Ensure CloudTrail trails are actively logging
     impact: 90
@@ -43632,7 +43638,6 @@ queries:
       aws.ec2.vpcEndpointServiceConfigurations.all(
         acceptanceRequired == true
       )
-  # No Terraform variants: VPC subnet flow-log enrollment is determined by `aws_flow_log` resources whose `subnet_id` references the subnet — a cross-resource correlation that requires inventorying every flow-log resource in the file. The runtime check inspects each subnet's resolved flow-logs at scan time; the equivalent variant pattern would have many false negatives without a graph of subnet-to-flow-log references.
   - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_endpoint_service")
     mql: |
@@ -43651,6 +43656,7 @@ queries:
       terraform.state.resources.where(type == "aws_vpc_endpoint_service").all(
         values["acceptance_required"] == true
       )
+  # No Terraform variants: VPC subnet flow-log enrollment is determined by `aws_flow_log` resources whose `subnet_id` references the subnet — a cross-resource correlation that requires inventorying every flow-log resource in the file. The runtime check inspects each subnet's resolved flow-logs at scan time; the equivalent variant pattern would have many false negatives without a graph of subnet-to-flow-log references.
   - uid: mondoo-aws-security-vpc-subnet-flow-logs-enabled
     title: Ensure VPC subnets have flow logs enabled
     impact: 60

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3995,6 +3995,7 @@ queries:
       terraform.state.resources.where(type == "aws_lambda_permission").none(
         values.principal == "*"
       )
+  # No Terraform variants: Pending OS upgrades are runtime telemetry on the live instance (`pendingMaintenanceActions`), not configuration. There is no Terraform attribute that represents pending maintenance actions.
   - uid: mondoo-aws-security-rds-instance-no-pending-os-upgrades
     title: Ensure no pending OS upgrades are available for RDS instances
     impact: 90
@@ -4519,6 +4520,7 @@ queries:
       terraform.state.resources.where(type == "aws_rds_cluster_parameter_group" && values.family == /postgres/).all(
         values.parameter.where(name == 'ssl').map(value).first == 1
       )
+  # No Terraform variants: Pending OS upgrades are runtime telemetry queried from the AWS API (`aws.rds.allPendingMaintenanceActions`), not configuration. There is no Terraform attribute that represents pending maintenance actions.
   - uid: mondoo-aws-security-rds-cluster-no-pending-os-upgrades
     title: Ensure no pending OS upgrades are available for RDS clusters
     impact: 90
@@ -18794,6 +18796,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS KMS Key
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS KMS key grants do not use wildcard (`*`) grantee principals. A wildcard principal in a KMS grant allows any AWS principal to use the granted operations on the key, effectively making the key publicly accessible for those operations.
@@ -18865,6 +18879,24 @@ queries:
   - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: aws.kms.key.grants.none(granteePrincipal == "*")
+  - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kms_grant")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_kms_grant").all(
+        arguments.grantee_principal != "*"
+      )
+  - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_kms_grant")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_kms_grant").all(
+        change.after["grantee_principal"] != "*"
+      )
+  - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_kms_grant")
+    mql: |
+      terraform.state.resources.where(type == "aws_kms_grant").all(
+        values["grantee_principal"] != "*"
+      )
   - uid: mondoo-aws-security-kms-key-origin-aws-kms
     title: Ensure customer-managed KMS keys use AWS_KMS origin
     impact: 60
@@ -19937,6 +19969,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Elastic Disaster Recovery (DRS) source server replication configurations have EBS encryption enabled. Encrypting replicated EBS volumes protects disaster recovery data at rest.
@@ -19978,6 +20022,24 @@ queries:
     mql: |
       aws.drs.sourceServers.all(
         replicationConfiguration.ebsEncryption != "NONE" && replicationConfiguration.ebsEncryption != ""
+      )
+  - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_drs_replication_configuration_template").all(
+        arguments.ebs_encryption != "NONE" && arguments.ebs_encryption != ""
+      )
+  - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_drs_replication_configuration_template").all(
+        change.after["ebs_encryption"] != "NONE" && change.after["ebs_encryption"] != ""
+      )
+  - uid: mondoo-aws-security-drs-replication-ebs-encrypted-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.state.resources.where(type == "aws_drs_replication_configuration_template").all(
+        values["ebs_encryption"] != "NONE" && values["ebs_encryption"] != ""
       )
   - uid: mondoo-aws-security-timestream-database-encrypted
     title: Ensure Amazon Timestream databases use KMS encryption
@@ -21077,6 +21139,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::EKS::Cluster").all(
       properties['AccessConfig'] != empty && properties['AccessConfig']['AuthenticationMode'] != "CONFIG_MAP"
       )
+  # No Terraform variants: Addon health status is runtime telemetry from the EKS control plane (`status == "ACTIVE"`); Terraform configures the addon but cannot represent operational health.
   - uid: mondoo-aws-security-eks-addon-healthy
     title: Ensure EKS cluster add-ons are in a healthy state
     impact: 60
@@ -22642,6 +22705,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EC2::Instance")
     mql: |
       cloudformation.template.resources.where(type == "AWS::EC2::Instance").all(properties['SourceDestCheck'] != false)
+  # No Terraform variants: Boot mode is determined by the AMI launched, not by an `aws_instance` argument. The runtime check inspects `currentInstanceBootMode` from the live instance; there is no clean Terraform analog.
   - uid: mondoo-aws-security-ec2-uefi-boot-mode
     title: Ensure EC2 instances use UEFI boot mode
     impact: 60
@@ -22850,6 +22914,7 @@ queries:
       terraform.state.resources.where(type == "aws_instance").none(
         values.instance_type == /^(t1|m1|m2|c1|cc1|cc2|cg1|cr1|hi1|hs1)\./
       )
+  # No Terraform variants: This check correlates account-level `aws.ec2.ebsEncryptionByDefault` with per-instance `hibernationConfigured`. The account-level EBS-encryption-by-default setting has no first-class Terraform resource (it's a regional API call), so this combination cannot be replicated against an HCL/plan/state asset.
   - uid: mondoo-aws-security-ec2-hibernation-encrypted-check
     title: Ensure EBS encryption by default is enabled when EC2 hibernation is in use
     impact: 50
@@ -24111,6 +24176,7 @@ queries:
       terraform.state.resources.where(type == "aws_directory_service_directory" && values.type == "MicrosoftAD").all(
         values.os_version != "SERVER_2012"
       )
+  # No Terraform variants: `ssoEnabled` is toggled via the `EnableSso`/`DisableSso` API; the `aws_directory_service_directory` Terraform resource has no `sso_enabled` argument. Provisioning this state requires an out-of-band API call.
   - uid: mondoo-aws-security-directoryservice-sso-enabled
     title: Ensure Directory Service directories have SSO enabled
     impact: 60
@@ -24181,6 +24247,7 @@ queries:
       aws.directoryservice.directories.where(stage == "Active" && type != "ADConnector").all(
         ssoEnabled == true
       )
+  # No Terraform variants: RADIUS MFA is enabled via the `EnableRadius` API and the `aws_directory_service_directory` resource exposes no `radius_*` arguments. There is no Terraform analog for this configuration.
   - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled
     title: Ensure Directory Service Managed AD has RADIUS MFA enabled
     impact: 80
@@ -25256,6 +25323,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have the transfer lock (registrar lock) enabled. Transfer lock prevents unauthorized or accidental domain transfers to another registrar, which is one of the most damaging attacks against an organization's online presence.
@@ -25311,6 +25390,24 @@ queries:
   - uid: mondoo-aws-security-route53-domain-transfer-lock-aws
     filters: asset.platform == "aws"
     mql: aws.route53.domains.all(transferLock == true)
+  - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_route53domains_registered_domain").all(
+        arguments.transfer_lock == true
+      )
+  - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_route53domains_registered_domain").all(
+        change.after["transfer_lock"] == true
+      )
+  - uid: mondoo-aws-security-route53-domain-transfer-lock-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_route53domains_registered_domain").all(
+        values["transfer_lock"] == true
+      )
   - uid: mondoo-aws-security-route53-domain-contact-privacy
     title: Ensure Route 53 registered domains have contact privacy protection enabled
     impact: 50
@@ -25327,6 +25424,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have privacy protection enabled for all contact types: admin, registrant, and tech. Without privacy protection, WHOIS records expose personal or organizational contact details to anyone who queries them.
@@ -25389,6 +25498,24 @@ queries:
       aws.route53.domains.all(
         adminPrivacy == true && registrantPrivacy == true && techPrivacy == true
       )
+  - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_route53domains_registered_domain").all(
+        arguments.admin_privacy == true && arguments.registrant_privacy == true && arguments.tech_privacy == true
+      )
+  - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_route53domains_registered_domain").all(
+        change.after["admin_privacy"] == true && change.after["registrant_privacy"] == true && change.after["tech_privacy"] == true
+      )
+  - uid: mondoo-aws-security-route53-domain-contact-privacy-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_route53domains_registered_domain").all(
+        values["admin_privacy"] == true && values["registrant_privacy"] == true && values["tech_privacy"] == true
+      )
   - uid: mondoo-aws-security-route53-domain-auto-renew
     title: Ensure Route 53 registered domains have auto-renew enabled
     impact: 80
@@ -25405,6 +25532,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that domains registered through Amazon Route 53 have automatic renewal enabled. Without auto-renew, domains can accidentally expire if manual renewal is missed, allowing attackers to register the lapsed domain and hijack all associated services.
@@ -25459,6 +25598,24 @@ queries:
   - uid: mondoo-aws-security-route53-domain-auto-renew-aws
     filters: asset.platform == "aws"
     mql: aws.route53.domains.all(autoRenew == true)
+  - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_route53domains_registered_domain").all(
+        arguments.auto_renew == true
+      )
+  - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_route53domains_registered_domain").all(
+        change.after["auto_renew"] == true
+      )
+  - uid: mondoo-aws-security-route53-domain-auto-renew-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_route53domains_registered_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_route53domains_registered_domain").all(
+        values["auto_renew"] == true
+      )
   - uid: mondoo-aws-security-memorydb-cluster-tls-enabled
     title: Ensure MemoryDB clusters have encryption in transit (TLS) enabled
     impact: 90
@@ -26952,6 +27109,7 @@ queries:
       values.workspace_creation_properties != empty &&
       values.workspace_creation_properties.all(enable_maintenance_mode == true)
       )
+  # No Terraform variants: The runtime check walks WorkSpaces directories down to security-group ingress rules — a cross-resource correlation. In Terraform, security-group rules are evaluated independently by the `secgroup-restricted-*` checks; there is no useful WorkSpaces-scoped HCL/plan/state analog.
   - uid: mondoo-aws-security-workspaces-no-unrestricted-inbound
     title: Ensure WorkSpaces security groups do not allow unrestricted inbound access
     impact: 80
@@ -27642,6 +27800,18 @@ queries:
         tags:
           mondoo.com/filter-title: CloudFormation
           mondoo.com/filter-icon: cloudformation
+      - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon Redshift clusters are configured to use the `Current` maintenance track rather than the `Trailing` track. The maintenance track determines which cluster version is applied during maintenance windows and directly affects the security posture of the cluster.
@@ -27729,6 +27899,24 @@ queries:
     mql: |
       cloudformation.template.resources.where(type == "AWS::Redshift::Cluster").all(
       properties['MaintenanceTrackName'] == "current" || properties['MaintenanceTrackName'] == "Current"
+      )
+  - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_redshift_cluster")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_redshift_cluster").all(
+        arguments.maintenance_track_name == "Current"
+      )
+  - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_redshift_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_redshift_cluster").all(
+        change.after["maintenance_track_name"] == "Current"
+      )
+  - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_redshift_cluster")
+    mql: |
+      terraform.state.resources.where(type == "aws_redshift_cluster").all(
+        values["maintenance_track_name"] == "Current"
       )
   - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption
     title: Ensure FSx file systems are encrypted with a customer-managed KMS key
@@ -29503,6 +29691,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::RDS::DBProxy").all(
       properties['DebugLogging'] != true
       )
+  # No Terraform variants: Snapshot encryption status is determined by the source cluster's `storage_encrypted` attribute and surfaced in the snapshot resource at runtime. The cluster-level `aws_docdb_cluster.storage_encrypted` setting is what governs this; auditing snapshots directly has no first-class Terraform analog.
   - uid: mondoo-aws-security-documentdb-snapshot-encrypted
     title: Ensure DocumentDB cluster snapshots are encrypted at rest
     impact: 80
@@ -30281,6 +30470,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::SageMaker::Model").all(
       properties['VpcConfig'] != empty && properties['VpcConfig']['Subnets'] != empty
       )
+  # No Terraform variants: SageMaker training jobs are imperative API calls (`CreateTrainingJob`); there is no `aws_sagemaker_training_job` Terraform resource that carries `enable_network_isolation`.
   - uid: mondoo-aws-security-sagemaker-training-job-network-isolation
     title: Ensure SageMaker training jobs have network isolation enabled
     impact: 80
@@ -30351,6 +30541,7 @@ queries:
   - uid: mondoo-aws-security-sagemaker-training-job-network-isolation-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.trainingJobs.all(enableNetworkIsolation == true)
+  # No Terraform variants: SageMaker training jobs are imperative API calls; the inter-container traffic encryption flag is set per-job via `CreateTrainingJob` and has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-training-job-encryption
     title: Ensure SageMaker training jobs encrypt inter-container traffic
     impact: 80
@@ -30421,6 +30612,7 @@ queries:
   - uid: mondoo-aws-security-sagemaker-training-job-encryption-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.trainingJobs.all(enableInterContainerTrafficEncryption == true)
+  # No Terraform variants: SageMaker training jobs are imperative API calls (`CreateTrainingJob`); the `vpc_config` attribute is per-job and has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured
     title: Ensure SageMaker training jobs are deployed within a VPC
     impact: 70
@@ -30491,6 +30683,7 @@ queries:
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.trainingJobs.all(vpcConfig != empty)
+  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); there is no `aws_sagemaker_processing_job` Terraform resource that carries `enable_network_isolation`.
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation
     title: Ensure SageMaker processing jobs have network isolation enabled
     impact: 80
@@ -30558,6 +30751,7 @@ queries:
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.processingJobs.all(enableNetworkIsolation == true)
+  # No Terraform variants: SageMaker processing jobs are imperative API calls; the inter-container traffic encryption flag has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption
     title: Ensure SageMaker processing jobs encrypt inter-container traffic
     impact: 80
@@ -30624,6 +30818,7 @@ queries:
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.processingJobs.all(enableInterContainerTrafficEncryption == true)
+  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); per-job VPC configuration has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured
     title: Ensure SageMaker processing jobs are deployed within a VPC
     impact: 70
@@ -30842,6 +31037,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::SageMaker::Domain").all(
       properties['KmsKeyId'] != empty
       )
+  # No Terraform variants: SageMaker training jobs are imperative API calls; per-job hyperparameters are not represented as a Terraform resource argument.
   - uid: mondoo-aws-security-sagemaker-training-hyperparameters-no-secrets
     title: Ensure SageMaker training hyperparameters do not contain AWS credentials
     impact: 85
@@ -30917,6 +31113,7 @@ queries:
           _.find(/(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/) != empty
         )
       )
+  # No Terraform variants: Hub content metadata is set via `ImportHubContent` API calls (no Terraform resource); the runtime check inspects content uploaded to a hub at scan time.
   - uid: mondoo-aws-security-sagemaker-hub-public-content-documented
     title: Ensure public-sourced SageMaker hub content includes review documentation
     impact: 70
@@ -30988,6 +31185,7 @@ queries:
           .where(sageMakerPublicHubContentArn != empty && status == "Available")
           .all(markdown != empty)
       )
+  # No Terraform variants: Model-package approval status is workflow state mutated by `UpdateModelPackage` API calls. The `aws_sagemaker_model_package` Terraform resource exposes a static `approval_status` but it cannot represent the post-approval validation chain this check enforces.
   - uid: mondoo-aws-security-sagemaker-model-package-approval-validated
     title: Ensure approved SageMaker model packages are validated and documented
     impact: 75
@@ -31076,6 +31274,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that every SageMaker code repository references a Secrets Manager secret for Git credentials. A code repository without a secret reference either clones anonymously from a public Git host, which is rare for internal repositories, or relies on credentials embedded elsewhere — neither pattern is acceptable for repositories used by notebooks, training jobs, or Studio apps.
@@ -31121,6 +31331,26 @@ queries:
   - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-aws
     filters: asset.platform == "aws"
     mql: aws.sagemaker.codeRepositories.all(secret != empty)
+  - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_code_repository")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sagemaker_code_repository").all(
+        blocks.where(type == "git_config").any(
+          arguments.secret_arn != null && arguments.secret_arn != ""
+        )
+      )
+  - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sagemaker_code_repository")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sagemaker_code_repository").all(
+        change.after["git_config"].any(_["secret_arn"] != null && _["secret_arn"] != "")
+      )
+  - uid: mondoo-aws-security-sagemaker-code-repository-uses-secret-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sagemaker_code_repository")
+    mql: |
+      terraform.state.resources.where(type == "aws_sagemaker_code_repository").all(
+        values["git_config"].any(_["secret_arn"] != null && _["secret_arn"] != "")
+      )
   - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config
     title: Ensure SageMaker monitoring jobs enforce network isolation and encryption
     impact: 75
@@ -31137,6 +31367,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that every SageMaker monitoring job definition — data quality, model quality, model bias, and model explainability — has network isolation enabled and inter-container traffic encryption enabled in its `networkConfig`. Monitoring jobs continuously read captured endpoint inference traffic, which typically contains the same sensitive inputs and outputs that the production endpoint handles.
@@ -31202,6 +31444,76 @@ queries:
       aws.sagemaker.modelExplainabilityJobDefinitions.all(
         networkConfig.enableNetworkIsolation == true &&
         networkConfig.enableInterContainerTrafficEncryption == true
+      )
+  # No Terraform variants: Verifying that the role does not attach `AdministratorAccess` requires resolving an IAM role and walking `aws_iam_role_policy_attachment` resources — a multi-resource correlation that the variant pattern does not express. Audit IAM role attachments via `iam-no-admin-policies` instead.
+  - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_sagemaker_data_quality_job_definition" || nameLabel == "aws_sagemaker_model_quality_job_definition" || nameLabel == "aws_sagemaker_model_bias_job_definition" || nameLabel == "aws_sagemaker_model_explainability_job_definition") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sagemaker_data_quality_job_definition").all(
+        blocks.where(type == "network_config").any(
+          arguments.enable_network_isolation == true && arguments.enable_inter_container_traffic_encryption == true
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_sagemaker_model_quality_job_definition").all(
+        blocks.where(type == "network_config").any(
+          arguments.enable_network_isolation == true && arguments.enable_inter_container_traffic_encryption == true
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_sagemaker_model_bias_job_definition").all(
+        blocks.where(type == "network_config").any(
+          arguments.enable_network_isolation == true && arguments.enable_inter_container_traffic_encryption == true
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_sagemaker_model_explainability_job_definition").all(
+        blocks.where(type == "network_config").any(
+          arguments.enable_network_isolation == true && arguments.enable_inter_container_traffic_encryption == true
+        )
+      )
+  - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_sagemaker_data_quality_job_definition" || type == "aws_sagemaker_model_quality_job_definition" || type == "aws_sagemaker_model_bias_job_definition" || type == "aws_sagemaker_model_explainability_job_definition") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sagemaker_data_quality_job_definition").all(
+        change.after["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_sagemaker_model_quality_job_definition").all(
+        change.after["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_sagemaker_model_bias_job_definition").all(
+        change.after["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_sagemaker_model_explainability_job_definition").all(
+        change.after["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      )
+  - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_sagemaker_data_quality_job_definition" || type == "aws_sagemaker_model_quality_job_definition" || type == "aws_sagemaker_model_bias_job_definition" || type == "aws_sagemaker_model_explainability_job_definition") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_sagemaker_data_quality_job_definition").all(
+        values["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_sagemaker_model_quality_job_definition").all(
+        values["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_sagemaker_model_bias_job_definition").all(
+        values["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_sagemaker_model_explainability_job_definition").all(
+        values["network_config"].any(
+          _["enable_network_isolation"] == true && _["enable_inter_container_traffic_encryption"] == true
+        )
       )
   - uid: mondoo-aws-security-sagemaker-domain-default-role-not-admin
     title: Ensure SageMaker domain default execution role is not AdministratorAccess
@@ -31272,6 +31584,7 @@ queries:
       aws.sagemaker.domains
         .where(defaultExecutionRole != empty)
         .all(defaultExecutionRole.attachedPolicies.none(name == "AdministratorAccess"))
+  # No Terraform variants: Verifying that the role does not attach `AdministratorAccess` requires resolving an IAM role and walking `aws_iam_role_policy_attachment` resources — a multi-resource correlation that the variant pattern does not express.
   - uid: mondoo-aws-security-sagemaker-notebook-role-not-admin
     title: Ensure SageMaker notebook instance IAM role is not AdministratorAccess
     impact: 90
@@ -31336,6 +31649,7 @@ queries:
       aws.sagemaker.notebookInstances
         .where(details.iamRole != empty)
         .all(details.iamRole.attachedPolicies.none(name == "AdministratorAccess"))
+  # No Terraform variants: SageMaker training/processing jobs are imperative API calls; the `iamRole` field is set per-job and dereferencing it back to its attached policies is a multi-resource correlation Terraform variants do not express.
   - uid: mondoo-aws-security-sagemaker-job-role-not-admin
     title: Ensure SageMaker training/processing job roles are not AdministratorAccess
     impact: 85
@@ -32244,6 +32558,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::MSK::Cluster").all(
       properties['LoggingInfo'] != empty && properties['LoggingInfo']['BrokerLogs'] != empty
       )
+  # No Terraform variants: This check follows a CloudTrail trail's `S3BucketName` to the referenced bucket and inspects its public ACL — a cross-resource correlation. The general `s3-bucket-level-public-access-prohibited-bucket` check covers the bucket directly in Terraform.
   - uid: mondoo-aws-security-cloudtrail-s3-bucket-not-public
     title: Ensure CloudTrail S3 bucket is not publicly accessible
     impact: 95
@@ -32345,6 +32660,7 @@ queries:
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
       aws.cloudtrail.trail.s3bucket.public == false
+  # No Terraform variants: This check follows a CloudTrail trail's `S3BucketName` to the referenced bucket and inspects its logging configuration — a cross-resource correlation. The general `s3-bucket-server-access-logging-enabled` check covers the bucket directly in Terraform.
   - uid: mondoo-aws-security-cloudtrail-s3-bucket-logging
     title: Ensure CloudTrail S3 bucket has access logging enabled
     impact: 50
@@ -35291,6 +35607,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::EC2::SecurityGroup").all(
       properties['SecurityGroupEgress'] == empty || properties['SecurityGroupEgress'].none(_['CidrIp'] == "0.0.0.0/0")
       )
+  # No Terraform variants: The root user's MFA configuration is reported via `aws.iam.credentialReport` and `aws.iam.virtualMfaDevices`; the AWS root account itself is not a Terraform-managed resource.
   - uid: mondoo-aws-security-iam-root-hardware-mfa
     title: Ensure root account has a hardware MFA device enabled
     impact: 90
@@ -35377,6 +35694,7 @@ queries:
     mql: |
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(mfaActive == true) &&
       aws.iam.virtualMfaDevices.none(serialNumber.contains("root-account-mfa-device"))
+  # No Terraform variants: Expiration of an IAM server certificate is runtime telemetry (`Expiration` timestamp from the IAM API). Terraform does not expose certificate expiration as an attribute on `aws_iam_server_certificate`.
   - uid: mondoo-aws-security-iam-expired-certificates
     title: Ensure expired SSL/TLS certificates are removed from IAM
     impact: 60
@@ -35601,6 +35919,7 @@ queries:
       terraform.state.resources.where(type == "aws_iam_role_policy_attachment").any(
         values.policy_arn == "arn:aws:iam::aws:policy/AWSSupportAccess"
       )
+  # No Terraform variants: Credential usage telemetry (`passwordLastUsed`, `accessKeyXLastUsedDate`) is reported by the IAM credential-report API and has no Terraform analog.
   - uid: mondoo-aws-security-iam-unused-credentials-disabled
     title: Ensure unused IAM credentials are disabled
     impact: 50
@@ -37363,6 +37682,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::SQS::QueuePolicy").all(
       properties['PolicyDocument'].string != /"Principal"\s*:\s*"\*"/
       )
+  # No Terraform variants: `aws_ecs_task_definition.container_definitions` is a JSON-encoded string in HCL — extracting and pattern-matching environment-variable names/values would require a JSON-walking variant pass that is not currently supported in the same shape as the runtime check.
   - uid: mondoo-aws-security-ecs-task-definition-no-plaintext-secrets
     title: Ensure ECS task definitions do not contain plaintext secrets
     impact: 90
@@ -37491,6 +37811,7 @@ queries:
           environment.none( value == /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ )
         )
       )
+  # No Terraform variants: The default VPC is created by AWS automatically per region; `aws_default_vpc` adopts an existing default VPC for management but does not delete it. The runtime check walks every region's VPCs to find any with `isDefault == true`; this regional inventory does not have a clean Terraform analog.
   - uid: mondoo-aws-security-no-default-vpc
     title: Ensure the default VPC is not used
     impact: 80
@@ -39283,6 +39604,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ecr-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ecr-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ecr-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Amazon ECR private repository access policies do not grant public access. A repository policy that allows the `*` principal enables any AWS account or unauthenticated user to pull container images, potentially exposing proprietary code, configuration, and embedded secrets.
@@ -39391,6 +39724,30 @@ queries:
           _['Principal']['AWS'].contains("*")
         )
       )
+  - uid: mondoo-aws-security-ecr-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ecr_repository_policy").all(
+        arguments.policy["Statement"].none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-ecr-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ecr_repository_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ecr_repository_policy").all(
+        change.after["policy"]["Statement"].none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-ecr-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ecr_repository_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_ecr_repository_policy").all(
+        values["policy"]["Statement"].none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
   - uid: mondoo-aws-security-ec2-launch-template-no-secrets
     title: Ensure EC2 launch templates do not contain secrets
     impact: 90
@@ -39407,6 +39764,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that EC2 launch template user data does not contain hard-coded secrets such as AWS access keys, private keys, passwords, or API tokens. Launch template user data is visible to anyone with EC2 describe permissions and is stored in plaintext, making it an insecure location for sensitive credentials.
@@ -39503,6 +39872,31 @@ queries:
         userData != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ &&
         userData != /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ &&
         userData != /(?i)(aws_secret_access_key|password|secret_key|api_key|apikey|access_token|auth_token)\s*[=:]\s*['"]?[A-Za-z0-9\/+=]{8,}/
+      )
+  # No Terraform variants: `isLogging` is runtime state from `GetTrailStatus`; Terraform's `aws_cloudtrail` has `enable_logging` (default `true`) but the runtime check verifies the actual logging service is running, not the declared default.
+  - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_launch_template")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_launch_template").all(
+        arguments.user_data == null ||
+        arguments.user_data == "" ||
+        arguments.user_data != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+      )
+  - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_launch_template")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_launch_template").all(
+        change.after["user_data"] == null ||
+        change.after["user_data"] == "" ||
+        change.after["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+      )
+  - uid: mondoo-aws-security-ec2-launch-template-no-secrets-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_launch_template")
+    mql: |
+      terraform.state.resources.where(type == "aws_launch_template").all(
+        values["user_data"] == null ||
+        values["user_data"] == "" ||
+        values["user_data"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
       )
   - uid: mondoo-aws-security-cloudtrail-is-logging
     title: Ensure CloudTrail trails are actively logging
@@ -39613,6 +40007,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS EBS Snapshot
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that EBS snapshots are not publicly shared. Public snapshots expose volume data to any AWS account, potentially leaking sensitive information such as application data, credentials, or encryption keys stored on the volume.
@@ -39695,6 +40101,24 @@ queries:
     filters: asset.platform == "aws-ebs-snapshot"
     mql: |
       aws.ec2.snapshot.isPublic == false
+  - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_snapshot_create_volume_permission")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_snapshot_create_volume_permission").all(
+        arguments.account_id != "all"
+      )
+  - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_snapshot_create_volume_permission")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_snapshot_create_volume_permission").all(
+        change.after["account_id"] != "all"
+      )
+  - uid: mondoo-aws-security-ec2-snapshot-not-public-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_snapshot_create_volume_permission")
+    mql: |
+      terraform.state.resources.where(type == "aws_snapshot_create_volume_permission").all(
+        values["account_id"] != "all"
+      )
   - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes
     title: Ensure launch configuration EBS volumes are encrypted
     impact: 80
@@ -40424,6 +40848,7 @@ queries:
         properties['StorageEncrypted'] == true &&
         properties['KmsKeyId'] != empty
       )
+  # No Terraform variants: `aws_db_snapshot` is rarely declared in Terraform; encryption is inherited from the source `aws_db_instance.kms_key_id`. Auditing snapshot KMS keys directly does not have a clean Terraform analog.
   - uid: mondoo-aws-security-rds-snapshot-cmk-encryption
     title: Ensure RDS snapshots use customer-managed KMS encryption
     impact: 70
@@ -42788,6 +43213,7 @@ queries:
       cloudformation.template.resources.where(type == "AWS::Cassandra::Table").all(
         properties['PointInTimeRecoveryEnabled'] == true
       )
+  # No Terraform variants: AppStream stack `contentRedirection.hostToClientEnabled` is not exposed as an argument on the `aws_appstream_stack` Terraform resource.
   - uid: mondoo-aws-security-appstream-stack-url-redirection-disabled
     title: Ensure AppStream stacks have URL redirection disabled
     impact: 70
@@ -42862,6 +43288,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPCs use DHCP options sets with custom DNS servers rather than the default AWS-provided DNS (AmazonProvidedDNS). Custom DNS servers allow organizations to enforce DNS-level security controls such as filtering, logging, and threat detection.
@@ -42952,6 +43390,27 @@ queries:
       aws.vpc.dhcpOptions.configurations.where(key == "domain-name-servers").all(
         values.none(_ == "AmazonProvidedDNS")
       )
+  - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_dhcp_options")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_vpc_dhcp_options").all(
+        arguments.domain_name_servers == null ||
+        arguments.domain_name_servers.none(_ == "AmazonProvidedDNS")
+      )
+  - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_vpc_dhcp_options")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_vpc_dhcp_options").all(
+        change.after["domain_name_servers"] == null ||
+        change.after["domain_name_servers"].none(_ == "AmazonProvidedDNS")
+      )
+  - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_vpc_dhcp_options")
+    mql: |
+      terraform.state.resources.where(type == "aws_vpc_dhcp_options").all(
+        values["domain_name_servers"] == null ||
+        values["domain_name_servers"].none(_ == "AmazonProvidedDNS")
+      )
   - uid: mondoo-aws-security-vpc-endpoint-security-groups
     title: Ensure VPC endpoints have security groups attached
     impact: 80
@@ -42968,6 +43427,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPC interface endpoints have security groups attached to control which resources can communicate with AWS services through the endpoint. Without security groups, any resource in the VPC can access the endpoint, bypassing network-level access controls.
@@ -43043,6 +43514,24 @@ queries:
       aws.vpc.endpoints.where(type == "Interface").all(
         securityGroups.length > 0
       )
+  - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_endpoint")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_vpc_endpoint").where(arguments.vpc_endpoint_type == "Interface").all(
+        arguments.security_group_ids != null && arguments.security_group_ids.length > 0
+      )
+  - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_vpc_endpoint")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_vpc_endpoint").where(change.after["vpc_endpoint_type"] == "Interface").all(
+        change.after["security_group_ids"] != null && change.after["security_group_ids"].length > 0
+      )
+  - uid: mondoo-aws-security-vpc-endpoint-security-groups-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_vpc_endpoint")
+    mql: |
+      terraform.state.resources.where(type == "aws_vpc_endpoint").where(values["vpc_endpoint_type"] == "Interface").all(
+        values["security_group_ids"] != null && values["security_group_ids"].length > 0
+      )
   - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required
     title: Ensure VPC endpoint services require acceptance
     impact: 80
@@ -43059,6 +43548,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPC endpoint service configurations (PrivateLink provider-side) require manual acceptance of connection requests. Without acceptance required, any AWS principal with the endpoint service name can create a connection, potentially allowing unauthorized access to internal services.
@@ -43130,6 +43631,25 @@ queries:
     mql: |
       aws.ec2.vpcEndpointServiceConfigurations.all(
         acceptanceRequired == true
+      )
+  # No Terraform variants: VPC subnet flow-log enrollment is determined by `aws_flow_log` resources whose `subnet_id` references the subnet — a cross-resource correlation that requires inventorying every flow-log resource in the file. The runtime check inspects each subnet's resolved flow-logs at scan time; the equivalent variant pattern would have many false negatives without a graph of subnet-to-flow-log references.
+  - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_endpoint_service")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_vpc_endpoint_service").all(
+        arguments.acceptance_required == true
+      )
+  - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_vpc_endpoint_service")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_vpc_endpoint_service").all(
+        change.after["acceptance_required"] == true
+      )
+  - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_vpc_endpoint_service")
+    mql: |
+      terraform.state.resources.where(type == "aws_vpc_endpoint_service").all(
+        values["acceptance_required"] == true
       )
   - uid: mondoo-aws-security-vpc-subnet-flow-logs-enabled
     title: Ensure VPC subnets have flow logs enabled
@@ -43247,6 +43767,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS EC2 VPC
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that VPC flow logs configured to deliver to CloudWatch Logs have an IAM role associated. Without an IAM role, flow logs cannot write to CloudWatch, causing log delivery to silently fail and creating a false sense of logging coverage.
@@ -43343,6 +43875,30 @@ queries:
       aws.vpc.flowLogs.where(destinationType == "cloud-watch-logs").all(
         iamRole != null
       )
+  - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_flow_log")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_flow_log").where(
+        arguments.log_destination_type == null || arguments.log_destination_type == "cloud-watch-logs"
+      ).all(
+        arguments.iam_role_arn != null && arguments.iam_role_arn != ""
+      )
+  - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_flow_log")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_flow_log").where(
+        change.after["log_destination_type"] == null || change.after["log_destination_type"] == "cloud-watch-logs"
+      ).all(
+        change.after["iam_role_arn"] != null && change.after["iam_role_arn"] != ""
+      )
+  - uid: mondoo-aws-security-vpc-flow-logs-iam-role-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_flow_log")
+    mql: |
+      terraform.state.resources.where(type == "aws_flow_log").where(
+        values["log_destination_type"] == null || values["log_destination_type"] == "cloud-watch-logs"
+      ).all(
+        values["iam_role_arn"] != null && values["iam_role_arn"] != ""
+      )
   - uid: mondoo-aws-security-client-vpn-security-groups
     title: Ensure Client VPN endpoints have security groups
     impact: 80
@@ -43359,6 +43915,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-client-vpn-security-groups-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-client-vpn-security-groups-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-client-vpn-security-groups-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Client VPN endpoints have security groups attached to control network access from VPN clients into the VPC. Without security groups, VPN clients may have unrestricted access to all resources within the associated VPC.
@@ -43451,6 +44019,24 @@ queries:
       aws.ec2.clientVpnEndpoints.all(
         securityGroups.length > 0
       )
+  - uid: mondoo-aws-security-client-vpn-security-groups-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ec2_client_vpn_endpoint")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ec2_client_vpn_endpoint").all(
+        arguments.security_group_ids != null && arguments.security_group_ids.length > 0
+      )
+  - uid: mondoo-aws-security-client-vpn-security-groups-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ec2_client_vpn_endpoint")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ec2_client_vpn_endpoint").all(
+        change.after["security_group_ids"] != null && change.after["security_group_ids"].length > 0
+      )
+  - uid: mondoo-aws-security-client-vpn-security-groups-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ec2_client_vpn_endpoint")
+    mql: |
+      terraform.state.resources.where(type == "aws_ec2_client_vpn_endpoint").all(
+        values["security_group_ids"] != null && values["security_group_ids"].length > 0
+      )
   - uid: mondoo-aws-security-prefix-list-no-broad-cidrs
     title: Ensure managed prefix lists do not contain overly broad CIDRs
     impact: 70
@@ -43467,6 +44053,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that customer-managed prefix lists do not contain overly broad CIDR ranges such as `0.0.0.0/0` or `::/0`. Prefix lists are referenced in security group rules and route tables; a broad CIDR in a prefix list effectively opens access to the entire internet, defeating the purpose of network segmentation.
@@ -43563,6 +44161,30 @@ queries:
       aws.ec2.managedPrefixLists.where(ownerId != "AWS").all(
         entries.none(cidr == "0.0.0.0/0") &&
         entries.none(cidr == "::/0")
+      )
+  - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ec2_managed_prefix_list")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ec2_managed_prefix_list").all(
+        blocks.where(type == "entry").all(
+          arguments.cidr != "0.0.0.0/0" && arguments.cidr != "::/0"
+        )
+      )
+  - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ec2_managed_prefix_list")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ec2_managed_prefix_list").all(
+        change.after["entry"] == null || change.after["entry"].all(
+          _["cidr"] != "0.0.0.0/0" && _["cidr"] != "::/0"
+        )
+      )
+  - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ec2_managed_prefix_list")
+    mql: |
+      terraform.state.resources.where(type == "aws_ec2_managed_prefix_list").all(
+        values["entry"] == null || values["entry"].all(
+          _["cidr"] != "0.0.0.0/0" && _["cidr"] != "::/0"
+        )
       )
   - uid: mondoo-aws-security-ssm-document-not-public
     title: Ensure SSM documents are not publicly shared
@@ -44065,6 +44687,7 @@ queries:
       terraform.state.resources.where(type == "aws_cloudwatch_log_destination_policy").all(
         values.access_policy.contains('"*"') == false
       )
+  # No Terraform variants: Allowed principals on a VPC endpoint service are managed through `aws_vpc_endpoint_service_allowed_principal` resources — one per principal — keyed by the service ID. Verifying that at least one principal exists and none equals `*` requires graph traversal across resources that the variant pattern does not express.
   - uid: mondoo-aws-security-vpc-endpoint-service-restrict-principals
     title: Ensure VPC endpoint services restrict allowed principals
     impact: 80
@@ -44187,6 +44810,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sfn-logging-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sfn-logging-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sfn-logging-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Step Functions state machines have logging enabled. Without logging, execution history and state transition events are not captured, making it difficult to detect failures, debug workflows, or investigate security incidents.
@@ -44247,6 +44882,30 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.sfn.stateMachines.all(loggingConfiguration['level'] != "OFF")
+  - uid: mondoo-aws-security-sfn-logging-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sfn_state_machine")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sfn_state_machine").all(
+        blocks.where(type == "logging_configuration").any(
+          arguments.level != "OFF" && arguments.level != null
+        )
+      )
+  - uid: mondoo-aws-security-sfn-logging-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sfn_state_machine")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sfn_state_machine").all(
+        change.after["logging_configuration"] != null && change.after["logging_configuration"].any(
+          _["level"] != "OFF" && _["level"] != null
+        )
+      )
+  - uid: mondoo-aws-security-sfn-logging-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sfn_state_machine")
+    mql: |
+      terraform.state.resources.where(type == "aws_sfn_state_machine").all(
+        values["logging_configuration"] != null && values["logging_configuration"].any(
+          _["level"] != "OFF" && _["level"] != null
+        )
+      )
   - uid: mondoo-aws-security-sfn-encryption-configured
     title: Ensure Step Functions state machines use CMK encryption
     impact: 70
@@ -44269,6 +44928,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sfn-encryption-configured-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sfn-encryption-configured-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sfn-encryption-configured-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Step Functions state machines are encrypted using a customer-managed KMS key rather than the default AWS-owned key. Customer-managed keys provide greater control over key lifecycle, access policies, and audit capabilities.
@@ -44329,6 +45000,30 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.sfn.stateMachines.all(encryptionConfiguration['type'] != "AWS_OWNED_KEY")
+  - uid: mondoo-aws-security-sfn-encryption-configured-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sfn_state_machine")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sfn_state_machine").all(
+        blocks.where(type == "encryption_configuration").any(
+          arguments.type != "AWS_OWNED_KEY" && arguments.type != null
+        )
+      )
+  - uid: mondoo-aws-security-sfn-encryption-configured-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sfn_state_machine")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sfn_state_machine").all(
+        change.after["encryption_configuration"] != null && change.after["encryption_configuration"].any(
+          _["type"] != "AWS_OWNED_KEY" && _["type"] != null
+        )
+      )
+  - uid: mondoo-aws-security-sfn-encryption-configured-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sfn_state_machine")
+    mql: |
+      terraform.state.resources.where(type == "aws_sfn_state_machine").all(
+        values["encryption_configuration"] != null && values["encryption_configuration"].any(
+          _["type"] != "AWS_OWNED_KEY" && _["type"] != null
+        )
+      )
   - uid: mondoo-aws-security-ram-no-external-principals
     title: Ensure RAM shares do not allow external principals
     impact: 80
@@ -44351,6 +45046,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ram-no-external-principals-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ram-no-external-principals-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ram-no-external-principals-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Resource Access Manager (RAM) resource shares do not allow external principals. When external principals are allowed, resources can be shared with AWS accounts outside your organization, increasing the risk of unauthorized access.
@@ -44403,6 +45110,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.ram.resourceShares.all(allowExternalPrincipals == false)
+  - uid: mondoo-aws-security-ram-no-external-principals-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ram_resource_share")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ram_resource_share").all(
+        arguments.allow_external_principals == false
+      )
+  - uid: mondoo-aws-security-ram-no-external-principals-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ram_resource_share")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ram_resource_share").all(
+        change.after["allow_external_principals"] == false
+      )
+  - uid: mondoo-aws-security-ram-no-external-principals-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ram_resource_share")
+    mql: |
+      terraform.state.resources.where(type == "aws_ram_resource_share").all(
+        values["allow_external_principals"] == false
+      )
   - uid: mondoo-aws-security-ram-no-wildcard-principals
     title: Ensure RAM shares do not use wildcard principals
     impact: 70
@@ -44425,6 +45150,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Resource Access Manager (RAM) resource shares do not use wildcard (*) principals. Wildcard principals grant access to all AWS accounts, effectively making shared resources publicly accessible.
@@ -44485,6 +45222,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.ram.resourceShares.all(principals.none(_ == "*"))
+  - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ram_principal_association")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ram_principal_association").all(
+        arguments.principal != "*"
+      )
+  - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ram_principal_association")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ram_principal_association").all(
+        change.after["principal"] != "*"
+      )
+  - uid: mondoo-aws-security-ram-no-wildcard-principals-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ram_principal_association")
+    mql: |
+      terraform.state.resources.where(type == "aws_ram_principal_association").all(
+        values["principal"] != "*"
+      )
   - uid: mondoo-aws-security-transfer-no-ftp
     title: Ensure Transfer Family servers do not use plain FTP
     impact: 90
@@ -44507,6 +45262,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-no-ftp-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-no-ftp-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-no-ftp-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Transfer Family servers do not use the plain FTP protocol. FTP transmits data and credentials in cleartext, making it vulnerable to interception and man-in-the-middle attacks.
@@ -44564,6 +45331,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.servers.all(protocols.none(_ == "FTP"))
+  - uid: mondoo-aws-security-transfer-no-ftp-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_server").all(
+        arguments.protocols == null || arguments.protocols.none(_ == "FTP")
+      )
+  - uid: mondoo-aws-security-transfer-no-ftp-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_server").all(
+        change.after["protocols"] == null || change.after["protocols"].none(_ == "FTP")
+      )
+  - uid: mondoo-aws-security-transfer-no-ftp-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_server").all(
+        values["protocols"] == null || values["protocols"].none(_ == "FTP")
+      )
   - uid: mondoo-aws-security-transfer-vpc-endpoint
     title: Ensure Transfer Family servers use VPC endpoints
     impact: 80
@@ -44586,6 +45371,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Transfer Family servers use VPC or VPC_ENDPOINT endpoint types instead of PUBLIC endpoints. VPC endpoints keep file transfer traffic within the AWS network, reducing exposure to internet-based threats.
@@ -44646,6 +45443,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.servers.all(endpointType == "VPC" || endpointType == "VPC_ENDPOINT")
+  - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_server").all(
+        arguments.endpoint_type == "VPC" || arguments.endpoint_type == "VPC_ENDPOINT"
+      )
+  - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_server").all(
+        change.after["endpoint_type"] == "VPC" || change.after["endpoint_type"] == "VPC_ENDPOINT"
+      )
+  - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_server").all(
+        values["endpoint_type"] == "VPC" || values["endpoint_type"] == "VPC_ENDPOINT"
+      )
   - uid: mondoo-aws-security-transfer-logging-enabled
     title: Ensure Transfer Family servers have logging enabled
     impact: 60
@@ -44668,6 +45483,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-logging-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-logging-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-logging-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Transfer Family servers have a logging role configured. Without a logging role, file transfer activity is not logged to CloudWatch, making it impossible to audit file access or detect unauthorized transfers.
@@ -44719,6 +45546,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.servers.all(loggingRole != empty)
+  - uid: mondoo-aws-security-transfer-logging-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_server").all(
+        arguments.logging_role != null && arguments.logging_role != ""
+      )
+  - uid: mondoo-aws-security-transfer-logging-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_server").all(
+        change.after["logging_role"] != null && change.after["logging_role"] != ""
+      )
+  - uid: mondoo-aws-security-transfer-logging-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_server").all(
+        values["logging_role"] != null && values["logging_role"] != ""
+      )
   - uid: mondoo-aws-security-transfer-security-policy
     title: Ensure Transfer Family servers use current security policies
     impact: 70
@@ -44741,6 +45586,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-security-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-security-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-security-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Transfer Family servers are not using the deprecated TransferSecurityPolicy-2018-11 security policy. This policy supports older, weaker cryptographic algorithms that are no longer considered secure.
@@ -44792,6 +45649,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.servers.all(securityPolicyName != "TransferSecurityPolicy-2018-11")
+  - uid: mondoo-aws-security-transfer-security-policy-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_server").all(
+        arguments.security_policy_name == null || arguments.security_policy_name != "TransferSecurityPolicy-2018-11"
+      )
+  - uid: mondoo-aws-security-transfer-security-policy-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_server").all(
+        change.after["security_policy_name"] == null || change.after["security_policy_name"] != "TransferSecurityPolicy-2018-11"
+      )
+  - uid: mondoo-aws-security-transfer-security-policy-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_server").all(
+        values["security_policy_name"] == null || values["security_policy_name"] != "TransferSecurityPolicy-2018-11"
+      )
   - uid: mondoo-aws-security-transfer-identity-provider
     title: Ensure Transfer Family servers use external identity providers
     impact: 60
@@ -44814,6 +45689,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-identity-provider-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-identity-provider-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-identity-provider-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Transfer Family servers use an external identity provider rather than the service-managed identity provider. Service-managed users authenticate with static passwords that are prime targets for credential stuffing attacks, cannot be protected with MFA, and cannot be centrally revoked when compromised.
@@ -44871,6 +45758,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.servers.all(identityProviderType != "SERVICE_MANAGED")
+  - uid: mondoo-aws-security-transfer-identity-provider-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_server").all(
+        arguments.identity_provider_type != null && arguments.identity_provider_type != "SERVICE_MANAGED"
+      )
+  - uid: mondoo-aws-security-transfer-identity-provider-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_server").all(
+        change.after["identity_provider_type"] != null && change.after["identity_provider_type"] != "SERVICE_MANAGED"
+      )
+  - uid: mondoo-aws-security-transfer-identity-provider-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_server")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_server").all(
+        values["identity_provider_type"] != null && values["identity_provider_type"] != "SERVICE_MANAGED"
+      )
   - uid: mondoo-aws-security-appmesh-egress-filter
     title: Ensure App Mesh meshes use DROP_ALL egress filter
     impact: 70
@@ -44893,6 +45798,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-appmesh-egress-filter-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appmesh-egress-filter-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appmesh-egress-filter-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS App Mesh meshes use the DROP_ALL egress filter type. The DROP_ALL filter blocks all outbound traffic from virtual services unless explicitly allowed through virtual services definitions, implementing a deny-by-default network posture.
@@ -44951,6 +45868,30 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.appmesh.meshes.all(egressFilterType == "DROP_ALL")
+  - uid: mondoo-aws-security-appmesh-egress-filter-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appmesh_mesh")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_appmesh_mesh").all(
+        blocks.where(type == "spec").any(
+          blocks.where(type == "egress_filter").any(arguments.type == "DROP_ALL")
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-egress-filter-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_appmesh_mesh")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_appmesh_mesh").all(
+        change.after["spec"] != null && change.after["spec"].any(
+          _["egress_filter"] != null && _["egress_filter"].any(_["type"] == "DROP_ALL")
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-egress-filter-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_appmesh_mesh")
+    mql: |
+      terraform.state.resources.where(type == "aws_appmesh_mesh").all(
+        values["spec"] != null && values["spec"].any(
+          _["egress_filter"] != null && _["egress_filter"].any(_["type"] == "DROP_ALL")
+        )
+      )
   - uid: mondoo-aws-security-identitycenter-session-duration
     title: Ensure Identity Center permission sets have short sessions
     impact: 60
@@ -44973,6 +45914,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-identitycenter-session-duration-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-session-duration-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-session-duration-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS IAM Identity Center permission sets have session durations of 12 hours or less. Excessively long session durations increase the risk of session hijacking and unauthorized access from stolen credentials.
@@ -45028,6 +45981,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.identitycenter.instances.all(permissionSets.all(sessionDuration <= "PT12H"))
+  - uid: mondoo-aws-security-identitycenter-session-duration-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ssoadmin_permission_set")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ssoadmin_permission_set").all(
+        arguments.session_duration == null || arguments.session_duration <= "PT12H"
+      )
+  - uid: mondoo-aws-security-identitycenter-session-duration-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ssoadmin_permission_set")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ssoadmin_permission_set").all(
+        change.after["session_duration"] == null || change.after["session_duration"] <= "PT12H"
+      )
+  - uid: mondoo-aws-security-identitycenter-session-duration-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ssoadmin_permission_set")
+    mql: |
+      terraform.state.resources.where(type == "aws_ssoadmin_permission_set").all(
+        values["session_duration"] == null || values["session_duration"] <= "PT12H"
+      )
   - uid: mondoo-aws-security-identitycenter-no-inline-policy
     title: Ensure Identity Center permission sets use managed policies
     impact: 50
@@ -45050,6 +46021,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS IAM Identity Center permission sets use managed policies instead of inline policies. Inline policies embedded in permission sets are hiding spots for backdoor permissions that are significantly harder to detect during access reviews, allowing an attacker with Identity Center administrative access to plant persistent, stealthy access across multiple AWS accounts.
@@ -45118,6 +46101,15 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.identitycenter.instances.all(permissionSets.all(inlinePolicy == "" || inlinePolicy == empty))
+  - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-hcl
+    filters: asset.platform == "terraform-hcl"
+    mql: terraform.resources.where(nameLabel == "aws_ssoadmin_permission_set_inline_policy") == empty
+  - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-plan
+    filters: asset.platform == "terraform-plan"
+    mql: terraform.plan.resourceChanges.where(type == "aws_ssoadmin_permission_set_inline_policy") == empty
+  - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-state
+    filters: asset.platform == "terraform-state"
+    mql: terraform.state.resources.where(type == "aws_ssoadmin_permission_set_inline_policy") == empty
   - uid: mondoo-aws-security-identitycenter-group-assignments
     title: Ensure Identity Center uses group-based assignments
     impact: 60
@@ -45140,6 +46132,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS IAM Identity Center account assignments use groups rather than individual users. Direct user-level assignments are a stealthy persistence mechanism: an attacker with Identity Center administrative access can grant a compromised user direct account access that is invisible to group-based access reviews, surviving group membership cleanup during incident response.
@@ -45215,6 +46219,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.identitycenter.instances.all(accountAssignments.all(principalType == "GROUP"))
+  - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ssoadmin_account_assignment")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ssoadmin_account_assignment").all(
+        arguments.principal_type == "GROUP"
+      )
+  - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ssoadmin_account_assignment")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ssoadmin_account_assignment").all(
+        change.after["principal_type"] == "GROUP"
+      )
+  - uid: mondoo-aws-security-identitycenter-group-assignments-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ssoadmin_account_assignment")
+    mql: |
+      terraform.state.resources.where(type == "aws_ssoadmin_account_assignment").all(
+        values["principal_type"] == "GROUP"
+      )
   - uid: mondoo-aws-security-secretsmanager-no-public-policy
     title: Ensure Secrets Manager secrets do not have public policies
     impact: 90
@@ -45237,6 +46259,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Secretsmanager Secret
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Secrets Manager secrets do not have resource policies that grant public access. A resource policy with a wildcard principal ("*") in an Allow statement without conditions effectively makes the secret accessible to any AWS account.
@@ -45320,6 +46354,30 @@ queries:
         aws.secretsmanager.secret.resourcePolicy != /"Effect"\s*:\s*"Allow"[\s\S]*?"Principal"\s*:\s*"\*"/
         aws.secretsmanager.secret.resourcePolicy != /"Effect"\s*:\s*"Allow"[\s\S]*?"Principal"\s*:\s*\{\s*"AWS"\s*:\s*"\*"\s*\}/
       }
+  - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_secretsmanager_secret_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_secretsmanager_secret_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_secretsmanager_secret_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_secretsmanager_secret_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-secretsmanager-no-public-policy-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_secretsmanager_secret_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_secretsmanager_secret_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
   - uid: mondoo-aws-security-ec2-serial-console-disabled
     title: Ensure EC2 serial console access is disabled
     impact: 80
@@ -45336,6 +46394,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that EC2 serial console access is disabled across all regions. The EC2 serial console provides text-based access to an instance's serial port, which can be used to troubleshoot boot and network issues. However, if enabled, it can provide an additional attack vector for accessing instances.
@@ -45374,6 +46444,24 @@ queries:
     mql: |
       aws.ec2.serialConsoleAccessEnabled.length > 0 &&
       aws.ec2.serialConsoleAccessEnabled.values.none(_ == true)
+  - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ec2_serial_console_access")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ec2_serial_console_access").all(
+        arguments.enabled == false
+      )
+  - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ec2_serial_console_access")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ec2_serial_console_access").all(
+        change.after["enabled"] == false
+      )
+  - uid: mondoo-aws-security-ec2-serial-console-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ec2_serial_console_access")
+    mql: |
+      terraform.state.resources.where(type == "aws_ec2_serial_console_access").all(
+        values["enabled"] == false
+      )
   - uid: mondoo-aws-security-ec2-ami-block-public-access
     title: Ensure AMI block public access is enabled
     impact: 80
@@ -45390,6 +46478,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AMI block public access is enabled across all regions. When enabled, this setting prevents AMIs from being publicly shared, protecting against accidental exposure of machine images that may contain sensitive configurations, credentials, or proprietary software.
@@ -45426,6 +46526,24 @@ queries:
   - uid: mondoo-aws-security-ec2-ami-block-public-access-aws
     filters: asset.platform == "aws"
     mql: aws.ec2.imageBlockPublicAccess.values.all(_ == "block-new-sharing")
+  - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ec2_image_block_public_access")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_ec2_image_block_public_access").all(
+        arguments.state == "block-new-sharing"
+      )
+  - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ec2_image_block_public_access")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_ec2_image_block_public_access").all(
+        change.after["state"] == "block-new-sharing"
+      )
+  - uid: mondoo-aws-security-ec2-ami-block-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ec2_image_block_public_access")
+    mql: |
+      terraform.state.resources.where(type == "aws_ec2_image_block_public_access").all(
+        values["state"] == "block-new-sharing"
+      )
   - uid: mondoo-aws-security-ec2-launch-template-imdsv2
     title: Ensure EC2 launch templates require IMDSv2
     impact: 80
@@ -45442,6 +46560,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that EC2 launch templates are configured to require Instance Metadata Service Version 2 (IMDSv2). IMDSv2 uses session-oriented authentication that requires a PUT request to obtain a token before metadata can be accessed, preventing SSRF attacks from extracting instance credentials.
@@ -45497,6 +46627,30 @@ queries:
       aws.ec2.launchTemplates.all(
         metadataOptions['HttpTokens'] == "required"
       )
+  - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_launch_template")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_launch_template").all(
+        blocks.where(type == "metadata_options").any(
+          arguments.http_tokens == "required"
+        )
+      )
+  - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_launch_template")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_launch_template").all(
+        change.after["metadata_options"] != null && change.after["metadata_options"].any(
+          _["http_tokens"] == "required"
+        )
+      )
+  - uid: mondoo-aws-security-ec2-launch-template-imdsv2-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_launch_template")
+    mql: |
+      terraform.state.resources.where(type == "aws_launch_template").all(
+        values["metadata_options"] != null && values["metadata_options"].any(
+          _["http_tokens"] == "required"
+        )
+      )
   - uid: mondoo-aws-security-s3-ownership-controls-enforced
     title: Ensure S3 buckets enforce bucket owner ownership
     impact: 70
@@ -45513,6 +46667,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that S3 buckets have ownership controls set to BucketOwnerEnforced. This setting disables ACLs on the bucket, meaning all objects are owned by the bucket owner regardless of who uploaded them. This simplifies access management by ensuring that only IAM policies and bucket policies control access.
@@ -45561,6 +46727,24 @@ queries:
   - uid: mondoo-aws-security-s3-ownership-controls-enforced-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: aws.s3.bucket.ownershipControls == "BucketOwnerEnforced"
+  - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_s3_bucket_ownership_controls").all(
+        blocks.where(type == "rule").any(arguments.object_ownership == "BucketOwnerEnforced")
+      )
+  - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_s3_bucket_ownership_controls").all(
+        change.after["rule"].any(_["object_ownership"] == "BucketOwnerEnforced")
+      )
+  - uid: mondoo-aws-security-s3-ownership-controls-enforced-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.state.resources.where(type == "aws_s3_bucket_ownership_controls").all(
+        values["rule"].any(_["object_ownership"] == "BucketOwnerEnforced")
+      )
   - uid: mondoo-aws-security-cloudtrail-insights-enabled
     title: Ensure CloudTrail Insights is enabled
     impact: 60
@@ -45577,6 +46761,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS CloudTrail Trail
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that CloudTrail trails have Insights enabled. CloudTrail Insights automatically analyzes management events to detect unusual API activity patterns, such as spikes in resource provisioning, bursts of IAM actions, or gaps in periodic maintenance activity.
@@ -45632,6 +46828,29 @@ queries:
     mql: |
       aws.cloudtrail.trail.insightSelectors.any(_['InsightType'] == "ApiCallRateInsight") &&
       aws.cloudtrail.trail.insightSelectors.any(_['InsightType'] == "ApiErrorRateInsight")
+  - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudtrail")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_cloudtrail").all(
+        blocks.where(type == "insight_selector").any(arguments.insight_type == "ApiCallRateInsight") &&
+        blocks.where(type == "insight_selector").any(arguments.insight_type == "ApiErrorRateInsight")
+      )
+  - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cloudtrail")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cloudtrail").all(
+        change.after["insight_selector"] != null &&
+        change.after["insight_selector"].any(_["insight_type"] == "ApiCallRateInsight") &&
+        change.after["insight_selector"].any(_["insight_type"] == "ApiErrorRateInsight")
+      )
+  - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloudtrail")
+    mql: |
+      terraform.state.resources.where(type == "aws_cloudtrail").all(
+        values["insight_selector"] != null &&
+        values["insight_selector"].any(_["insight_type"] == "ApiCallRateInsight") &&
+        values["insight_selector"].any(_["insight_type"] == "ApiErrorRateInsight")
+      )
   - uid: mondoo-aws-security-securityhub-standards-enabled
     title: Ensure Security Hub has standards enabled
     impact: 70
@@ -45648,6 +46867,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Security Hub has at least one security standard enabled. Security standards (such as AWS Foundational Security Best Practices, CIS AWS Foundations Benchmark, or PCI DSS) provide automated security checks against AWS resources.
@@ -45685,6 +46916,21 @@ queries:
       aws.securityhub.hubs.all(
         enabledStandards.length > 0
       )
+  - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_securityhub_account")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_securityhub_account") != empty &&
+      terraform.resources.where(nameLabel == "aws_securityhub_standards_subscription") != empty
+  - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_securityhub_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_securityhub_account") != empty &&
+      terraform.plan.resourceChanges.where(type == "aws_securityhub_standards_subscription") != empty
+  - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_securityhub_account")
+    mql: |
+      terraform.state.resources.where(type == "aws_securityhub_account") != empty &&
+      terraform.state.resources.where(type == "aws_securityhub_standards_subscription") != empty
   - uid: mondoo-aws-security-sns-no-public-access
     title: Ensure SNS topics do not allow public access
     impact: 80
@@ -45701,6 +46947,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sns-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SNS topic access policies do not grant public access. An SNS topic with a policy that allows Principal "*" without conditions enables any AWS account or unauthenticated user to publish or subscribe to the topic.
@@ -45749,6 +47007,30 @@ queries:
           _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
         )
       )
+  - uid: mondoo-aws-security-sns-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sns_topic_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-sns-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sns_topic_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sns_topic_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-sns-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sns_topic_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_sns_topic_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
   - uid: mondoo-aws-security-drs-private-replication
     title: Ensure DRS uses private IP for data replication
     impact: 70
@@ -45765,6 +47047,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-drs-private-replication-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-private-replication-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-private-replication-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Elastic Disaster Recovery (DRS) replication configurations use private IP addresses for data plane routing. When set to PUBLIC_IP, replication data traverses the public internet, increasing exposure to interception and eavesdropping.
@@ -45804,6 +47098,24 @@ queries:
       aws.drs.sourceServers.all(
         replicationConfiguration.dataPlaneRouting == "PRIVATE_IP"
       )
+  - uid: mondoo-aws-security-drs-private-replication-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_drs_replication_configuration_template").all(
+        arguments.data_plane_routing == "PRIVATE_IP"
+      )
+  - uid: mondoo-aws-security-drs-private-replication-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_drs_replication_configuration_template").all(
+        change.after["data_plane_routing"] == "PRIVATE_IP"
+      )
+  - uid: mondoo-aws-security-drs-private-replication-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.state.resources.where(type == "aws_drs_replication_configuration_template").all(
+        values["data_plane_routing"] == "PRIVATE_IP"
+      )
   - uid: mondoo-aws-security-drs-no-public-recovery-ip
     title: Ensure DRS recovery instances have no public IPs
     impact: 70
@@ -45820,6 +47132,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS Elastic Disaster Recovery (DRS) replication configurations do not create public IP addresses for recovery instances. Recovery instances with public IPs are directly accessible from the internet, increasing the attack surface during disaster recovery scenarios.
@@ -45858,10 +47182,44 @@ queries:
       aws.drs.sourceServers.all(
         replicationConfiguration.createPublicIP != true
       )
+  - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_drs_replication_configuration_template").all(
+        arguments.create_public_ip == false || arguments.create_public_ip == null
+      )
+  - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_drs_replication_configuration_template").all(
+        change.after["create_public_ip"] == false || change.after["create_public_ip"] == null
+      )
+  - uid: mondoo-aws-security-drs-no-public-recovery-ip-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_drs_replication_configuration_template")
+    mql: |
+      terraform.state.resources.where(type == "aws_drs_replication_configuration_template").all(
+        values["create_public_ip"] == false || values["create_public_ip"] == null
+      )
   - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade
     title: Ensure Neptune cluster instances have automatic minor version upgrades enabled
     impact: 60
-    filters: asset.platform == "aws-neptune-cluster"
+    variants:
+      - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-aws
+        tags:
+          mondoo.com/filter-title: AWS Neptune Cluster
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
@@ -45870,10 +47228,6 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/soc2-2017: soc2-control-cc7-1-1
-    mql: |
-      aws.neptune.instances.where(clusterIdentifier == aws.neptune.cluster.clusterIdentifier).all(
-        autoMinorVersionUpgrade == true
-      )
     docs:
       desc: |
         This check verifies that every Neptune instance attached to the cluster has `autoMinorVersionUpgrade` enabled. When enabled, AWS applies minor-version engine patches during the cluster's maintenance window, closing known CVEs without requiring operator action. When disabled, each instance stays on whatever engine version it was launched with until an operator manually triggers an upgrade.
@@ -45925,10 +47279,50 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/manage-console-maintaining.html
         title: AWS Documentation - Maintaining an Amazon Neptune DB cluster
+  - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-aws
+    filters: asset.platform == "aws-neptune-cluster"
+    mql: |
+      aws.neptune.instances.where(clusterIdentifier == aws.neptune.cluster.clusterIdentifier).all(
+        autoMinorVersionUpgrade == true
+      )
+  - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_neptune_cluster_instance")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_neptune_cluster_instance").all(
+        arguments.auto_minor_version_upgrade == true
+      )
+  - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_neptune_cluster_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_neptune_cluster_instance").all(
+        change.after["auto_minor_version_upgrade"] == true
+      )
+  - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_neptune_cluster_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_neptune_cluster_instance").all(
+        values["auto_minor_version_upgrade"] == true
+      )
   - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade
     title: Ensure DocumentDB cluster instances have automatic minor version upgrades enabled
     impact: 60
-    filters: asset.platform == "aws-documentdb-cluster"
+    variants:
+      - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-aws
+        tags:
+          mondoo.com/filter-title: AWS DocumentDB Cluster
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
@@ -45937,10 +47331,6 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/soc2-2017: soc2-control-cc7-1-1
-    mql: |
-      aws.documentdb.instances.where(clusterIdentifier == aws.documentdb.cluster.clusterIdentifier).all(
-        autoMinorVersionUpgrade == true
-      )
     docs:
       desc: |
         This check verifies that every DocumentDB instance in the cluster has `autoMinorVersionUpgrade` enabled. When enabled, AWS applies minor-version engine patches during the cluster's maintenance window. When disabled, each instance stays on its launched engine version until an operator manually performs an upgrade — a pattern that tends to fall behind AWS's patch cadence.
@@ -45994,6 +47384,30 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-maintain.html
         title: AWS Documentation - Maintaining Amazon DocumentDB
+  - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-aws
+    filters: asset.platform == "aws-documentdb-cluster"
+    mql: |
+      aws.documentdb.instances.where(clusterIdentifier == aws.documentdb.cluster.clusterIdentifier).all(
+        autoMinorVersionUpgrade == true
+      )
+  - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_docdb_cluster_instance").all(
+        arguments.auto_minor_version_upgrade == true
+      )
+  - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_docdb_cluster_instance").all(
+        change.after["auto_minor_version_upgrade"] == true
+      )
+  - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_docdb_cluster_instance").all(
+        values["auto_minor_version_upgrade"] == true
+      )
   - uid: mondoo-aws-security-secgroup-restricted-postgresql
     title: Ensure security groups restrict incoming PostgreSQL traffic
     impact: 95
@@ -46007,6 +47421,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the PostgreSQL port (5432) from the internet (`0.0.0.0/0` or `::/0`). Database engines should never be exposed to the public internet; access should be limited to specific application or bastion subnets.
@@ -46048,6 +47474,39 @@ queries:
         fromPort <= 5432 && toPort >= 5432 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 5432 && arguments.to_port >= 5432).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 5432 && arguments.to_port >= 5432).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 5432 && _["to_port"] >= 5432).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 5432 && change.after["to_port"] >= 5432).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 5432 && _["to_port"] >= 5432).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 5432 && values["to_port"] >= 5432).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-mysql
     title: Ensure security groups restrict incoming MySQL/MariaDB/Aurora traffic
     impact: 95
@@ -46061,6 +47520,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the MySQL/MariaDB/Aurora port (3306) from `0.0.0.0/0` or `::/0`. Public exposure of relational database engines is one of the most frequently exploited cloud misconfigurations.
@@ -46090,6 +47561,39 @@ queries:
         fromPort <= 3306 && toPort >= 3306 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 3306 && arguments.to_port >= 3306).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 3306 && arguments.to_port >= 3306).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 3306 && _["to_port"] >= 3306).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 3306 && change.after["to_port"] >= 3306).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 3306 && _["to_port"] >= 3306).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 3306 && values["to_port"] >= 3306).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-mssql
     title: Ensure security groups restrict incoming Microsoft SQL Server traffic
     impact: 95
@@ -46103,6 +47607,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on Microsoft SQL Server's TDS port (1433) from `0.0.0.0/0` or `::/0`. Internet-exposed SQL Server is a recurring vector for ransomware that abuses `xp_cmdshell` and weak `sa` passwords.
@@ -46132,6 +47648,39 @@ queries:
         fromPort <= 1433 && toPort >= 1433 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 1433 && arguments.to_port >= 1433).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 1433 && arguments.to_port >= 1433).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 1433 && _["to_port"] >= 1433).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 1433 && change.after["to_port"] >= 1433).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 1433 && _["to_port"] >= 1433).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 1433 && values["to_port"] >= 1433).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-oracle
     title: Ensure security groups restrict incoming Oracle Database traffic
     impact: 90
@@ -46145,6 +47694,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Oracle Database listener port (1521) from `0.0.0.0/0` or `::/0`.
@@ -46170,6 +47731,39 @@ queries:
         fromPort <= 1521 && toPort >= 1521 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 1521 && arguments.to_port >= 1521).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 1521 && arguments.to_port >= 1521).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 1521 && _["to_port"] >= 1521).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 1521 && change.after["to_port"] >= 1521).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 1521 && _["to_port"] >= 1521).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 1521 && values["to_port"] >= 1521).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-mongodb
     title: Ensure security groups restrict incoming MongoDB traffic
     impact: 95
@@ -46183,6 +47777,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the MongoDB port (27017) from `0.0.0.0/0` or `::/0`. Internet-exposed MongoDB instances have been at the center of multiple mass ransom campaigns where attackers wipe collections and demand payment.
@@ -46209,6 +47815,39 @@ queries:
         fromPort <= 27017 && toPort >= 27017 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 27017 && arguments.to_port >= 27017).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 27017 && arguments.to_port >= 27017).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 27017 && _["to_port"] >= 27017).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 27017 && change.after["to_port"] >= 27017).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 27017 && _["to_port"] >= 27017).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 27017 && values["to_port"] >= 27017).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-redis
     title: Ensure security groups restrict incoming Redis traffic
     impact: 90
@@ -46222,6 +47861,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Redis port (6379) from `0.0.0.0/0` or `::/0`. Open Redis servers have repeatedly been used to mine cryptocurrency, plant SSH keys via `CONFIG SET dir`, and pivot into application infrastructure.
@@ -46247,6 +47898,39 @@ queries:
         fromPort <= 6379 && toPort >= 6379 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 6379 && arguments.to_port >= 6379).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 6379 && arguments.to_port >= 6379).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 6379 && _["to_port"] >= 6379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 6379 && change.after["to_port"] >= 6379).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 6379 && _["to_port"] >= 6379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 6379 && values["to_port"] >= 6379).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-memcached
     title: Ensure security groups restrict incoming Memcached traffic
     impact: 80
@@ -46259,6 +47943,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Memcached port (11211) from `0.0.0.0/0` or `::/0`. Public Memcached servers have been weaponized for record-breaking UDP reflection/amplification DDoS attacks (>1 Tbps).
@@ -46284,6 +47980,39 @@ queries:
         fromPort <= 11211 && toPort >= 11211 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 11211 && arguments.to_port >= 11211).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 11211 && arguments.to_port >= 11211).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 11211 && _["to_port"] >= 11211).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 11211 && change.after["to_port"] >= 11211).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 11211 && _["to_port"] >= 11211).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 11211 && values["to_port"] >= 11211).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-elasticsearch
     title: Ensure security groups restrict incoming Elasticsearch/OpenSearch traffic
     impact: 90
@@ -46297,6 +48026,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Elasticsearch/OpenSearch ports (9200/9300) from `0.0.0.0/0` or `::/0`. Public clusters have been the source of repeated mass-data leaks where indices containing PII were freely accessible without authentication.
@@ -46323,6 +48064,39 @@ queries:
         fromPort <= 9300 && toPort >= 9200 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 9300 && arguments.to_port >= 9200).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 9300 && arguments.to_port >= 9200).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 9300 && _["to_port"] >= 9200).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 9300 && change.after["to_port"] >= 9200).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 9300 && _["to_port"] >= 9200).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 9300 && values["to_port"] >= 9200).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-winrm
     title: Ensure security groups restrict incoming WinRM traffic
     impact: 90
@@ -46336,6 +48110,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Windows Remote Management ports (5985 HTTP, 5986 HTTPS) from `0.0.0.0/0` or `::/0`.
@@ -46361,6 +48147,39 @@ queries:
         fromPort <= 5986 && toPort >= 5985 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 5986 && arguments.to_port >= 5985).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 5986 && arguments.to_port >= 5985).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 5986 && _["to_port"] >= 5985).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 5986 && change.after["to_port"] >= 5985).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 5986 && _["to_port"] >= 5985).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 5986 && values["to_port"] >= 5985).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-docker-daemon
     title: Ensure security groups restrict incoming Docker daemon traffic
     impact: 100
@@ -46374,6 +48193,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on Docker daemon API ports (2375 plaintext, 2376 TLS) from `0.0.0.0/0` or `::/0`. The Docker daemon API is the equivalent of root on the host; any reachable client can spawn privileged containers and escape to the host filesystem.
@@ -46402,6 +48233,39 @@ queries:
         fromPort <= 2376 && toPort >= 2375 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 2376 && arguments.to_port >= 2375).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 2376 && arguments.to_port >= 2375).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 2376 && _["to_port"] >= 2375).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 2376 && change.after["to_port"] >= 2375).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 2376 && _["to_port"] >= 2375).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 2376 && values["to_port"] >= 2375).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api
     title: Ensure security groups restrict incoming Kubernetes API server traffic
     impact: 95
@@ -46415,6 +48279,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the Kubernetes API server port (6443) from `0.0.0.0/0` or `::/0`. The API server is the control plane for the entire cluster and must not be reachable from the public internet.
@@ -46443,6 +48319,39 @@ queries:
         fromPort <= 6443 && toPort >= 6443 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 6443 && arguments.to_port >= 6443).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 6443 && arguments.to_port >= 6443).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 6443 && _["to_port"] >= 6443).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 6443 && change.after["to_port"] >= 6443).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 6443 && _["to_port"] >= 6443).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 6443 && values["to_port"] >= 6443).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-kubelet
     title: Ensure security groups restrict incoming Kubernetes kubelet traffic
     impact: 95
@@ -46455,6 +48364,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on the kubelet API ports (10250 secure, 10255 read-only) from `0.0.0.0/0` or `::/0`.
@@ -46480,6 +48401,39 @@ queries:
         fromPort <= 10255 && toPort >= 10250 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 10255 && arguments.to_port >= 10250).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 10255 && arguments.to_port >= 10250).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 10255 && _["to_port"] >= 10250).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 10255 && change.after["to_port"] >= 10250).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 10255 && _["to_port"] >= 10250).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 10255 && values["to_port"] >= 10250).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-etcd
     title: Ensure security groups restrict incoming etcd traffic
     impact: 100
@@ -46493,6 +48447,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Security Group
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that AWS security groups do not allow inbound traffic on etcd ports (2379 client, 2380 peer) from `0.0.0.0/0` or `::/0`. etcd holds the entire Kubernetes cluster state, including all Secrets in the cluster — public exposure is a complete cluster compromise.
@@ -46519,6 +48485,39 @@ queries:
         fromPort <= 2380 && toPort >= 2379 && toPort != 0).none(
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
+  - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources.where(nameLabel == "aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 2380 && arguments.to_port >= 2379).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources.where(nameLabel == "aws_vpc_security_group_ingress_rule" && arguments.from_port <= 2380 && arguments.to_port >= 2379).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_security_group").all(
+        change.after["ingress"].where(_["from_port"] <= 2380 && _["to_port"] >= 2379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.plan.resourceChanges.where(type == "aws_vpc_security_group_ingress_rule").where(change.after["from_port"] <= 2380 && change.after["to_port"] >= 2379).all(
+        change.after["cidr_ipv4"] != "0.0.0.0/0" && change.after["cidr_ipv6"] != "::/0"
+      )
+  - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.state.resources.where(type == "aws_security_group").all(
+        values["ingress"].where(_["from_port"] <= 2380 && _["to_port"] >= 2379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.state.resources.where(type == "aws_vpc_security_group_ingress_rule").where(values["from_port"] <= 2380 && values["to_port"] >= 2379).all(
+        values["cidr_ipv4"] != "0.0.0.0/0" && values["cidr_ipv6"] != "::/0"
+      )
   - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal
     title: Ensure S3 bucket policies do not grant access to anonymous principals
     impact: 100
@@ -46532,6 +48531,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that S3 bucket policies do not contain `Allow` statements with a wildcard `Principal` (`"*"` or `{"AWS": "*"}`). A bucket policy that allows access from any principal makes objects readable or writable by anyone on the internet, regardless of whether Block Public Access is enabled at the account level.
@@ -46566,6 +48577,30 @@ queries:
         _['Principal']['AWS'] == "*" ||
         _['Principal']['AWS'] != null && _['Principal']['AWS'].contains("*")
       )
+  - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_s3_bucket_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_s3_bucket_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_s3_bucket_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_s3_bucket_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_s3_bucket_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
   - uid: mondoo-aws-security-s3-bucket-policy-secure-transport
     title: Ensure S3 bucket policies enforce secure transport
     impact: 80
@@ -46579,6 +48614,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that an S3 bucket policy explicitly denies any request that does not use secure transport (`aws:SecureTransport: "false"`). Without an explicit deny, S3 happily accepts plain-HTTP requests, exposing object data and authorization headers in transit.
@@ -46630,6 +48677,39 @@ queries:
         _['Condition']['Bool'] != null &&
         _['Condition']['Bool']['aws:SecureTransport'] == false
       )
+  - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_s3_bucket_policy").all(
+        arguments.policy["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_s3_bucket_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_s3_bucket_policy").all(
+        change.after["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_s3_bucket_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_s3_bucket_policy").all(
+        values["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
   - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced
     title: Ensure S3 buckets disable ACLs by enforcing bucket-owner ownership
     impact: 70
@@ -46641,6 +48721,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS S3 Bucket
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the S3 bucket has Object Ownership set to `BucketOwnerEnforced`. With this setting, ACLs are disabled and access is governed exclusively by IAM and bucket policies, removing an entire class of historical mistakes (objects uploaded with public-read ACLs).
@@ -46667,6 +48759,24 @@ queries:
     filters: asset.platform == "aws-s3-bucket"
     mql: |
       aws.s3.bucket.ownershipControls == "BucketOwnerEnforced"
+  - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_s3_bucket_ownership_controls").all(
+        blocks.where(type == "rule").any(arguments.object_ownership == "BucketOwnerEnforced")
+      )
+  - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_s3_bucket_ownership_controls").all(
+        change.after["rule"].any(_["object_ownership"] == "BucketOwnerEnforced")
+      )
+  - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_s3_bucket_ownership_controls")
+    mql: |
+      terraform.state.resources.where(type == "aws_s3_bucket_ownership_controls").all(
+        values["rule"].any(_["object_ownership"] == "BucketOwnerEnforced")
+      )
   - uid: mondoo-aws-security-sns-topic-cmk-encryption
     title: Ensure SNS topics are encrypted with a customer-managed KMS key
     impact: 70
@@ -46679,6 +48789,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all SNS topics are encrypted with a customer-managed KMS key (CMK), not the default `aws/sns` AWS-managed key. CMKs allow rotation, fine-grained key policies, and the ability to revoke access by disabling or deleting the key.
@@ -46703,6 +48825,30 @@ queries:
         attributes["KmsMasterKeyId"] != empty &&
         attributes["KmsMasterKeyId"] != "alias/aws/sns"
       )
+  - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sns_topic").all(
+        arguments.kms_master_key_id != null &&
+        arguments.kms_master_key_id != "" &&
+        arguments.kms_master_key_id != "alias/aws/sns"
+      )
+  - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sns_topic")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sns_topic").all(
+        change.after["kms_master_key_id"] != null &&
+        change.after["kms_master_key_id"] != "" &&
+        change.after["kms_master_key_id"] != "alias/aws/sns"
+      )
+  - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sns_topic")
+    mql: |
+      terraform.state.resources.where(type == "aws_sns_topic").all(
+        values["kms_master_key_id"] != null &&
+        values["kms_master_key_id"] != "" &&
+        values["kms_master_key_id"] != "alias/aws/sns"
+      )
   - uid: mondoo-aws-security-sqs-queue-cmk-encryption
     title: Ensure SQS queues are encrypted with a customer-managed KMS key
     impact: 70
@@ -46715,6 +48861,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all SQS queues are encrypted with a customer-managed KMS key (CMK) rather than SQS-managed encryption (SSE-SQS) or the AWS-managed `aws/sqs` key.
@@ -46737,4 +48895,28 @@ queries:
     mql: |
       aws.sqs.queues.all(
         kmsKey != null && kmsKey.keyManager == "CUSTOMER"
+      )
+  - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sqs_queue").all(
+        arguments.kms_master_key_id != null &&
+        arguments.kms_master_key_id != "" &&
+        arguments.kms_master_key_id != "alias/aws/sqs"
+      )
+  - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sqs_queue")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sqs_queue").all(
+        change.after["kms_master_key_id"] != null &&
+        change.after["kms_master_key_id"] != "" &&
+        change.after["kms_master_key_id"] != "alias/aws/sqs"
+      )
+  - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sqs_queue")
+    mql: |
+      terraform.state.resources.where(type == "aws_sqs_queue").all(
+        values["kms_master_key_id"] != null &&
+        values["kms_master_key_id"] != "" &&
+        values["kms_master_key_id"] != "alias/aws/sqs"
       )


### PR DESCRIPTION
## Summary

Extends 60 AWS security checks in `content/mondoo-aws-security.mql.yaml` to also run against Terraform HCL, plan, and state assets, mirroring the GCP rollout in #2436. For 33 runtime-only or cross-resource checks, this PR adds a `# No Terraform variants:` comment explaining why a config-time analog is not feasible (runtime telemetry, cross-resource correlation, or no Terraform resource analog).

### What changed

- **58 checks** gained `-terraform-hcl`, `-terraform-plan`, and `-terraform-state` child variants alongside the existing `-aws` variant. For each, the HCL pattern uses `terraform.resources.where(nameLabel == "aws_*")`, the plan pattern uses `terraform.plan.resourceChanges.where(type == "aws_*")`, and the state pattern uses `terraform.state.resources.where(type == "aws_*")`.
- **2 checks** that lacked a `variants:` block entirely (`mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade`, `mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade`) were converted to a full `variants:` block: the runtime MQL was moved into a new `-aws` child, and three Terraform child variants were added (`aws_neptune_cluster_instance.auto_minor_version_upgrade`, `aws_docdb_cluster_instance.auto_minor_version_upgrade`).
- **33 checks** received a `# No Terraform variants: <reason>` comment.

### Coverage notes

- **Security-group port restrictions**: 13 checks (`secgroup-restricted-postgresql`, `-mysql`, `-mssql`, `-oracle`, `-mongodb`, `-redis`, `-memcached`, `-elasticsearch`, `-winrm`, `-docker-daemon`, `-kubernetes-api`, `-kubelet`, `-etcd`) cover BOTH the older inline-rule shape (`aws_security_group` with nested `ingress` blocks) AND the modern standalone shape (`aws_vpc_security_group_ingress_rule`).
- **JSON-policy checks** (`s3-bucket-policy-no-public-principal`, `s3-bucket-policy-secure-transport`, `secretsmanager-no-public-policy`, `sns-no-public-access`, `ecr-no-public-access`): the variants access the policy dict directly (`arguments.policy["Statement"]` / `change.after["policy"]["Statement"]` / `values["policy"]["Statement"]`) rather than `parse.json` because cnquery's Terraform provider returns the parsed dict for `jsonencode(...)` policy fields. Raw heredoc-string policies remain unchecked but won't error.
- **MQL parser quirks worked around**: filters and `.all(...)` bodies never start with a parenthesized clause; the `aws_security_group` / `aws_vpc_security_group_ingress_rule` either-of filter uses a single `where(nameLabel == "..." || nameLabel == "...")` rather than `&& (a || b)`.

### Runtime-only / cross-resource (commented, not variant-ed)

| Reason | Examples |
| --- | --- |
| Runtime telemetry (status, expiration, last-used dates) | `rds-instance-no-pending-os-upgrades`, `rds-cluster-no-pending-os-upgrades`, `eks-addon-healthy`, `iam-expired-certificates`, `iam-unused-credentials-disabled`, `iam-root-hardware-mfa`, `cloudtrail-is-logging` |
| No Terraform resource for the imperative API | `sagemaker-training-job-*` (3), `sagemaker-processing-job-*` (3), `sagemaker-training-hyperparameters-no-secrets`, `sagemaker-hub-public-content-documented`, `sagemaker-model-package-approval-validated`, `directoryservice-sso-enabled`, `directoryservice-radius-mfa-enabled`, `appstream-stack-url-redirection-disabled`, `documentdb-snapshot-encrypted`, `rds-snapshot-cmk-encryption` |
| Cross-resource correlation not expressible as a flat variant | `cloudtrail-s3-bucket-not-public`, `cloudtrail-s3-bucket-logging`, `workspaces-no-unrestricted-inbound`, `vpc-subnet-flow-logs-enabled`, `vpc-endpoint-service-restrict-principals`, `sagemaker-{domain,notebook,job}-role-not-admin`, `ec2-hibernation-encrypted-check`, `no-default-vpc`, `ecs-task-definition-no-plaintext-secrets` |
| Boot mode is AMI-determined, not an `aws_instance` argument | `ec2-uefi-boot-mode` |

### Deferred

None. All 93 audit candidates from `content/mondoo-aws-security.mql.yaml` are covered (60 with new variants, 33 with comments).

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` — passes
- [x] `python3 content/validation/validate_remediation_commands.py aws` — 686 passed, 0 failed
- [ ] Manual spot-check pending: scan a representative Terraform repo with the new variants enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)