### PR TITLE
✨ Restructure AI policy remediation steps per OS

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -307,26 +307,12 @@ queries:
       desc: |
         This check ensures that Goose, an open-source AI agent by Block, is not configured on the endpoint. Goose can connect to multiple AI providers and execute code with full system access via extensions.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Goose configuration.
 
             ```bash
             rm -rf ~/.config/goose
-            ```
-        - id: linux
-          desc: |
-            Remove Goose configuration.
-
-            ```bash
-            rm -rf ~/.config/goose
-            ```
-        - id: windows
-          desc: |
-            Remove Goose configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:APPDATA\goose"
             ```
 
   - uid: mondoo-ai-security-no-zed
@@ -363,26 +349,12 @@ queries:
       desc: |
         This check ensures that Cline, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Cline configuration.
 
             ```bash
             rm -rf ~/.cline
-            ```
-        - id: linux
-          desc: |
-            Remove Cline configuration.
-
-            ```bash
-            rm -rf ~/.cline
-            ```
-        - id: windows
-          desc: |
-            Remove Cline configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
             ```
 
   - uid: mondoo-ai-security-no-roo
@@ -393,26 +365,12 @@ queries:
       desc: |
         This check ensures that Roo Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Roo Code configuration.
 
             ```bash
             rm -rf ~/.roo
-            ```
-        - id: linux
-          desc: |
-            Remove Roo Code configuration.
-
-            ```bash
-            rm -rf ~/.roo
-            ```
-        - id: windows
-          desc: |
-            Remove Roo Code configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.roo"
             ```
 
   - uid: mondoo-ai-security-no-continuedev
@@ -423,26 +381,12 @@ queries:
       desc: |
         This check ensures that Continue, an open-source AI coding assistant, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Continue configuration.
 
             ```bash
             rm -rf ~/.continue
-            ```
-        - id: linux
-          desc: |
-            Remove Continue configuration.
-
-            ```bash
-            rm -rf ~/.continue
-            ```
-        - id: windows
-          desc: |
-            Remove Continue configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.continue"
             ```
 
   - uid: mondoo-ai-security-no-trae
@@ -453,26 +397,12 @@ queries:
       desc: |
         This check ensures that Trae, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Trae configuration.
 
             ```bash
             rm -rf ~/.trae
-            ```
-        - id: linux
-          desc: |
-            Remove Trae configuration.
-
-            ```bash
-            rm -rf ~/.trae
-            ```
-        - id: windows
-          desc: |
-            Remove Trae configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.trae"
             ```
 
   - uid: mondoo-ai-security-no-opencode
@@ -483,26 +413,12 @@ queries:
       desc: |
         This check ensures that OpenCode, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove OpenCode configuration.
 
             ```bash
             rm -rf ~/.config/opencode
-            ```
-        - id: linux
-          desc: |
-            Remove OpenCode configuration.
-
-            ```bash
-            rm -rf ~/.config/opencode
-            ```
-        - id: windows
-          desc: |
-            Remove OpenCode configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:APPDATA\opencode"
             ```
 
   - uid: mondoo-ai-security-no-kiro
@@ -513,26 +429,12 @@ queries:
       desc: |
         This check ensures that Kiro, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Kiro configuration.
 
             ```bash
             rm -rf ~/.kiro
-            ```
-        - id: linux
-          desc: |
-            Remove Kiro configuration.
-
-            ```bash
-            rm -rf ~/.kiro
-            ```
-        - id: windows
-          desc: |
-            Remove Kiro configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.kiro"
             ```
 
   - uid: mondoo-ai-security-no-pi
@@ -543,26 +445,12 @@ queries:
       desc: |
         This check ensures that Pi, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Pi configuration.
 
             ```bash
             rm -rf ~/.pi/agent
-            ```
-        - id: linux
-          desc: |
-            Remove Pi configuration.
-
-            ```bash
-            rm -rf ~/.pi/agent
-            ```
-        - id: windows
-          desc: |
-            Remove Pi configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.pi\agent"
             ```
 
   - uid: mondoo-ai-security-no-mistral-vibe
@@ -573,26 +461,12 @@ queries:
       desc: |
         This check ensures that Mistral Vibe, an AI coding agent by Mistral, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Mistral Vibe configuration.
 
             ```bash
             rm -rf ~/.vibe
-            ```
-        - id: linux
-          desc: |
-            Remove Mistral Vibe configuration.
-
-            ```bash
-            rm -rf ~/.vibe
-            ```
-        - id: windows
-          desc: |
-            Remove Mistral Vibe configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.vibe"
             ```
 
   - uid: mondoo-ai-security-no-antigravity
@@ -603,26 +477,12 @@ queries:
       desc: |
         This check ensures that Antigravity (Google), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Antigravity configuration.
 
             ```bash
             rm -rf ~/.gemini/antigravity
-            ```
-        - id: linux
-          desc: |
-            Remove Antigravity configuration.
-
-            ```bash
-            rm -rf ~/.gemini/antigravity
-            ```
-        - id: windows
-          desc: |
-            Remove Antigravity configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.gemini\antigravity"
             ```
 
   - uid: mondoo-ai-security-no-ibm-bob
@@ -633,26 +493,12 @@ queries:
       desc: |
         This check ensures that IBM Bob, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove IBM Bob configuration.
 
             ```bash
             rm -rf ~/.bob
-            ```
-        - id: linux
-          desc: |
-            Remove IBM Bob configuration.
-
-            ```bash
-            rm -rf ~/.bob
-            ```
-        - id: windows
-          desc: |
-            Remove IBM Bob configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.bob"
             ```
 
   - uid: mondoo-ai-security-no-openclaw
@@ -663,26 +509,12 @@ queries:
       desc: |
         This check ensures that OpenClaw, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove OpenClaw configuration.
 
             ```bash
             rm -rf ~/.openclaw
-            ```
-        - id: linux
-          desc: |
-            Remove OpenClaw configuration.
-
-            ```bash
-            rm -rf ~/.openclaw
-            ```
-        - id: windows
-          desc: |
-            Remove OpenClaw configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"
             ```
 
   - uid: mondoo-ai-security-no-snowflake-cortex
@@ -693,26 +525,12 @@ queries:
       desc: |
         This check ensures that Snowflake Cortex Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Snowflake Cortex configuration.
 
             ```bash
             rm -rf ~/.snowflake/cortex
-            ```
-        - id: linux
-          desc: |
-            Remove Snowflake Cortex configuration.
-
-            ```bash
-            rm -rf ~/.snowflake/cortex
-            ```
-        - id: windows
-          desc: |
-            Remove Snowflake Cortex configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.snowflake\cortex"
             ```
 
   - uid: mondoo-ai-security-no-junie
@@ -723,26 +541,12 @@ queries:
       desc: |
         This check ensures that Junie (JetBrains), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Junie configuration.
 
             ```bash
             rm -rf ~/.junie
-            ```
-        - id: linux
-          desc: |
-            Remove Junie configuration.
-
-            ```bash
-            rm -rf ~/.junie
-            ```
-        - id: windows
-          desc: |
-            Remove Junie configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.junie"
             ```
 
   - uid: mondoo-ai-security-no-augment
@@ -753,26 +557,12 @@ queries:
       desc: |
         This check ensures that Augment, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Augment configuration.
 
             ```bash
             rm -rf ~/.augment
-            ```
-        - id: linux
-          desc: |
-            Remove Augment configuration.
-
-            ```bash
-            rm -rf ~/.augment
-            ```
-        - id: windows
-          desc: |
-            Remove Augment configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.augment"
             ```
 
   - uid: mondoo-ai-security-no-warp
@@ -783,26 +573,12 @@ queries:
       desc: |
         This check ensures that Warp, an AI-powered terminal, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Warp configuration.
 
             ```bash
             rm -rf ~/.warp
-            ```
-        - id: linux
-          desc: |
-            Remove Warp configuration.
-
-            ```bash
-            rm -rf ~/.warp
-            ```
-        - id: windows
-          desc: |
-            Remove Warp configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
             ```
 
   - uid: mondoo-ai-security-no-kilocode
@@ -813,26 +589,12 @@ queries:
       desc: |
         This check ensures that Kilo Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Kilo Code configuration.
 
             ```bash
             rm -rf ~/.kilocode
-            ```
-        - id: linux
-          desc: |
-            Remove Kilo Code configuration.
-
-            ```bash
-            rm -rf ~/.kilocode
-            ```
-        - id: windows
-          desc: |
-            Remove Kilo Code configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.kilocode"
             ```
 
   - uid: mondoo-ai-security-no-openhands
@@ -843,26 +605,12 @@ queries:
       desc: |
         This check ensures that OpenHands, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove OpenHands configuration.
 
             ```bash
             rm -rf ~/.openhands
-            ```
-        - id: linux
-          desc: |
-            Remove OpenHands configuration.
-
-            ```bash
-            rm -rf ~/.openhands
-            ```
-        - id: windows
-          desc: |
-            Remove OpenHands configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.openhands"
             ```
 
   - uid: mondoo-ai-security-no-qwen-code
@@ -873,26 +621,12 @@ queries:
       desc: |
         This check ensures that Qwen Code (Alibaba), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Remove Qwen Code configuration.
 
             ```bash
             rm -rf ~/.qwen
-            ```
-        - id: linux
-          desc: |
-            Remove Qwen Code configuration.
-
-            ```bash
-            rm -rf ~/.qwen
-            ```
-        - id: windows
-          desc: |
-            Remove Qwen Code configuration.
-
-            ```powershell
-            Remove-Item -Recurse -Force "$env:USERPROFILE\.qwen"
             ```
 
   # ---------------------------------------------------------------------------
@@ -909,7 +643,7 @@ queries:
       desc: |
         This check ensures that no Codeium AI coding extensions are installed in VS Code-compatible editors. Codeium transmits source code to cloud AI models for completion and chat.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
 
@@ -931,53 +665,7 @@ queries:
             windsurf --uninstall-extension codeium.codeium
             ```
 
-            You can also uninstall from within the editor: open the Extensions view (`Cmd+Shift+X`), search for the extension, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
-
-            VS Code:
-
-            ```bash
-            code --uninstall-extension codeium.codeium
-            ```
-
-            Cursor:
-
-            ```bash
-            cursor --uninstall-extension codeium.codeium
-            ```
-
-            Windsurf:
-
-            ```bash
-            windsurf --uninstall-extension codeium.codeium
-            ```
-
-            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
-
-            VS Code:
-
-            ```powershell
-            code --uninstall-extension codeium.codeium
-            ```
-
-            Cursor:
-
-            ```powershell
-            cursor --uninstall-extension codeium.codeium
-            ```
-
-            Windsurf:
-
-            ```powershell
-            windsurf --uninstall-extension codeium.codeium
-            ```
-
-            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
+            You can also uninstall from within the editor: open the Extensions view, search for the extension, and click **Uninstall**.
 
 
   - uid: mondoo-ai-security-no-vscode-tabnine-extension
@@ -991,7 +679,7 @@ queries:
       desc: |
         This check ensures that no Tabnine AI coding extensions are installed in VS Code-compatible editors. Tabnine can transmit source code to cloud models depending on configuration.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1001,29 +689,7 @@ queries:
             windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
-            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
-            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
-            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
-            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Tabnine, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-supermaven-extension
     title: No Supermaven extensions in VS Code-compatible editors
@@ -1036,7 +702,7 @@ queries:
       desc: |
         This check ensures that no Supermaven AI coding extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1046,29 +712,7 @@ queries:
             windsurf --uninstall-extension supermaven.supermaven   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension supermaven.supermaven       # VS Code
-            cursor --uninstall-extension supermaven.supermaven     # Cursor
-            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension supermaven.supermaven       # VS Code
-            cursor --uninstall-extension supermaven.supermaven     # Cursor
-            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Supermaven, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-continue-extension
     title: No Continue extensions in VS Code-compatible editors
@@ -1081,7 +725,7 @@ queries:
       desc: |
         This check ensures that no Continue AI coding extensions are installed in VS Code-compatible editors. Continue is an open-source AI assistant that can connect to various LLM providers.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1091,29 +735,7 @@ queries:
             windsurf --uninstall-extension continue.continue   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension continue.continue       # VS Code
-            cursor --uninstall-extension continue.continue     # Cursor
-            windsurf --uninstall-extension continue.continue   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension continue.continue       # VS Code
-            cursor --uninstall-extension continue.continue     # Cursor
-            windsurf --uninstall-extension continue.continue   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Continue, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cline-extension
     title: No Cline extensions in VS Code-compatible editors
@@ -1126,7 +748,7 @@ queries:
       desc: |
         This check ensures that no Cline (formerly Claude Dev) AI coding extensions are installed in VS Code-compatible editors. Cline is an autonomous AI agent that can execute code and modify files.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1136,29 +758,7 @@ queries:
             windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
-            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
-            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
-            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
-            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Cline, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cody-extension
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
@@ -1171,7 +771,7 @@ queries:
       desc: |
         This check ensures that no Sourcegraph Cody AI coding extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1181,29 +781,7 @@ queries:
             windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension sourcegraph.cody-ai       # VS Code
-            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
-            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension sourcegraph.cody-ai       # VS Code
-            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
-            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Cody, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-codex-extension
     title: No OpenAI Codex extensions in VS Code-compatible editors
@@ -1216,7 +794,7 @@ queries:
       desc: |
         This check ensures that no OpenAI Codex extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1226,29 +804,7 @@ queries:
             windsurf --uninstall-extension openai.codex   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension openai.codex       # VS Code
-            cursor --uninstall-extension openai.codex     # Cursor
-            windsurf --uninstall-extension openai.codex   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension openai.codex       # VS Code
-            cursor --uninstall-extension openai.codex     # Cursor
-            windsurf --uninstall-extension openai.codex   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Codex, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-claude-extension
     title: No Claude extensions in VS Code-compatible editors
@@ -1261,7 +817,7 @@ queries:
       desc: |
         This check ensures that no Anthropic Claude extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1271,29 +827,7 @@ queries:
             windsurf --uninstall-extension anthropic.claude   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension anthropic.claude       # VS Code
-            cursor --uninstall-extension anthropic.claude     # Cursor
-            windsurf --uninstall-extension anthropic.claude   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension anthropic.claude       # VS Code
-            cursor --uninstall-extension anthropic.claude     # Cursor
-            windsurf --uninstall-extension anthropic.claude   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Claude, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cursor-extension
     title: No Cursor-specific extensions in VS Code-compatible editors
@@ -1306,7 +840,7 @@ queries:
       desc: |
         This check ensures that no Cursor-specific AI extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1316,29 +850,7 @@ queries:
             windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension <cursor.extension-name>       # VS Code
-            cursor --uninstall-extension <cursor.extension-name>     # Cursor
-            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension <cursor.extension-name>       # VS Code
-            cursor --uninstall-extension <cursor.extension-name>     # Cursor
-            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for the extension, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-roo-extension
     title: No Roo Code extensions in VS Code-compatible editors
@@ -1351,7 +863,7 @@ queries:
       desc: |
         This check ensures that no Roo Code AI coding extensions are installed in VS Code-compatible editors. Roo Code is an autonomous AI agent forked from Cline.
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -1361,29 +873,7 @@ queries:
             windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
             ```
 
-            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
-        - id: linux
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```bash
-            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
-            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
-            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
-        - id: windows
-          desc: |
-            Uninstall the extension from whichever editor(s) have it installed:
-
-            ```powershell
-            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
-            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
-            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
-            ```
-
-            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+            Or open the Extensions view in the editor, search for Roo Code, and click **Uninstall**.
 
   # ---------------------------------------------------------------------------
   # MCP server governance
@@ -1418,7 +908,7 @@ queries:
               return /(?i)(mondoo|github|jira)/
         ```
       remediation:
-        - id: macos
+        - id: shell
           desc: |
             Review and remove unapproved MCP servers from each agent's configuration.
 
@@ -1428,30 +918,6 @@ queries:
             - GitHub Copilot: `~/.config/github-copilot/`
             - Windsurf: `~/.codeium/windsurf/`
             - Gemini CLI: `~/.gemini/`
-
-            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
-        - id: linux
-          desc: |
-            Review and remove unapproved MCP servers from each agent's configuration.
-
-            - Claude Code: `~/.claude/settings.json`
-            - OpenAI Codex: `~/.codex/`
-            - Cursor: `~/.cursor/mcp.json`
-            - GitHub Copilot: `~/.config/github-copilot/`
-            - Windsurf: `~/.codeium/windsurf/`
-            - Gemini CLI: `~/.gemini/`
-
-            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
-        - id: windows
-          desc: |
-            Review and remove unapproved MCP servers from each agent's configuration.
-
-            - Claude Code: `%USERPROFILE%\.claude\settings.json`
-            - OpenAI Codex: `%USERPROFILE%\.codex\`
-            - Cursor: `%USERPROFILE%\.cursor\mcp.json`
-            - GitHub Copilot: `%APPDATA%\github-copilot\`
-            - Windsurf: `%USERPROFILE%\.codeium\windsurf\`
-            - Gemini CLI: `%USERPROFILE%\.gemini\`
 
             Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
 

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -307,12 +307,26 @@ queries:
       desc: |
         This check ensures that Goose, an open-source AI agent by Block, is not configured on the endpoint. Goose can connect to multiple AI providers and execute code with full system access via extensions.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Goose configuration.
 
             ```bash
             rm -rf ~/.config/goose
+            ```
+        - id: linux
+          desc: |
+            Remove Goose configuration.
+
+            ```bash
+            rm -rf ~/.config/goose
+            ```
+        - id: windows
+          desc: |
+            Remove Goose configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\goose"
             ```
 
   - uid: mondoo-ai-security-no-zed
@@ -349,12 +363,26 @@ queries:
       desc: |
         This check ensures that Cline, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Cline configuration.
 
             ```bash
             rm -rf ~/.cline
+            ```
+        - id: linux
+          desc: |
+            Remove Cline configuration.
+
+            ```bash
+            rm -rf ~/.cline
+            ```
+        - id: windows
+          desc: |
+            Remove Cline configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
             ```
 
   - uid: mondoo-ai-security-no-roo
@@ -365,12 +393,26 @@ queries:
       desc: |
         This check ensures that Roo Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Roo Code configuration.
 
             ```bash
             rm -rf ~/.roo
+            ```
+        - id: linux
+          desc: |
+            Remove Roo Code configuration.
+
+            ```bash
+            rm -rf ~/.roo
+            ```
+        - id: windows
+          desc: |
+            Remove Roo Code configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.roo"
             ```
 
   - uid: mondoo-ai-security-no-continuedev
@@ -381,12 +423,26 @@ queries:
       desc: |
         This check ensures that Continue, an open-source AI coding assistant, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Continue configuration.
 
             ```bash
             rm -rf ~/.continue
+            ```
+        - id: linux
+          desc: |
+            Remove Continue configuration.
+
+            ```bash
+            rm -rf ~/.continue
+            ```
+        - id: windows
+          desc: |
+            Remove Continue configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.continue"
             ```
 
   - uid: mondoo-ai-security-no-trae
@@ -397,12 +453,26 @@ queries:
       desc: |
         This check ensures that Trae, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Trae configuration.
 
             ```bash
             rm -rf ~/.trae
+            ```
+        - id: linux
+          desc: |
+            Remove Trae configuration.
+
+            ```bash
+            rm -rf ~/.trae
+            ```
+        - id: windows
+          desc: |
+            Remove Trae configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.trae"
             ```
 
   - uid: mondoo-ai-security-no-opencode
@@ -413,12 +483,26 @@ queries:
       desc: |
         This check ensures that OpenCode, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove OpenCode configuration.
 
             ```bash
             rm -rf ~/.config/opencode
+            ```
+        - id: linux
+          desc: |
+            Remove OpenCode configuration.
+
+            ```bash
+            rm -rf ~/.config/opencode
+            ```
+        - id: windows
+          desc: |
+            Remove OpenCode configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\opencode"
             ```
 
   - uid: mondoo-ai-security-no-kiro
@@ -429,12 +513,26 @@ queries:
       desc: |
         This check ensures that Kiro, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Kiro configuration.
 
             ```bash
             rm -rf ~/.kiro
+            ```
+        - id: linux
+          desc: |
+            Remove Kiro configuration.
+
+            ```bash
+            rm -rf ~/.kiro
+            ```
+        - id: windows
+          desc: |
+            Remove Kiro configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.kiro"
             ```
 
   - uid: mondoo-ai-security-no-pi
@@ -445,12 +543,26 @@ queries:
       desc: |
         This check ensures that Pi, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Pi configuration.
 
             ```bash
             rm -rf ~/.pi/agent
+            ```
+        - id: linux
+          desc: |
+            Remove Pi configuration.
+
+            ```bash
+            rm -rf ~/.pi/agent
+            ```
+        - id: windows
+          desc: |
+            Remove Pi configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.pi\agent"
             ```
 
   - uid: mondoo-ai-security-no-mistral-vibe
@@ -461,12 +573,26 @@ queries:
       desc: |
         This check ensures that Mistral Vibe, an AI coding agent by Mistral, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Mistral Vibe configuration.
 
             ```bash
             rm -rf ~/.vibe
+            ```
+        - id: linux
+          desc: |
+            Remove Mistral Vibe configuration.
+
+            ```bash
+            rm -rf ~/.vibe
+            ```
+        - id: windows
+          desc: |
+            Remove Mistral Vibe configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.vibe"
             ```
 
   - uid: mondoo-ai-security-no-antigravity
@@ -477,12 +603,26 @@ queries:
       desc: |
         This check ensures that Antigravity (Google), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Antigravity configuration.
 
             ```bash
             rm -rf ~/.gemini/antigravity
+            ```
+        - id: linux
+          desc: |
+            Remove Antigravity configuration.
+
+            ```bash
+            rm -rf ~/.gemini/antigravity
+            ```
+        - id: windows
+          desc: |
+            Remove Antigravity configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.gemini\antigravity"
             ```
 
   - uid: mondoo-ai-security-no-ibm-bob
@@ -493,12 +633,26 @@ queries:
       desc: |
         This check ensures that IBM Bob, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove IBM Bob configuration.
 
             ```bash
             rm -rf ~/.bob
+            ```
+        - id: linux
+          desc: |
+            Remove IBM Bob configuration.
+
+            ```bash
+            rm -rf ~/.bob
+            ```
+        - id: windows
+          desc: |
+            Remove IBM Bob configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.bob"
             ```
 
   - uid: mondoo-ai-security-no-openclaw
@@ -509,12 +663,26 @@ queries:
       desc: |
         This check ensures that OpenClaw, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove OpenClaw configuration.
 
             ```bash
             rm -rf ~/.openclaw
+            ```
+        - id: linux
+          desc: |
+            Remove OpenClaw configuration.
+
+            ```bash
+            rm -rf ~/.openclaw
+            ```
+        - id: windows
+          desc: |
+            Remove OpenClaw configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"
             ```
 
   - uid: mondoo-ai-security-no-snowflake-cortex
@@ -525,12 +693,26 @@ queries:
       desc: |
         This check ensures that Snowflake Cortex Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Snowflake Cortex configuration.
 
             ```bash
             rm -rf ~/.snowflake/cortex
+            ```
+        - id: linux
+          desc: |
+            Remove Snowflake Cortex configuration.
+
+            ```bash
+            rm -rf ~/.snowflake/cortex
+            ```
+        - id: windows
+          desc: |
+            Remove Snowflake Cortex configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.snowflake\cortex"
             ```
 
   - uid: mondoo-ai-security-no-junie
@@ -541,12 +723,26 @@ queries:
       desc: |
         This check ensures that Junie (JetBrains), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Junie configuration.
 
             ```bash
             rm -rf ~/.junie
+            ```
+        - id: linux
+          desc: |
+            Remove Junie configuration.
+
+            ```bash
+            rm -rf ~/.junie
+            ```
+        - id: windows
+          desc: |
+            Remove Junie configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.junie"
             ```
 
   - uid: mondoo-ai-security-no-augment
@@ -557,12 +753,26 @@ queries:
       desc: |
         This check ensures that Augment, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Augment configuration.
 
             ```bash
             rm -rf ~/.augment
+            ```
+        - id: linux
+          desc: |
+            Remove Augment configuration.
+
+            ```bash
+            rm -rf ~/.augment
+            ```
+        - id: windows
+          desc: |
+            Remove Augment configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.augment"
             ```
 
   - uid: mondoo-ai-security-no-warp
@@ -573,12 +783,26 @@ queries:
       desc: |
         This check ensures that Warp, an AI-powered terminal, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Warp configuration.
 
             ```bash
             rm -rf ~/.warp
+            ```
+        - id: linux
+          desc: |
+            Remove Warp configuration.
+
+            ```bash
+            rm -rf ~/.warp
+            ```
+        - id: windows
+          desc: |
+            Remove Warp configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
             ```
 
   - uid: mondoo-ai-security-no-kilocode
@@ -589,12 +813,26 @@ queries:
       desc: |
         This check ensures that Kilo Code, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Kilo Code configuration.
 
             ```bash
             rm -rf ~/.kilocode
+            ```
+        - id: linux
+          desc: |
+            Remove Kilo Code configuration.
+
+            ```bash
+            rm -rf ~/.kilocode
+            ```
+        - id: windows
+          desc: |
+            Remove Kilo Code configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.kilocode"
             ```
 
   - uid: mondoo-ai-security-no-openhands
@@ -605,12 +843,26 @@ queries:
       desc: |
         This check ensures that OpenHands, an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove OpenHands configuration.
 
             ```bash
             rm -rf ~/.openhands
+            ```
+        - id: linux
+          desc: |
+            Remove OpenHands configuration.
+
+            ```bash
+            rm -rf ~/.openhands
+            ```
+        - id: windows
+          desc: |
+            Remove OpenHands configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.openhands"
             ```
 
   - uid: mondoo-ai-security-no-qwen-code
@@ -621,12 +873,26 @@ queries:
       desc: |
         This check ensures that Qwen Code (Alibaba), an AI coding agent, is not configured on the endpoint.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Remove Qwen Code configuration.
 
             ```bash
             rm -rf ~/.qwen
+            ```
+        - id: linux
+          desc: |
+            Remove Qwen Code configuration.
+
+            ```bash
+            rm -rf ~/.qwen
+            ```
+        - id: windows
+          desc: |
+            Remove Qwen Code configuration.
+
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.qwen"
             ```
 
   # ---------------------------------------------------------------------------
@@ -643,7 +909,7 @@ queries:
       desc: |
         This check ensures that no Codeium AI coding extensions are installed in VS Code-compatible editors. Codeium transmits source code to cloud AI models for completion and chat.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
 
@@ -665,7 +931,53 @@ queries:
             windsurf --uninstall-extension codeium.codeium
             ```
 
-            You can also uninstall from within the editor: open the Extensions view, search for the extension, and click **Uninstall**.
+            You can also uninstall from within the editor: open the Extensions view (`Cmd+Shift+X`), search for the extension, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
+
+            VS Code:
+
+            ```bash
+            code --uninstall-extension codeium.codeium
+            ```
+
+            Cursor:
+
+            ```bash
+            cursor --uninstall-extension codeium.codeium
+            ```
+
+            Windsurf:
+
+            ```bash
+            windsurf --uninstall-extension codeium.codeium
+            ```
+
+            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
+
+            VS Code:
+
+            ```powershell
+            code --uninstall-extension codeium.codeium
+            ```
+
+            Cursor:
+
+            ```powershell
+            cursor --uninstall-extension codeium.codeium
+            ```
+
+            Windsurf:
+
+            ```powershell
+            windsurf --uninstall-extension codeium.codeium
+            ```
+
+            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
 
 
   - uid: mondoo-ai-security-no-vscode-tabnine-extension
@@ -679,7 +991,7 @@ queries:
       desc: |
         This check ensures that no Tabnine AI coding extensions are installed in VS Code-compatible editors. Tabnine can transmit source code to cloud models depending on configuration.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -689,7 +1001,29 @@ queries:
             windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Tabnine, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
+            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
+            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
+            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
+            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-supermaven-extension
     title: No Supermaven extensions in VS Code-compatible editors
@@ -702,7 +1036,7 @@ queries:
       desc: |
         This check ensures that no Supermaven AI coding extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -712,7 +1046,29 @@ queries:
             windsurf --uninstall-extension supermaven.supermaven   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Supermaven, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension supermaven.supermaven       # VS Code
+            cursor --uninstall-extension supermaven.supermaven     # Cursor
+            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension supermaven.supermaven       # VS Code
+            cursor --uninstall-extension supermaven.supermaven     # Cursor
+            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-continue-extension
     title: No Continue extensions in VS Code-compatible editors
@@ -725,7 +1081,7 @@ queries:
       desc: |
         This check ensures that no Continue AI coding extensions are installed in VS Code-compatible editors. Continue is an open-source AI assistant that can connect to various LLM providers.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -735,7 +1091,29 @@ queries:
             windsurf --uninstall-extension continue.continue   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Continue, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cline-extension
     title: No Cline extensions in VS Code-compatible editors
@@ -748,7 +1126,7 @@ queries:
       desc: |
         This check ensures that no Cline (formerly Claude Dev) AI coding extensions are installed in VS Code-compatible editors. Cline is an autonomous AI agent that can execute code and modify files.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -758,7 +1136,29 @@ queries:
             windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Cline, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cody-extension
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
@@ -771,7 +1171,7 @@ queries:
       desc: |
         This check ensures that no Sourcegraph Cody AI coding extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -781,7 +1181,29 @@ queries:
             windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Cody, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension sourcegraph.cody-ai       # VS Code
+            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
+            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension sourcegraph.cody-ai       # VS Code
+            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
+            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-codex-extension
     title: No OpenAI Codex extensions in VS Code-compatible editors
@@ -794,7 +1216,7 @@ queries:
       desc: |
         This check ensures that no OpenAI Codex extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -804,7 +1226,29 @@ queries:
             windsurf --uninstall-extension openai.codex   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Codex, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension openai.codex       # VS Code
+            cursor --uninstall-extension openai.codex     # Cursor
+            windsurf --uninstall-extension openai.codex   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension openai.codex       # VS Code
+            cursor --uninstall-extension openai.codex     # Cursor
+            windsurf --uninstall-extension openai.codex   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-claude-extension
     title: No Claude extensions in VS Code-compatible editors
@@ -817,7 +1261,7 @@ queries:
       desc: |
         This check ensures that no Anthropic Claude extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -827,7 +1271,29 @@ queries:
             windsurf --uninstall-extension anthropic.claude   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Claude, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension anthropic.claude       # VS Code
+            cursor --uninstall-extension anthropic.claude     # Cursor
+            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension anthropic.claude       # VS Code
+            cursor --uninstall-extension anthropic.claude     # Cursor
+            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cursor-extension
     title: No Cursor-specific extensions in VS Code-compatible editors
@@ -840,7 +1306,7 @@ queries:
       desc: |
         This check ensures that no Cursor-specific AI extensions are installed in VS Code-compatible editors.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -850,7 +1316,29 @@ queries:
             windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for the extension, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension <cursor.extension-name>       # VS Code
+            cursor --uninstall-extension <cursor.extension-name>     # Cursor
+            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension <cursor.extension-name>       # VS Code
+            cursor --uninstall-extension <cursor.extension-name>     # Cursor
+            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-roo-extension
     title: No Roo Code extensions in VS Code-compatible editors
@@ -863,7 +1351,7 @@ queries:
       desc: |
         This check ensures that no Roo Code AI coding extensions are installed in VS Code-compatible editors. Roo Code is an autonomous AI agent forked from Cline.
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Uninstall the extension from whichever editor(s) have it installed:
 
@@ -873,7 +1361,29 @@ queries:
             windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
             ```
 
-            Or open the Extensions view in the editor, search for Roo Code, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
 
   # ---------------------------------------------------------------------------
   # MCP server governance
@@ -908,7 +1418,7 @@ queries:
               return /(?i)(mondoo|github|jira)/
         ```
       remediation:
-        - id: shell
+        - id: macos
           desc: |
             Review and remove unapproved MCP servers from each agent's configuration.
 
@@ -918,6 +1428,30 @@ queries:
             - GitHub Copilot: `~/.config/github-copilot/`
             - Windsurf: `~/.codeium/windsurf/`
             - Gemini CLI: `~/.gemini/`
+
+            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
+        - id: linux
+          desc: |
+            Review and remove unapproved MCP servers from each agent's configuration.
+
+            - Claude Code: `~/.claude/settings.json`
+            - OpenAI Codex: `~/.codex/`
+            - Cursor: `~/.cursor/mcp.json`
+            - GitHub Copilot: `~/.config/github-copilot/`
+            - Windsurf: `~/.codeium/windsurf/`
+            - Gemini CLI: `~/.gemini/`
+
+            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
+        - id: windows
+          desc: |
+            Review and remove unapproved MCP servers from each agent's configuration.
+
+            - Claude Code: `%USERPROFILE%\.claude\settings.json`
+            - OpenAI Codex: `%USERPROFILE%\.codex\`
+            - Cursor: `%USERPROFILE%\.cursor\mcp.json`
+            - GitHub Copilot: `%APPDATA%\github-copilot\`
+            - Windsurf: `%USERPROFILE%\.codeium\windsurf\`
+            - Gemini CLI: `%USERPROFILE%\.gemini\`
 
             Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
 

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -115,35 +115,37 @@ queries:
         Running unapproved AI tools can lead to data egress, where proprietary source code, customer data, or secrets are sent to untrusted AI providers. Only AI tools reviewed and approved by the security team should be permitted.
 
         Customize the `mondooAiSecurityApprovedProcesses` property to match your organization's approved tool list.
-      remediation: |
-        Identify and terminate unapproved AI processes, then uninstall the tool.
+      remediation:
+        - id: macos
+          desc: |
+            Identify and terminate unapproved AI processes, then uninstall the tool.
 
-        **macOS:**
+            ```bash
+            ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
+            kill <PID>
+            brew uninstall <tool_name>  # if installed via Homebrew
+            # Or drag the application from /Applications to Trash
+            ```
+        - id: linux
+          desc: |
+            Identify and terminate unapproved AI processes, then uninstall the tool.
 
-        ```bash
-        ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
-        kill <PID>
-        brew uninstall <tool_name>  # if installed via Homebrew
-        # Or drag the application from /Applications to Trash
-        ```
+            ```bash
+            ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
+            kill <PID>
+            sudo apt remove <package_name>   # Debian/Ubuntu
+            sudo dnf remove <package_name>   # RHEL/Fedora
+            ```
+        - id: windows
+          desc: |
+            Identify and terminate unapproved AI processes, then uninstall the tool.
 
-        **Linux:**
-
-        ```bash
-        ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
-        kill <PID>
-        sudo apt remove <package_name>   # Debian/Ubuntu
-        sudo dnf remove <package_name>   # RHEL/Fedora
-        ```
-
-        **Windows:**
-
-        ```powershell
-        Get-Process | Where-Object { $_.Name -match 'ollama|lmstudio|cursor|windsurf|codeium' }
-        Stop-Process -Name <process_name>
-        winget uninstall <tool_name>
-        # Or uninstall via Settings > Apps > Installed Apps
-        ```
+            ```powershell
+            Get-Process | Where-Object { $_.Name -match 'ollama|lmstudio|cursor|windsurf|codeium' }
+            Stop-Process -Name <process_name>
+            winget uninstall <tool_name>
+            # Or uninstall via Settings > Apps > Installed Apps
+            ```
 
   - uid: mondoo-ai-security-no-unapproved-ai-packages
     title: No unapproved AI tools installed via package managers
@@ -163,33 +165,37 @@ queries:
         This check ensures that no unapproved AI tools are installed via system package managers (apt, dnf, rpm, Windows Uninstall registry).
 
         Installed but idle AI tools still represent risk since they can be launched at any time and may contain cached credentials or configuration from prior use.
-      remediation: |
-        Remove unapproved AI packages using the system package manager.
+      remediation:
+        - id: macos
+          desc: |
+            Remove unapproved AI packages using the system package manager.
 
-        **macOS:**
+            ```bash
+            brew uninstall <package_name>
+            ```
+        - id: linux
+          desc: |
+            Remove unapproved AI packages using the system package manager.
 
-        ```bash
-        brew uninstall <package_name>
-        ```
+            Debian/Ubuntu:
 
-        **Linux (Debian/Ubuntu):**
+            ```bash
+            sudo apt remove <package_name>
+            ```
 
-        ```bash
-        sudo apt remove <package_name>
-        ```
+            RHEL/Fedora:
 
-        **Linux (RHEL/Fedora):**
+            ```bash
+            sudo dnf remove <package_name>
+            ```
+        - id: windows
+          desc: |
+            Remove unapproved AI packages using the system package manager.
 
-        ```bash
-        sudo dnf remove <package_name>
-        ```
-
-        **Windows:**
-
-        ```powershell
-        winget uninstall <package_name>
-        # Or uninstall via Settings > Apps > Installed Apps
-        ```
+            ```powershell
+            winget uninstall <package_name>
+            # Or uninstall via Settings > Apps > Installed Apps
+            ```
 
   - uid: mondoo-ai-security-no-unapproved-homebrew-ai-packages
     title: No unapproved AI tools installed via Homebrew
@@ -208,12 +214,14 @@ queries:
     docs:
       desc: |
         This check ensures that no unapproved AI tools are installed via Homebrew on macOS. Homebrew casks are a common installation method for desktop AI applications.
-      remediation: |
-        Remove unapproved AI packages:
+      remediation:
+        - id: macos
+          desc: |
+            Remove unapproved AI packages:
 
-        ```bash
-        brew uninstall <package_name>
-        ```
+            ```bash
+            brew uninstall <package_name>
+            ```
 
   # ---------------------------------------------------------------------------
   # Unapproved AI agent configurations
@@ -228,30 +236,32 @@ queries:
         This check ensures that Cursor, an AI-native code editor, is not configured on the endpoint. Cursor sends code to cloud AI models for completion and chat, which can result in proprietary source code being transmitted to third-party services.
 
         If Cursor is approved in your organization, remove this check or add an exception.
-      remediation: |
-        Uninstall Cursor and remove its configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall Cursor and remove its configuration.
 
-        **macOS:**
+            ```bash
+            rm -rf ~/Library/Application\ Support/Cursor
+            rm -rf ~/.cursor
+            ```
+        - id: linux
+          desc: |
+            Uninstall Cursor and remove its configuration.
 
-        ```bash
-        rm -rf ~/Library/Application\ Support/Cursor
-        rm -rf ~/.cursor
-        ```
+            ```bash
+            rm -rf ~/.config/Cursor
+            rm -rf ~/.cursor
+            ```
+        - id: windows
+          desc: |
+            Uninstall Cursor and remove its configuration.
 
-        **Linux:**
-
-        ```bash
-        rm -rf ~/.config/Cursor
-        rm -rf ~/.cursor
-        ```
-
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:APPDATA\Cursor"
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.cursor"
-        winget uninstall Cursor
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\Cursor"
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.cursor"
+            winget uninstall Cursor
+            ```
 
   - uid: mondoo-ai-security-no-windsurf
     title: Windsurf editor is not configured on this endpoint
@@ -261,30 +271,32 @@ queries:
     docs:
       desc: |
         This check ensures that Windsurf (Codeium), an AI-native code editor, is not configured on the endpoint.
-      remediation: |
-        Uninstall Windsurf and remove its configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall Windsurf and remove its configuration.
 
-        **macOS:**
+            ```bash
+            rm -rf ~/Library/Application\ Support/Windsurf
+            rm -rf ~/.codeium/windsurf
+            ```
+        - id: linux
+          desc: |
+            Uninstall Windsurf and remove its configuration.
 
-        ```bash
-        rm -rf ~/Library/Application\ Support/Windsurf
-        rm -rf ~/.codeium/windsurf
-        ```
+            ```bash
+            rm -rf ~/.config/Windsurf
+            rm -rf ~/.codeium/windsurf
+            ```
+        - id: windows
+          desc: |
+            Uninstall Windsurf and remove its configuration.
 
-        **Linux:**
-
-        ```bash
-        rm -rf ~/.config/Windsurf
-        rm -rf ~/.codeium/windsurf
-        ```
-
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:APPDATA\Windsurf"
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.codeium\windsurf"
-        winget uninstall Windsurf
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\Windsurf"
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.codeium\windsurf"
+            winget uninstall Windsurf
+            ```
 
   - uid: mondoo-ai-security-no-goose
     title: Goose AI agent is not configured on this endpoint
@@ -294,20 +306,28 @@ queries:
     docs:
       desc: |
         This check ensures that Goose, an open-source AI agent by Block, is not configured on the endpoint. Goose can connect to multiple AI providers and execute code with full system access via extensions.
-      remediation: |
-        Remove Goose configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Goose configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.config/goose
+            ```
+        - id: linux
+          desc: |
+            Remove Goose configuration.
 
-        ```bash
-        rm -rf ~/.config/goose
-        ```
+            ```bash
+            rm -rf ~/.config/goose
+            ```
+        - id: windows
+          desc: |
+            Remove Goose configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:APPDATA\goose"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\goose"
+            ```
 
   - uid: mondoo-ai-security-no-zed
     title: Zed editor is not configured on this endpoint
@@ -317,22 +337,23 @@ queries:
     docs:
       desc: |
         This check ensures that Zed, an editor with built-in AI features, is not configured on the endpoint.
-      remediation: |
-        Remove Zed configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Zed configuration.
 
-        **macOS:**
+            ```bash
+            rm -rf ~/Library/Application\ Support/Zed
+            rm -rf ~/.config/zed
+            ```
+        - id: linux
+          desc: |
+            Remove Zed configuration.
 
-        ```bash
-        rm -rf ~/Library/Application\ Support/Zed
-        rm -rf ~/.config/zed
-        ```
-
-        **Linux:**
-
-        ```bash
-        rm -rf ~/.config/zed
-        rm -rf ~/.local/share/zed
-        ```
+            ```bash
+            rm -rf ~/.config/zed
+            rm -rf ~/.local/share/zed
+            ```
 
   - uid: mondoo-ai-security-no-cline
     title: Cline agent is not configured on this endpoint
@@ -341,20 +362,28 @@ queries:
     docs:
       desc: |
         This check ensures that Cline, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Cline configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Cline configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.cline
+            ```
+        - id: linux
+          desc: |
+            Remove Cline configuration.
 
-        ```bash
-        rm -rf ~/.cline
-        ```
+            ```bash
+            rm -rf ~/.cline
+            ```
+        - id: windows
+          desc: |
+            Remove Cline configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
+            ```
 
   - uid: mondoo-ai-security-no-roo
     title: Roo Code agent is not configured on this endpoint
@@ -363,20 +392,28 @@ queries:
     docs:
       desc: |
         This check ensures that Roo Code, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Roo Code configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Roo Code configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.roo
+            ```
+        - id: linux
+          desc: |
+            Remove Roo Code configuration.
 
-        ```bash
-        rm -rf ~/.roo
-        ```
+            ```bash
+            rm -rf ~/.roo
+            ```
+        - id: windows
+          desc: |
+            Remove Roo Code configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.roo"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.roo"
+            ```
 
   - uid: mondoo-ai-security-no-continuedev
     title: Continue agent is not configured on this endpoint
@@ -385,20 +422,28 @@ queries:
     docs:
       desc: |
         This check ensures that Continue, an open-source AI coding assistant, is not configured on the endpoint.
-      remediation: |
-        Remove Continue configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Continue configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.continue
+            ```
+        - id: linux
+          desc: |
+            Remove Continue configuration.
 
-        ```bash
-        rm -rf ~/.continue
-        ```
+            ```bash
+            rm -rf ~/.continue
+            ```
+        - id: windows
+          desc: |
+            Remove Continue configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.continue"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.continue"
+            ```
 
   - uid: mondoo-ai-security-no-trae
     title: Trae agent is not configured on this endpoint
@@ -407,20 +452,28 @@ queries:
     docs:
       desc: |
         This check ensures that Trae, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Trae configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Trae configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.trae
+            ```
+        - id: linux
+          desc: |
+            Remove Trae configuration.
 
-        ```bash
-        rm -rf ~/.trae
-        ```
+            ```bash
+            rm -rf ~/.trae
+            ```
+        - id: windows
+          desc: |
+            Remove Trae configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.trae"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.trae"
+            ```
 
   - uid: mondoo-ai-security-no-opencode
     title: OpenCode agent is not configured on this endpoint
@@ -429,20 +482,28 @@ queries:
     docs:
       desc: |
         This check ensures that OpenCode, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove OpenCode configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove OpenCode configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.config/opencode
+            ```
+        - id: linux
+          desc: |
+            Remove OpenCode configuration.
 
-        ```bash
-        rm -rf ~/.config/opencode
-        ```
+            ```bash
+            rm -rf ~/.config/opencode
+            ```
+        - id: windows
+          desc: |
+            Remove OpenCode configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:APPDATA\opencode"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:APPDATA\opencode"
+            ```
 
   - uid: mondoo-ai-security-no-kiro
     title: Kiro agent is not configured on this endpoint
@@ -451,20 +512,28 @@ queries:
     docs:
       desc: |
         This check ensures that Kiro, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Kiro configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Kiro configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.kiro
+            ```
+        - id: linux
+          desc: |
+            Remove Kiro configuration.
 
-        ```bash
-        rm -rf ~/.kiro
-        ```
+            ```bash
+            rm -rf ~/.kiro
+            ```
+        - id: windows
+          desc: |
+            Remove Kiro configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.kiro"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.kiro"
+            ```
 
   - uid: mondoo-ai-security-no-pi
     title: Pi agent is not configured on this endpoint
@@ -473,20 +542,28 @@ queries:
     docs:
       desc: |
         This check ensures that Pi, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Pi configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Pi configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.pi/agent
+            ```
+        - id: linux
+          desc: |
+            Remove Pi configuration.
 
-        ```bash
-        rm -rf ~/.pi/agent
-        ```
+            ```bash
+            rm -rf ~/.pi/agent
+            ```
+        - id: windows
+          desc: |
+            Remove Pi configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.pi\agent"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.pi\agent"
+            ```
 
   - uid: mondoo-ai-security-no-mistral-vibe
     title: Mistral Vibe is not configured on this endpoint
@@ -495,20 +572,28 @@ queries:
     docs:
       desc: |
         This check ensures that Mistral Vibe, an AI coding agent by Mistral, is not configured on the endpoint.
-      remediation: |
-        Remove Mistral Vibe configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Mistral Vibe configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.vibe
+            ```
+        - id: linux
+          desc: |
+            Remove Mistral Vibe configuration.
 
-        ```bash
-        rm -rf ~/.vibe
-        ```
+            ```bash
+            rm -rf ~/.vibe
+            ```
+        - id: windows
+          desc: |
+            Remove Mistral Vibe configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.vibe"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.vibe"
+            ```
 
   - uid: mondoo-ai-security-no-antigravity
     title: Antigravity agent is not configured on this endpoint
@@ -517,20 +602,28 @@ queries:
     docs:
       desc: |
         This check ensures that Antigravity (Google), an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Antigravity configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Antigravity configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.gemini/antigravity
+            ```
+        - id: linux
+          desc: |
+            Remove Antigravity configuration.
 
-        ```bash
-        rm -rf ~/.gemini/antigravity
-        ```
+            ```bash
+            rm -rf ~/.gemini/antigravity
+            ```
+        - id: windows
+          desc: |
+            Remove Antigravity configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.gemini\antigravity"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.gemini\antigravity"
+            ```
 
   - uid: mondoo-ai-security-no-ibm-bob
     title: IBM Bob is not configured on this endpoint
@@ -539,20 +632,28 @@ queries:
     docs:
       desc: |
         This check ensures that IBM Bob, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove IBM Bob configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove IBM Bob configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.bob
+            ```
+        - id: linux
+          desc: |
+            Remove IBM Bob configuration.
 
-        ```bash
-        rm -rf ~/.bob
-        ```
+            ```bash
+            rm -rf ~/.bob
+            ```
+        - id: windows
+          desc: |
+            Remove IBM Bob configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.bob"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.bob"
+            ```
 
   - uid: mondoo-ai-security-no-openclaw
     title: OpenClaw is not configured on this endpoint
@@ -561,20 +662,28 @@ queries:
     docs:
       desc: |
         This check ensures that OpenClaw, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove OpenClaw configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove OpenClaw configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.openclaw
+            ```
+        - id: linux
+          desc: |
+            Remove OpenClaw configuration.
 
-        ```bash
-        rm -rf ~/.openclaw
-        ```
+            ```bash
+            rm -rf ~/.openclaw
+            ```
+        - id: windows
+          desc: |
+            Remove OpenClaw configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"
+            ```
 
   - uid: mondoo-ai-security-no-snowflake-cortex
     title: Snowflake Cortex Code is not configured on this endpoint
@@ -583,20 +692,28 @@ queries:
     docs:
       desc: |
         This check ensures that Snowflake Cortex Code, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Snowflake Cortex configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Snowflake Cortex configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.snowflake/cortex
+            ```
+        - id: linux
+          desc: |
+            Remove Snowflake Cortex configuration.
 
-        ```bash
-        rm -rf ~/.snowflake/cortex
-        ```
+            ```bash
+            rm -rf ~/.snowflake/cortex
+            ```
+        - id: windows
+          desc: |
+            Remove Snowflake Cortex configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.snowflake\cortex"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.snowflake\cortex"
+            ```
 
   - uid: mondoo-ai-security-no-junie
     title: Junie is not configured on this endpoint
@@ -605,20 +722,28 @@ queries:
     docs:
       desc: |
         This check ensures that Junie (JetBrains), an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Junie configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Junie configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.junie
+            ```
+        - id: linux
+          desc: |
+            Remove Junie configuration.
 
-        ```bash
-        rm -rf ~/.junie
-        ```
+            ```bash
+            rm -rf ~/.junie
+            ```
+        - id: windows
+          desc: |
+            Remove Junie configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.junie"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.junie"
+            ```
 
   - uid: mondoo-ai-security-no-augment
     title: Augment is not configured on this endpoint
@@ -627,20 +752,28 @@ queries:
     docs:
       desc: |
         This check ensures that Augment, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Augment configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Augment configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.augment
+            ```
+        - id: linux
+          desc: |
+            Remove Augment configuration.
 
-        ```bash
-        rm -rf ~/.augment
-        ```
+            ```bash
+            rm -rf ~/.augment
+            ```
+        - id: windows
+          desc: |
+            Remove Augment configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.augment"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.augment"
+            ```
 
   - uid: mondoo-ai-security-no-warp
     title: Warp AI terminal is not configured on this endpoint
@@ -649,20 +782,28 @@ queries:
     docs:
       desc: |
         This check ensures that Warp, an AI-powered terminal, is not configured on the endpoint.
-      remediation: |
-        Remove Warp configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Warp configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.warp
+            ```
+        - id: linux
+          desc: |
+            Remove Warp configuration.
 
-        ```bash
-        rm -rf ~/.warp
-        ```
+            ```bash
+            rm -rf ~/.warp
+            ```
+        - id: windows
+          desc: |
+            Remove Warp configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
+            ```
 
   - uid: mondoo-ai-security-no-kilocode
     title: Kilo Code is not configured on this endpoint
@@ -671,20 +812,28 @@ queries:
     docs:
       desc: |
         This check ensures that Kilo Code, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Kilo Code configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Kilo Code configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.kilocode
+            ```
+        - id: linux
+          desc: |
+            Remove Kilo Code configuration.
 
-        ```bash
-        rm -rf ~/.kilocode
-        ```
+            ```bash
+            rm -rf ~/.kilocode
+            ```
+        - id: windows
+          desc: |
+            Remove Kilo Code configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.kilocode"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.kilocode"
+            ```
 
   - uid: mondoo-ai-security-no-openhands
     title: OpenHands is not configured on this endpoint
@@ -693,20 +842,28 @@ queries:
     docs:
       desc: |
         This check ensures that OpenHands, an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove OpenHands configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove OpenHands configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.openhands
+            ```
+        - id: linux
+          desc: |
+            Remove OpenHands configuration.
 
-        ```bash
-        rm -rf ~/.openhands
-        ```
+            ```bash
+            rm -rf ~/.openhands
+            ```
+        - id: windows
+          desc: |
+            Remove OpenHands configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.openhands"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.openhands"
+            ```
 
   - uid: mondoo-ai-security-no-qwen-code
     title: Qwen Code is not configured on this endpoint
@@ -715,20 +872,28 @@ queries:
     docs:
       desc: |
         This check ensures that Qwen Code (Alibaba), an AI coding agent, is not configured on the endpoint.
-      remediation: |
-        Remove Qwen Code configuration.
+      remediation:
+        - id: macos
+          desc: |
+            Remove Qwen Code configuration.
 
-        **macOS/Linux:**
+            ```bash
+            rm -rf ~/.qwen
+            ```
+        - id: linux
+          desc: |
+            Remove Qwen Code configuration.
 
-        ```bash
-        rm -rf ~/.qwen
-        ```
+            ```bash
+            rm -rf ~/.qwen
+            ```
+        - id: windows
+          desc: |
+            Remove Qwen Code configuration.
 
-        **Windows:**
-
-        ```powershell
-        Remove-Item -Recurse -Force "$env:USERPROFILE\.qwen"
-        ```
+            ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.qwen"
+            ```
 
   # ---------------------------------------------------------------------------
   # IDE extension governance
@@ -743,28 +908,77 @@ queries:
     docs:
       desc: |
         This check ensures that no Codeium AI coding extensions are installed in VS Code-compatible editors. Codeium transmits source code to cloud AI models for completion and chat.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
 
-        **VS Code:**
+            VS Code:
 
-        ```bash
-        code --uninstall-extension codeium.codeium
-        ```
+            ```bash
+            code --uninstall-extension codeium.codeium
+            ```
 
-        **Cursor:**
+            Cursor:
 
-        ```bash
-        cursor --uninstall-extension codeium.codeium
-        ```
+            ```bash
+            cursor --uninstall-extension codeium.codeium
+            ```
 
-        **Windsurf:**
+            Windsurf:
 
-        ```bash
-        windsurf --uninstall-extension codeium.codeium
-        ```
+            ```bash
+            windsurf --uninstall-extension codeium.codeium
+            ```
 
-        You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`), search for the extension, and click **Uninstall**.
+            You can also uninstall from within the editor: open the Extensions view (`Cmd+Shift+X`), search for the extension, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
+
+            VS Code:
+
+            ```bash
+            code --uninstall-extension codeium.codeium
+            ```
+
+            Cursor:
+
+            ```bash
+            cursor --uninstall-extension codeium.codeium
+            ```
+
+            Windsurf:
+
+            ```bash
+            windsurf --uninstall-extension codeium.codeium
+            ```
+
+            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed. Each VS Code-compatible editor has its own CLI command:
+
+            VS Code:
+
+            ```powershell
+            code --uninstall-extension codeium.codeium
+            ```
+
+            Cursor:
+
+            ```powershell
+            cursor --uninstall-extension codeium.codeium
+            ```
+
+            Windsurf:
+
+            ```powershell
+            windsurf --uninstall-extension codeium.codeium
+            ```
+
+            You can also uninstall from within the editor: open the Extensions view (`Ctrl+Shift+X`), search for the extension, and click **Uninstall**.
+
 
   - uid: mondoo-ai-security-no-vscode-tabnine-extension
     title: No Tabnine extensions in VS Code-compatible editors
@@ -776,16 +990,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Tabnine AI coding extensions are installed in VS Code-compatible editors. Tabnine can transmit source code to cloud models depending on configuration.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension tabnine.tabnine-vscode       # VS Code
-        cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
-        windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
+            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
+            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
+            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
+            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension tabnine.tabnine-vscode       # VS Code
+            cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
+            windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Tabnine, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-supermaven-extension
     title: No Supermaven extensions in VS Code-compatible editors
@@ -797,16 +1035,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Supermaven AI coding extensions are installed in VS Code-compatible editors.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension supermaven.supermaven       # VS Code
-        cursor --uninstall-extension supermaven.supermaven     # Cursor
-        windsurf --uninstall-extension supermaven.supermaven   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension supermaven.supermaven       # VS Code
+            cursor --uninstall-extension supermaven.supermaven     # Cursor
+            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension supermaven.supermaven       # VS Code
+            cursor --uninstall-extension supermaven.supermaven     # Cursor
+            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension supermaven.supermaven       # VS Code
+            cursor --uninstall-extension supermaven.supermaven     # Cursor
+            windsurf --uninstall-extension supermaven.supermaven   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Supermaven, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-continue-extension
     title: No Continue extensions in VS Code-compatible editors
@@ -818,16 +1080,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Continue AI coding extensions are installed in VS Code-compatible editors. Continue is an open-source AI assistant that can connect to various LLM providers.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension continue.continue       # VS Code
-        cursor --uninstall-extension continue.continue     # Cursor
-        windsurf --uninstall-extension continue.continue   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Continue, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cline-extension
     title: No Cline extensions in VS Code-compatible editors
@@ -839,16 +1125,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Cline (formerly Claude Dev) AI coding extensions are installed in VS Code-compatible editors. Cline is an autonomous AI agent that can execute code and modify files.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension saoudrizwan.claude-dev       # VS Code
-        cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
-        windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cline, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cody-extension
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
@@ -860,16 +1170,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Sourcegraph Cody AI coding extensions are installed in VS Code-compatible editors.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension sourcegraph.cody-ai       # VS Code
-        cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
-        windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension sourcegraph.cody-ai       # VS Code
+            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
+            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension sourcegraph.cody-ai       # VS Code
+            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
+            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension sourcegraph.cody-ai       # VS Code
+            cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
+            windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Cody, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-codex-extension
     title: No OpenAI Codex extensions in VS Code-compatible editors
@@ -881,16 +1215,40 @@ queries:
     docs:
       desc: |
         This check ensures that no OpenAI Codex extensions are installed in VS Code-compatible editors.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension openai.codex       # VS Code
-        cursor --uninstall-extension openai.codex     # Cursor
-        windsurf --uninstall-extension openai.codex   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension openai.codex       # VS Code
+            cursor --uninstall-extension openai.codex     # Cursor
+            windsurf --uninstall-extension openai.codex   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension openai.codex       # VS Code
+            cursor --uninstall-extension openai.codex     # Cursor
+            windsurf --uninstall-extension openai.codex   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension openai.codex       # VS Code
+            cursor --uninstall-extension openai.codex     # Cursor
+            windsurf --uninstall-extension openai.codex   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Codex, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-claude-extension
     title: No Claude extensions in VS Code-compatible editors
@@ -902,16 +1260,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Anthropic Claude extensions are installed in VS Code-compatible editors.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension anthropic.claude       # VS Code
-        cursor --uninstall-extension anthropic.claude     # Cursor
-        windsurf --uninstall-extension anthropic.claude   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension anthropic.claude       # VS Code
+            cursor --uninstall-extension anthropic.claude     # Cursor
+            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension anthropic.claude       # VS Code
+            cursor --uninstall-extension anthropic.claude     # Cursor
+            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension anthropic.claude       # VS Code
+            cursor --uninstall-extension anthropic.claude     # Cursor
+            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Claude, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-cursor-extension
     title: No Cursor-specific extensions in VS Code-compatible editors
@@ -923,16 +1305,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Cursor-specific AI extensions are installed in VS Code-compatible editors.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension <cursor.extension-name>       # VS Code
-        cursor --uninstall-extension <cursor.extension-name>     # Cursor
-        windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension <cursor.extension-name>       # VS Code
+            cursor --uninstall-extension <cursor.extension-name>     # Cursor
+            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension <cursor.extension-name>       # VS Code
+            cursor --uninstall-extension <cursor.extension-name>     # Cursor
+            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension <cursor.extension-name>       # VS Code
+            cursor --uninstall-extension <cursor.extension-name>     # Cursor
+            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for the extension, and click **Uninstall**.
 
   - uid: mondoo-ai-security-no-vscode-roo-extension
     title: No Roo Code extensions in VS Code-compatible editors
@@ -944,16 +1350,40 @@ queries:
     docs:
       desc: |
         This check ensures that no Roo Code AI coding extensions are installed in VS Code-compatible editors. Roo Code is an autonomous AI agent forked from Cline.
-      remediation: |
-        Uninstall the extension from whichever editor(s) have it installed:
+      remediation:
+        - id: macos
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
 
-        ```bash
-        code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
-        cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
-        windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
-        ```
+            ```bash
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
 
-        Or open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+            Or open the Extensions view (`Cmd+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+        - id: linux
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```bash
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
+        - id: windows
+          desc: |
+            Uninstall the extension from whichever editor(s) have it installed:
+
+            ```powershell
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+
+            Or open the Extensions view (`Ctrl+Shift+X`) in the editor, search for Roo Code, and click **Uninstall**.
 
   # ---------------------------------------------------------------------------
   # MCP server governance
@@ -987,40 +1417,43 @@ queries:
             mql: |
               return /(?i)(mondoo|github|jira)/
         ```
-      remediation: |
-        Review and remove unapproved MCP servers from each agent's configuration. The configuration file locations differ by operating system.
+      remediation:
+        - id: macos
+          desc: |
+            Review and remove unapproved MCP servers from each agent's configuration.
 
-        **Claude Code:**
+            - Claude Code: `~/.claude/settings.json`
+            - OpenAI Codex: `~/.codex/`
+            - Cursor: `~/.cursor/mcp.json`
+            - GitHub Copilot: `~/.config/github-copilot/`
+            - Windsurf: `~/.codeium/windsurf/`
+            - Gemini CLI: `~/.gemini/`
 
-        - macOS/Linux: `~/.claude/settings.json`
-        - Windows: `%USERPROFILE%\.claude\settings.json`
+            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
+        - id: linux
+          desc: |
+            Review and remove unapproved MCP servers from each agent's configuration.
 
-        **OpenAI Codex:**
+            - Claude Code: `~/.claude/settings.json`
+            - OpenAI Codex: `~/.codex/`
+            - Cursor: `~/.cursor/mcp.json`
+            - GitHub Copilot: `~/.config/github-copilot/`
+            - Windsurf: `~/.codeium/windsurf/`
+            - Gemini CLI: `~/.gemini/`
 
-        - macOS/Linux: `~/.codex/`
-        - Windows: `%USERPROFILE%\.codex\`
+            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
+        - id: windows
+          desc: |
+            Review and remove unapproved MCP servers from each agent's configuration.
 
-        **Cursor:**
+            - Claude Code: `%USERPROFILE%\.claude\settings.json`
+            - OpenAI Codex: `%USERPROFILE%\.codex\`
+            - Cursor: `%USERPROFILE%\.cursor\mcp.json`
+            - GitHub Copilot: `%APPDATA%\github-copilot\`
+            - Windsurf: `%USERPROFILE%\.codeium\windsurf\`
+            - Gemini CLI: `%USERPROFILE%\.gemini\`
 
-        - macOS/Linux: `~/.cursor/mcp.json`
-        - Windows: `%USERPROFILE%\.cursor\mcp.json`
-
-        **GitHub Copilot:**
-
-        - macOS/Linux: `~/.config/github-copilot/`
-        - Windows: `%APPDATA%\github-copilot\`
-
-        **Windsurf:**
-
-        - macOS/Linux: `~/.codeium/windsurf/`
-        - Windows: `%USERPROFILE%\.codeium\windsurf\`
-
-        **Gemini CLI:**
-
-        - macOS/Linux: `~/.gemini/`
-        - Windows: `%USERPROFILE%\.gemini\`
-
-        Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
+            Open the relevant configuration file, locate the `mcpServers` section, and remove any server entries that are not in the approved list.
 
   # ---------------------------------------------------------------------------
   # Local LLM runtimes
@@ -1039,32 +1472,34 @@ queries:
         Local LLMs can be used to process sensitive data outside of approved channels, and the model weights themselves may carry license restrictions that create legal exposure.
 
         **Note:** Local LLM processes will also trigger the "No unapproved AI agent processes" check (impact 80) if they are not in the approved process list. This is intentional — local LLM runtimes appear in both the general agent group and the dedicated LLM group to ensure visibility regardless of which group an operator enables.
-      remediation: |
-        Stop and uninstall local LLM runtimes.
+      remediation:
+        - id: macos
+          desc: |
+            Stop and uninstall local LLM runtimes.
 
-        **macOS:**
+            ```bash
+            brew uninstall ollama
+            # For LM Studio and GPT4All, drag the app from /Applications to Trash
+            ```
+        - id: linux
+          desc: |
+            Stop and uninstall local LLM runtimes.
 
-        ```bash
-        brew uninstall ollama
-        # For LM Studio and GPT4All, drag the app from /Applications to Trash
-        ```
+            ```bash
+            sudo systemctl stop ollama
+            sudo apt remove ollama       # Debian/Ubuntu
+            sudo dnf remove ollama       # RHEL/Fedora
+            # For AppImage-based tools (LM Studio), delete the AppImage file
+            ```
+        - id: windows
+          desc: |
+            Stop and uninstall local LLM runtimes.
 
-        **Linux:**
-
-        ```bash
-        sudo systemctl stop ollama
-        sudo apt remove ollama       # Debian/Ubuntu
-        sudo dnf remove ollama       # RHEL/Fedora
-        # For AppImage-based tools (LM Studio), delete the AppImage file
-        ```
-
-        **Windows:**
-
-        ```powershell
-        Stop-Process -Name ollama
-        winget uninstall Ollama
-        # For LM Studio and GPT4All, uninstall via Settings > Apps > Installed Apps
-        ```
+            ```powershell
+            Stop-Process -Name ollama
+            winget uninstall Ollama
+            # For LM Studio and GPT4All, uninstall via Settings > Apps > Installed Apps
+            ```
 
   - uid: mondoo-ai-security-no-local-llm-listening-ports
     title: No local LLM inference servers are listening
@@ -1082,19 +1517,28 @@ queries:
         - **1337**: LocalAI
 
         A listening port on these addresses indicates an active LLM inference server that could be used to process sensitive data outside approved channels.
-      remediation: |
-        Identify and stop the process listening on the flagged port:
+      remediation:
+        - id: macos
+          desc: |
+            Identify and stop the process listening on the flagged port:
 
-        **macOS/Linux:**
+            ```bash
+            lsof -i :<port>
+            kill <PID>
+            ```
+        - id: linux
+          desc: |
+            Identify and stop the process listening on the flagged port:
 
-        ```bash
-        lsof -i :<port>
-        kill <PID>
-        ```
+            ```bash
+            lsof -i :<port>
+            kill <PID>
+            ```
+        - id: windows
+          desc: |
+            Identify and stop the process listening on the flagged port:
 
-        **Windows:**
-
-        ```powershell
-        Get-NetTCPConnection -LocalPort <port> | Select-Object OwningProcess
-        Stop-Process -Id <PID>
-        ```
+            ```powershell
+            Get-NetTCPConnection -LocalPort <port> | Select-Object OwningProcess
+            Stop-Process -Id <PID>
+            ```


### PR DESCRIPTION
## Summary

All 38 checks in `content/mondoo-ai-security.mql.yaml` had unstructured remediation — plain Markdown strings that mixed per-OS instructions inside a single `remediation: |` block. This PR converts every remediation to the structured `[{id, desc}]` form so each operating system renders as its own remediation step in the UI.

- Each check now has one entry per OS using the canonical IDs `macos`, `linux`, and `windows`.
- Where the original prose combined OSes (e.g., `**macOS/Linux:**`), the content is duplicated into separate `id: macos` and `id: linux` entries — the structured form has one OS per entry.
- Checks that had no Windows section (`mondoo-ai-security-no-zed`) only emit `id: macos` and `id: linux`. The macOS-only Homebrew check emits `id: macos`.
- All commands, code fences, and intro sentences from the original Markdown are preserved.

## Test plan

- [x] `cnspec policy lint content/mondoo-ai-security.mql.yaml` passes
- [x] `inspect-policies.py` shows per-OS IDs (`macos`, `linux`, `windows`) for every check — no `(unstructured)` entries remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)