### PR TITLE
:sparkles: Restructure DigitalOcean remediation into console/cli

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -107,11 +107,15 @@ queries:
         **Why this matters**
 
         DigitalOcean uses the account email for password resets and other recovery workflows. If the email is unverified, an attacker who plants or coerces an unverified address into the account can take over the account through the self-service recovery flow. Verification binds the identity on the account to a mailbox the legitimate owner demonstrably controls.
-      remediation: |
-        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
-        2. Navigate to **Settings** > **Profile**.
-        3. If the email address shows as unverified, click **Resend verification email**.
-        4. Open the verification email and follow the confirmation link.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
+
+            1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+            2. Navigate to **Settings** > **Profile**.
+            3. If the email address shows as unverified, click **Resend verification email**.
+            4. Open the verification email and follow the confirmation link.
     refs:
       - url: https://docs.digitalocean.com/products/accounts/security/
         title: DigitalOcean account security
@@ -136,26 +140,27 @@ queries:
         **Why this matters**
 
         A Droplet not attached to a VPC cannot use private networking to reach other resources. Without VPC-level segmentation, an attacker who compromises one Droplet has broader reach across the account and lateral movement is harder to contain. VPCs also reduce unnecessary internet exposure by allowing private-only traffic between resources in the same VPC.
-      remediation: |
-        DigitalOcean does not support moving an existing Droplet into a VPC directly. To remediate, create a snapshot of the Droplet, create a replacement Droplet from the snapshot inside the target VPC, and retire the original.
+      remediation:
+        - id: console
+          desc: |
+            DigitalOcean does not support moving an existing Droplet into a VPC directly. To fix this in the DigitalOcean Cloud Control Panel, create a snapshot of the Droplet, create a replacement Droplet from the snapshot inside the target VPC, and retire the original:
 
-        **From the DigitalOcean Control Panel**
+            1. Navigate to **Images** > **Snapshots** and take a snapshot of the affected Droplet.
+            2. Create a new Droplet from the snapshot and select a VPC (not the default) in the **VPC Network** section.
+            3. Update DNS, firewall rules, and monitoring to point at the new Droplet.
+            4. Destroy the original Droplet.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, snapshot the Droplet and create a replacement inside the target VPC:
 
-        1. Navigate to **Images** > **Snapshots** and take a snapshot of the affected Droplet.
-        2. Create a new Droplet from the snapshot and select a VPC (not the default) in the **VPC Network** section.
-        3. Update DNS, firewall rules, and monitoring to point at the new Droplet.
-        4. Destroy the original Droplet.
-
-        **From `doctl`**
-
-        ```bash
-        doctl compute droplet-action snapshot <droplet-id> --snapshot-name <name>
-        doctl compute droplet create <new-name> \
-          --image <snapshot-id> \
-          --size <size> \
-          --region <region> \
-          --vpc-uuid <vpc-uuid>
-        ```
+            ```bash
+            doctl compute droplet-action snapshot <droplet-id> --snapshot-name <name>
+            doctl compute droplet create <new-name> \
+              --image <snapshot-id> \
+              --size <size> \
+              --region <region> \
+              --vpc-uuid <vpc-uuid>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/vpc/
         title: DigitalOcean VPC overview
@@ -189,21 +194,24 @@ queries:
         **Why this matters**
 
         SSH exposed to the entire internet is a primary target for credential stuffing, brute-force login attempts, and exploitation of any future SSH server CVE. Even with key-based authentication, open SSH exposes the SSH daemon itself as an attack surface. SSH access should be restricted to a known trusted CIDR range, a bastion host, or a VPN.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
-        2. Edit the offending inbound rule for SSH and change the source from `All IPv4`/`All IPv6` to a specific trusted CIDR, tag, or Droplet ID.
-        3. Save the firewall.
+            1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
+            2. Edit the offending inbound rule for SSH and change the source from `All IPv4`/`All IPv6` to a specific trusted CIDR, tag, or Droplet ID.
+            3. Save the firewall.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, replace the unrestricted SSH rule with one scoped to a trusted CIDR:
 
-        **From `doctl`**
-
-        ```bash
-        doctl compute firewall remove-rules <firewall-id> \
-          --inbound-rules "protocol:tcp,ports:22,address:0.0.0.0/0"
-        doctl compute firewall add-rules <firewall-id> \
-          --inbound-rules "protocol:tcp,ports:22,address:<your-trusted-cidr>"
-        ```
+            ```bash
+            doctl compute firewall remove-rules <firewall-id> \
+              --inbound-rules "protocol:tcp,ports:22,address:0.0.0.0/0"
+            doctl compute firewall add-rules <firewall-id> \
+              --inbound-rules "protocol:tcp,ports:22,address:<your-trusted-cidr>"
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/firewalls/how-to/configure-rules/
         title: Configure Cloud Firewall rules
@@ -237,19 +245,22 @@ queries:
         **Why this matters**
 
         RDP is a long-standing target of ransomware deployment and has been involved in repeated high-impact breaches. The RDP protocol itself has had multiple critical pre-authentication RCE CVEs (for example BlueKeep). Exposing RDP to the internet should be treated as an immediate security incident.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
-        2. Remove the RDP rule entirely, or restrict the source to a specific trusted CIDR, tag, or Droplet ID.
-        3. Save the firewall.
+            1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
+            2. Remove the RDP rule entirely, or restrict the source to a specific trusted CIDR, tag, or Droplet ID.
+            3. Save the firewall.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, remove the unrestricted RDP rule:
 
-        **From `doctl`**
-
-        ```bash
-        doctl compute firewall remove-rules <firewall-id> \
-          --inbound-rules "protocol:tcp,ports:3389,address:0.0.0.0/0"
-        ```
+            ```bash
+            doctl compute firewall remove-rules <firewall-id> \
+              --inbound-rules "protocol:tcp,ports:3389,address:0.0.0.0/0"
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/firewalls/how-to/configure-rules/
         title: Configure Cloud Firewall rules
@@ -285,15 +296,24 @@ queries:
         **Why this matters**
 
         Databases exposed directly to the internet are routinely scanned and compromised — credential brute force, unauthenticated misconfiguration exploitation, and ransom-style data extortion are all well-documented outcomes. Database traffic should only traverse private networks; applications needing external access should reach the database through a bastion or through the application tier, not directly.
-      remediation: |
-        Remove or restrict the offending inbound rule so the source is a trusted CIDR, tag, or Droplet ID.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        ```bash
-        doctl compute firewall remove-rules <firewall-id> \
-          --inbound-rules "protocol:tcp,ports:5432,address:0.0.0.0/0"
-        ```
+            1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
+            2. Remove the wide-open inbound rule for the offending database port, or restrict its source to a specific trusted CIDR, tag, or Droplet ID.
+            3. Repeat for each offending port. For managed databases, prefer the database's built-in **Trusted Sources** restriction (see the `db-firewall-configured` check).
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, remove or restrict the offending inbound rule so the source is a trusted CIDR, tag, or Droplet ID:
 
-        Repeat for each offending port. For managed databases, prefer the database's built-in **Trusted Sources** restriction (see the `db-firewall-configured` check).
+            ```bash
+            doctl compute firewall remove-rules <firewall-id> \
+              --inbound-rules "protocol:tcp,ports:5432,address:0.0.0.0/0"
+            ```
+
+            Repeat for each offending port (`3306`, `5432`, `27017`, `6379`, `9092`, `9200`).
     refs:
       - url: https://docs.digitalocean.com/products/networking/firewalls/how-to/configure-rules/
         title: Configure Cloud Firewall rules
@@ -325,13 +345,23 @@ queries:
         **Why this matters**
 
         An "allow all ports from anywhere" rule is functionally equivalent to having no firewall. It exposes every service running on the Droplet — intended or unintended, known or forgotten — to every host on the internet. This is the highest-severity network misconfiguration.
-      remediation: |
-        Remove the wide-open rule and replace it with narrow rules that expose only the specific ports required by the workload, scoped to trusted source CIDRs.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        ```bash
-        doctl compute firewall remove-rules <firewall-id> \
-          --inbound-rules "protocol:tcp,ports:0,address:0.0.0.0/0"
-        ```
+            1. Navigate to **Networking** > **Firewalls** and open the affected firewall.
+            2. Remove the wide-open rule (`All ports` or full port range with `All IPv4`/`All IPv6` source).
+            3. Replace it with narrow rules that expose only the specific ports required by the workload, scoped to trusted source CIDRs, tags, or Droplet IDs.
+            4. Save the firewall.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, remove the wide-open rule and replace it with narrow rules that expose only the specific ports required by the workload, scoped to trusted source CIDRs:
+
+            ```bash
+            doctl compute firewall remove-rules <firewall-id> \
+              --inbound-rules "protocol:tcp,ports:0,address:0.0.0.0/0"
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/firewalls/how-to/configure-rules/
         title: Configure Cloud Firewall rules
@@ -356,21 +386,24 @@ queries:
         **Why this matters**
 
         A managed database with no Trusted Sources accepts connections from any source that knows a valid credential. That makes the database reachable by anyone who obtains or guesses a password — credential leaks from application logs, developer laptops, or source control become full database compromise. Restricting to Trusted Sources cuts off that lateral path even if credentials leak.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Databases** and open the affected cluster.
-        2. Go to **Settings** > **Trusted Sources**.
-        3. Add the Droplets, tags, apps, Kubernetes clusters, or specific IP addresses that need database access.
+            1. Navigate to **Databases** and open the affected cluster.
+            2. Go to **Settings** > **Trusted Sources**.
+            3. Add the Droplets, tags, apps, Kubernetes clusters, or specific IP addresses that need database access.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, append a Trusted Source rule for each Droplet or CIDR that needs access:
 
-        **From `doctl`**
-
-        ```bash
-        doctl databases firewalls append <database-id> \
-          --rule droplet:<droplet-id>
-        doctl databases firewalls append <database-id> \
-          --rule ip_addr:<cidr>
-        ```
+            ```bash
+            doctl databases firewalls append <database-id> \
+              --rule droplet:<droplet-id>
+            doctl databases firewalls append <database-id> \
+              --rule ip_addr:<cidr>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
         title: Secure a managed database cluster
@@ -395,23 +428,24 @@ queries:
         **Why this matters**
 
         A managed database outside any VPC must be reached over the public internet, even from applications in the same DigitalOcean account. That requires TLS termination on the client, a public DNS record for the database, and — crucially — a failure-open posture if an application misconfigures its connection. A VPC-attached database can be reached on a private endpoint, keeping all traffic on internal networks.
-      remediation: |
-        DigitalOcean does not support moving an existing managed database into a VPC. To remediate, create a fork or a new cluster in the desired VPC, migrate the data, and retire the original.
+      remediation:
+        - id: console
+          desc: |
+            DigitalOcean does not support moving an existing managed database into a VPC. To fix this in the DigitalOcean Cloud Control Panel, create a fork or a new cluster in the desired VPC, migrate the data, and retire the original:
 
-        **From the DigitalOcean Control Panel**
+            1. Navigate to **Databases** and open the affected cluster.
+            2. Create a fork (point-in-time snapshot) and, in the creation flow, select a VPC under **Network**.
+            3. Cut applications over to the new cluster's private endpoint, then destroy the original.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, create a replacement cluster inside the target VPC and migrate data into it:
 
-        1. Navigate to **Databases** and open the affected cluster.
-        2. Create a fork (point-in-time snapshot) and, in the creation flow, select a VPC under **Network**.
-        3. Cut applications over to the new cluster's private endpoint, then destroy the original.
-
-        **From `doctl`**
-
-        ```bash
-        doctl databases create <new-name> \
-          --engine <engine> \
-          --region <region> \
-          --private-network-uuid <vpc-uuid>
-        ```
+            ```bash
+            doctl databases create <new-name> \
+              --engine <engine> \
+              --region <region> \
+              --private-network-uuid <vpc-uuid>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/connect/
         title: Connect to a managed database cluster
@@ -450,14 +484,14 @@ queries:
         - MongoDB: 3.6, 4.0, 4.2, 4.4, 5.0
         - Kafka: 2.8, 3.0 through 3.4
         - OpenSearch: 1.x
-      remediation: |
-        Major-version upgrades for managed databases on DigitalOcean require a migration path. Review the DigitalOcean upgrade documentation for your engine, run the upgrade in a non-production clone first, then cut over.
+      remediation:
+        - id: console
+          desc: |
+            Major-version upgrades for managed databases on DigitalOcean require a migration path. Review the DigitalOcean upgrade documentation for your engine, run the upgrade in a non-production clone first, then cut over. To fix this in the DigitalOcean Cloud Control Panel:
 
-        **From the DigitalOcean Control Panel**
-
-        1. Navigate to **Databases** and open the affected cluster.
-        2. Go to **Settings** > **Upgrade Major Version** (availability depends on engine).
-        3. Follow the prompts; otherwise, create a new cluster on a supported version and migrate data using `pg_dump`/`mysqldump`/native replication.
+            1. Navigate to **Databases** and open the affected cluster.
+            2. Go to **Settings** > **Upgrade Major Version** (availability depends on engine).
+            3. Follow the prompts; otherwise, create a new cluster on a supported version and migrate data using `pg_dump`/`mysqldump`/native replication.
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/upgrade-major-version/
         title: Upgrade a managed database major version
@@ -484,19 +518,22 @@ queries:
         **Why this matters**
 
         A load balancer that accepts plaintext HTTP and serves the response in plaintext exposes every request to interception and modification — credentials, session cookies, API keys, and response content are all readable by any host on the network path. Redirecting HTTP to HTTPS forces subsequent requests over TLS, closing the window where a downgrade or sidejacking attack can succeed.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Networking** > **Load Balancers** and open the affected load balancer.
-        2. Go to **Settings** > **Forwarding Rules**.
-        3. Enable **Redirect HTTP to HTTPS**. Confirm that an HTTPS forwarding rule and TLS certificate are configured.
+            1. Navigate to **Networking** > **Load Balancers** and open the affected load balancer.
+            2. Go to **Settings** > **Forwarding Rules**.
+            3. Enable **Redirect HTTP to HTTPS**. Confirm that an HTTPS forwarding rule and TLS certificate are configured.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, enable the redirect on the affected load balancer:
 
-        **From `doctl`**
-
-        ```bash
-        doctl compute load-balancer update <lb-id> \
-          --redirect-http-to-https
-        ```
+            ```bash
+            doctl compute load-balancer update <lb-id> \
+              --redirect-http-to-https
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/load-balancers/how-to/ssl-termination/
         title: Load balancer SSL termination and redirect
@@ -521,18 +558,21 @@ queries:
         **Why this matters**
 
         Kubernetes control-plane and node components receive regular security patches. Clusters without auto-upgrade depend on an operator remembering to apply each patch release; that window is where known-exploited CVEs land on production. Enabling auto-upgrade ensures patches are applied within the configured maintenance window without manual intervention.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Kubernetes** and open the affected cluster.
-        2. Go to **Settings** > **Maintenance**.
-        3. Enable **Automatically upgrade my cluster to patch releases**.
+            1. Navigate to **Kubernetes** and open the affected cluster.
+            2. Go to **Settings** > **Maintenance**.
+            3. Enable **Automatically upgrade my cluster to patch releases**.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, enable auto-upgrade on the affected cluster:
 
-        **From `doctl`**
-
-        ```bash
-        doctl kubernetes cluster update <cluster-id> --auto-upgrade=true
-        ```
+            ```bash
+            doctl kubernetes cluster update <cluster-id> --auto-upgrade=true
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/upgrade-cluster/
         title: Upgrade a DOKS cluster
@@ -559,19 +599,22 @@ queries:
         **Why this matters**
 
         DigitalOcean supports only the latest three Kubernetes minor versions. Clusters on older minors no longer receive security patches from the provider, and upstream Kubernetes itself drops support for minors older than roughly one year. Running an unsupported minor means known CVEs accumulate without remediation.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Kubernetes** and open the affected cluster.
-        2. Go to **Overview** and click **Upgrade Available** if present.
-        3. Select a supported version and confirm the upgrade.
+            1. Navigate to **Kubernetes** and open the affected cluster.
+            2. Go to **Overview** and click **Upgrade Available** if present.
+            3. Select a supported version and confirm the upgrade.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, list the available versions and then upgrade the cluster:
 
-        **From `doctl`**
-
-        ```bash
-        doctl kubernetes options versions
-        doctl kubernetes cluster upgrade <cluster-id> --version <supported-version>
-        ```
+            ```bash
+            doctl kubernetes options versions
+            doctl kubernetes cluster upgrade <cluster-id> --version <supported-version>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/details/supported-releases/
         title: DOKS supported Kubernetes releases
@@ -596,21 +639,24 @@ queries:
         **Why this matters**
 
         An expired TLS certificate breaks the trust chain clients rely on. Users see certificate warnings and are trained to click through — which normalizes certificate bypass and gives real man-in-the-middle attempts cover. API clients often fail closed and take down dependent services, so an expired certificate is both a security failure and an availability incident.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Networking** > **Certificates**.
-        2. Identify the expired certificate and either upload a renewed version or regenerate a Let's Encrypt certificate.
-        3. Update any load balancers, CDN endpoints, or App Platform apps referencing the old certificate.
+            1. Navigate to **Networking** > **Certificates**.
+            2. Identify the expired certificate and either upload a renewed version or regenerate a Let's Encrypt certificate.
+            3. Update any load balancers, CDN endpoints, or App Platform apps referencing the old certificate.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, create a renewed Let's Encrypt certificate and then update any consumers to reference it:
 
-        **From `doctl`**
-
-        ```bash
-        doctl compute certificate create \
-          --name <new-name> \
-          --type lets_encrypt \
-          --dns-names <domain>
-        ```
+            ```bash
+            doctl compute certificate create \
+              --name <new-name> \
+              --type lets_encrypt \
+              --dns-names <domain>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/certificates/
         title: DigitalOcean TLS certificates
@@ -635,18 +681,21 @@ queries:
         **Why this matters**
 
         A CDN endpoint on a custom domain without a TLS certificate cannot terminate HTTPS for that domain — clients either fall back to HTTP or hit certificate warnings. Either outcome exposes user traffic to interception, content injection, and credential theft. The CDN is typically the first hop users reach, so protecting it with TLS is load-bearing for the whole request path.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **Networking** > **CDN** and open the affected endpoint.
-        2. Under **Custom subdomain**, select an existing certificate or create a new Let's Encrypt certificate for the domain.
-        3. Save the CDN configuration.
+            1. Navigate to **Networking** > **CDN** and open the affected endpoint.
+            2. Under **Custom subdomain**, select an existing certificate or create a new Let's Encrypt certificate for the domain.
+            3. Save the CDN configuration.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, attach a certificate to the affected CDN endpoint:
 
-        **From `doctl`**
-
-        ```bash
-        doctl compute cdn update <cdn-id> --certificate-id <cert-id>
-        ```
+            ```bash
+            doctl compute cdn update <cdn-id> --certificate-id <cert-id>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/cdn/how-to/use-custom-subdomain/
         title: CDN custom subdomain and TLS
@@ -671,20 +720,23 @@ queries:
         **Why this matters**
 
         A Spaces access key with no grants is effectively a root credential for object storage. If that key leaks — committed to source control, logged by an application, embedded in a client binary — the blast radius is every bucket in the account. Grant-scoped keys limit an exposed credential to exactly the bucket and operations the application needs.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **API** > **Spaces Keys**.
-        2. Delete the unscoped key and create a replacement with specific bucket grants (for example, read-only on a single bucket).
-        3. Rotate the key in every application that consumed the old one.
+            1. Navigate to **API** > **Spaces Keys**.
+            2. Delete the unscoped key and create a replacement with specific bucket grants (for example, read-only on a single bucket).
+            3. Rotate the key in every application that consumed the old one.
+        - id: cli
+          desc: |
+            To fix this on the command line using the `doctl` CLI, create a scoped replacement key and delete the unscoped one:
 
-        **From `doctl`**
-
-        ```bash
-        doctl spaces keys create <new-name> \
-          --grants "bucket=<bucket-name>;permission=read"
-        doctl spaces keys delete <old-key>
-        ```
+            ```bash
+            doctl spaces keys create <new-name> \
+              --grants "bucket=<bucket-name>;permission=read"
+            doctl spaces keys delete <old-key>
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/spaces/how-to/manage-access/
         title: Manage Spaces access keys and grants
@@ -709,13 +761,15 @@ queries:
         **Why this matters**
 
         An app served over plaintext HTTP exposes every request and response to interception and tampering. App Platform serves managed TLS certificates automatically, so there is no technical reason for an app to be HTTP-only — an HTTP `liveUrl` typically indicates a misconfigured custom domain or a development app promoted to production without a TLS setup.
-      remediation: |
-        **From the DigitalOcean Control Panel**
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
 
-        1. Navigate to **App Platform** and open the affected app.
-        2. Go to **Settings** > **Domains**.
-        3. Remove or correct any custom domain without a managed certificate, and verify that the generated app URL on `ondigitalocean.app` is reachable over HTTPS.
-        4. Trigger a new deployment if needed.
+            1. Navigate to **App Platform** and open the affected app.
+            2. Go to **Settings** > **Domains**.
+            3. Remove or correct any custom domain without a managed certificate, and verify that the generated app URL on `ondigitalocean.app` is reachable over HTTPS.
+            4. Trigger a new deployment if needed.
     refs:
       - url: https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/
         title: Manage App Platform domains and certificates


### PR DESCRIPTION
## Summary

Splits each combined Markdown remediation blob in \`mondoo-digitalocean-security\` into the canonical multi-id structure (\`id: console\`, \`id: cli\`), matching how AWS, Azure, OCI, GCP, and Hetzner policies are authored.

Every entry leads with a consistent intro sentence:

- Console: \"To fix this in the DigitalOcean Cloud Control Panel:\"
- CLI: \"To fix this on the command line using the \`doctl\` CLI, ...:\"

## Coverage

- **16** checks total
- **16** \`id: console\` entries
- **13** \`id: cli\` entries (using \`doctl\`)
- **3** checks are console-only (no doctl-driven fix exists): \`account-email-verified\`, \`db-engine-supported-version\`, \`app-platform-https\`

## Test plan

- [x] \`cnspec policy lint content/mondoo-digitalocean-security.mql.yaml\` passes with no warnings or errors.
- [ ] Spot-check the rendered console and cli entries for one or two checks in the docs UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)