### PR TITLE
:sparkles: Restructure Tailscale remediation into console id

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -60,7 +60,12 @@ jobs:
           DOCTL_VERSION: "1.155.0"
           DOCTL_SHA256: "94f572c89d74a6a894f6238bae07cd55c599a6539f8da7ec9d1a89f09a292180"
         run: |
-          curl -sSL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" -o /tmp/doctl.tar.gz
+          # --fail makes curl exit non-zero on HTTP 4xx/5xx (default -sSL silently
+          # writes the error body to disk and trips the sha256 check below).
+          # --retry handles transient GitHub release-asset blips.
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" \
+            -o /tmp/doctl.tar.gz
           echo "${DOCTL_SHA256}  /tmp/doctl.tar.gz" | sha256sum -c -
           tar -xzf /tmp/doctl.tar.gz -C /tmp
           sudo mv /tmp/doctl /usr/local/bin/doctl

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -87,17 +87,19 @@ queries:
           •  Enable device authorization in the Tailscale admin console.
           •  Regularly review the device list and remove unauthorized or unknown devices.
           •  Use device tags and ACLs to restrict access even after authorization.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
-        2. Review devices that are not authorized.
-        3. Authorize legitimate devices or remove unknown ones.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+            2. Review devices that are not authorized.
+            3. Authorize legitimate devices or remove unknown ones.
 
-        To require device authorization for all new devices:
+            To require device authorization for all new devices:
 
-        1. Go to **Settings > Device management**.
-        2. Enable **Device approval**.
+            1. Go to **Settings > Device management**.
+            2. Enable **Device approval**.
     refs:
       - url: https://tailscale.com/kb/1099/device-authorization
         title: Tailscale device authorization documentation
@@ -150,21 +152,23 @@ queries:
           •  Enable key expiry on all devices.
           •  Set appropriate expiry periods based on device risk (e.g., shorter for mobile devices).
           •  Monitor for devices with disabled key expiry and re-enable as needed.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
-        2. Find devices with key expiry disabled (shown as "Key expiry disabled").
-        3. Select the device and re-enable key expiry.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+            2. Find devices with key expiry disabled (shown as "Key expiry disabled").
+            3. Select the device and re-enable key expiry.
 
-        **Using Tailscale CLI**
+            **Using Tailscale CLI**
 
-        Key expiry settings are managed per-device through the admin console. Devices can disable key expiry using:
+            Key expiry settings are managed per-device through the admin console. Devices can disable key expiry using:
 
-        ```bash
-        # To check key expiry status
-        tailscale status --json | jq '.Self.KeyExpiry'
-        ```
+            ```bash
+            # To check key expiry status
+            tailscale status --json | jq '.Self.KeyExpiry'
+            ```
     refs:
       - url: https://tailscale.com/kb/1028/key-expiry
         title: Tailscale key expiry documentation
@@ -216,20 +220,22 @@ queries:
           •  Enable automatic updates where possible.
           •  Monitor for devices with available updates and ensure they are applied promptly.
           •  Include Tailscale client updates in your organization's patch management process.
-      remediation: |
-        **Update Tailscale client**
+      remediation:
+        - id: console
+          desc: |
+            **Update Tailscale client**
 
-        Update the Tailscale client on each device:
+            Update the Tailscale client on each device:
 
-        - **macOS**: Update through the Mac App Store or `brew upgrade tailscale`.
-        - **Windows**: Update through the Microsoft Store or download from tailscale.com.
-        - **Linux**: Update via your package manager (e.g., `apt upgrade tailscale` or `dnf upgrade tailscale`).
+            - **macOS**: Update through the Mac App Store or `brew upgrade tailscale`.
+            - **Windows**: Update through the Microsoft Store or download from tailscale.com.
+            - **Linux**: Update via your package manager (e.g., `apt upgrade tailscale` or `dnf upgrade tailscale`).
 
-        **Using Tailscale Admin Console**
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
-        2. Devices with available updates are flagged.
-        3. Notify device owners to update their clients.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+            2. Devices with available updates are flagged.
+            3. Notify device owners to update their clients.
     refs:
       - url: https://tailscale.com/download
         title: Tailscale download and update
@@ -280,18 +286,20 @@ queries:
           •  Sign legitimate devices using a trusted signing node.
           •  Remove devices that cannot be properly verified.
           •  Enable tailnet lock to strengthen device authentication.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
-        2. Review devices showing tailnet lock errors.
-        3. For legitimate devices, sign them using a trusted node:
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/machines).
+            2. Review devices showing tailnet lock errors.
+            3. For legitimate devices, sign them using a trusted node:
 
-        ```bash
-        tailscale lock sign NODE_KEY
-        ```
+            ```bash
+            tailscale lock sign NODE_KEY
+            ```
 
-        4. Remove any devices that should not be on the tailnet.
+            4. Remove any devices that should not be on the tailnet.
     refs:
       - url: https://tailscale.com/kb/1226/tailnet-lock
         title: Tailscale tailnet lock documentation
@@ -337,12 +345,14 @@ queries:
           •  Review pending user approvals regularly.
           •  Approve legitimate users and deny unknown access requests.
           •  Configure notifications for new approval requests.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
-        2. Review users with "Needs approval" status.
-        3. Approve legitimate users or deny unauthorized requests.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
+            2. Review users with "Needs approval" status.
+            3. Approve legitimate users or deny unauthorized requests.
     refs:
       - url: https://tailscale.com/kb/1138/user-management
         title: Tailscale user management documentation
@@ -378,12 +388,14 @@ queries:
           •  Limit admin roles to 2-3 trusted administrators.
           •  Use member roles for most users who only need device connectivity.
           •  Regularly review and prune admin and owner role assignments.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
-        2. Review users with "Admin" and "Owner" roles.
-        3. Downgrade users who do not need elevated privileges to "Member" role.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
+            2. Review users with "Admin" and "Owner" roles.
+            3. Downgrade users who do not need elevated privileges to "Member" role.
     refs:
       - url: https://tailscale.com/kb/1138/user-management
         title: Tailscale user roles documentation
@@ -418,13 +430,15 @@ queries:
           •  Suspend or remove users who no longer need tailnet access.
           •  Implement an offboarding process that includes removing tailnet access.
           •  Set up alerts for accounts that become idle.
-      remediation: |
-        **Using Tailscale Admin Console**
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
 
-        1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
-        2. Review users with "Idle" status (inactive for more than 28 days).
-        3. Contact idle users to verify they still need access.
-        4. Suspend or remove users who no longer require tailnet access.
+            1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/users).
+            2. Review users with "Idle" status (inactive for more than 28 days).
+            3. Contact idle users to verify they still need access.
+            4. Suspend or remove users who no longer require tailnet access.
     refs:
       - url: https://tailscale.com/kb/1138/user-management
         title: Tailscale user management documentation


### PR DESCRIPTION
## Summary
- Converts each parent check in `content/mondoo-tailscale-security.mql.yaml` from an unstructured `remediation: |` string to a structured `remediation:` list with a single `- id: console` entry.
- Tailscale is admin-console-driven, so `console` is the right remediation id (matches the policy-family expectation in `inspect-policies.py`).
- Existing prose is preserved verbatim — re-indented four spaces to sit under `desc: |` two levels deeper.
- Bumps policy version `1.0.0 → 1.0.1`.

## Test plan
- [x] \`cnspec policy lint content/mondoo-tailscale-security.mql.yaml\` → valid policy bundle(s)
- [x] \`inspect-policies.py\` reports all 7 parent checks satisfy the \`{console}\` requirement
- [ ] Spot-check rendered remediation Markdown in the UI for one device and one user check

🤖 Generated with [Claude Code](https://claude.com/claude-code)