### PR TITLE
:star: Restructure Snowflake remediation into console / sql ids + fix some bugs

### DIFF
--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -508,7 +508,7 @@ queries:
       - url: https://docs.snowflake.com/en/user-guide/network-policies
         title: Snowflake network policy documentation
   - uid: mondoo-snowflake-security-network-policies-no-unrestricted-access
-    title: Ensure network policies do not allow unrestricted access from 0.0.0.0/0
+    title: Ensure no network policy allows 0.0.0.0/0 or ::/0
     impact: 90
     filters: asset.platform == 'snowflake'
     tags:
@@ -523,17 +523,17 @@ queries:
       snowflake.account.networkPolicies.none(allowedIpList.contains("0.0.0.0/0") || allowedIpList.contains("::/0"))
     docs:
       desc: |
-        This check ensures that no network policies contain 0.0.0.0/0 in their allowed IP list, which would permit access from any IP address and effectively nullify the network policy.
+        This check ensures that no network policy contains a wildcard CIDR — `0.0.0.0/0` for IPv4 or `::/0` for IPv6 — in its `ALLOWED_IP_LIST`. Either entry permits access from any address and effectively nullifies the network policy.
 
         **Why this matters**
 
-        A network policy that allows 0.0.0.0/0 provides no network-level access control:
+        A network policy that allows `0.0.0.0/0` or `::/0` provides no network-level access control:
           •  The policy exists but offers no protection, creating a false sense of security.
           •  All the risks of having no network policy apply equally.
           •  Audit and compliance checks may incorrectly pass because a network policy exists.
 
         Risk mitigation
-          •  Replace 0.0.0.0/0 entries with specific trusted IP ranges.
+          •  Replace `0.0.0.0/0` and `::/0` entries with specific trusted IP ranges.
           •  Audit network policies regularly for overly permissive entries.
           •  Use the smallest CIDR blocks that cover your organization's legitimate access points.
       remediation:

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -75,10 +75,21 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
       compliance/soc2-2017: soc2-control-cc6-1-4
     mql: |
-      snowflake.account.users.where(disabled == false).all(extAuthnDuo == true)
+      snowflake.account.users.where(disabled == false && hasPassword == true).all(extAuthnDuo == true)
     docs:
       desc: |
-        This check ensures that multi-factor authentication (MFA) via Duo is enabled for all active Snowflake users. MFA adds a critical layer of security beyond passwords, significantly reducing the risk of account compromise.
+        This check ensures that every active user who can sign in with a password has Duo multi-factor authentication enrolled. MFA adds a critical layer of security beyond passwords, significantly reducing the risk of account compromise.
+
+        **Scope of this check**
+
+        The check evaluates `disabled == false && hasPassword == true`. It deliberately excludes users that have no password set — service users using key-pair authentication or OAuth cannot enroll in Duo and would otherwise produce false positives.
+
+        The check looks at the `extAuthnDuo` flag (Duo enrollment). It does *not* yet detect TOTP or SAML-based MFA enforced via an authentication policy. If your account uses authentication policies for MFA enforcement instead of (or in addition to) Duo, also confirm an MFA-required policy is attached account-wide:
+
+        ```sql
+        SHOW PARAMETERS LIKE 'AUTHENTICATION_POLICY' IN ACCOUNT;
+        DESC AUTHENTICATION POLICY <policy_name>;
+        ```
 
         **Why this matters**
 
@@ -90,9 +101,9 @@ queries:
         Snowflake has been the target of high-profile attacks where stolen credentials were used to access customer data. MFA would have prevented many of these breaches.
 
         Risk mitigation
-          •  Enable Duo MFA for all active users.
+          •  Enroll Duo MFA for every user who can authenticate with a password — or attach an authentication policy that requires MFA at the account level.
           •  Prioritize MFA for users with ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN roles.
-          •  Consider using key-pair authentication for service accounts.
+          •  Use key-pair authentication or OAuth for service users instead of passwords.
           •  Regularly audit MFA enrollment status.
       remediation:
         - id: console
@@ -428,10 +439,12 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
     mql: |
-      snowflake.account.networkPolicies.length > 0
+      snowflake.account.parameters.where(key == "NETWORK_POLICY").any(value != "")
     docs:
       desc: |
-        This check ensures that at least one network policy is configured in the Snowflake account. Network policies restrict which IP addresses or network ranges can connect to Snowflake, providing network-level access control.
+        This check ensures that a network policy is *attached* to the Snowflake account. Network policies restrict which IP addresses or network ranges can connect to Snowflake, providing network-level access control.
+
+        Snowflake's `SHOW PARAMETERS LIKE 'NETWORK_POLICY' IN ACCOUNT` returns the name of the policy currently bound at the account level. The check looks at this parameter rather than just whether any policy is defined — an account can have several `CREATE NETWORK POLICY` definitions sitting unattached, in which case no IP gating is enforced at all.
 
         **Why this matters**
 
@@ -507,7 +520,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
     mql: |
-      snowflake.account.networkPolicies.none(allowedIpList.contains("0.0.0.0/0"))
+      snowflake.account.networkPolicies.none(allowedIpList.contains("0.0.0.0/0") || allowedIpList.contains("::/0"))
     docs:
       desc: |
         This check ensures that no network policies contain 0.0.0.0/0 in their allowed IP list, which would permit access from any IP address and effectively nullify the network policy.
@@ -529,7 +542,7 @@ queries:
             **Using Snowsight**
 
             1. In Snowsight, go to **Admin** → **Security** → **Network Policies**.
-            2. Open the policy whose **Allowed IPs** include `0.0.0.0/0`.
+            2. Open the policy whose **Allowed IPs** include `0.0.0.0/0` (or the IPv6 wildcard `::/0`).
             3. Replace `0.0.0.0/0` with the specific CIDR ranges your organization actually uses (office, VPN, data-center egress).
             4. Save the policy.
         - id: sql
@@ -543,7 +556,7 @@ queries:
                 DESC NETWORK POLICY <policy_name>;
                 ```
 
-            2. Replace the open `0.0.0.0/0` entry with the specific CIDR ranges your organization actually uses:
+            2. Replace the open `0.0.0.0/0` (and/or IPv6 `::/0`) entry with the specific CIDR ranges your organization actually uses:
 
                 ```sql
                 ALTER NETWORK POLICY <policy_name>

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -97,24 +97,51 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Enable MFA for a user**
+            **Enroll MFA in Snowsight (per user)**
 
-            Each Snowflake user must enroll in MFA through the Snowflake UI:
+            Each Snowflake user must enroll in MFA from their own profile.
+            Have affected users:
 
-            1. Log in to the Snowflake web interface.
-            2. Select your username in the top-left corner.
-            3. Select **Profile**.
-            4. In the **Multi-factor authentication** section, select **Enroll**.
-            5. Follow the Duo enrollment instructions.
+            1. Log in to the Snowflake web interface (Snowsight).
+            2. Select their username in the top-left corner and choose **Profile**.
+            3. In the **Multi-factor authentication** section, select **Enroll**.
+            4. Follow the Duo enrollment prompts.
+
+            Administrators can monitor enrollment from **Admin** → **Users & Roles** → **Users**, where the **MFA** column shows enrolled vs not enrolled.
         - id: sql
           desc: |
-            **Enforce MFA with a Snowflake account parameter**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            Administrators can require MFA enrollment for all users:
+            **Recommended: enforce MFA via an authentication policy**
+
+            Authentication policies are the modern way to require MFA. A Snowflake account attaches at most one authentication policy, so inspect existing policies first:
+
+            ```sql
+            SHOW AUTHENTICATION POLICIES;
+            SHOW PARAMETERS LIKE 'AUTHENTICATION_POLICY' IN ACCOUNT;
+            ```
+
+            Create (or update) a policy that requires MFA, then attach it at the account level:
+
+            ```sql
+            CREATE AUTHENTICATION POLICY IF NOT EXISTS require_mfa_policy
+              AUTHENTICATION_METHODS     = ('PASSWORD', 'SAML')
+              MFA_AUTHENTICATION_METHODS = ('PASSWORD', 'SAML')
+              MFA_ENROLLMENT             = 'REQUIRED'
+              COMMENT                    = 'Require MFA enrollment on every login';
+
+            ALTER ACCOUNT SET AUTHENTICATION POLICY require_mfa_policy;
+            ```
+
+            **Legacy account parameter (still supported)**
+
+            On accounts not yet using authentication policies, the older parameter forces MFA enrollment on the next login:
 
             ```sql
             ALTER ACCOUNT SET REQUIRE_MFA = TRUE;
             ```
+
+            Note: `REQUIRE_MFA` only enforces enrollment for *new* logins — it does not retroactively log out sessions that authenticated before the change.
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-mfa
         title: Snowflake MFA documentation
@@ -150,21 +177,33 @@ queries:
           •  Ensure all ACCOUNTADMIN users have MFA enabled.
           •  Regularly review and prune ACCOUNTADMIN role assignments.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Users & Roles** → **Roles**.
+            2. Open the `ACCOUNTADMIN` role and review the **Granted to** list.
+            3. For every user that does not need full account control, remove the grant and assign a least-privilege role (for example `SYSADMIN` or `SECURITYADMIN`) instead.
+            4. Keep at least two named users with `ACCOUNTADMIN` so the account cannot be locked out if one break-glass account becomes unavailable.
         - id: sql
           desc: |
-            **Review ACCOUNTADMIN assignments**
+            Run as `ACCOUNTADMIN` (or `SECURITYADMIN`) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            SHOW GRANTS OF ROLE ACCOUNTADMIN;
-            ```
+            1. List both directions of `ACCOUNTADMIN` — who has been granted the role, and what privileges the role itself holds:
 
-            **Revoke ACCOUNTADMIN from users who don't need it**
+                ```sql
+                SHOW GRANTS OF ROLE ACCOUNTADMIN;
+                SHOW GRANTS TO ROLE ACCOUNTADMIN;
+                ```
 
-            ```sql
-            REVOKE ROLE ACCOUNTADMIN FROM USER username;
-            ```
+            2. For each user that does not need full account control, revoke `ACCOUNTADMIN` and grant a least-privilege role instead. Common day-to-day roles are `SYSADMIN` (object/warehouse management) and `SECURITYADMIN` (user and role management):
 
-            Assign more appropriate roles like SYSADMIN or SECURITYADMIN for day-to-day administration tasks.
+                ```sql
+                REVOKE ROLE ACCOUNTADMIN FROM USER <user_name>;
+                GRANT ROLE SYSADMIN TO USER <user_name>;        -- example
+                ```
+
+            3. Keep at least two named users with `ACCOUNTADMIN` so the account cannot be locked out if one break-glass account becomes unavailable.
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-access-control-overview
         title: Snowflake access control overview
@@ -199,23 +238,36 @@ queries:
           •  Set expiration policies for temporary passwords.
           •  Disable accounts that have not completed initial setup within a reasonable time frame.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Users & Roles** → **Users**.
+            2. Identify users still flagged "must change password" (also visible in the user detail page).
+            3. Notify each affected user to log in and complete their password change.
+            4. For accounts that have not logged in for an extended period, open the user and select **Disable user** instead of leaving the password change pending indefinitely.
         - id: sql
           desc: |
-            **Identify users with pending password changes**
+            Run as `ACCOUNTADMIN` or `SECURITYADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            SELECT NAME, MUST_CHANGE_PASSWORD, CREATED_ON, LAST_SUCCESS_LOGIN
-            FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-            WHERE MUST_CHANGE_PASSWORD = 'true' AND DISABLED = 'false';
-            ```
+            1. Identify the affected users — those still flagged "must change password" and not disabled:
 
-            **Notify users or disable unused accounts**
+                ```sql
+                SELECT NAME, CREATED_ON, LAST_SUCCESS_LOGIN, MUST_CHANGE_PASSWORD
+                FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+                WHERE MUST_CHANGE_PASSWORD = 'true'
+                  AND DISABLED = 'false';
+                ```
 
-            For users who have not logged in:
+                `ACCOUNT_USAGE` views can lag the live state by up to ~3 hours. For an authoritative snapshot, run `SHOW USERS;` and inspect the `must_change_password` column.
 
-            ```sql
-            ALTER USER username SET DISABLED = TRUE;
-            ```
+            2. Ask each affected user to log in and complete their password change. For accounts that have not logged in for an extended period, disable them instead:
+
+                ```sql
+                ALTER USER <user_name> SET DISABLED = TRUE;
+                ```
+
+            3. After a rotation cycle, re-run the query in step 1 — the result should be empty.
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-user
         title: Snowflake user management documentation
@@ -250,20 +302,40 @@ queries:
           •  Encourage use of passphrases for easier memorization of long passwords.
           •  Combine password length requirements with MFA for defense-in-depth.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Password Policies**.
+            2. If a policy is already attached to the account, open it; otherwise click **+ Password Policy** and create one.
+            3. Set **Minimum length** to at least `14`.
+            4. Save the policy and confirm it is attached at the account level.
         - id: sql
           desc: |
-            **Create or update a password policy**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE OR REPLACE PASSWORD POLICY my_password_policy
-              PASSWORD_MIN_LENGTH = 14;
-            ```
+            > **Important:** A Snowflake account attaches **at most one** password policy. Prefer `ALTER PASSWORD POLICY` on the existing policy. Do not blindly `CREATE OR REPLACE` — that will overwrite settings other policy checks may have already configured.
 
-            **Apply the password policy to the account**
+            1. Find the policy currently attached to the account:
 
-            ```sql
-            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-            ```
+                ```sql
+                SHOW PASSWORD POLICIES;
+                SHOW PARAMETERS LIKE 'PASSWORD_POLICY' IN ACCOUNT;
+                ```
+
+            2. Update the existing policy:
+
+                ```sql
+                ALTER PASSWORD POLICY <policy_name> SET PASSWORD_MIN_LENGTH = 14;
+                ```
+
+            3. If no policy is attached yet, create one and attach it. Subsequent password-policy checks should `ALTER` this same policy:
+
+                ```sql
+                CREATE PASSWORD POLICY IF NOT EXISTS <policy_name>
+                  PASSWORD_MIN_LENGTH = 14;
+                ALTER ACCOUNT SET PASSWORD POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -303,21 +375,43 @@ queries:
           •  Monitor lockout events for signs of attack.
           •  Combine lockout with MFA for defense-in-depth.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Password Policies**.
+            2. If a policy is already attached to the account, open it; otherwise click **+ Password Policy** and create one.
+            3. Set **Maximum retries** (e.g. `5`) and **Lockout time** (e.g. `15` minutes).
+            4. Save the policy and confirm it is attached at the account level.
         - id: sql
           desc: |
-            **Create or update a password policy**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE OR REPLACE PASSWORD POLICY my_password_policy
-              PASSWORD_MAX_RETRIES = 5
-              PASSWORD_LOCKOUT_TIME_MINS = 15;
-            ```
+            > **Important:** A Snowflake account attaches **at most one** password policy. Prefer `ALTER PASSWORD POLICY` on the existing policy. Do not blindly `CREATE OR REPLACE` — that will overwrite settings other policy checks may have already configured.
 
-            **Apply the password policy to the account**
+            1. Find the policy currently attached to the account:
 
-            ```sql
-            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-            ```
+                ```sql
+                SHOW PASSWORD POLICIES;
+                SHOW PARAMETERS LIKE 'PASSWORD_POLICY' IN ACCOUNT;
+                ```
+
+            2. Update the existing policy:
+
+                ```sql
+                ALTER PASSWORD POLICY <policy_name> SET
+                  PASSWORD_MAX_RETRIES       = 5,
+                  PASSWORD_LOCKOUT_TIME_MINS = 15;
+                ```
+
+            3. If no policy is attached yet, create one and attach it. Subsequent password-policy checks should `ALTER` this same policy:
+
+                ```sql
+                CREATE PASSWORD POLICY IF NOT EXISTS <policy_name>
+                  PASSWORD_MAX_RETRIES       = 5
+                  PASSWORD_LOCKOUT_TIME_MINS = 15;
+                ALTER ACCOUNT SET PASSWORD POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -357,21 +451,46 @@ queries:
           •  Use network rules for more granular control.
           •  Regularly review and update IP allowlists as network infrastructure changes.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Network Policies**.
+            2. Click **+ Network Policy**, give it a name, and add **Allowed IP addresses** (CIDR ranges representing your office, VPN, or data center egress).
+            3. Save the policy.
+            4. Open **Account Details** (top-right user menu) → **Network policy** and select the policy you just created so it is enforced account-wide.
         - id: sql
           desc: |
-            **Create a network policy**
+            Run as `ACCOUNTADMIN` (or `SECURITYADMIN`) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE NETWORK POLICY my_network_policy
-              ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8')
-              BLOCKED_IP_LIST = ();
-            ```
+            > **Important:** A Snowflake account attaches **at most one** network policy at a time. If one is already attached, prefer `ALTER NETWORK POLICY` on it (see the unrestricted-access check) instead of creating a new one.
 
-            **Apply the network policy to the account**
+            1. Inspect existing network policies and what is attached:
 
-            ```sql
-            ALTER ACCOUNT SET NETWORK_POLICY = my_network_policy;
-            ```
+                ```sql
+                SHOW NETWORK POLICIES;
+                SHOW PARAMETERS LIKE 'NETWORK_POLICY' IN ACCOUNT;
+                ```
+
+            2. Create the policy with the CIDR ranges your organization actually uses (replace the example ranges):
+
+                ```sql
+                CREATE NETWORK POLICY <policy_name>
+                  ALLOWED_IP_LIST = ('203.0.113.0/24', '198.51.100.0/24')
+                  BLOCKED_IP_LIST = ();
+                ```
+
+            3. Attach it to the account:
+
+                ```sql
+                ALTER ACCOUNT SET NETWORK_POLICY = <policy_name>;
+                ```
+
+            4. Verify the policy is attached and contains the expected ranges:
+
+                ```sql
+                DESC NETWORK POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/network-policies
         title: Snowflake network policy documentation
@@ -405,16 +524,37 @@ queries:
           •  Audit network policies regularly for overly permissive entries.
           •  Use the smallest CIDR blocks that cover your organization's legitimate access points.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Network Policies**.
+            2. Open the policy whose **Allowed IPs** include `0.0.0.0/0`.
+            3. Replace `0.0.0.0/0` with the specific CIDR ranges your organization actually uses (office, VPN, data-center egress).
+            4. Save the policy.
         - id: sql
           desc: |
-            **Update the network policy to restrict access**
+            Run as `ACCOUNTADMIN` (or `SECURITYADMIN`) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            ALTER NETWORK POLICY my_network_policy
-              SET ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8');
-            ```
+            1. Find the offending policy and read its current IP list:
 
-            Replace the IP ranges above with the specific CIDR blocks used by your organization.
+                ```sql
+                SHOW NETWORK POLICIES;
+                DESC NETWORK POLICY <policy_name>;
+                ```
+
+            2. Replace the open `0.0.0.0/0` entry with the specific CIDR ranges your organization actually uses:
+
+                ```sql
+                ALTER NETWORK POLICY <policy_name>
+                  SET ALLOWED_IP_LIST = ('203.0.113.0/24', '198.51.100.0/24');
+                ```
+
+            3. Verify the change:
+
+                ```sql
+                DESC NETWORK POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/network-policies
         title: Snowflake network policy documentation
@@ -450,21 +590,34 @@ queries:
           •  Assign SYSADMIN, SECURITYADMIN, or custom roles as defaults.
           •  Regularly audit user default role assignments.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Users & Roles** → **Users**.
+            2. Filter or sort the user list by **Default role** and find users whose default role is `ACCOUNTADMIN`.
+            3. Open each user, change **Default role** to a least-privilege role (for example `SYSADMIN` or a project-specific role), and save.
+            4. Users can still `USE ROLE ACCOUNTADMIN` when explicit elevation is needed; this only changes which role is active at login.
         - id: sql
           desc: |
-            **Change a user's default role**
+            Run as `ACCOUNTADMIN` or `SECURITYADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            ALTER USER username SET DEFAULT_ROLE = SYSADMIN;
-            ```
+            1. Identify users whose default role is `ACCOUNTADMIN`:
 
-            **Identify users with ACCOUNTADMIN as default role**
+                ```sql
+                SELECT NAME, DEFAULT_ROLE
+                FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+                WHERE DEFAULT_ROLE = 'ACCOUNTADMIN'
+                  AND DISABLED = 'false';
+                ```
 
-            ```sql
-            SELECT NAME, DEFAULT_ROLE
-            FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-            WHERE DEFAULT_ROLE = 'ACCOUNTADMIN' AND DISABLED = 'false';
-            ```
+            2. For each affected user, change their default role to the least-privilege role they need day-to-day (`SYSADMIN`, `SECURITYADMIN`, or a custom role):
+
+                ```sql
+                ALTER USER <user_name> SET DEFAULT_ROLE = SYSADMIN;
+                ```
+
+            3. The user can still `USE ROLE ACCOUNTADMIN` when explicit elevation is needed; this only changes which role is active at login.
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-access-control-overview
         title: Snowflake access control best practices
@@ -498,23 +651,47 @@ queries:
           •  Combine complexity requirements with minimum length requirements for maximum protection.
           •  Use MFA as an additional layer of protection.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Password Policies**.
+            2. If a policy is already attached to the account, open it; otherwise click **+ Password Policy** and create one.
+            3. Set each character-class minimum to at least `1`: **Min upper case**, **Min lower case**, **Min numeric**, **Min special**.
+            4. Save the policy and confirm it is attached at the account level.
         - id: sql
           desc: |
-            **Create or update a password policy**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE OR REPLACE PASSWORD POLICY my_password_policy
-              PASSWORD_MIN_UPPER_CASE_CHARS = 1
-              PASSWORD_MIN_LOWER_CASE_CHARS = 1
-              PASSWORD_MIN_NUMERIC_CHARS = 1
-              PASSWORD_MIN_SPECIAL_CHARS = 1;
-            ```
+            > **Important:** A Snowflake account attaches **at most one** password policy. Prefer `ALTER PASSWORD POLICY` on the existing policy. Do not blindly `CREATE OR REPLACE` — that will overwrite settings other policy checks may have already configured.
 
-            **Apply the password policy to the account**
+            1. Find the policy currently attached to the account:
 
-            ```sql
-            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-            ```
+                ```sql
+                SHOW PASSWORD POLICIES;
+                SHOW PARAMETERS LIKE 'PASSWORD_POLICY' IN ACCOUNT;
+                ```
+
+            2. Update the existing policy:
+
+                ```sql
+                ALTER PASSWORD POLICY <policy_name> SET
+                  PASSWORD_MIN_UPPER_CASE_CHARS = 1,
+                  PASSWORD_MIN_LOWER_CASE_CHARS = 1,
+                  PASSWORD_MIN_NUMERIC_CHARS    = 1,
+                  PASSWORD_MIN_SPECIAL_CHARS    = 1;
+                ```
+
+            3. If no policy is attached yet, create one and attach it. Subsequent password-policy checks should `ALTER` this same policy:
+
+                ```sql
+                CREATE PASSWORD POLICY IF NOT EXISTS <policy_name>
+                  PASSWORD_MIN_UPPER_CASE_CHARS = 1
+                  PASSWORD_MIN_LOWER_CASE_CHARS = 1
+                  PASSWORD_MIN_NUMERIC_CHARS    = 1
+                  PASSWORD_MIN_SPECIAL_CHARS    = 1;
+                ALTER ACCOUNT SET PASSWORD POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -549,20 +726,40 @@ queries:
           •  Notify users in advance of upcoming password expiration.
           •  Monitor for users who have not rotated passwords on schedule.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Password Policies**.
+            2. If a policy is already attached to the account, open it; otherwise click **+ Password Policy** and create one.
+            3. Set **Max age (days)** to a value appropriate for your environment (commonly `90`).
+            4. Save the policy and confirm it is attached at the account level.
         - id: sql
           desc: |
-            **Create or update a password policy**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE OR REPLACE PASSWORD POLICY my_password_policy
-              PASSWORD_MAX_AGE_DAYS = 90;
-            ```
+            > **Important:** A Snowflake account attaches **at most one** password policy. Prefer `ALTER PASSWORD POLICY` on the existing policy. Do not blindly `CREATE OR REPLACE` — that will overwrite settings other policy checks may have already configured.
 
-            **Apply the password policy to the account**
+            1. Find the policy currently attached to the account:
 
-            ```sql
-            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-            ```
+                ```sql
+                SHOW PASSWORD POLICIES;
+                SHOW PARAMETERS LIKE 'PASSWORD_POLICY' IN ACCOUNT;
+                ```
+
+            2. Update the existing policy:
+
+                ```sql
+                ALTER PASSWORD POLICY <policy_name> SET PASSWORD_MAX_AGE_DAYS = 90;
+                ```
+
+            3. If no policy is attached yet, create one and attach it. Subsequent password-policy checks should `ALTER` this same policy:
+
+                ```sql
+                CREATE PASSWORD POLICY IF NOT EXISTS <policy_name>
+                  PASSWORD_MAX_AGE_DAYS = 90;
+                ALTER ACCOUNT SET PASSWORD POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -596,20 +793,40 @@ queries:
           •  Combine password history with maximum age and complexity requirements.
           •  Educate users about the importance of using unique passwords.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Admin** → **Security** → **Password Policies**.
+            2. If a policy is already attached to the account, open it; otherwise click **+ Password Policy** and create one.
+            3. Set **Password history** to at least `5`.
+            4. Save the policy and confirm it is attached at the account level.
         - id: sql
           desc: |
-            **Create or update a password policy**
+            Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            CREATE OR REPLACE PASSWORD POLICY my_password_policy
-              PASSWORD_HISTORY = 5;
-            ```
+            > **Important:** A Snowflake account attaches **at most one** password policy. Prefer `ALTER PASSWORD POLICY` on the existing policy. Do not blindly `CREATE OR REPLACE` — that will overwrite settings other policy checks may have already configured.
 
-            **Apply the password policy to the account**
+            1. Find the policy currently attached to the account:
 
-            ```sql
-            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-            ```
+                ```sql
+                SHOW PASSWORD POLICIES;
+                SHOW PARAMETERS LIKE 'PASSWORD_POLICY' IN ACCOUNT;
+                ```
+
+            2. Update the existing policy:
+
+                ```sql
+                ALTER PASSWORD POLICY <policy_name> SET PASSWORD_HISTORY = 5;
+                ```
+
+            3. If no policy is attached yet, create one and attach it. Subsequent password-policy checks should `ALTER` this same policy:
+
+                ```sql
+                CREATE PASSWORD POLICY IF NOT EXISTS <policy_name>
+                  PASSWORD_HISTORY = 5;
+                ALTER ACCOUNT SET PASSWORD POLICY <policy_name>;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -649,19 +866,41 @@ queries:
           •  Use longer retention periods (up to 90 days with Enterprise edition) for critical data.
           •  Monitor databases with zero retention time and remediate promptly.
       remediation:
+        - id: console
+          desc: |
+            **Using Snowsight**
+
+            1. In Snowsight, go to **Data** → **Databases** and open the affected database.
+            2. Click the gear icon and select **Edit**.
+            3. Set **Time Travel retention (days)** to a value appropriate for your restore objectives. `1` is the minimum on Standard accounts; Enterprise and above support up to `90`. Most production workloads use `7` or higher.
+            4. Save.
         - id: sql
           desc: |
-            **Set retention time for a database**
+            Run as `ACCOUNTADMIN` (or the database owner) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
 
-            ```sql
-            ALTER DATABASE my_database SET DATA_RETENTION_TIME_IN_DAYS = 1;
-            ```
+            `1` is the minimum on Standard accounts; Enterprise and above support up to `90`. Production workloads typically want `7` or higher to give incident response a useful restore window.
 
-            **Set default retention for new databases at the account level**
+            1. Find databases below the desired retention threshold:
 
-            ```sql
-            ALTER ACCOUNT SET DATA_RETENTION_TIME_IN_DAYS = 1;
-            ```
+                ```sql
+                SHOW DATABASES;
+                SELECT DATABASE_NAME, RETENTION_TIME
+                FROM SNOWFLAKE.ACCOUNT_USAGE.DATABASES
+                WHERE DELETED IS NULL
+                  AND RETENTION_TIME < 1;
+                ```
+
+            2. Raise retention on each affected database:
+
+                ```sql
+                ALTER DATABASE <database_name> SET DATA_RETENTION_TIME_IN_DAYS = 7;
+                ```
+
+            3. Raise the account-level default so newly created databases inherit the safer value:
+
+                ```sql
+                ALTER ACCOUNT SET DATA_RETENTION_TIME_IN_DAYS = 7;
+                ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/data-time-travel
         title: Snowflake Time Travel documentation

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-snowflake-security
     name: Mondoo Snowflake Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -94,24 +94,27 @@ queries:
           •  Prioritize MFA for users with ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN roles.
           •  Consider using key-pair authentication for service accounts.
           •  Regularly audit MFA enrollment status.
-      remediation: |
-        **Enable MFA for a user**
+      remediation:
+        - id: console
+          desc: |
+            **Enable MFA for a user**
 
-        Each Snowflake user must enroll in MFA through the Snowflake UI:
+            Each Snowflake user must enroll in MFA through the Snowflake UI:
 
-        1. Log in to the Snowflake web interface.
-        2. Select your username in the top-left corner.
-        3. Select **Profile**.
-        4. In the **Multi-factor authentication** section, select **Enroll**.
-        5. Follow the Duo enrollment instructions.
+            1. Log in to the Snowflake web interface.
+            2. Select your username in the top-left corner.
+            3. Select **Profile**.
+            4. In the **Multi-factor authentication** section, select **Enroll**.
+            5. Follow the Duo enrollment instructions.
+        - id: sql
+          desc: |
+            **Enforce MFA with a Snowflake account parameter**
 
-        **Enforce MFA with a Snowflake account parameter**
+            Administrators can require MFA enrollment for all users:
 
-        Administrators can require MFA enrollment for all users:
-
-        ```sql
-        ALTER ACCOUNT SET REQUIRE_MFA = TRUE;
-        ```
+            ```sql
+            ALTER ACCOUNT SET REQUIRE_MFA = TRUE;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-mfa
         title: Snowflake MFA documentation
@@ -146,20 +149,22 @@ queries:
           •  Use SECURITYADMIN and SYSADMIN for day-to-day administration.
           •  Ensure all ACCOUNTADMIN users have MFA enabled.
           •  Regularly review and prune ACCOUNTADMIN role assignments.
-      remediation: |
-        **Review ACCOUNTADMIN assignments**
+      remediation:
+        - id: sql
+          desc: |
+            **Review ACCOUNTADMIN assignments**
 
-        ```sql
-        SHOW GRANTS OF ROLE ACCOUNTADMIN;
-        ```
+            ```sql
+            SHOW GRANTS OF ROLE ACCOUNTADMIN;
+            ```
 
-        **Revoke ACCOUNTADMIN from users who don't need it**
+            **Revoke ACCOUNTADMIN from users who don't need it**
 
-        ```sql
-        REVOKE ROLE ACCOUNTADMIN FROM USER username;
-        ```
+            ```sql
+            REVOKE ROLE ACCOUNTADMIN FROM USER username;
+            ```
 
-        Assign more appropriate roles like SYSADMIN or SECURITYADMIN for day-to-day administration tasks.
+            Assign more appropriate roles like SYSADMIN or SECURITYADMIN for day-to-day administration tasks.
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-access-control-overview
         title: Snowflake access control overview
@@ -193,22 +198,24 @@ queries:
           •  Follow up with users who have not changed their initial passwords.
           •  Set expiration policies for temporary passwords.
           •  Disable accounts that have not completed initial setup within a reasonable time frame.
-      remediation: |
-        **Identify users with pending password changes**
+      remediation:
+        - id: sql
+          desc: |
+            **Identify users with pending password changes**
 
-        ```sql
-        SELECT NAME, MUST_CHANGE_PASSWORD, CREATED_ON, LAST_SUCCESS_LOGIN
-        FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-        WHERE MUST_CHANGE_PASSWORD = 'true' AND DISABLED = 'false';
-        ```
+            ```sql
+            SELECT NAME, MUST_CHANGE_PASSWORD, CREATED_ON, LAST_SUCCESS_LOGIN
+            FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+            WHERE MUST_CHANGE_PASSWORD = 'true' AND DISABLED = 'false';
+            ```
 
-        **Notify users or disable unused accounts**
+            **Notify users or disable unused accounts**
 
-        For users who have not logged in:
+            For users who have not logged in:
 
-        ```sql
-        ALTER USER username SET DISABLED = TRUE;
-        ```
+            ```sql
+            ALTER USER username SET DISABLED = TRUE;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-user
         title: Snowflake user management documentation
@@ -242,19 +249,21 @@ queries:
           •  Set minimum password length to 14 or more characters in all password policies.
           •  Encourage use of passphrases for easier memorization of long passwords.
           •  Combine password length requirements with MFA for defense-in-depth.
-      remediation: |
-        **Create or update a password policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create or update a password policy**
 
-        ```sql
-        CREATE OR REPLACE PASSWORD POLICY my_password_policy
-          PASSWORD_MIN_LENGTH = 14;
-        ```
+            ```sql
+            CREATE OR REPLACE PASSWORD POLICY my_password_policy
+              PASSWORD_MIN_LENGTH = 14;
+            ```
 
-        **Apply the password policy to the account**
+            **Apply the password policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -293,20 +302,22 @@ queries:
           •  Set reasonable lockout duration (e.g., 15-30 minutes).
           •  Monitor lockout events for signs of attack.
           •  Combine lockout with MFA for defense-in-depth.
-      remediation: |
-        **Create or update a password policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create or update a password policy**
 
-        ```sql
-        CREATE OR REPLACE PASSWORD POLICY my_password_policy
-          PASSWORD_MAX_RETRIES = 5
-          PASSWORD_LOCKOUT_TIME_MINS = 15;
-        ```
+            ```sql
+            CREATE OR REPLACE PASSWORD POLICY my_password_policy
+              PASSWORD_MAX_RETRIES = 5
+              PASSWORD_LOCKOUT_TIME_MINS = 15;
+            ```
 
-        **Apply the password policy to the account**
+            **Apply the password policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -345,20 +356,22 @@ queries:
           •  Apply network policies at the account level for broad protection.
           •  Use network rules for more granular control.
           •  Regularly review and update IP allowlists as network infrastructure changes.
-      remediation: |
-        **Create a network policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create a network policy**
 
-        ```sql
-        CREATE NETWORK POLICY my_network_policy
-          ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8')
-          BLOCKED_IP_LIST = ();
-        ```
+            ```sql
+            CREATE NETWORK POLICY my_network_policy
+              ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8')
+              BLOCKED_IP_LIST = ();
+            ```
 
-        **Apply the network policy to the account**
+            **Apply the network policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET NETWORK_POLICY = my_network_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET NETWORK_POLICY = my_network_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/network-policies
         title: Snowflake network policy documentation
@@ -391,15 +404,17 @@ queries:
           •  Replace 0.0.0.0/0 entries with specific trusted IP ranges.
           •  Audit network policies regularly for overly permissive entries.
           •  Use the smallest CIDR blocks that cover your organization's legitimate access points.
-      remediation: |
-        **Update the network policy to restrict access**
+      remediation:
+        - id: sql
+          desc: |
+            **Update the network policy to restrict access**
 
-        ```sql
-        ALTER NETWORK POLICY my_network_policy
-          SET ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8');
-        ```
+            ```sql
+            ALTER NETWORK POLICY my_network_policy
+              SET ALLOWED_IP_LIST = ('192.168.1.0/24', '10.0.0.0/8');
+            ```
 
-        Replace the IP ranges above with the specific CIDR blocks used by your organization.
+            Replace the IP ranges above with the specific CIDR blocks used by your organization.
     refs:
       - url: https://docs.snowflake.com/en/user-guide/network-policies
         title: Snowflake network policy documentation
@@ -434,20 +449,22 @@ queries:
           •  Use ACCOUNTADMIN only when explicitly required by switching roles.
           •  Assign SYSADMIN, SECURITYADMIN, or custom roles as defaults.
           •  Regularly audit user default role assignments.
-      remediation: |
-        **Change a user's default role**
+      remediation:
+        - id: sql
+          desc: |
+            **Change a user's default role**
 
-        ```sql
-        ALTER USER username SET DEFAULT_ROLE = SYSADMIN;
-        ```
+            ```sql
+            ALTER USER username SET DEFAULT_ROLE = SYSADMIN;
+            ```
 
-        **Identify users with ACCOUNTADMIN as default role**
+            **Identify users with ACCOUNTADMIN as default role**
 
-        ```sql
-        SELECT NAME, DEFAULT_ROLE
-        FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-        WHERE DEFAULT_ROLE = 'ACCOUNTADMIN' AND DISABLED = 'false';
-        ```
+            ```sql
+            SELECT NAME, DEFAULT_ROLE
+            FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+            WHERE DEFAULT_ROLE = 'ACCOUNTADMIN' AND DISABLED = 'false';
+            ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/security-access-control-overview
         title: Snowflake access control best practices
@@ -480,22 +497,24 @@ queries:
           •  Require at least one character from each category (uppercase, lowercase, numeric, special).
           •  Combine complexity requirements with minimum length requirements for maximum protection.
           •  Use MFA as an additional layer of protection.
-      remediation: |
-        **Create or update a password policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create or update a password policy**
 
-        ```sql
-        CREATE OR REPLACE PASSWORD POLICY my_password_policy
-          PASSWORD_MIN_UPPER_CASE_CHARS = 1
-          PASSWORD_MIN_LOWER_CASE_CHARS = 1
-          PASSWORD_MIN_NUMERIC_CHARS = 1
-          PASSWORD_MIN_SPECIAL_CHARS = 1;
-        ```
+            ```sql
+            CREATE OR REPLACE PASSWORD POLICY my_password_policy
+              PASSWORD_MIN_UPPER_CASE_CHARS = 1
+              PASSWORD_MIN_LOWER_CASE_CHARS = 1
+              PASSWORD_MIN_NUMERIC_CHARS = 1
+              PASSWORD_MIN_SPECIAL_CHARS = 1;
+            ```
 
-        **Apply the password policy to the account**
+            **Apply the password policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -529,19 +548,21 @@ queries:
           •  Combine password rotation with MFA for defense-in-depth.
           •  Notify users in advance of upcoming password expiration.
           •  Monitor for users who have not rotated passwords on schedule.
-      remediation: |
-        **Create or update a password policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create or update a password policy**
 
-        ```sql
-        CREATE OR REPLACE PASSWORD POLICY my_password_policy
-          PASSWORD_MAX_AGE_DAYS = 90;
-        ```
+            ```sql
+            CREATE OR REPLACE PASSWORD POLICY my_password_policy
+              PASSWORD_MAX_AGE_DAYS = 90;
+            ```
 
-        **Apply the password policy to the account**
+            **Apply the password policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -574,19 +595,21 @@ queries:
           •  Set password history to at least 5 previous passwords.
           •  Combine password history with maximum age and complexity requirements.
           •  Educate users about the importance of using unique passwords.
-      remediation: |
-        **Create or update a password policy**
+      remediation:
+        - id: sql
+          desc: |
+            **Create or update a password policy**
 
-        ```sql
-        CREATE OR REPLACE PASSWORD POLICY my_password_policy
-          PASSWORD_HISTORY = 5;
-        ```
+            ```sql
+            CREATE OR REPLACE PASSWORD POLICY my_password_policy
+              PASSWORD_HISTORY = 5;
+            ```
 
-        **Apply the password policy to the account**
+            **Apply the password policy to the account**
 
-        ```sql
-        ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
-        ```
+            ```sql
+            ALTER ACCOUNT SET PASSWORD POLICY my_password_policy;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy
         title: Snowflake password policy documentation
@@ -625,18 +648,20 @@ queries:
           •  Set retention time to at least 1 day for all databases.
           •  Use longer retention periods (up to 90 days with Enterprise edition) for critical data.
           •  Monitor databases with zero retention time and remediate promptly.
-      remediation: |
-        **Set retention time for a database**
+      remediation:
+        - id: sql
+          desc: |
+            **Set retention time for a database**
 
-        ```sql
-        ALTER DATABASE my_database SET DATA_RETENTION_TIME_IN_DAYS = 1;
-        ```
+            ```sql
+            ALTER DATABASE my_database SET DATA_RETENTION_TIME_IN_DAYS = 1;
+            ```
 
-        **Set default retention for new databases at the account level**
+            **Set default retention for new databases at the account level**
 
-        ```sql
-        ALTER ACCOUNT SET DATA_RETENTION_TIME_IN_DAYS = 1;
-        ```
+            ```sql
+            ALTER ACCOUNT SET DATA_RETENTION_TIME_IN_DAYS = 1;
+            ```
     refs:
       - url: https://docs.snowflake.com/en/user-guide/data-time-travel
         title: Snowflake Time Travel documentation

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-snowflake-security
     name: Mondoo Snowflake Security
-    version: 1.0.1
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## Summary

Three commits, scoped to `content/mondoo-snowflake-security.mql.yaml`:

1. **Restructure remediations into `console` / `sql`.** Splits each unstructured `remediation: |` string into a structured list with `id: console` and/or `id: sql` based on the actual steps. The MFA check gets both ids (per-user enrollment is a UI flow; account-wide enforcement is SQL); the other 11 checks are SQL-only.
2. **Bring every remediation up to a uniform, runnable level.** See **Remediation rewrite** below.
3. **Fix three correctness issues in the MQL itself.** See **MQL correctness fixes** below.

Bumps policy `version: 1.0.0 → 1.1.0` (minor — substantive remediation rewrite + MQL bug fixes).

## Remediation rewrite

The motivating problem was that the five password-policy checks each said `CREATE OR REPLACE PASSWORD POLICY my_password_policy ...` with a different parameter — run literally, the second one would overwrite the first, and a Snowflake account attaches at most one password policy anyway. Same shape for network policies.

Applied uniformly:

- **Discovery first.** Every block opens with the relevant `SHOW`/`DESCRIBE`/`SELECT` so the operator inspects state before mutating anything.
- **Don't clobber single-policy resources.** Password-policy and network-policy remediations now prefer `ALTER ... SET ...` against the existing policy. The `CREATE` path is kept as a fallback for the case where no policy is attached yet, with a clear note that subsequent checks must `ALTER` the same policy.
- **Modernize MFA.** The MFA remediation now leads with the modern authentication-policy approach (`CREATE AUTHENTICATION POLICY ... MFA_ENROLLMENT = 'REQUIRED'`) and keeps the legacy `REQUIRE_MFA` account parameter as a fallback. Adds the caveat that `REQUIRE_MFA` only enforces enrollment for *new* logins.
- **Required role + where to run.** Each `id: sql` block states the role required (`ACCOUNTADMIN`, `SECURITYADMIN`, or the database owner) and that it can run in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
- **Snowsight console paths added** where they exist: password policies (Admin → Security → Password Policies), network policies (Admin → Security → Network Policies), default-role changes (Admin → Users & Roles → Users), Time Travel retention (Data → Databases), pending-password-change users, and ACCOUNTADMIN role review.
- **Consistent placeholders.** `<user_name>`, `<policy_name>`, `<database_name>`, and example CIDRs `203.0.113.0/24` / `198.51.100.0/24` replace the previous mix of `username`, `my_password_policy`, `my_database`, and the misleading-as-prod `192.168.1.0/24`/`10.0.0.0/8` examples.
- **Light corrections.** Time Travel retention now recommends `7` (not the bare `1` minimum) for production workloads. ACCOUNTADMIN review adds `SHOW GRANTS TO ROLE ACCOUNTADMIN` alongside `SHOW GRANTS OF` so operators audit both sub-grants and assignments.

## MQL correctness fixes

| fix | before | after |
|---|---|---|
| MFA scope (no false positives on service users) | `users.where(disabled == false).all(extAuthnDuo == true)` | `users.where(disabled == false && hasPassword == true).all(extAuthnDuo == true)` |
| Network policy actually attached, not just defined | `networkPolicies.length > 0` | `parameters.where(key == "NETWORK_POLICY").any(value != "")` |
| Reject IPv6 wildcard too | `none(allowedIpList.contains("0.0.0.0/0"))` | `none(allowedIpList.contains("0.0.0.0/0") \|\| allowedIpList.contains("::/0"))` |

The MFA-scope fix removes a class of false positives: service users using key-pair authentication or OAuth have no password and cannot enroll in Duo; under the old MQL they'd be flagged as findings. Description text now also explains that the check covers Duo specifically and that accounts using authentication policies with TOTP/SAML MFA should additionally verify `SHOW PARAMETERS LIKE 'AUTHENTICATION_POLICY' IN ACCOUNT` resolves to a policy with `MFA_ENROLLMENT = 'REQUIRED'`.

The network-policy-attached fix closes a hole where an account could have several orphaned `CREATE NETWORK POLICY` definitions sitting unattached and pass the check while no IP gating was actually enforced. Reading the account-level `NETWORK_POLICY` parameter mirrors Snowflake's `SHOW PARAMETERS LIKE 'NETWORK_POLICY' IN ACCOUNT`.

The IPv6 wildcard fix matches Snowflake's `ALLOWED_IP_LIST` semantics, which accept both IPv4 and IPv6 CIDRs.

## Test plan
- [x] `cnspec policy lint content/mondoo-snowflake-security.mql.yaml` → valid policy bundle(s)
- [x] `inspect-policies.py` reports every check now carries a structured `console` / `sql` remediation (no `unstructured` entries)
- [ ] Spot-check rendered remediation Markdown in the UI for the MFA check (both ids), one password-policy check, and the network-policy check
- [ ] Run `cnspec scan snowflake` against a test account that has (a) a service user using key-pair auth and (b) several unattached network policies, and confirm the MFA and network-policy-attached checks behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)