### PR TITLE
fix(unifi): convert unstructured remediations to console remediation blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ settings.local.json
 
 # python
 __pycache__/
+
+# git worktrees
+.worktrees/

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -117,13 +117,15 @@ queries:
           - Attackers can perform man-in-the-middle attacks without any authentication barrier.
           - Open networks provide no protection against rogue clients joining the network.
           - Even guest networks should use WPA with a shared key or captive portal authentication.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select the open wireless network.
-        3. Change the **Security** setting to **WPA2** or **WPA3**.
-        4. Set a strong passphrase or configure enterprise (802.1X) authentication.
+            1. Go to **Settings > WiFi**.
+            2. Select the open wireless network.
+            3. Change the **Security** setting to **WPA2** or **WPA3**.
+            4. Set a strong passphrase or configure enterprise (802.1X) authentication.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -158,13 +160,15 @@ queries:
           - Data confidentiality for all wireless traffic.
           - Protection against eavesdropping and session hijacking.
           - Compliance with modern security standards and best practices.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each wireless network.
-        3. Set **Security** to **WPA Personal** or **WPA Enterprise**.
-        4. Ensure WPA mode is set to **WPA2** or higher.
+            1. Go to **Settings > WiFi**.
+            2. Select each wireless network.
+            3. Set **Security** to **WPA Personal** or **WPA Enterprise**.
+            4. Ensure WPA mode is set to **WPA2** or higher.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -194,13 +198,15 @@ queries:
           - Protected Management Frames (PMF) are mandatory, preventing deauthentication attacks.
 
         WPA3 transition mode allows WPA2 clients to connect while still offering WPA3 to capable devices.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each wireless network.
-        3. Enable **WPA3** or **WPA2/WPA3 Transition** mode.
-        4. Verify that all critical client devices support WPA3 or transition mode before disabling WPA2 entirely.
+            1. Go to **Settings > WiFi**.
+            2. Select each wireless network.
+            3. Enable **WPA3** or **WPA2/WPA3 Transition** mode.
+            4. Verify that all critical client devices support WPA3 or transition mode before disabling WPA2 entirely.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -233,13 +239,15 @@ queries:
           - Deauthentication and disassociation flooding attacks.
           - Forced roaming to rogue access points.
           - Denial-of-service attacks targeting wireless clients.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each wireless network.
-        3. Under advanced settings, set **PMF** to **Optional** or **Required**.
-        4. Note: Setting PMF to **Required** may cause connectivity issues with older clients that do not support 802.11w.
+            1. Go to **Settings > WiFi**.
+            2. Select each wireless network.
+            3. Under advanced settings, set **PMF** to **Optional** or **Required**.
+            4. Note: Setting PMF to **Required** may cause connectivity issues with older clients that do not support 802.11w.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -268,13 +276,15 @@ queries:
           - AES-CCMP is the standard cipher for WPA2 and provides strong 128-bit encryption.
           - GCMP-256 is used with WPA3 and provides 256-bit encryption for the highest level of protection.
           - Using weak ciphers undermines the security provided by WPA2/WPA3, even with a strong passphrase.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each wireless network.
-        3. Under advanced settings, ensure the encryption cipher is set to **CCMP** (AES) or **GCMP-256**.
-        4. Avoid selecting TKIP or mixed-mode cipher configurations.
+            1. Go to **Settings > WiFi**.
+            2. Select each wireless network.
+            3. Under advanced settings, ensure the encryption cipher is set to **CCMP** (AES) or **GCMP-256**.
+            4. Avoid selecting TKIP or mixed-mode cipher configurations.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -303,12 +313,14 @@ queries:
           - Regular rekeying limits the amount of data encrypted under a single key, reducing the value of a captured key.
           - Industry best practice recommends a rekey interval of 3600 seconds or less.
           - A value of 0 disables rekeying entirely, which is a security risk.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each wireless network.
-        3. Under advanced settings, set the **Group Rekey Interval** to **3600** seconds or less.
+            1. Go to **Settings > WiFi**.
+            2. Select each wireless network.
+            3. Under advanced settings, set the **Group Rekey Interval** to **3600** seconds or less.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -342,12 +354,14 @@ queries:
           - All client traffic is forced through the gateway, enabling firewall inspection.
           - Clients cannot discover or communicate with each other directly.
           - ARP spoofing and other Layer 2 attacks between clients are prevented.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select each guest wireless network.
-        3. Under advanced settings, enable **L2 Isolation** (Client Isolation).
+            1. Go to **Settings > WiFi**.
+            2. Select each guest wireless network.
+            3. Under advanced settings, enable **L2 Isolation** (Client Isolation).
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
@@ -380,13 +394,15 @@ queries:
           - Client-to-client isolation, preventing guests from communicating with each other.
           - Separation from the management network and other VLANs.
           - Optional captive portal authentication for access control.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > WiFi**.
-        2. Select the guest wireless network.
-        3. Enable the **Guest** toggle to activate guest policies.
-        4. Optionally configure a captive portal under **Settings > Hotspot**.
+            1. Go to **Settings > WiFi**.
+            2. Select the guest wireless network.
+            3. Enable the **Guest** toggle to activate guest policies.
+            4. Optionally configure a captive portal under **Settings > Hotspot**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115000166827
         title: UniFi guest network configuration
@@ -421,13 +437,15 @@ queries:
           - Automatic blocking of known attack patterns and exploits.
           - Protection against network-based attacks, malware communication, and data exfiltration.
           - Real-time threat mitigation without manual intervention.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Threat Management**.
-        2. Enable **Threat Management**.
-        3. Set the mode to **IPS** (Intrusion Prevention System).
-        4. Review and enable appropriate threat categories for your environment.
+            1. Go to **Settings > Security > Threat Management**.
+            2. Enable **Threat Management**.
+            3. Set the mode to **IPS** (Intrusion Prevention System).
+            4. Review and enable appropriate threat categories for your environment.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
@@ -457,12 +475,14 @@ queries:
           - Protects all devices on the network regardless of their individual security software.
 
         DNS filtering works as a first line of defense before traffic reaches the target host.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Threat Management**.
-        2. Enable **DNS Filtering**.
-        3. Select the appropriate filtering level for your environment.
+            1. Go to **Settings > Security > Threat Management**.
+            2. Enable **DNS Filtering**.
+            3. Select the appropriate filtering level for your environment.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
@@ -491,11 +511,13 @@ queries:
           - Detects lateral movement from compromised devices scanning the network.
           - Provides early warning of internal threats before they reach critical assets.
           - Low false-positive rate since legitimate traffic should never reach the honeypot.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Threat Management**.
-        2. Enable **Internal Honeypot**.
+            1. Go to **Settings > Security > Threat Management**.
+            2. Enable **Internal Honeypot**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
@@ -530,12 +552,14 @@ queries:
           - Only explicitly configured port forwards are active.
           - The firewall maintains full control over inbound traffic.
           - Internal devices cannot modify the gateway's NAT configuration.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Gateway**.
-        2. Disable **UPnP**.
-        3. Manually configure any required port forwarding rules under **Settings > Routing > Port Forwarding**.
+            1. Go to **Settings > Security > Gateway**.
+            2. Disable **UPnP**.
+            3. Manually configure any required port forwarding rules under **Settings > Routing > Port Forwarding**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
@@ -565,11 +589,13 @@ queries:
           - Network mapping tools use broadcast pings to discover hosts on a subnet.
 
         Disabling broadcast ping responses reduces the gateway's attack surface.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Gateway**.
-        2. Disable **Broadcast Ping**.
+            1. Go to **Settings > Security > Gateway**.
+            2. Disable **Broadcast Ping**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
@@ -599,11 +625,13 @@ queries:
           - Accepting redirects allows external hosts to influence the gateway's routing decisions.
 
         Disabling ICMP redirect acceptance ensures that only statically configured or protocol-learned routes are used.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Gateway**.
-        2. Disable **Receive Redirects** under the ICMP settings.
+            1. Go to **Settings > Security > Gateway**.
+            2. Disable **Receive Redirects** under the ICMP settings.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
@@ -631,11 +659,13 @@ queries:
           - Without SYN cookies, the gateway allocates resources for each half-open connection.
           - A SYN flood can consume all available connection slots, denying service to legitimate users.
           - SYN cookies allow the gateway to validate connections without maintaining state for half-open connections.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > Gateway**.
-        2. Enable **SYN Cookies**.
+            1. Go to **Settings > Security > Gateway**.
+            2. Enable **SYN Cookies**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
@@ -669,11 +699,13 @@ queries:
           - Only allows DHCP responses from trusted ports.
           - Prevents rogue DHCP servers from operating on the network.
           - Provides a foundation for dynamic ARP inspection and IP source guard.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Networks > Global Switch Settings**.
-        2. Enable **DHCP Snooping**.
+            1. Go to **Settings > Networks > Global Switch Settings**.
+            2. Enable **DHCP Snooping**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
         title: UniFi switch configuration
@@ -706,11 +738,13 @@ queries:
           - Loop prevention with rapid convergence (seconds vs. 30-50 seconds for legacy STP).
           - Backward compatibility with legacy STP devices.
           - Protection against accidental or malicious loop creation.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Networks > Global Switch Settings**.
-        2. Set **STP Version** to **RSTP**.
+            1. Go to **Settings > Networks > Global Switch Settings**.
+            2. Set **STP Version** to **RSTP**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
         title: UniFi switch configuration
@@ -745,12 +779,14 @@ queries:
           - Devices are managed exclusively through the UniFi controller.
           - No direct shell access is available to potential attackers.
           - Credential-based attacks against device SSH are not possible.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Advanced**.
-        2. Disable **SSH**.
-        3. If SSH is required for troubleshooting, enable it temporarily and disable it when done.
+            1. Go to **Settings > System > Advanced**.
+            2. Disable **SSH**.
+            3. If SSH is required for troubleshooting, enable it temporarily and disable it when done.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi device SSH access
@@ -780,12 +816,14 @@ queries:
           - Automated tools can attempt thousands of password combinations per minute.
           - Default or weak passwords on network devices are a common attack vector.
           - Key-based authentication provides stronger security and is not susceptible to brute-force attacks.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Advanced**.
-        2. If SSH must remain enabled, disable **SSH Password Authentication**.
-        3. Configure SSH key-based authentication instead.
+            1. Go to **Settings > System > Advanced**.
+            2. If SSH must remain enabled, disable **SSH Password Authentication**.
+            3. Configure SSH key-based authentication instead.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi device SSH access
@@ -814,11 +852,13 @@ queries:
           - They can be used to gather information useful for further attacks.
           - Debug interfaces may bypass normal access controls.
           - Production environments should only run with production-grade interfaces enabled.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Advanced**.
-        2. Disable **Debug Tools**.
+            1. Go to **Settings > System > Advanced**.
+            2. Disable **Debug Tools**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi advanced system settings
@@ -846,13 +886,15 @@ queries:
           - All site settings, firewall rules, network configurations, and device adoption records could be lost.
           - Recovery without a backup requires manual reconfiguration of every setting and re-adoption of all devices.
           - Regular backups enable rapid recovery from ransomware, hardware failure, or accidental misconfiguration.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Backups**.
-        2. Enable **Auto Backup**.
-        3. Configure the backup schedule and retention period.
-        4. Consider also enabling **Backup to Cloud** for off-site protection.
+            1. Go to **Settings > System > Backups**.
+            2. Enable **Auto Backup**.
+            3. Configure the backup schedule and retention period.
+            4. Consider also enabling **Backup to Cloud** for off-site protection.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/226218448
         title: UniFi backup and restore
@@ -885,12 +927,14 @@ queries:
           - Security patches are applied promptly across all devices.
           - The firmware fleet remains consistent and up to date.
           - Reduced operational burden for network administrators.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Firmware**.
-        2. Enable **Auto Update**.
-        3. Configure the update window to a low-traffic period.
+            1. Go to **Settings > System > Firmware**.
+            2. Enable **Auto Update**.
+            3. Configure the update window to a low-traffic period.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204911424
         title: UniFi firmware management
@@ -918,11 +962,13 @@ queries:
           - Telemetry may include network topology and usage patterns.
           - Organizations with strict data governance policies may need to disable external data sharing.
           - Reducing unnecessary outbound data flows limits potential information leakage.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System**.
-        2. Disable **Send Analytics and Improvement Data**.
+            1. Go to **Settings > System**.
+            2. Disable **Send Analytics and Improvement Data**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi system settings
@@ -956,13 +1002,15 @@ queries:
           - Logs are preserved independently of the controller.
           - Security events can be monitored and alerted on in real time.
           - Compliance requirements for log retention and integrity are met.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > System > Remote Logging**.
-        2. Enable **Remote Syslog**.
-        3. Configure the syslog server IP address and port.
-        4. Enable **Log All Contents** for comprehensive logging.
+            1. Go to **Settings > System > Remote Logging**.
+            2. Enable **Remote Syslog**.
+            3. Configure the syslog server IP address and port.
+            4. Enable **Log All Contents** for comprehensive logging.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi remote logging settings
@@ -994,13 +1042,15 @@ queries:
           - Brute-force attacks against exposed management interfaces are common.
           - Known vulnerabilities in management interfaces can be exploited remotely.
           - Management interfaces should only be accessible from trusted internal networks or through a VPN.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Routing > Port Forwarding**.
-        2. Review all enabled port forwarding rules.
-        3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
-        4. Use a VPN to access management interfaces remotely instead of port forwarding.
+            1. Go to **Settings > Routing > Port Forwarding**.
+            2. Review all enabled port forwarding rules.
+            3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
+            4. Use a VPN to access management interfaces remotely instead of port forwarding.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi port forwarding settings
@@ -1033,11 +1083,13 @@ queries:
           - Encryption of DNS queries, preventing eavesdropping and tampering.
           - Protection against DNS spoofing and man-in-the-middle attacks.
           - Privacy for network users' browsing activity.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Security > DNS Shield** or **Settings > Internet**.
-        2. Enable **DNS over HTTPS**.
+            1. Go to **Settings > Security > DNS Shield** or **Settings > Internet**.
+            2. Enable **DNS over HTTPS**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360052224054
         title: UniFi DNS settings
@@ -1072,12 +1124,14 @@ queries:
           - Traffic from guest networks cannot reach other VLANs.
           - Compromised devices are contained within their own network segment.
           - Defense-in-depth is maintained even if firewall rules are misconfigured.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Networks**.
-        2. Select each guest or IoT network.
-        3. Enable **Network Isolation** to prevent inter-VLAN routing.
+            1. Go to **Settings > Networks**.
+            2. Select each guest or IoT network.
+            3. Enable **Network Isolation** to prevent inter-VLAN routing.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi network settings
@@ -1111,12 +1165,14 @@ queries:
           - Multicast traffic is only forwarded to ports with hosts that have joined the multicast group.
           - Network bandwidth is conserved by eliminating unnecessary multicast flooding.
           - The attack surface for multicast-based reconnaissance is reduced.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > Networks**.
-        2. Select each LAN network.
-        3. Under advanced settings, enable **IGMP Snooping**.
+            1. Go to **Settings > Networks**.
+            2. Select each LAN network.
+            3. Under advanced settings, enable **IGMP Snooping**.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
         title: UniFi switch configuration
@@ -1146,13 +1202,15 @@ queries:
           - WireGuard uses modern, audited cryptographic primitives (ChaCha20, Curve25519) and has a minimal codebase, reducing the risk of vulnerabilities.
           - IPsec with IKEv2 provides strong encryption and is well-suited for site-to-site tunnels.
           - Legacy VPN protocols may use deprecated ciphers or have known implementation weaknesses.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > VPN > VPN Server**.
-        2. Select each VPN server configuration.
-        3. Set the protocol to **WireGuard** or **IPsec**.
-        4. Migrate any existing OpenVPN tunnels to a modern protocol.
+            1. Go to **Settings > VPN > VPN Server**.
+            2. Select each VPN server configuration.
+            3. Set the protocol to **WireGuard** or **IPsec**.
+            4. Migrate any existing OpenVPN tunnels to a modern protocol.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
         title: UniFi VPN configuration
@@ -1181,14 +1239,16 @@ queries:
           - Security monitoring and logging that depends on VPN connectivity will have gaps during disconnection.
           - Persistent disconnection may indicate misconfiguration, credential expiration, or an active attack disrupting the tunnel.
           - Stale VPN configurations that are enabled but non-functional should be investigated and remediated.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > VPN > VPN Client**.
-        2. Review VPN client tunnels that are enabled but disconnected.
-        3. Verify the remote endpoint is reachable and credentials are valid.
-        4. Check firewall rules on both ends to ensure VPN traffic is permitted.
-        5. Disable any VPN client configurations that are no longer needed.
+            1. Go to **Settings > VPN > VPN Client**.
+            2. Review VPN client tunnels that are enabled but disconnected.
+            3. Verify the remote endpoint is reachable and credentials are valid.
+            4. Check firewall rules on both ends to ensure VPN traffic is permitted.
+            5. Disable any VPN client configurations that are no longer needed.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
         title: UniFi VPN configuration
@@ -1217,13 +1277,15 @@ queries:
           - A VPN client using a weak protocol exposes traffic to interception at any point along the tunnel path.
           - WireGuard and IPsec provide authenticated encryption with modern ciphers and smaller attack surfaces.
           - Standardizing on modern protocols across both server and client configurations ensures consistent security posture.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Settings > VPN > VPN Client**.
-        2. Select each VPN client configuration.
-        3. Set the protocol to **WireGuard** or **IPsec**.
-        4. Coordinate with the remote site to ensure protocol compatibility.
+            1. Go to **Settings > VPN > VPN Client**.
+            2. Select each VPN client configuration.
+            3. Set the protocol to **WireGuard** or **IPsec**.
+            4. Coordinate with the remote site to ensure protocol compatibility.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
         title: UniFi VPN configuration
@@ -1258,13 +1320,15 @@ queries:
           - Known vulnerabilities are patched promptly.
           - Devices have the latest security features and hardening improvements.
           - The network is not exposed to publicly disclosed exploits targeting older firmware.
-      remediation: |
-        **Using UniFi Network Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using UniFi Network Console**
 
-        1. Go to **Devices** and review devices showing available updates.
-        2. Click **Update** on each device with a pending firmware upgrade.
-        3. If devices fail to update, verify they are properly adopted and can reach the update servers.
-        4. Enable **Auto Update** under **Settings > System > Firmware** to prevent future drift.
+            1. Go to **Devices** and review devices showing available updates.
+            2. Click **Update** on each device with a pending firmware upgrade.
+            3. If devices fail to update, verify they are properly adopted and can reach the update servers.
+            4. Enable **Auto Update** under **Settings > System > Firmware** to prevent future drift.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204911424
         title: UniFi firmware management


### PR DESCRIPTION
## Summary

- All 32 checks in `mondoo-unifi-security.mql.yaml` had bare `remediation: |` string blocks with no structured type
- Converted each to `remediation: - id: console` so the remediation type is machine-readable
- Content of each remediation is preserved verbatim under `desc: |`

## Test Plan

- [x] `cnspec policy lint content/mondoo-unifi-security.mql.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)