### PR TITLE
:sparkles: Add doctl validation to remediation-command CI

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -49,6 +49,19 @@ jobs:
         # pip install always resolves to the latest oci-cli on PyPI.
         run: pip install --upgrade oci-cli
 
+      - name: Install doctl
+        # Pinned release tarball from
+        # https://github.com/digitalocean/doctl/releases. Bump DOCTL_VERSION
+        # when DigitalOcean ships new commands or flags. No auth needed for
+        # `doctl --help` introspection.
+        env:
+          DOCTL_VERSION: "1.155.0"
+        run: |
+          curl -sSL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" -o /tmp/doctl.tar.gz
+          tar -xzf /tmp/doctl.tar.gz -C /tmp
+          sudo mv /tmp/doctl /usr/local/bin/doctl
+          doctl version
+
       - name: Validate remediation commands
         run: python3 content/validation/validate_remediation_commands.py --github-actions
 

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -52,12 +52,16 @@ jobs:
       - name: Install doctl
         # Pinned release tarball from
         # https://github.com/digitalocean/doctl/releases. Bump DOCTL_VERSION
-        # when DigitalOcean ships new commands or flags. No auth needed for
+        # and DOCTL_SHA256 in lockstep when DigitalOcean ships new commands
+        # or flags — the SHA-256 is published in the per-release
+        # `doctl-<version>-checksums.sha256` file. No auth needed for
         # `doctl --help` introspection.
         env:
           DOCTL_VERSION: "1.155.0"
+          DOCTL_SHA256: "94f572c89d74a6a894f6238bae07cd55c599a6539f8da7ec9d1a89f09a292180"
         run: |
           curl -sSL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" -o /tmp/doctl.tar.gz
+          echo "${DOCTL_SHA256}  /tmp/doctl.tar.gz" | sha256sum -c -
           tar -xzf /tmp/doctl.tar.gz -C /tmp
           sudo mv /tmp/doctl /usr/local/bin/doctl
           doctl version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,16 +425,18 @@ The `content/validation/` directory contains tooling to verify that CLI commands
 **Validate commands:**
 
 ```bash
-# Validate all policies (currently AWS, Azure, and OCI)
+# Validate all policies (currently AWS, Azure, OCI, GCP, and DigitalOcean)
 python3 content/validation/validate_remediation_commands.py
 
 # Validate a specific cloud
 python3 content/validation/validate_remediation_commands.py aws
 python3 content/validation/validate_remediation_commands.py azure
 python3 content/validation/validate_remediation_commands.py oci
+python3 content/validation/validate_remediation_commands.py gcp
+python3 content/validation/validate_remediation_commands.py digitalocean
 ```
 
-The validator checks each `aws`/`az`/`oci` command in ```` ```bash ```` code blocks within `id: cli` remediation sections against a known-good database of commands and flags. Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+The validator checks each `aws`/`az`/`oci`/`gcloud`/`doctl` command in ```` ```bash ```` code blocks within `id: cli` remediation sections against a known-good database of commands and flags. Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
 
 **How the validator sources command data:**
 
@@ -443,6 +445,7 @@ The validator builds its commands database for `aws`, `oci`, and `gcp` **in-memo
 - **aws**: introspects botocore service models bundled with the AWS CLI v2
 - **oci**: walks the Click command tree from the `oci_cli` Python package
 - **gcp**: reads the Google Cloud SDK's static completion tree
+- **digitalocean**: walks the `doctl --help` Cobra tree breadth-first (parallelized; ~1s for the full ~475-command tree)
 
 If a required CLI is missing, the validator prints actionable install hints and exits non-zero.
 

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -23,7 +23,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent
 CMD_DATA_DIR = SCRIPT_DIR / "cmd_data"
 
-VALIDATORS = ["aws", "azure", "oci", "gcp"]
+VALIDATORS = ["aws", "azure", "oci", "gcp", "digitalocean"]
 
 # Collected failures for annotation output.  Each entry is a dict with keys:
 # file, line, uid, command, errors, cloud
@@ -1249,6 +1249,293 @@ def validate_gcloud() -> tuple[int, int]:
 
 
 # ---------------------------------------------------------------------------
+# doctl (DigitalOcean) validation
+# ---------------------------------------------------------------------------
+#
+# Unlike aws/oci/gcp, doctl is a Go binary with no Python introspection
+# surface and no static completion tree we can parse. We walk `doctl --help`
+# breadth-first, parsing each subcommand and flag list out of the Cobra-
+# rendered help text. The walk is parallelized; a full traversal of the
+# ~475-command tree completes in roughly one second.
+
+DO_POLICY_FILE = SCRIPT_DIR / ".." / "mondoo-digitalocean-security.mql.yaml"
+
+# Cobra-rendered section headers like "Available Commands:", "Manage
+# DigitalOcean Resources:", "View Billing:". The top-level `doctl --help`
+# uses category headers instead of "Available Commands:".
+_DOCTL_SECTION_HEADER = re.compile(r"^[A-Z][^:\n]*:\s*$")
+
+# Subcommand line: "  <name>   <description>" — two-space indent, then a
+# lowercase identifier, then at least two spaces before the description.
+_DOCTL_SUBCOMMAND_LINE = re.compile(r"^  ([a-z][a-z0-9-]*)\s{2,}")
+
+# Flag line: "      --flag-name <type>   <description>" or
+# "  -X, --flag-name <type>   <description>". We only capture the long form.
+_DOCTL_FLAG_LINE = re.compile(r"^\s+(?:-\w,\s+)?(--[a-z][a-z0-9-]*)")
+
+
+def _doctl_help(path: str) -> str:
+    """Return stdout+stderr of `doctl <path> --help`."""
+    args = ["doctl"] + (path.split() if path else []) + ["--help"]
+    r = subprocess.run(args, capture_output=True, text=True, timeout=15)
+    return r.stdout + r.stderr
+
+
+def _parse_doctl_help(text: str) -> tuple[list[str], list[str]]:
+    """Extract (subcommands, flags) from a doctl --help blob.
+
+    Handles both the top-level layout (category headers like "Manage
+    DigitalOcean Resources:") and group/leaf layouts ("Available Commands:"
+    / "Flags:" / "Global Flags:").
+    """
+    subcommands: list[str] = []
+    flags: list[str] = []
+    in_flags = False
+    in_cmds = False
+
+    for line in text.split("\n"):
+        if line.startswith("Flags:") or line.startswith("Global Flags:"):
+            in_flags = True
+            in_cmds = False
+            continue
+        if _DOCTL_SECTION_HEADER.match(line):
+            in_flags = False
+            in_cmds = True
+            continue
+        if line.strip() == "":
+            continue
+
+        if in_flags:
+            m = _DOCTL_FLAG_LINE.match(line)
+            if m:
+                flags.append(m.group(1))
+        elif in_cmds:
+            m = _DOCTL_SUBCOMMAND_LINE.match(line)
+            if m:
+                subcommands.append(m.group(1))
+
+    return sorted(set(subcommands)), sorted(set(flags))
+
+
+def detect_doctl_services_from_policy() -> list[str]:
+    """Return the set of top-level doctl services used in the DO policy."""
+    if not DO_POLICY_FILE.exists():
+        return []
+
+    content = DO_POLICY_FILE.read_text()
+    services = set()
+    for match in re.finditer(r"```bash\s*\n(.*?)```", content, re.DOTALL):
+        block = match.group(1)
+        joined = re.sub(r"\\\s*\n\s*", " ", block)
+        for line in joined.split("\n"):
+            line = line.strip()
+            if line.startswith("doctl "):
+                parts = line.split()
+                if len(parts) >= 2 and not parts[1].startswith("-"):
+                    services.add(parts[1])
+    return sorted(services)
+
+
+def build_doctl_commands_db() -> dict[str, list[str]]:
+    """Build an in-memory doctl commands database by walking the Cobra help
+    tree breadth-first, scoped to services used in the DO policy.
+
+    Returns an empty dict if the policy file has no doctl commands. Exits
+    with a helpful error if doctl is not installed.
+    """
+    services = detect_doctl_services_from_policy()
+    if not services:
+        return {}
+
+    doctl_path = subprocess.run(
+        ["which", "doctl"], capture_output=True, text=True
+    ).stdout.strip()
+    if not doctl_path:
+        print(
+            "Error: doctl CLI not found in PATH.\n"
+            "\n"
+            "Validating doctl remediation commands requires the doctl CLI to\n"
+            "be installed locally — its `--help` output is the source of truth\n"
+            "for valid commands and flags.\n"
+            "\n"
+            "Install options:\n"
+            "  macOS (Homebrew): brew install doctl\n"
+            "  Linux (snap):     snap install doctl\n"
+            "  Other:            https://docs.digitalocean.com/reference/doctl/how-to/install/\n"
+            "\n"
+            "After installing, ensure `doctl` is on your PATH and re-run:\n"
+            f"  python3 {sys.argv[0]} digitalocean\n"
+            "\n"
+            "To skip doctl validation, run a different target instead\n"
+            "(e.g. `aws`, `azure`, `oci`, or `gcp`).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Breadth-first walk, parallelizing the subprocess calls in each round.
+    visited: set[str] = set()
+    results: dict[str, dict] = {}
+    queue: list[str] = [s for s in services]
+
+    while queue:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            future_to_path = {}
+            for path in queue:
+                if path in visited:
+                    continue
+                visited.add(path)
+                future_to_path[pool.submit(_doctl_help, path)] = path
+            next_queue: list[str] = []
+            for fut, path in future_to_path.items():
+                try:
+                    text = fut.result()
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"Warning: timed out fetching `doctl {path} --help`",
+                        file=sys.stderr,
+                    )
+                    continue
+                subs, flags = _parse_doctl_help(text)
+                results[path] = {"subcommands": subs, "flags": flags}
+                for s in subs:
+                    sub_path = f"{path} {s}".strip()
+                    if sub_path not in visited:
+                        next_queue.append(sub_path)
+            queue = next_queue
+
+    # Flatten {"compute firewall": {subcommands, flags}, ...} into the
+    # validator's expected shape: a flat map where group entries hold the
+    # list of valid subcommand names and leaf entries hold the flag list.
+    commands: dict[str, list[str]] = {}
+    for path, node in results.items():
+        if node["subcommands"]:
+            commands[path] = node["subcommands"]
+        else:
+            commands[path] = node["flags"]
+    return commands
+
+
+def parse_doctl_command(cmd: str, commands_db: dict[str, list[str]]) -> tuple[str, list[str]]:
+    """Parse a doctl command into (command_path, flags).
+
+    doctl commands have variable-depth paths (e.g. 'compute firewall add-rules').
+    We match the longest known command path from the database. If no match is
+    found, the raw command path (tokens before the first flag) is returned so
+    the caller can report it as unknown.
+    """
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        tokens = cmd.split()
+
+    if len(tokens) < 2 or tokens[0] != "doctl":
+        return "", []
+
+    parts = tokens[1:]  # skip 'doctl'
+    command_path = ""
+    raw_path_parts = []
+    for i in range(len(parts)):
+        if parts[i].startswith("-"):
+            break
+        raw_path_parts.append(parts[i])
+        candidate = " ".join(parts[: i + 1])
+        if candidate in commands_db:
+            command_path = candidate
+
+    if not command_path and raw_path_parts:
+        command_path = " ".join(raw_path_parts)
+
+    flags = []
+    for token in parts:
+        if token.startswith("--"):
+            flags.append(token.split("=")[0])
+
+    return command_path, flags
+
+
+def validate_doctl_command(
+    command_path: str,
+    flags: list[str],
+    commands_db: dict[str, list[str]],
+) -> tuple[bool, list[str]]:
+    """Validate a parsed doctl command against the commands database."""
+    errors = []
+
+    if command_path not in commands_db:
+        errors.append(f"unknown command 'doctl {command_path}'")
+        return False, errors
+
+    entry = commands_db[command_path]
+    # Group entries hold subcommand names; leaf entries hold flag names
+    # (which start with `--`). If we landed on a group, the user is missing
+    # a required subcommand.
+    if entry and not entry[0].startswith("-"):
+        errors.append(
+            f"'doctl {command_path}' is a command group; missing subcommand"
+        )
+        return False, errors
+
+    valid_flags = set(entry)
+    for flag in flags:
+        if flag not in valid_flags:
+            errors.append(f"unknown flag '{flag}' for 'doctl {command_path}'")
+
+    return len(errors) == 0, errors
+
+
+def validate_digitalocean() -> tuple[int, int]:
+    """Validate doctl CLI commands. Returns (pass_count, fail_count)."""
+    if not DO_POLICY_FILE.exists():
+        print(f"Error: Policy file not found: {DO_POLICY_FILE}", file=sys.stderr)
+        sys.exit(1)
+
+    commands_db = build_doctl_commands_db()
+    if not commands_db:
+        return 0, 0
+
+    content = DO_POLICY_FILE.read_text()
+    blocks = extract_bash_blocks(content)
+
+    pass_count = 0
+    fail_count = 0
+
+    policy_relpath = str(DO_POLICY_FILE.resolve().relative_to(Path.cwd()))
+
+    for block_text, block_line, uid in blocks:
+        commands = split_commands(block_text, "doctl", block_line)
+        for cmd, line_num in commands:
+            command_path, flags = parse_doctl_command(cmd, commands_db)
+
+            if not command_path:
+                continue
+
+            is_valid, errors = validate_doctl_command(
+                command_path, flags, commands_db
+            )
+
+            if is_valid:
+                print(f"[PASS] {uid}")
+                print(f"       {truncate_cmd(cmd)}")
+                pass_count += 1
+            else:
+                print(f"[FAIL] {uid}")
+                print(f"       {truncate_cmd(cmd)}")
+                for error in errors:
+                    print(f"       {error}")
+                fail_count += 1
+                FAILURES.append({
+                    "file": policy_relpath,
+                    "line": line_num,
+                    "uid": uid,
+                    "command": truncate_cmd(cmd),
+                    "errors": errors,
+                    "cloud": "digitalocean",
+                })
+
+    return pass_count, fail_count
+
+
+# ---------------------------------------------------------------------------
 # GitHub Actions annotations
 # ---------------------------------------------------------------------------
 
@@ -1316,6 +1603,11 @@ def main():
 
     if target in ("all", "gcp"):
         p, f = validate_gcloud()
+        total_pass += p
+        total_fail += f
+
+    if target in ("all", "digitalocean"):
+        p, f = validate_digitalocean()
         total_pass += p
         total_fail += f
 

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -6,11 +6,12 @@
 # against known-good sets of subcommands and flags.
 #
 # Usage:
-#   python3 validate_remediation_commands.py            # validate all
-#   python3 validate_remediation_commands.py aws         # validate AWS commands only
-#   python3 validate_remediation_commands.py azure       # validate Azure commands only
-#   python3 validate_remediation_commands.py oci         # validate OCI commands only
-#   python3 validate_remediation_commands.py gcp         # validate gcloud commands only
+#   python3 validate_remediation_commands.py               # validate all
+#   python3 validate_remediation_commands.py aws           # validate AWS commands only
+#   python3 validate_remediation_commands.py azure         # validate Azure commands only
+#   python3 validate_remediation_commands.py oci           # validate OCI commands only
+#   python3 validate_remediation_commands.py gcp           # validate gcloud commands only
+#   python3 validate_remediation_commands.py digitalocean  # validate doctl commands only
 
 import concurrent.futures
 import json
@@ -1373,12 +1374,14 @@ def build_doctl_commands_db() -> dict[str, list[str]]:
         sys.exit(1)
 
     # Breadth-first walk, parallelizing the subprocess calls in each round.
+    # The executor is created once and reused across rounds so we don't pay
+    # thread-pool startup cost on every level of the tree.
     visited: set[str] = set()
     results: dict[str, dict] = {}
-    queue: list[str] = [s for s in services]
+    queue = list(services)
 
-    while queue:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        while queue:
             future_to_path = {}
             for path in queue:
                 if path in visited:


### PR DESCRIPTION
## Summary

Extends \`content/validation/validate_remediation_commands.py\` with a \`digitalocean\` target that walks the \`doctl --help\` Cobra tree breadth-first (parallelized; the full ~475-command tree completes in roughly one second) and validates every \`doctl\` command in \`id: cli\` remediation blocks of \`mondoo-digitalocean-security.mql.yaml\` against the parsed subcommand and flag set.

Pairs with #2450 (which introduced the \`id: cli\` blocks the validator scans).

## Changes

- **Validator**: new \`validate_digitalocean()\` plus \`build_doctl_commands_db()\` and Cobra help-output parser (handles both top-level category headers and group/leaf \"Available Commands:\" / \"Flags:\" / \"Global Flags:\" sections).
- **Workflow**: \`.github/workflows/validate-remediation.yaml\` installs doctl 1.155.0 from the official GitHub release tarball before running the validator.
- **Docs**: \`CLAUDE.md\` adds \`digitalocean\` to the supported clouds and explains the doctl introspection mechanism.

## Why help-walking and not a checked-in JSON

Unlike aws/oci/gcp, doctl is a Go binary with no Python introspection surface and no static completion tree. Walking \`--help\` is the only option. It is fast enough (~1s wall clock for the full tree) that it fits the in-memory pattern used by aws/oci/gcp; no need to cache to JSON the way Azure does.

## Test plan

- [x] Local: \`python3 content/validation/validate_remediation_commands.py digitalocean\` → 18 passed, 0 failed.
- [x] Mutation test: injected \`--autoupgrade\` (typo) and \`doctl spaces ky create\` (typo'd subcommand) — both correctly fail.
- [x] Wall clock for the full doctl walk: ~0.8s with 16-worker parallelism.
- [ ] CI run on this PR exercises the new doctl install step on \`ubuntu-latest\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)