### PR TITLE
🐛 Fix mondoo-gcp-security-tf-pass fixture for #2436's variants

### DIFF
--- a/content/testdata/mondoo-gcp-security-tf-pass/logging.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/logging.tf
@@ -22,6 +22,10 @@ resource "google_storage_bucket" "log_bucket" {
     retention_period = 2592000 # 30 days in seconds
   }
 
+  soft_delete_policy {
+    retention_duration_seconds = 1209600 # 14 days
+  }
+
   encryption {
     default_kms_key_name = google_kms_crypto_key.key.id
   }

--- a/content/testdata/mondoo-gcp-security-tf-pass/mysql.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/mysql.tf
@@ -66,9 +66,10 @@ resource "google_sql_database" "mysql_database" {
   instance = google_sql_database_instance.mysql_public_instance.name
 }
 
-# Create a user for the database
+# Create an IAM user for the database (CLOUD_IAM_USER satisfies the
+# cloud-sql-users-use-iam-auth check; password is omitted for IAM users).
 resource "google_sql_user" "mysql_user" {
   name     = var.user_name
   instance = google_sql_database_instance.mysql_public_instance.name
-  password = var.user_password
+  type     = "CLOUD_IAM_USER"
 }

--- a/content/testdata/mondoo-gcp-security-tf-pass/postgres.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/postgres.tf
@@ -76,9 +76,10 @@ resource "google_sql_database" "postgres_database" {
   instance = google_sql_database_instance.postgres_public_instance.name
 }
 
-# Create a user for the database
+# Create an IAM user for the database (CLOUD_IAM_USER satisfies the
+# cloud-sql-users-use-iam-auth check; password is omitted for IAM users).
 resource "google_sql_user" "postgres_user" {
   name     = var.user_name
   instance = google_sql_database_instance.postgres_public_instance.name
-  password = var.user_password
+  type     = "CLOUD_IAM_USER"
 }

--- a/content/testdata/mondoo-gcp-security-tf-pass/sqlserver.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/sqlserver.tf
@@ -66,9 +66,11 @@ resource "google_sql_database" "sqlserver_database" {
   instance = google_sql_database_instance.sqlserver_public_instance.name
 }
 
-# Create a user for the database
+# SQL Server does not support CLOUD_IAM_* user types; the runtime and
+# Terraform variants of cloud-sql-users-use-iam-auth exempt the engine-managed
+# "sqlserver" system account. Use that name here so the BUILT_IN user passes.
 resource "google_sql_user" "sqlserver_user" {
-  name     = var.user_name
+  name     = "sqlserver"
   instance = google_sql_database_instance.sqlserver_public_instance.name
   password = var.user_password
 }

--- a/content/testdata/mondoo-gcp-security-tf-pass/storage.tf
+++ b/content/testdata/mondoo-gcp-security-tf-pass/storage.tf
@@ -19,6 +19,10 @@ resource "google_storage_bucket" "data" {
     retention_period = 2592000 # 30 days
   }
 
+  soft_delete_policy {
+    retention_duration_seconds = 1209600 # 14 days
+  }
+
   encryption {
     default_kms_key_name = google_kms_crypto_key.key.id
   }


### PR DESCRIPTION
## Summary

PR #2436 added Terraform variants for `cloud-storage-bucket-soft-delete-enabled` and `cloud-sql-users-use-iam-auth` but did not extend `content/testdata/mondoo-gcp-security-tf-pass/` to exercise them. The merged variants now run against the fixture in CI and fail, breaking the `go-test` job on every PR that branches off main.

The failing checks observed in CI:
- `mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl` — score 0
- `mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-hcl` — score 0
- The corresponding parent multi-variant scores drop to 25–30 because the runtime variant alone passes.

## Changes

- `storage.tf` and `logging.tf`: add `soft_delete_policy { retention_duration_seconds = 1209600 }` to both `google_storage_bucket` resources (14-day retention).
- `mysql.tf` and `postgres.tf`: switch the user to `type = "CLOUD_IAM_USER"` and drop the password field — IAM users authenticate via Google Cloud IAM.
- `sqlserver.tf`: SQL Server does not support `CLOUD_IAM_*`. The check exempts the engine-managed `sqlserver` system account, so rename the user to literal `"sqlserver"` instead of `var.user_name`.

## Test plan

- [x] `go test ./content` passes locally
- [ ] `go-test` job passes in CI

## Knock-on effect

Open PRs #2437 (Azure), #2438 (GCP follow-up), #2439 (AWS), and #2440 (OCI) all inherited this `go-test` failure from main. Once this hotfix lands, they need to rebase to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)