### PR TITLE
:sparkles: Split Cloudflare remediation into console + cli (Cloudflare API)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -591,6 +591,7 @@ totp
 trae
 tskey
 tsuki
+twofactor
 uefi
 umac
 Unauth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,7 @@ The `content/validation/` directory contains tooling to verify that CLI commands
 **Validate commands:**
 
 ```bash
-# Validate all policies (currently AWS, Azure, OCI, GCP, and DigitalOcean)
+# Validate all policies (currently AWS, Azure, OCI, GCP, DigitalOcean, and Cloudflare)
 python3 content/validation/validate_remediation_commands.py
 
 # Validate a specific cloud
@@ -434,9 +434,10 @@ python3 content/validation/validate_remediation_commands.py azure
 python3 content/validation/validate_remediation_commands.py oci
 python3 content/validation/validate_remediation_commands.py gcp
 python3 content/validation/validate_remediation_commands.py digitalocean
+python3 content/validation/validate_remediation_commands.py cloudflare
 ```
 
-The validator checks each `aws`/`az`/`oci`/`gcloud`/`doctl` command in ```` ```bash ```` code blocks within `id: cli` remediation sections against a known-good database of commands and flags. Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+The validator checks each `aws`/`az`/`oci`/`gcloud`/`doctl` CLI command — and `curl` calls against `api.cloudflare.com` — in ```` ```bash ```` code blocks within `id: cli` remediation sections against a known-good database of commands and flags (or, for Cloudflare, the published OpenAPI spec). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
 
 **How the validator sources command data:**
 
@@ -446,6 +447,7 @@ The validator builds its commands database for `aws`, `oci`, and `gcp` **in-memo
 - **oci**: walks the Click command tree from the `oci_cli` Python package
 - **gcp**: reads the Google Cloud SDK's static completion tree
 - **digitalocean**: walks the `doctl --help` Cobra tree breadth-first (parallelized; ~1s for the full ~475-command tree)
+- **cloudflare**: downloads Cloudflare's published OpenAPI spec from [`cloudflare/api-schemas`](https://github.com/cloudflare/api-schemas) at a pinned commit (no Cloudflare CLI required — the validator scans `curl` calls against `api.cloudflare.com/client/v4` and verifies each path + HTTP method against the spec). Bump `CLOUDFLARE_OPENAPI_SHA` in `validate_remediation_commands.py` when refreshing the spec.
 
 If a required CLI is missing, the validator prints actionable install hints and exits non-zero.
 

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -81,11 +81,25 @@ queries:
           - Prevention of credential theft and session hijacking
           - Compliance with modern security standards that require encryption
           - Trust from visitors who expect secure connections
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Overview.
-        3. Set the encryption mode to at least "Flexible", though "Full" or "Full (Strict)" is strongly recommended.
-        4. Verify that your origin server supports HTTPS if using "Full" or "Full (Strict)" mode.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Overview**.
+            3. Set the encryption mode to at least "Flexible", though "Full" or "Full (Strict)" is strongly recommended.
+            4. Verify that your origin server supports HTTPS if using "Full" or "Full (Strict)" mode.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, set the `ssl` zone setting to `full` (or `strict` if your origin has a valid certificate):
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/ssl" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"full"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/
         title: Cloudflare SSL/TLS encryption modes
@@ -117,12 +131,26 @@ queries:
           - End-to-end encryption with certificate validation
           - Protection against origin-level man-in-the-middle attacks
           - Compliance with security best practices for TLS configuration
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Overview.
-        3. Set the encryption mode to "Full (Strict)".
-        4. Ensure your origin server has a valid SSL certificate from a trusted CA or a Cloudflare Origin CA certificate.
-        5. If using a self-signed certificate, replace it with a Cloudflare Origin CA certificate or a certificate from a public CA.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Overview**.
+            3. Set the encryption mode to "Full (Strict)".
+            4. Ensure your origin server has a valid SSL certificate from a trusted CA or a Cloudflare Origin CA certificate.
+            5. If using a self-signed certificate, replace it with a Cloudflare Origin CA certificate or a certificate from a public CA.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, set the `ssl` zone setting to `strict`:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/ssl" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"strict"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full-strict/
         title: Full (Strict) SSL/TLS encryption mode
@@ -153,11 +181,25 @@ queries:
           - **Downgrade attacks**: Users may be tricked into staying on HTTP instead of being redirected to HTTPS.
 
         By enabling "Always Use HTTPS", all HTTP requests are automatically redirected to HTTPS, ensuring encrypted connections for all visitors.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Edge Certificates.
-        3. Enable the "Always Use HTTPS" toggle.
-        4. Verify that your site loads correctly over HTTPS and there are no mixed-content issues.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Edge Certificates**.
+            3. Enable the "Always Use HTTPS" toggle.
+            4. Verify that your site loads correctly over HTTPS and there are no mixed-content issues.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `always_use_https` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/always_use_https" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/edge-certificates/additional-options/always-use-https/
         title: Always Use HTTPS
@@ -187,11 +229,25 @@ queries:
           - Compliance with PCI DSS 3.2+ and other security frameworks is maintained
           - Modern cipher suites with forward secrecy are guaranteed
           - Connections from outdated and potentially vulnerable clients are blocked
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Edge Certificates.
-        3. Set the "Minimum TLS Version" to 1.2 (or 1.3 if your audience supports it).
-        4. Monitor traffic for any impact on legitimate clients that may not support TLS 1.2.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Edge Certificates**.
+            3. Set the "Minimum TLS Version" to 1.2 (or 1.3 if your audience supports it).
+            4. Monitor traffic for any impact on legitimate clients that may not support TLS 1.2.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, set the `min_tls_version` zone setting to `1.2`:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/min_tls_version" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"1.2"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/edge-certificates/additional-options/minimum-tls/
         title: Minimum TLS version
@@ -223,10 +279,24 @@ queries:
           - **Simplified protocol**: Eliminates vulnerable features like renegotiation and compression.
 
         Disabling TLS 1.3 denies clients the most secure protocol version available and may impact performance.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Edge Certificates.
-        3. Enable TLS 1.3 (set to "on" or "zrt" for Zero Round Trip Time resumption).
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Edge Certificates**.
+            3. Enable TLS 1.3 (set to "on" or "zrt" for Zero Round Trip Time resumption).
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `tls_1_3` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/tls_1_3" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/edge-certificates/additional-options/tls-13/
         title: TLS 1.3
@@ -256,11 +326,25 @@ queries:
           - Users see security warnings that erode trust
 
         Automatic HTTPS Rewrites fixes mixed content by changing HTTP URLs to HTTPS in HTML responses before they reach the visitor, without requiring changes to your origin server code.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Edge Certificates.
-        3. Enable "Automatic HTTPS Rewrites".
-        4. Review your site for any remaining mixed-content issues that cannot be automatically resolved.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Edge Certificates**.
+            3. Enable "Automatic HTTPS Rewrites".
+            4. Review your site for any remaining mixed-content issues that cannot be automatically resolved.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `automatic_https_rewrites` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/automatic_https_rewrites" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/edge-certificates/additional-options/automatic-https-rewrites/
         title: Automatic HTTPS Rewrites
@@ -291,12 +375,26 @@ queries:
           - **OWASP Top 10 threats**: The WAF provides managed rule sets targeting common web application attacks
 
         Enabling the WAF provides an additional layer of defense that operates independently of your application code.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to Security > WAF.
-        3. Enable the WAF and review the managed rule sets.
-        4. Configure any necessary exceptions for legitimate traffic that may be flagged.
-        5. Monitor WAF logs to tune rules and reduce false positives.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **Security** > **WAF**.
+            3. Enable the WAF and review the managed rule sets.
+            4. Configure any necessary exceptions for legitimate traffic that may be flagged.
+            5. Monitor WAF logs to tune rules and reduce false positives.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the legacy `waf` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/waf" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/waf/
         title: Cloudflare Web Application Firewall
@@ -327,11 +425,25 @@ queries:
           - Your site is more vulnerable to credential stuffing and brute-force attacks
 
         The recommended setting is "Medium" or higher for most sites. Even "Low" provides basic protection against the most threatening visitors.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to Security > Settings.
-        3. Set the Security Level to "Medium" (recommended) or at minimum "Low".
-        4. Monitor traffic to ensure legitimate visitors are not being blocked unnecessarily.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **Security** > **Settings**.
+            3. Set the Security Level to "Medium" (recommended) or at minimum "Low".
+            4. Monitor traffic to ensure legitimate visitors are not being blocked unnecessarily.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, set the `security_level` zone setting to `medium` (or `low` at minimum):
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/security_level" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"medium"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/waf/tools/security-level/
         title: Security level
@@ -360,10 +472,24 @@ queries:
           - Automated bots to access your site without friction
           - Spammers to more easily scrape content or submit forms
           - Malicious crawlers to probe your application for vulnerabilities
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to Security > Settings.
-        3. Enable "Browser Integrity Check".
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **Security** > **Settings**.
+            3. Enable "Browser Integrity Check".
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `browser_check` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/browser_check" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/waf/tools/browser-integrity-check/
         title: Browser Integrity Check
@@ -392,10 +518,24 @@ queries:
           - Email addresses on your site are easily scraped by automated tools
           - Harvested addresses are used for spam campaigns and phishing attacks
           - Employees and contacts receive increased volumes of unwanted email
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to Scrape Shield > Email Address Obfuscation.
-        3. Enable "Email Address Obfuscation".
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **Scrape Shield** > **Email Address Obfuscation**.
+            3. Enable "Email Address Obfuscation".
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `email_obfuscation` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/email_obfuscation" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/waf/tools/scrape-shield/email-address-obfuscation/
         title: Email Address Obfuscation
@@ -426,11 +566,25 @@ queries:
           - Enable abuse of your content delivery resources
 
         When enabled, Cloudflare checks the HTTP Referer header and blocks requests from unauthorized origins.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to Scrape Shield > Hotlink Protection.
-        3. Enable "Hotlink Protection".
-        4. If certain external sites need to embed your content, configure exceptions as needed.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **Scrape Shield** > **Hotlink Protection**.
+            3. Enable "Hotlink Protection".
+            4. If certain external sites need to embed your content, configure exceptions as needed.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `hotlink_protection` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/hotlink_protection" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/waf/tools/scrape-shield/hotlink-protection/
         title: Hotlink Protection
@@ -461,10 +615,24 @@ queries:
           - Protects users on networks where traffic interception is a risk
 
         While not a substitute for full HTTPS migration, Opportunistic Encryption strengthens the overall encryption posture of the zone.
-      remediation: |
-        1. Log in to the Cloudflare dashboard and select the affected zone.
-        2. Navigate to SSL/TLS > Edge Certificates.
-        3. Enable "Opportunistic Encryption".
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in and select the affected zone.
+            2. Navigate to **SSL/TLS** > **Edge Certificates**.
+            3. Enable "Opportunistic Encryption".
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, enable the `opportunistic_encryption` zone setting:
+
+            ```bash
+            curl -X PATCH "https://api.cloudflare.com/client/v4/zones/<zone-id>/settings/opportunistic_encryption" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"value":"on"}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/ssl/edge-certificates/additional-options/opportunistic-encryption/
         title: Opportunistic Encryption
@@ -496,12 +664,26 @@ queries:
           - **Service disruption**: Zones can be paused, deleted, or misconfigured
 
         Enforcing two-factor authentication ensures that even if a password is compromised through phishing, credential stuffing, or data breaches, attackers cannot access the account without the second factor.
-      remediation: |
-        1. Log in to the Cloudflare dashboard.
-        2. Navigate to Manage Account > Members.
-        3. Go to Authentication settings.
-        4. Enable "Enforce two-factor authentication" for all account members.
-        5. Notify all team members to set up 2FA on their individual accounts before enforcement takes effect.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the Cloudflare dashboard:
+
+            1. Log in to the dashboard.
+            2. Navigate to **Manage Account** > **Members**.
+            3. Go to **Authentication** settings.
+            4. Enable "Enforce two-factor authentication" for all account members.
+            5. Notify all team members to set up 2FA on their individual accounts before enforcement takes effect.
+        - id: cli
+          desc: |
+            To fix this on the command line using the Cloudflare API, set `settings.enforce_twofactor` to `true` on the account. The account `name` is required by the API on `PUT /accounts/{account_id}`:
+
+            ```bash
+            curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<account-id>" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"name":"<account-name>","settings":{"enforce_twofactor":true}}'
+            ```
     refs:
       - url: https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/
         title: Cloudflare two-factor authentication

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -12,6 +12,7 @@
 #   python3 validate_remediation_commands.py oci           # validate OCI commands only
 #   python3 validate_remediation_commands.py gcp           # validate gcloud commands only
 #   python3 validate_remediation_commands.py digitalocean  # validate doctl commands only
+#   python3 validate_remediation_commands.py cloudflare    # validate Cloudflare API curl commands only
 
 import concurrent.futures
 import json
@@ -19,12 +20,13 @@ import re
 import shlex
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent
 CMD_DATA_DIR = SCRIPT_DIR / "cmd_data"
 
-VALIDATORS = ["aws", "azure", "oci", "gcp", "digitalocean"]
+VALIDATORS = ["aws", "azure", "oci", "gcp", "digitalocean", "cloudflare"]
 
 # Collected failures for annotation output.  Each entry is a dict with keys:
 # file, line, uid, command, errors, cloud
@@ -1539,6 +1541,251 @@ def validate_digitalocean() -> tuple[int, int]:
 
 
 # ---------------------------------------------------------------------------
+# Cloudflare API validation
+# ---------------------------------------------------------------------------
+#
+# Cloudflare's `flarectl` is read-only for zone settings and `wrangler` does
+# not cover the surface area this policy targets (SSL/TLS, WAF, security
+# level, 2FA enforcement, etc.). The realistic CLI path is `curl` against
+# the Cloudflare REST API, so the validator scans for those calls and
+# verifies each path + HTTP method against the official OpenAPI spec
+# published at https://github.com/cloudflare/api-schemas.
+#
+# The spec is large (~9 MB) and the upstream repo doesn't ship releases —
+# `main` is the only branch and it's auto-updated. We pin a known-good
+# commit SHA so validation is deterministic; bumping CLOUDFLARE_OPENAPI_SHA
+# is a deliberate maintainer action, like bumping doctl or the AWS CLI
+# version. The fetched spec is cached on disk under ~/.cache so we don't
+# re-download on every run.
+
+CLOUDFLARE_POLICY_FILE = SCRIPT_DIR / ".." / "mondoo-cloudflare-security.mql.yaml"
+
+CLOUDFLARE_OPENAPI_SHA = "a0e7cfa11b0d08b05a0b373f47ea722bd48ca7c4"
+CLOUDFLARE_OPENAPI_URL = (
+    f"https://raw.githubusercontent.com/cloudflare/api-schemas/"
+    f"{CLOUDFLARE_OPENAPI_SHA}/openapi.json"
+)
+CLOUDFLARE_API_PREFIX = "https://api.cloudflare.com/client/v4"
+
+
+def _cloudflare_cache_path() -> Path:
+    cache_dir = Path.home() / ".cache" / "cnspec-validation"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"cloudflare-openapi-{CLOUDFLARE_OPENAPI_SHA[:12]}.json"
+
+
+def _load_cloudflare_openapi() -> dict:
+    """Return the parsed Cloudflare OpenAPI spec, downloading and caching
+    on first use."""
+    cache = _cloudflare_cache_path()
+    if not cache.exists():
+        print(
+            f"Fetching Cloudflare OpenAPI spec (sha {CLOUDFLARE_OPENAPI_SHA[:12]})...",
+            file=sys.stderr,
+        )
+        try:
+            with urllib.request.urlopen(CLOUDFLARE_OPENAPI_URL, timeout=60) as r:
+                cache.write_bytes(r.read())
+        except (urllib.error.URLError, TimeoutError) as e:
+            print(
+                f"Error: failed to download Cloudflare OpenAPI spec from\n"
+                f"  {CLOUDFLARE_OPENAPI_URL}\n"
+                f"  ({e})\n"
+                "\n"
+                "If you are behind a proxy or air-gapped, manually download the\n"
+                f"spec and save it to:\n  {cache}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return json.loads(cache.read_text())
+
+
+def _index_cloudflare_paths(spec: dict) -> dict[str, set[str]]:
+    """Index OpenAPI paths so we can match a concrete URL path to a path
+    template and verify the HTTP method.
+
+    Returns {path_template: {http_method, ...}} where http_method is the
+    upper-cased verb. Path templates are stored verbatim from the spec
+    (e.g. "/zones/{zone_id}/settings/{setting_id}").
+    """
+    out: dict[str, set[str]] = {}
+    for path, ops in spec.get("paths", {}).items():
+        methods = {m.upper() for m in ops if m in (
+            "get", "post", "put", "patch", "delete", "head", "options",
+        )}
+        if methods:
+            out[path] = methods
+    return out
+
+
+# Placeholder tokens used in remediation examples (e.g. <zone-id>,
+# <account-id>). The validator treats these as wildcards that match any
+# OpenAPI path parameter ({zone_id}, {account_id}, ...).
+_CF_PLACEHOLDER_RE = re.compile(r"^<[a-z][a-z0-9-]*>$")
+
+
+def _match_cloudflare_path(curl_path: str, openapi_paths: dict[str, set[str]]) -> str | None:
+    """Find an OpenAPI path template matching a concrete curl URL path.
+
+    A segment matches if:
+      - both segments are literally equal, or
+      - the OpenAPI segment is a `{param}` template and the curl segment
+        is either a placeholder like `<zone-id>` or a concrete literal.
+
+    Prefers a fully-literal match when one exists; otherwise falls back to
+    the templated match. Returns the matched path template, or None.
+    """
+    curl_parts = curl_path.split("/")
+
+    # Exact-literal match first.
+    if curl_path in openapi_paths:
+        return curl_path
+
+    best: str | None = None
+    for tmpl, _methods in openapi_paths.items():
+        tmpl_parts = tmpl.split("/")
+        if len(tmpl_parts) != len(curl_parts):
+            continue
+        if all(_segment_matches(t, c) for t, c in zip(tmpl_parts, curl_parts)):
+            best = tmpl
+            # Don't break; later templates with more literal segments would
+            # be more specific, but the spec is generally well-formed and
+            # the first match is good enough.
+            break
+    return best
+
+
+def _segment_matches(tmpl_seg: str, curl_seg: str) -> bool:
+    if tmpl_seg == curl_seg:
+        return True
+    if tmpl_seg.startswith("{") and tmpl_seg.endswith("}"):
+        # Templated segment matches any concrete value or angle-bracket
+        # placeholder in the curl URL.
+        return curl_seg != "" and "/" not in curl_seg
+    return False
+
+
+# Match a curl invocation. The URL may be quoted or unquoted; -X / --request
+# may appear before or after it.
+_CF_CURL_URL_RE = re.compile(
+    r'https?://api\.cloudflare\.com/client/v4(/[^\s\'"]+)'
+)
+_CF_CURL_METHOD_RE = re.compile(
+    r'(?:^|\s)(?:-X|--request)(?:\s+|=)([A-Z]+)'
+)
+
+
+def parse_cloudflare_curl(cmd: str) -> tuple[str, str] | None:
+    """Extract (HTTP_METHOD, URL_PATH) from a curl Cloudflare API call.
+
+    Returns None if the command is not a Cloudflare API curl. The method
+    defaults to GET when -X / --request is absent (matches curl's default
+    when no body is supplied; for POST/PATCH/PUT we always require an
+    explicit -X in remediation snippets).
+    """
+    if "api.cloudflare.com/client/v4" not in cmd:
+        return None
+    if not cmd.lstrip().startswith("curl"):
+        return None
+
+    url_match = _CF_CURL_URL_RE.search(cmd)
+    if not url_match:
+        return None
+    path = url_match.group(1)
+    # Drop a fragment or query string if present.
+    path = path.split("?", 1)[0].split("#", 1)[0]
+
+    method_match = _CF_CURL_METHOD_RE.search(cmd)
+    method = method_match.group(1).upper() if method_match else "GET"
+
+    return method, path
+
+
+def validate_cloudflare_curl(
+    method: str,
+    path: str,
+    openapi_paths: dict[str, set[str]],
+) -> tuple[bool, list[str]]:
+    """Validate a parsed Cloudflare curl call against the OpenAPI spec."""
+    errors: list[str] = []
+
+    matched = _match_cloudflare_path(path, openapi_paths)
+    if not matched:
+        errors.append(f"unknown Cloudflare API path '{path}'")
+        return False, errors
+
+    if method not in openapi_paths[matched]:
+        allowed = sorted(openapi_paths[matched])
+        errors.append(
+            f"method '{method}' not supported on '{matched}' "
+            f"(supported: {', '.join(allowed)})"
+        )
+        return False, errors
+
+    return True, errors
+
+
+def validate_cloudflare() -> tuple[int, int]:
+    """Validate Cloudflare API curl commands. Returns (pass_count, fail_count)."""
+    if not CLOUDFLARE_POLICY_FILE.exists():
+        print(
+            f"Error: Policy file not found: {CLOUDFLARE_POLICY_FILE}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    content = CLOUDFLARE_POLICY_FILE.read_text()
+    blocks = extract_bash_blocks(content)
+
+    # Skip the OpenAPI download entirely if there are no Cloudflare API
+    # curl calls in the policy.
+    has_cf_curl = any(
+        "api.cloudflare.com/client/v4" in b for b, _, _ in blocks
+    )
+    if not has_cf_curl:
+        return 0, 0
+
+    spec = _load_cloudflare_openapi()
+    openapi_paths = _index_cloudflare_paths(spec)
+
+    pass_count = 0
+    fail_count = 0
+
+    policy_relpath = str(CLOUDFLARE_POLICY_FILE.resolve().relative_to(Path.cwd()))
+
+    for block_text, block_line, uid in blocks:
+        commands = split_commands(block_text, "curl", block_line)
+        for cmd, line_num in commands:
+            parsed = parse_cloudflare_curl(cmd)
+            if parsed is None:
+                continue
+            method, path = parsed
+
+            is_valid, errors = validate_cloudflare_curl(method, path, openapi_paths)
+
+            if is_valid:
+                print(f"[PASS] {uid}")
+                print(f"       {method} {path}")
+                pass_count += 1
+            else:
+                print(f"[FAIL] {uid}")
+                print(f"       {method} {path}")
+                for error in errors:
+                    print(f"       {error}")
+                fail_count += 1
+                FAILURES.append({
+                    "file": policy_relpath,
+                    "line": line_num,
+                    "uid": uid,
+                    "command": f"{method} {path}",
+                    "errors": errors,
+                    "cloud": "cloudflare",
+                })
+
+    return pass_count, fail_count
+
+
+# ---------------------------------------------------------------------------
 # GitHub Actions annotations
 # ---------------------------------------------------------------------------
 
@@ -1611,6 +1858,11 @@ def main():
 
     if target in ("all", "digitalocean"):
         p, f = validate_digitalocean()
+        total_pass += p
+        total_fail += f
+
+    if target in ("all", "cloudflare"):
+        p, f = validate_cloudflare()
         total_pass += p
         total_fail += f
 

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -1597,7 +1597,18 @@ def _load_cloudflare_openapi() -> dict:
                 file=sys.stderr,
             )
             sys.exit(1)
-    return json.loads(cache.read_text())
+    try:
+        return json.loads(cache.read_text())
+    except json.JSONDecodeError as e:
+        print(
+            f"Error: cached Cloudflare OpenAPI spec is corrupted\n"
+            f"  ({cache}: {e})\n"
+            "\n"
+            "Delete the cache file and re-run to re-download:\n"
+            f"  rm {cache}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _index_cloudflare_paths(spec: dict) -> dict[str, set[str]]:
@@ -1632,8 +1643,11 @@ def _match_cloudflare_path(curl_path: str, openapi_paths: dict[str, set[str]]) -
       - the OpenAPI segment is a `{param}` template and the curl segment
         is either a placeholder like `<zone-id>` or a concrete literal.
 
-    Prefers a fully-literal match when one exists; otherwise falls back to
-    the templated match. Returns the matched path template, or None.
+    When multiple templates match, prefers the one with the most literal
+    (non-`{param}`) segments — so e.g. `/zones/{id}/dns_records/import`
+    wins over `/zones/{id}/dns_records/{record_id}` for a curl call to
+    `/zones/<zone-id>/dns_records/import`. Returns the matched path
+    template, or None.
     """
     curl_parts = curl_path.split("/")
 
@@ -1642,16 +1656,19 @@ def _match_cloudflare_path(curl_path: str, openapi_paths: dict[str, set[str]]) -
         return curl_path
 
     best: str | None = None
-    for tmpl, _methods in openapi_paths.items():
+    best_specificity = -1
+    for tmpl in openapi_paths:
         tmpl_parts = tmpl.split("/")
         if len(tmpl_parts) != len(curl_parts):
             continue
-        if all(_segment_matches(t, c) for t, c in zip(tmpl_parts, curl_parts)):
+        if not all(_segment_matches(t, c) for t, c in zip(tmpl_parts, curl_parts)):
+            continue
+        specificity = sum(
+            1 for p in tmpl_parts if p and not (p.startswith("{") and p.endswith("}"))
+        )
+        if specificity > best_specificity:
             best = tmpl
-            # Don't break; later templates with more literal segments would
-            # be more specific, but the spec is generally well-formed and
-            # the first match is good enough.
-            break
+            best_specificity = specificity
     return best
 
 


### PR DESCRIPTION
## Summary

Restructures \`mondoo-cloudflare-security\` so each of the 13 checks has both \`id: console\` and \`id: cli\` remediation entries, and adds a Cloudflare validator to the remediation-command CI.

## Why \`curl\` against the REST API instead of a CLI

I evaluated both \`flarectl\` and \`wrangler\` and neither covers the surface this policy targets:

- **flarectl** is read-only for zone settings — \`flarectl zone settings <zone>\` lists settings but the CLI has no \`update\` subcommand for SSL mode, TLS version, WAF, security level, browser check, email obfuscation, hotlink protection, opportunistic encryption, or 2FA enforcement (verified against the source at \`cmd/flarectl/flarectl.go\`).
- **wrangler 4.x** covers Workers / Pages / R2 / D1 / KV / Queues / AI / Vectorize / Hyperdrive / Tunnels / mTLS — none of which are the subject of this policy.

\`curl\` against \`https://api.cloudflare.com/client/v4/...\` is what Cloudflare's own docs lead with for these settings, and it gives us a stable, well-documented API surface to validate against.

## Validator

New \`validate_cloudflare()\` in \`content/validation/validate_remediation_commands.py\`:

- Downloads the official OpenAPI spec from [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) at a pinned commit SHA.
- Caches the ~9 MB spec under \`~/.cache/cnspec-validation/cloudflare-openapi-<sha>.json\` so subsequent runs hit disk only.
- Parses each \`curl\` invocation in the policy's \`id: cli\` blocks (extracting URL and \`-X\` method), normalizes the path, and matches it against the OpenAPI path templates (handling \`<zone-id>\` placeholders against \`{zone_id}\` template params).
- Verifies the HTTP method exists on the matched path.

Bumping \`CLOUDFLARE_OPENAPI_SHA\` is a deliberate maintainer action, like bumping \`DOCTL_VERSION\`.

## Test plan

- [x] \`cnspec policy lint content/mondoo-cloudflare-security.mql.yaml\` → valid bundle.
- [x] \`python3 content/validation/validate_remediation_commands.py cloudflare\` → 13/13 PASS, 0.15s on cached runs (1.04s on first download).
- [x] Mutation test:
  - Bogus path \`/zonez/...\` → \`unknown Cloudflare API path\`.
  - Wrong method \`POST /zones/.../settings/...\` → \`method 'POST' not supported on '/zones/{zone_id}/settings/{setting_id}' (supported: GET, PATCH)\`.
- [ ] CI run on this PR exercises the new \`cloudflare\` target inside \`validate-remediation.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)