### PR TITLE
:recycle: Move Okta remediation steps from variants onto parent checks

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.0
+    version: 2.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.2.0
+    version: 2.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -174,6 +174,16 @@ queries:
         All other admins should only have the permissions as required for their role.
 
         Plan for a recurring assessment of all admin privileges to ensure that these best practices are met.
+      remediation:
+        - id: console
+          desc: |
+            ### Change admin privileges to a user or an Okta group
+
+            1. In the Admin Console, go to **Security > Administrators**.
+            2. Under **Admin Roles**, select the Super filter to display only super administrators.
+            3. Next to each user entry, select **Edit**. The Edit Administrator window is displayed.
+            4. From the list of administrator roles, assign a role other than super admin to the user.
+            5. Select **Update Administrator**.
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/healthinsight-security-task-recomendations.htm
         title: HealthInsight tasks and recommendations
@@ -188,17 +198,6 @@ queries:
   - uid: mondoo-okta-security-limit-super-admins-api
     filters: asset.platform == "okta-org"
     mql: okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < props.mondooOktaSecurityMaxOktaSuperAdmins )
-    docs:
-      remediation:
-        - id: console
-          desc: |
-            ### Change admin privileges to a user or an Okta group
-
-            1. In the Admin Console, go to **Security > Administrators**.
-            2. Under **Admin Roles**, select the Super filter to display only super administrators.
-            3. Next to each user entry, select **Edit**. The Edit Administrator window is displayed.
-            4. From the list of administrator roles, assign a role other than super admin to the user.
-            5. Select **Update Administrator**.
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses
     title: Enable Okta ThreatInsight to block suspicious IP addresses
     impact: 100
@@ -246,17 +245,18 @@ queries:
         Low
 
         Legitimate users within your org see no change in behavior. Clients connecting from blocked network zones see a 403 (access denied) error.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
-        title: Okta ThreatInsight
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
-    filters: asset.platform == "okta-org"
-    mql: |
-      okta.networks.any( usage == "BLOCKLIST" && gateways.length > 0 )
-    docs:
       remediation:
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_network_zone" "example_blocklist" {
+              name     = "myBlockList"
+              type     = "IP"
+              usage    = "BLOCKLIST"
+              gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
+              proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
+            }
+            ```
         - id: console
           desc: |
             ### Block specific IP addresses
@@ -284,60 +284,30 @@ queries:
             3. Select Tor anonymizer proxy for IP Type.
             4. Select Block access from IPs matching conditions listed in this zone.
             5. Select Save.
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
+        title: Okta ThreatInsight
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
+    filters: asset.platform == "okta-org"
+    mql: |
+      okta.networks.any( usage == "BLOCKLIST" && gateways.length > 0 )
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
       terraform.resources.where( nameLabel == "okta_network_zone" ).one( arguments['usage'] == "BLOCKLIST" )
       terraform.resources.where( nameLabel == "okta_network_zone" && arguments['usage'] == "BLOCKLIST" ).all( arguments['gateways'].length > 0 )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_network_zone" "example_blocklist" {
-              name     = "myBlockList"
-              type     = "IP"
-              usage    = "BLOCKLIST"
-              gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
-              proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
-            }
-            ```
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
       terraform.plan.resourceChanges.where( type == "okta_network_zone" ).one( change.after['usage'] == "BLOCKLIST" )
       terraform.plan.resourceChanges.where( type == "okta_network_zone" && change.after['usage'] == "BLOCKLIST" ).all( change.after['gateways'].length > 0 )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_network_zone" "example_blocklist" {
-              name     = "myBlockList"
-              type     = "IP"
-              usage    = "BLOCKLIST"
-              gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
-              proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
-            }
-            ```
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_network_zone/ )
     mql: |
       terraform.state.resources.where( type == 'okta_network_zone' ).contains( values['usage'] == "BLOCKLIST" )
       terraform.state.resources.where( type == 'okta_network_zone' ).contains( values['usage'] == "BLOCKLIST" && values['gateways'].length > 0 )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_network_zone" "example_blocklist" {
-              name     = "myBlockList"
-              type     = "IP"
-              usage    = "BLOCKLIST"
-              gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
-              proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
-            }
-            ```
   - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies
     title: Disable weaker MFA factors in factor enrollment policies
     impact: 80
@@ -388,6 +358,45 @@ queries:
         High
 
         When signing in to their org, end users are prompted to enroll in required factors and may enroll in any factors set to optional. Factors that have been disabled aren't visible to end users.
+      remediation:
+        - id: console
+          desc: |
+            ### Enable strong factors for factor enrollment
+            1. In the Admin Console, go to **Security > Multifactor**.
+            2. Select Factor Enrollment.
+            3. Select Edit.
+            4. Set the factor of your choice to Required, Optional, or Disabled.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_policy_mfa_default" "classic_example" {
+              is_oie      = false
+
+              okta_verify = {
+                enroll = "REQUIRED"
+              }
+
+              okta_otp = {
+                enroll = "REQUIRED"
+              }
+
+              google_otp = {
+                enroll = "REQUIRED"
+              }
+
+              okta_email = {
+                enroll = "NOT_ALLOWED"
+              }
+
+              okta_sms = {
+                enroll = "NOT_ALLOWED"
+              }
+
+              phone_number = {
+                enroll = "NOT_ALLOWED"
+              }
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/strong-factors.htm
         title: Disable weaker MFA factors in factor enrollment policies
@@ -399,132 +408,24 @@ queries:
       okta.policies.mfaEnroll.all( _.settings['factors']['okta_email']['enroll']['self'] != /(OPTIONAL|REQUIRED)/ )
       okta.policies.mfaEnroll.all( _.settings['factors']['okta_sms']['enroll']['self'] != /(OPTIONAL|REQUIRED)/ )
       okta.policies.mfaEnroll.all( _.settings['factors']['phone_number']['enroll']['self'] != /(OPTIONAL|REQUIRED)/ )
-    docs:
-      remediation:
-        - id: console
-          desc: |
-            ### Enable strong factors for factor enrollment
-            1. In the Admin Console, go to **Security > Multifactor**.
-            2. Select Factor Enrollment.
-            3. Select Edit.
-            4. Set the factor of your choice to Required, Optional, or Disabled.
   - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
       terraform.resources.where( nameLabel == "okta_policy_mfa_default" ).all( arguments['okta_sms']['enroll'] != /(OPTIONAL|REQUIRED)/)
       terraform.resources.where( nameLabel == "okta_policy_mfa_default" ).all( arguments['okta_email']['enroll'] != /(OPTIONAL|REQUIRED)/)
       terraform.resources.where( nameLabel == "okta_policy_mfa_default" ).all( arguments['phone_number']['enroll'] != /(OPTIONAL|REQUIRED)/)
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
       terraform.plan.resourceChanges.where( type == "okta_policy_mfa_default" ).all( change.after['okta_email']['enroll'] != /(OPTIONAL|REQUIRED)/ )
       terraform.plan.resourceChanges.where( type == "okta_policy_mfa_default" ).all( change.after['okta_sms']['enroll'] != /(OPTIONAL|REQUIRED)/ )
       terraform.plan.resourceChanges.where( type == "okta_policy_mfa_default" ).all( change.after['phone_number']['enroll'] != /(OPTIONAL|REQUIRED)/ )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default/ )
     mql: |
       terraform.state.resources.where( type == 'okta_policy_mfa_default' ).all( values['okta_sms']['enroll'] != /(OPTIONAL|REQUIRED)/ )
       terraform.state.resources.where( type == 'okta_policy_mfa_default' ).all( values['okta_email']['enroll'] != /(OPTIONAL|REQUIRED)/ )
       terraform.state.resources.where( type == 'okta_policy_mfa_default' ).all( values['phone_number']['enroll'] != /(OPTIONAL|REQUIRED)/ )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa
     title: Enable Okta Verify (with Push if available) for MFA
     impact: 80
@@ -558,127 +459,58 @@ queries:
         Okta Verify is a multifactor authentication (MFA) app developed by Okta. It lets users verify their identity when they sign in to Okta and makes it less likely that someone pretending to be the user can gain access to the account.
 
         To use Okta Verify, you must first enable and configure it for your org, and then your end users must install the Okta Verify app on their device and set it up. Then, when end users sign in to Okta, they can verify their identity by approving a push notification in the app, or by entering a one-time code provided by the app into Okta.
+      remediation:
+        - id: console
+          desc: |
+            See [Enable and configure Okta Verify](https://help.okta.com/en-us/Content/Topics/Mobile/okta-verify-overview.htm) in Okta's documentation site.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_policy_mfa_default" "classic_example" {
+              is_oie      = false
+
+              okta_verify = {
+                enroll = "REQUIRED"
+              }
+
+              okta_otp = {
+                enroll = "REQUIRED"
+              }
+
+              google_otp = {
+                enroll = "REQUIRED"
+              }
+
+              okta_email = {
+                enroll = "NOT_ALLOWED"
+              }
+
+              okta_sms = {
+                enroll = "NOT_ALLOWED"
+              }
+
+              phone_number = {
+                enroll = "NOT_ALLOWED"
+              }
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/mfa/mfa-home.htm
         title: Okta Multifactor Authentication
   - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-api
     filters: asset.platform == "okta-org"
     mql: okta.policies.mfaEnroll.any( _.settings['factors']['okta_otp'] )
-    docs:
-      remediation:
-        - id: console
-          desc: |
-            See [Enable and configure Okta Verify](https://help.okta.com/en-us/Content/Topics/Mobile/okta-verify-overview.htm) in Okta's documentation site.
   - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_policy_mfa_default" ).any( arguments['okta_otp']['enroll'] == /REQUIRED/)
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
       terraform.plan.resourceChanges.where( type == "okta_policy_mfa_default" ).any( change.after['okta_otp']['enroll'] == /REQUIRED/ )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default/ )
     mql: |
       terraform.state.resources.where( type == 'okta_policy_mfa_default' ).any( values['okta_otp']['enroll'] == /REQUIRED/ )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_policy_mfa_default" "classic_example" {
-              is_oie      = false
-
-              okta_verify = {
-                enroll = "REQUIRED"
-              }
-
-              okta_otp = {
-                enroll = "REQUIRED"
-              }
-
-              google_otp = {
-                enroll = "REQUIRED"
-              }
-
-              okta_email = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              okta_sms = {
-                enroll = "NOT_ALLOWED"
-              }
-
-              phone_number = {
-                enroll = "NOT_ALLOWED"
-              }
-            }
-            ```
   - uid: mondoo-okta-security-okta-mfa-access
     title: Require at least one factor in every MFA enrollment policy
     impact: 100
@@ -714,17 +546,6 @@ queries:
         Low
 
         If a factor is required as part of the MFA enrollment policy, end users must enroll in the factor before they can sign in to their org. Setup varies depending on the factor specified.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/mfa/mfa-home.htm
-        title: Okta Multifactor Authentication
-      - url: https://help.okta.com/en-us/content/topics/security/policies/policies-home.htm
-        title: Okta Security Policies
-  - uid: mondoo-okta-security-okta-mfa-access-api
-    filters: asset.platform == "okta-org"
-    mql: |
-      everyoneGroupId = okta.groups.where( profile['name'] == "Everyone" ).map(id)[0]
-      okta.policies.mfaEnroll.one( status == "ACTIVE" && conditions['people']['groups']['include'].contains(everyoneGroupId) )
-    docs:
       remediation:
         - id: console
           desc: |
@@ -762,6 +583,16 @@ queries:
             3. Choose one of the active policy rules in the list and select Edit. The Edit Rule dialog appears.
             4. Under the condition THEN Enroll in multi-factor, select the first time a user signs in.
             5. Select **Update Rule**.
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/mfa/mfa-home.htm
+        title: Okta Multifactor Authentication
+      - url: https://help.okta.com/en-us/content/topics/security/policies/policies-home.htm
+        title: Okta Security Policies
+  - uid: mondoo-okta-security-okta-mfa-access-api
+    filters: asset.platform == "okta-org"
+    mql: |
+      everyoneGroupId = okta.groups.where( profile['name'] == "Everyone" ).map(id)[0]
+      okta.policies.mfaEnroll.one( status == "ACTIVE" && conditions['people']['groups']['include'].contains(everyoneGroupId) )
   - uid: mondoo-okta-security-okta-enforce-session-lifetime
     title: Enforce a limited session lifetime for all policies
     impact: 80
@@ -799,6 +630,15 @@ queries:
         Moderate
 
         A countdown timer appears to users when there are five minutes of session time remaining.
+      remediation:
+        - id: console
+          desc: |
+            ### Set the session lifetime for a policy
+            1. In the Admin Console, go to **Security > Authentication**.
+            2. Select **Sign On**.
+            3. Select **Add Rule** or **Edit** to modify an existing policy rule.
+            4. Under **Session expires after**, set the session lifetime duration in minutes, hours, or days.
+            5. Select **Create Rule** or **Save Rule** once your changes have been made.
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Okta Sign-On Policies
@@ -816,16 +656,6 @@ queries:
     mql: |
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionIdleMinutes"] <= props.mondooOktaSecurityMaxSessionIdleMinutes ))
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionLifetimeMinutes"] <= props.mondooOktaSecurityMaxSessionLifetimeMinutes ))
-    docs:
-      remediation:
-        - id: console
-          desc: |
-            ### Set the session lifetime for a policy
-            1. In the Admin Console, go to **Security > Authentication**.
-            2. Select **Sign On**.
-            3. Select **Add Rule** or **Edit** to modify an existing policy rule.
-            4. Under **Session expires after**, set the session lifetime duration in minutes, hours, or days.
-            5. Select **Create Rule** or **Save Rule** once your changes have been made.
   - uid: mondoo-okta-security-okta-auth-openid-saml
     title: Enable SAML or OIDC authentication for supported apps
     impact: 100
@@ -871,6 +701,65 @@ queries:
         None
 
         When signing in to their org, end users are prompted to enroll in required factors and may enroll in any factors set to optional. Factors that have been disabled aren't visible to end users.
+      remediation:
+        - id: console
+          desc: |
+            ### Use the Okta Admin Console
+
+            1. Log into the organization as an administrator.
+            2. Select **Applications > Applications**.
+            3. Select **Create App Integration** or **Browse App Catalog** to see the available apps.
+            4. Assign OIDC or SAML.
+        - id: terraform
+          desc: |
+            ### Configure a SAML application with Terraform
+
+            >Note: If you receive the error `You do not have permission to access the feature you are requesting` contact support and request feature flag `ADVANCED_SSO` be applied to your org.
+
+            ```hcl
+            resource "okta_app_saml" "example" {
+              label                    = "example"
+              sso_url                  = "https://example.com"
+              recipient                = "https://example.com"
+              destination              = "https://example.com"
+              audience                 = "https://example.com/audience"
+              subject_name_id_template = "$${user.userName}"
+              subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+              response_signed          = true
+              signature_algorithm      = "RSA_SHA256"
+              digest_algorithm         = "SHA256"
+              honor_force_authn        = false
+              authn_context_class_ref  = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+
+              attribute_statements {
+                type         = "GROUP"
+                name         = "groups"
+                filter_type  = "REGEX"
+                filter_value = ".*"
+              }
+            }
+            ```
+
+            ### Configure an OIDC provider with Terraform
+
+            ```hcl
+            resource "okta_idp_oidc" "example" {
+              name                  = "example"
+              authorization_url     = "https://idp.example.com/authorize"
+              authorization_binding = "HTTP-REDIRECT"
+              token_url             = "https://idp.example.com/token"
+              token_binding         = "HTTP-POST"
+              user_info_url         = "https://idp.example.com/userinfo"
+              user_info_binding     = "HTTP-REDIRECT"
+              jwks_url              = "https://idp.example.com/keys"
+              jwks_binding          = "HTTP-REDIRECT"
+              scopes                = ["openid"]
+              client_id             = "efg456"
+              client_secret         = "efg456"
+              issuer_url            = "https://id.example.com"
+              username_template     = "idpuser.email"
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Okta Sign-On Policies
@@ -883,127 +772,14 @@ queries:
     docs:
       desc: |
         This check explicitly skips Okta Bookmark apps and Active Directory integration apps, which cannot be configured with SAML or OIDC authentication by design.
-      remediation:
-        - id: console
-          desc: |
-            ### Use the Okta Admin Console
-
-            1. Log into the organization as an administrator.
-            2. Select **Applications > Applications**.
-            3. Select **Create App Integration** or **Browse App Catalog** to see the available apps.
-            4. Assign OIDC or SAML.
   - uid: mondoo-okta-security-okta-auth-openid-saml-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
       terraform.resources.any( nameLabel == "okta_idp_oidc" || nameLabel == "okta_app_saml" )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ### Configure a SAML application with Terraform
-
-            >Note: If you receive the error `You do not have permission to access the feature you are requesting` contact support and request feature flag `ADVANCED_SSO` be applied to your org.
-
-            ```hcl
-            resource "okta_app_saml" "example" {
-              label                    = "example"
-              sso_url                  = "https://example.com"
-              recipient                = "https://example.com"
-              destination              = "https://example.com"
-              audience                 = "https://example.com/audience"
-              subject_name_id_template = "$${user.userName}"
-              subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-              response_signed          = true
-              signature_algorithm      = "RSA_SHA256"
-              digest_algorithm         = "SHA256"
-              honor_force_authn        = false
-              authn_context_class_ref  = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
-
-              attribute_statements {
-                type         = "GROUP"
-                name         = "groups"
-                filter_type  = "REGEX"
-                filter_value = ".*"
-              }
-            }
-            ```
-
-            ### Configure an OIDC provider with Terraform
-
-            ```hcl
-            resource "okta_idp_oidc" "example" {
-              name                  = "example"
-              authorization_url     = "https://idp.example.com/authorize"
-              authorization_binding = "HTTP-REDIRECT"
-              token_url             = "https://idp.example.com/token"
-              token_binding         = "HTTP-POST"
-              user_info_url         = "https://idp.example.com/userinfo"
-              user_info_binding     = "HTTP-REDIRECT"
-              jwks_url              = "https://idp.example.com/keys"
-              jwks_binding          = "HTTP-REDIRECT"
-              scopes                = ["openid"]
-              client_id             = "efg456"
-              client_secret         = "efg456"
-              issuer_url            = "https://id.example.com"
-              username_template     = "idpuser.email"
-            }
-            ```
   - uid: mondoo-okta-security-okta-auth-openid-saml-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
       terraform.plan.resourceChanges.any( type == /okta_idp_oidc/ || type == /okta_app_saml/ )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ### Configure a SAML application with Terraform
-
-            >Note: If you receive the error `You do not have permission to access the feature you are requesting` contact support and request feature flag `ADVANCED_SSO` be applied to your org.
-
-            ```hcl
-            resource "okta_app_saml" "example" {
-              label                    = "example"
-              sso_url                  = "https://example.com"
-              recipient                = "https://example.com"
-              destination              = "https://example.com"
-              audience                 = "https://example.com/audience"
-              subject_name_id_template = "$${user.userName}"
-              subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-              response_signed          = true
-              signature_algorithm      = "RSA_SHA256"
-              digest_algorithm         = "SHA256"
-              honor_force_authn        = false
-              authn_context_class_ref  = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
-
-              attribute_statements {
-                type         = "GROUP"
-                name         = "groups"
-                filter_type  = "REGEX"
-                filter_value = ".*"
-              }
-            }
-            ```
-
-            ### Configure an OIDC provider with Terraform
-
-            ```hcl
-            resource "okta_idp_oidc" "example" {
-              name                  = "example"
-              authorization_url     = "https://idp.example.com/authorize"
-              authorization_binding = "HTTP-REDIRECT"
-              token_url             = "https://idp.example.com/token"
-              token_binding         = "HTTP-POST"
-              user_info_url         = "https://idp.example.com/userinfo"
-              user_info_binding     = "HTTP-REDIRECT"
-              jwks_url              = "https://idp.example.com/keys"
-              jwks_binding          = "HTTP-REDIRECT"
-              scopes                = ["openid"]
-              client_id             = "efg456"
-              client_secret         = "efg456"
-              issuer_url            = "https://id.example.com"
-              username_template     = "idpuser.email"
-            }
-            ```
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting
     title: Enable Suspicious Activity Reporting
     impact: 80
@@ -1047,15 +823,6 @@ queries:
         ### User impact
 
         Low
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
-        title: Okta ThreatInsight
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['reportSuspiciousActivityEnabled'] == true
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1081,54 +848,34 @@ queries:
             2. In the Security notification emails section, select Edit.
             3. Select either Enabled or Disabled from the dropdown beside the option that you want to enable or disable.
             4. Select Save.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_security_notification_emails" "example" {
+              report_suspicious_activity_enabled       = true
+              send_email_for_factor_enrollment_enabled = true
+              send_email_for_factor_reset_enabled      = true
+              send_email_for_new_device_enabled        = true
+              send_email_for_password_changed_enabled  = true
+            }
+            ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
+        title: Okta ThreatInsight
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.securityNotificationEmails['reportSuspiciousActivityEnabled'] == true
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_security_notification_emails" ).all( arguments['report_suspicious_activity_enabled'] == /var/ || arguments['report_suspicious_activity_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['report_suspicious_activity_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_security_notification_emails/ )
     mql: terraform.state.resources.where( type == /okta_security_notification_emails/ ).all( values['report_suspicious_activity_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users
     title: Enable sign-on notifications for end users
     impact: 80
@@ -1177,13 +924,6 @@ queries:
 
         ### Known limitations
         Currently, new sign-on notifications don't use Improved New Device Behavior Detection when sending email notifications for new sign-ins. Changes to `deviceToken` or browser cookies may not trigger a new sign-on email notification.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForNewDeviceEnabled'] == true
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1192,54 +932,32 @@ queries:
             2. Under **Security Notification Emails**, select **Edit**.
             3. Set **New sign-on notification email** to **Enabled**.
             4. Select **Save**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_security_notification_emails" "example" {
+              report_suspicious_activity_enabled       = true
+              send_email_for_factor_enrollment_enabled = true
+              send_email_for_factor_reset_enabled      = true
+              send_email_for_new_device_enabled        = true
+              send_email_for_password_changed_enabled  = true
+            }
+            ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.securityNotificationEmails['sendEmailForNewDeviceEnabled'] == true
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_security_notification_emails" ).all( arguments['send_email_for_new_device_enabled'] == /var/ || arguments['send_email_for_new_device_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_new_device_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_security_notification_emails/ )
     mql: terraform.state.resources.where( type == /okta_security_notification_emails/ ).all( values['send_email_for_new_device_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-enrollment-notifications
     title: Enable factor enrollment notifications for end users
     impact: 80
@@ -1285,13 +1003,6 @@ queries:
         Low
 
         End users are sent a confirmation email if they or an admin enroll in a new factor for their account.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-factor-enrollment-notifications-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForFactorEnrollmentEnabled'] == true
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1300,54 +1011,32 @@ queries:
             2. Under **Security Notification Emails**, select **Edit**.
             3. Set **MFA enrolled notification email** to **Enabled**.
             4. Select **Save**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_security_notification_emails" "example" {
+              report_suspicious_activity_enabled       = true
+              send_email_for_factor_enrollment_enabled = true
+              send_email_for_factor_reset_enabled      = true
+              send_email_for_new_device_enabled        = true
+              send_email_for_password_changed_enabled  = true
+            }
+            ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-factor-enrollment-notifications-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.securityNotificationEmails['sendEmailForFactorEnrollmentEnabled'] == true
   - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_security_notification_emails" ).all( arguments['send_email_for_factor_enrollment_enabled'] == /var/ || arguments['send_email_for_factor_enrollment_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_factor_enrollment_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_security_notification_emails/ )
     mql: terraform.state.resources.where( type == /okta_security_notification_emails/ ).all( values['send_email_for_factor_enrollment_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users
     title: Enable factor reset notifications for end users
     impact: 80
@@ -1393,13 +1082,6 @@ queries:
         Low
 
         End users are sent an email notification if they or an admin reset a factor for their account.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForFactorResetEnabled'] == true
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1408,54 +1090,32 @@ queries:
             2. Under **Security Notification Emails**, select **Edit**.
             3. Set **MFA reset notification email** to **Enabled**.
             4. Select **Save**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_security_notification_emails" "example" {
+              report_suspicious_activity_enabled       = true
+              send_email_for_factor_enrollment_enabled = true
+              send_email_for_factor_reset_enabled      = true
+              send_email_for_new_device_enabled        = true
+              send_email_for_password_changed_enabled  = true
+            }
+            ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.securityNotificationEmails['sendEmailForFactorResetEnabled'] == true
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_security_notification_emails" ).all( arguments['send_email_for_factor_reset_enabled'] == /var/ || arguments['send_email_for_factor_reset_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_factor_reset_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_security_notification_emails/ )
     mql: terraform.state.resources.where( type == /okta_security_notification_emails/ ).all( values['send_email_for_factor_reset_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users
     title: Enable password changed notification for end users
     impact: 80
@@ -1501,13 +1161,6 @@ queries:
         Low
 
         End users are sent an email notification if they change or reset the password on their account. Password changed notifications aren't sent if the admin sets a temporary password for the account, changes the password by API or if the end user is in an inactive state.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
-        title: Okta Security Administration
-  - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForPasswordChangedEnabled'] == true
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1516,54 +1169,32 @@ queries:
             2. Under **Security Notification Emails**, select **Edit**.
             3. Set **Password changed notification email** to **Enabled**.
             4. Select **Save**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_security_notification_emails" "example" {
+              report_suspicious_activity_enabled       = true
+              send_email_for_factor_enrollment_enabled = true
+              send_email_for_factor_reset_enabled      = true
+              send_email_for_new_device_enabled        = true
+              send_email_for_password_changed_enabled  = true
+            }
+            ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+        title: Okta Security Administration
+  - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.securityNotificationEmails['sendEmailForPasswordChangedEnabled'] == true
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources.where( nameLabel == "okta_security_notification_emails" ).all( arguments['send_email_for_password_changed_enabled'] == /var/ || arguments['send_email_for_password_changed_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: terraform.plan.resourceChanges.where( type == /okta_security_notification_emails/ ).all( change.after['send_email_for_password_changed_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_security_notification_emails/ )
     mql: terraform.state.resources.where( type == /okta_security_notification_emails/ ).all( values['send_email_for_password_changed_enabled'] == true )
-    docs:
-      remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "okta_security_notification_emails" "example" {
-              report_suspicious_activity_enabled       = true
-              send_email_for_factor_enrollment_enabled = true
-              send_email_for_factor_reset_enabled      = true
-              send_email_for_new_device_enabled        = true
-              send_email_for_password_changed_enabled  = true
-            }
-            ```
   - uid: mondoo-okta-security-password-settings-minimum-length
     title: Enable strong password settings for password policies - minimum length
     impact: 30
@@ -1602,16 +1233,6 @@ queries:
         Longer passwords are more difficult for users to remember, especially when combined with other complexity requirements (for example, require uppercase, lowercase, symbols, and so on). NIST recommends longer passwords that are easy to remember (“phrase-like”) but more difficult to obtain from brute force attacks.
 
         These recommendations are provided by Okta as an example of typical password standards. They're derived from current cybersecurity industry best practices. They aren't intended to replace internationally recognized cybersecurity standards, such as ISO 27001, National Institute of Standards and Technology (NIST), PCI-DSS, or others. Your IT department may need to adjust these settings to comply with whichever cybersecurity standard your organization has chosen to follow.
-    refs:
-      - url: https://help.okta.com/en-us/content/topics/security/policies/configure-password-policies.htm
-        title: Okta Password Policies
-      - url: https://help.okta.com/en-us/content/topics/security/policies/policies-home.htm
-        title: Okta Security Policies
-  - uid: mondoo-okta-security-password-settings-minimum-length-api
-    filters: asset.platform == "okta-org"
-    mql: |
-      okta.policies.password.all( settings['password']['complexity']['minLength'] >= 15 )
-    docs:
       remediation:
         - id: console
           desc: |
@@ -1621,12 +1242,6 @@ queries:
             2. In the Password tab, review each policy. To edit the policy, select Edit.
             3. Edit the password settings based on the recommendations.
             4. To enable each setting, select the checkboxes for Password History, Password Age, Lock out, and Common Password Check.
-  - uid: mondoo-okta-security-password-settings-minimum-length-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
-    mql: |
-      terraform.resources.where( nameLabel == /okta_policy_password/ ).all( arguments['password_min_length'] == /var/ || arguments['password_min_length'] >= 15 )
-    docs:
-      remediation:
         - id: terraform
           desc: |
             ```hcl
@@ -1634,6 +1249,19 @@ queries:
               password_min_length            = var.password_minimum_length
             }
             ```
+    refs:
+      - url: https://help.okta.com/en-us/content/topics/security/policies/configure-password-policies.htm
+        title: Okta Password Policies
+      - url: https://help.okta.com/en-us/content/topics/security/policies/policies-home.htm
+        title: Okta Security Policies
+  - uid: mondoo-okta-security-password-settings-minimum-length-api
+    filters: asset.platform == "okta-org"
+    mql: |
+      okta.policies.password.all( settings['password']['complexity']['minLength'] >= 15 )
+  - uid: mondoo-okta-security-password-settings-minimum-length-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.where( nameLabel == /okta_policy_password/ ).all( arguments['password_min_length'] == /var/ || arguments['password_min_length'] >= 15 )
   - uid: mondoo-okta-security-password-settings-minimum-length-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
@@ -2606,15 +2234,6 @@ queries:
         Low
 
         Legitimate users are not affected. Only IP addresses identified as malicious by Okta's threat intelligence are blocked. If a legitimate user is affected, admins can add their IP to the ThreatInsight exclude list.
-    refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/threat-insight/configure-threatinsight.htm
-        title: Configure Okta ThreatInsight
-      - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/healthinsight-security-task-recomendations.htm
-        title: HealthInsight tasks and recommendations
-  - uid: mondoo-okta-security-threatinsight-action-block-api
-    filters: asset.platform == "okta-org"
-    mql: okta.organization.threatInsightSettings.action == "block"
-    docs:
       remediation:
         - id: console
           desc: |
@@ -2625,6 +2244,14 @@ queries:
             3. Under **Action**, select **Log and block**.
             4. Optionally, add trusted network zones to the exclude list to prevent false positives.
             5. Select **Save**.
+    refs:
+      - url: https://help.okta.com/en-us/Content/Topics/Security/threat-insight/configure-threatinsight.htm
+        title: Configure Okta ThreatInsight
+      - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/healthinsight-security-task-recomendations.htm
+        title: HealthInsight tasks and recommendations
+  - uid: mondoo-okta-security-threatinsight-action-block-api
+    filters: asset.platform == "okta-org"
+    mql: okta.organization.threatInsightSettings.action == "block"
   - uid: mondoo-okta-security-trusted-origins-https
     title: Ensure all active trusted origins use HTTPS
     impact: 90
@@ -2663,13 +2290,6 @@ queries:
         None
 
         Updating trusted origin URLs from HTTP to HTTPS is a backend configuration change. End users experience no disruption as long as the application supports HTTPS.
-    refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/API_Trusted-Origins.htm
-        title: Trusted Origins
-  - uid: mondoo-okta-security-trusted-origins-https-api
-    filters: asset.platform == "okta-org"
-    mql: okta.trustedOrigins.where(status == "ACTIVE").all(origin == /^https:\/\//)
-    docs:
       remediation:
         - id: console
           desc: |
@@ -2682,6 +2302,12 @@ queries:
                b. Update the **Origin URL** to use `https://` instead of `http://`.
                c. Select **Save**.
             4. If the underlying application does not yet support HTTPS, configure TLS on the application first, then update the trusted origin.
+    refs:
+      - url: https://help.okta.com/en-us/Content/Topics/Security/API_Trusted-Origins.htm
+        title: Trusted Origins
+  - uid: mondoo-okta-security-trusted-origins-https-api
+    filters: asset.platform == "okta-org"
+    mql: okta.trustedOrigins.where(status == "ACTIVE").all(origin == /^https:\/\//)
   - uid: mondoo-okta-security-signon-requires-mfa
     title: Ensure sign-on policy rules require MFA
     impact: 90
@@ -2724,16 +2350,6 @@ queries:
         Moderate
 
         Users are prompted for an additional factor when signing in. If they have already enrolled in a factor through MFA enrollment policies, no additional setup is needed.
-    refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/policies/configure-signon-policy.htm
-        title: Configure Sign-On Policies
-  - uid: mondoo-okta-security-signon-requires-mfa-api
-    filters: asset.platform == "okta-org"
-    mql: |
-      okta.policies.signOn.where(status == "ACTIVE").all(
-        rules.where(status == "ACTIVE" && name != "Catch-all Rule").all(actions["signon"]["requireFactor"] == true)
-      )
-    docs:
       remediation:
         - id: console
           desc: |
@@ -2747,6 +2363,15 @@ queries:
             6. Select **Save**.
 
             Repeat for all active sign-on policy rules to ensure comprehensive MFA enforcement.
+    refs:
+      - url: https://help.okta.com/en-us/Content/Topics/Security/policies/configure-signon-policy.htm
+        title: Configure Sign-On Policies
+  - uid: mondoo-okta-security-signon-requires-mfa-api
+    filters: asset.platform == "okta-org"
+    mql: |
+      okta.policies.signOn.where(status == "ACTIVE").all(
+        rules.where(status == "ACTIVE" && name != "Catch-all Rule").all(actions["signon"]["requireFactor"] == true)
+      )
   - uid: mondoo-okta-security-limit-org-admins
     title: Limit the number of organization admins
     impact: 80
@@ -2793,15 +2418,6 @@ queries:
         None
 
         Reassigning users to more specific admin roles does not affect end-user sign-in or application access.
-    refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/Administrators.htm
-        title: Administrators
-      - url: https://help.okta.com/en-us/Content/Topics/Security/administrators-admin-comparison.htm
-        title: Administrator Role Comparison
-  - uid: mondoo-okta-security-limit-org-admins-api
-    filters: asset.platform == "okta-org"
-    mql: okta.groups.where(roles.contains(type == "ORG_ADMIN")).all(members.length < props.maxOrgAdmins)
-    docs:
       remediation:
         - id: console
           desc: |
@@ -2814,3 +2430,11 @@ queries:
                b. Assign a more specific role such as Help Desk Admin, Application Admin, or Read-Only Admin based on their actual responsibilities.
                c. Select **Update Administrator**.
             4. Periodically review org admin assignments to ensure ongoing compliance with the principle of least privilege.
+    refs:
+      - url: https://help.okta.com/en-us/Content/Topics/Security/Administrators.htm
+        title: Administrators
+      - url: https://help.okta.com/en-us/Content/Topics/Security/administrators-admin-comparison.htm
+        title: Administrator Role Comparison
+  - uid: mondoo-okta-security-limit-org-admins-api
+    filters: asset.platform == "okta-org"
+    mql: okta.groups.where(roles.contains(type == "ORG_ADMIN")).all(members.length < props.maxOrgAdmins)


### PR DESCRIPTION
## Summary
- For every parent check in \`content/mondoo-okta-security.mql.yaml\` that has a \`variants:\` block, the per-variant \`docs.remediation\` entries are now consolidated on the parent. Variant children only carry their MQL and \`filters:\` — no \`docs:\` block.
- 27 remediation entries moved across 17 parents.
- The 17 \`password-settings-*\` parents that had no remediation on any of their variants are unchanged — there was nothing to move.
- Bumps policy \`version: 2.2.0 → 2.3.0\`.

## Mechanics
The refactor was driven by a small \`ruamel.yaml\` script that:
1. Walked every parent that has \`variants:\`.
2. Collected every \`docs.remediation\` entry from each variant child.
3. Deduped by \`id\` (first occurrence wins — relevant for parents like \`threatinsight-block-suspicious-ip-addresses\` whose three terraform variants each carried an identical \`id: terraform\` block).
4. Appended the merged list to the parent's \`docs.remediation\`.
5. Removed \`docs.remediation\` from each variant child; dropped \`docs:\` if it became empty.

A round-trip through \`ruamel.yaml\` against the unchanged source produced a zero-line diff, so every diff line in this PR comes from the actual move, not from formatting drift.

## Test plan
- [x] \`cnspec policy lint content/mondoo-okta-security.mql.yaml\` → valid policy bundle(s)
- [x] Audit script confirms zero variant children still carry \`docs.remediation\` and that all 17 parents whose variants had remediation now own it
- [ ] Spot-check rendered remediation Markdown in the UI for one console-only parent (\`limit-super-admins\`) and one parent with multiple ids (\`threatinsight-block-suspicious-ip-addresses\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)