### PR TITLE
:sparkles: Add Okta Terraform variants for 5 previously-deferred checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -640,6 +640,7 @@ vty
 vzdump
 wafv
 wazuh
+webauthn
 webfilter
 webroot
 webui

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -480,7 +480,6 @@ rebrands
 Redir
 rediraccept
 reissuance
-rejectattr
 remoteadministrator
 removexattr
 renameat
@@ -553,7 +552,6 @@ solr
 sourcegraph
 sourceroute
 spdx
-splitlines
 spo
 SProtection
 sqladmin
@@ -642,7 +640,6 @@ wafv
 wazuh
 webauthn
 webfilter
-webroot
 webui
 widescale
 WIFI

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -723,8 +723,8 @@ queries:
   - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
-      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_idle'] == /var/ || arguments['session_idle'] <= 120 )
-      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_lifetime'] == /var/ || arguments['session_lifetime'] <= 1440 )
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_idle'] == /^var\./ || arguments['session_idle'] <= 120 )
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_lifetime'] == /^var\./ || arguments['session_lifetime'] <= 1440 )
   - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
@@ -2819,7 +2819,7 @@ queries:
   - uid: mondoo-okta-security-signon-requires-mfa-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
-      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['mfa_required'] == /var/ || arguments['mfa_required'] == true || arguments['factor_required'] == true )
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['mfa_required'] == /^var\./ || arguments['mfa_required'] == true || arguments['factor_required'] == true )
   - uid: mondoo-okta-security-signon-requires-mfa-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.4.0
+    version: 2.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -625,15 +625,15 @@ queries:
   - uid: mondoo-okta-security-okta-mfa-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
-      terraform.resources.any( nameLabel == "okta_policy_mfa_default" || nameLabel == "okta_policy_factor_enrollment" )
+      terraform.resources.where( nameLabel == "okta_policy_mfa_default" ).any( arguments['okta_otp']['enroll'] == /REQUIRED/ || arguments['okta_verify']['enroll'] == /REQUIRED/ || arguments['fido_webauthn']['enroll'] == /REQUIRED/ || arguments['webauthn']['enroll'] == /REQUIRED/ || arguments['google_otp']['enroll'] == /REQUIRED/ )
   - uid: mondoo-okta-security-okta-mfa-access-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
     mql: |
-      terraform.plan.resourceChanges.any( type == "okta_policy_mfa_default" || type == "okta_policy_factor_enrollment" )
+      terraform.plan.resourceChanges.where( type == "okta_policy_mfa_default" ).any( change.after['okta_otp']['enroll'] == /REQUIRED/ || change.after['okta_verify']['enroll'] == /REQUIRED/ || change.after['fido_webauthn']['enroll'] == /REQUIRED/ || change.after['webauthn']['enroll'] == /REQUIRED/ || change.after['google_otp']['enroll'] == /REQUIRED/ )
   - uid: mondoo-okta-security-okta-mfa-access-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default|okta_policy_factor_enrollment/ )
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default/ )
     mql: |
-      terraform.state.resources.any( type == "okta_policy_mfa_default" || type == "okta_policy_factor_enrollment" )
+      terraform.state.resources.where( type == "okta_policy_mfa_default" ).any( values['okta_otp']['enroll'] == /REQUIRED/ || values['okta_verify']['enroll'] == /REQUIRED/ || values['fido_webauthn']['enroll'] == /REQUIRED/ || values['webauthn']['enroll'] == /REQUIRED/ || values['google_otp']['enroll'] == /REQUIRED/ )
   - uid: mondoo-okta-security-okta-enforce-session-lifetime
     title: Enforce a limited session lifetime for all policies
     impact: 80
@@ -720,6 +720,11 @@ queries:
     mql: |
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionIdleMinutes"] <= props.mondooOktaSecurityMaxSessionIdleMinutes ))
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionLifetimeMinutes"] <= props.mondooOktaSecurityMaxSessionLifetimeMinutes ))
+  # The HCL variant accepts a `var.something` reference for session_idle /
+  # session_lifetime as a static-analysis pass-through — the resolved value
+  # isn't known at HCL-parse time. Plan and state variants below evaluate the
+  # resolved value, so they don't need the escape hatch and intentionally
+  # omit it.
   - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
@@ -2810,12 +2815,6 @@ queries:
       okta.policies.signOn.where(status == "ACTIVE").all(
         rules.where(status == "ACTIVE" && name != "Catch-all Rule").all(actions["signon"]["requireFactor"] == true)
       )
-  # No Terraform variants: counts ORG_ADMIN role assignments across the org.
-  # Per-user `okta_user_admin_roles` HCL would only see TF-managed grants and
-  # miss assignments made via the API or Admin Console — the runtime check
-  # against the live tenant is the source of truth.
-  # No Terraform remediation: same reason — guidance limited to TF-managed
-  # users would be misleading.
   - uid: mondoo-okta-security-signon-requires-mfa-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: |
@@ -2828,6 +2827,12 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_rule_signon/ )
     mql: |
       terraform.state.resources.where( type == "okta_policy_rule_signon" ).all( values['mfa_required'] == true || values['factor_required'] == true )
+  # No Terraform variants: counts ORG_ADMIN role assignments across the org.
+  # Per-user `okta_user_admin_roles` HCL would only see TF-managed grants and
+  # miss assignments made via the API or Admin Console — the runtime check
+  # against the live tenant is the source of truth.
+  # No Terraform remediation: same reason — guidance limited to TF-managed
+  # users would be misleading.
   - uid: mondoo-okta-security-limit-org-admins
     title: Limit the number of organization admins
     impact: 80

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.0
+    version: 2.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -517,10 +517,6 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default/ )
     mql: |
       terraform.state.resources.where( type == 'okta_policy_mfa_default' ).any( values['okta_otp']['enroll'] == /REQUIRED/ )
-  # No Terraform variants: not yet implemented. `okta_policy_mfa_default` /
-  # `okta_policy_factor_enrollment` are candidate resources. Add HCL / plan /
-  # state variants and an `id: terraform` remediation in a follow-up.
-  # No Terraform remediation: rides with variants — see above.
   - uid: mondoo-okta-security-okta-mfa-access
     title: Require at least one factor in every MFA enrollment policy
     impact: 100
@@ -537,6 +533,18 @@ queries:
         tags:
           mondoo.com/filter-title: Okta Organization
           mondoo.com/filter-icon: okta
+      - uid: mondoo-okta-security-okta-mfa-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-okta-mfa-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-okta-mfa-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         Enabling at least one required factor for your org ensures that end users assigned to a given policy are enrolled in MFA.
@@ -593,6 +601,17 @@ queries:
             3. Choose one of the active policy rules in the list and select Edit. The Edit Rule dialog appears.
             4. Under the condition THEN Enroll in multi-factor, select the first time a user signs in.
             5. Select **Update Rule**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_policy_mfa_default" "default" {
+              is_oie = true
+
+              okta_otp = {
+                enroll = "REQUIRED"
+              }
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/mfa/mfa-home.htm
         title: Okta Multifactor Authentication
@@ -603,11 +622,18 @@ queries:
     mql: |
       everyoneGroupId = okta.groups.where( profile['name'] == "Everyone" ).map(id)[0]
       okta.policies.mfaEnroll.one( status == "ACTIVE" && conditions['people']['groups']['include'].contains(everyoneGroupId) )
-  # No Terraform variants: not yet implemented. `okta_policy_signon` +
-  # `okta_policy_rule_signon` (with `session_lifetime`) are the candidate
-  # resources. Add HCL / plan / state variants and an `id: terraform`
-  # remediation in a follow-up.
-  # No Terraform remediation: rides with variants — see above.
+  - uid: mondoo-okta-security-okta-mfa-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.any( nameLabel == "okta_policy_mfa_default" || nameLabel == "okta_policy_factor_enrollment" )
+  - uid: mondoo-okta-security-okta-mfa-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
+    mql: |
+      terraform.plan.resourceChanges.any( type == "okta_policy_mfa_default" || type == "okta_policy_factor_enrollment" )
+  - uid: mondoo-okta-security-okta-mfa-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_mfa_default|okta_policy_factor_enrollment/ )
+    mql: |
+      terraform.state.resources.any( type == "okta_policy_mfa_default" || type == "okta_policy_factor_enrollment" )
   - uid: mondoo-okta-security-okta-enforce-session-lifetime
     title: Enforce a limited session lifetime for all policies
     impact: 80
@@ -624,6 +650,18 @@ queries:
         tags:
           mondoo.com/filter-title: Okta Organization
           mondoo.com/filter-icon: okta
+      - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         The session lifetime determines the maximum idle time of a user's Okta session, and when the session expires.
@@ -654,6 +692,17 @@ queries:
             3. Select **Add Rule** or **Edit** to modify an existing policy rule.
             4. Under **Session expires after**, set the session lifetime duration in minutes, hours, or days.
             5. Select **Create Rule** or **Save Rule** once your changes have been made.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_policy_rule_signon" "default" {
+              policy_id        = okta_policy_signon.default.id
+              name             = "Require MFA"
+              status           = "ACTIVE"
+              session_idle     = 120
+              session_lifetime = 1440
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Okta Sign-On Policies
@@ -671,6 +720,21 @@ queries:
     mql: |
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionIdleMinutes"] <= props.mondooOktaSecurityMaxSessionIdleMinutes ))
       okta.policies.signOn.where(_.rules.all(status == "ACTIVE")).all(_.rules.all(actions["signon"]["session"]["mondooOktaSecurityMaxSessionLifetimeMinutes"] <= props.mondooOktaSecurityMaxSessionLifetimeMinutes ))
+  - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_idle'] == /var/ || arguments['session_idle'] <= 120 )
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['session_lifetime'] == /var/ || arguments['session_lifetime'] <= 1440 )
+  - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
+    mql: |
+      terraform.plan.resourceChanges.where( type == "okta_policy_rule_signon" ).all( change.after['session_idle'] <= 120 )
+      terraform.plan.resourceChanges.where( type == "okta_policy_rule_signon" ).all( change.after['session_lifetime'] <= 1440 )
+  - uid: mondoo-okta-security-okta-enforce-session-lifetime-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_rule_signon/ )
+    mql: |
+      terraform.state.resources.where( type == "okta_policy_rule_signon" ).all( values['session_idle'] <= 120 )
+      terraform.state.resources.where( type == "okta_policy_rule_signon" ).all( values['session_lifetime'] <= 1440 )
   - uid: mondoo-okta-security-okta-auth-openid-saml
     title: Enable SAML or OIDC authentication for supported apps
     impact: 100
@@ -2479,10 +2543,6 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_password/ )
     mql: |
       terraform.state.resources.where( type == /okta_policy_password/ ).all( values['question_recovery'] == "ACTIVE" )
-  # No Terraform variants: not yet implemented. `okta_threat_insight_settings`
-  # (with `action = "block"`) is the candidate resource. Add HCL / plan /
-  # state variants and an `id: terraform` remediation in a follow-up.
-  # No Terraform remediation: rides with variants — see above.
   - uid: mondoo-okta-security-threatinsight-action-block
     title: Ensure ThreatInsight is configured to block suspicious login attempts
     impact: 100
@@ -2499,6 +2559,18 @@ queries:
         tags:
           mondoo.com/filter-title: Okta Organization
           mondoo.com/filter-icon: okta
+      - uid: mondoo-okta-security-threatinsight-action-block-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-threatinsight-action-block-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-threatinsight-action-block-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Okta ThreatInsight is configured to actively block suspicious login attempts rather than only auditing or ignoring them.
@@ -2535,6 +2607,13 @@ queries:
             3. Under **Action**, select **Log and block**.
             4. Optionally, add trusted network zones to the exclude list to prevent false positives.
             5. Select **Save**.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_threat_insight_settings" "default" {
+              action = "block"
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/threat-insight/configure-threatinsight.htm
         title: Configure Okta ThreatInsight
@@ -2543,11 +2622,18 @@ queries:
   - uid: mondoo-okta-security-threatinsight-action-block-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.threatInsightSettings.action == "block"
-  # No Terraform variants: not yet implemented. `okta_trusted_origin` (with an
-  # `origin` argument matching `^https://`) is the candidate resource. Add
-  # HCL / plan / state variants and an `id: terraform` remediation in a
-  # follow-up.
-  # No Terraform remediation: rides with variants — see above.
+  - uid: mondoo-okta-security-threatinsight-action-block-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.where( nameLabel == "okta_threat_insight_settings" ).all( arguments['action'] == "block" )
+  - uid: mondoo-okta-security-threatinsight-action-block-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
+    mql: |
+      terraform.plan.resourceChanges.where( type == "okta_threat_insight_settings" ).all( change.after['action'] == "block" )
+  - uid: mondoo-okta-security-threatinsight-action-block-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_threat_insight_settings/ )
+    mql: |
+      terraform.state.resources.where( type == "okta_threat_insight_settings" ).all( values['action'] == "block" )
   - uid: mondoo-okta-security-trusted-origins-https
     title: Ensure all active trusted origins use HTTPS
     impact: 90
@@ -2564,6 +2650,18 @@ queries:
         tags:
           mondoo.com/filter-title: Okta Organization
           mondoo.com/filter-icon: okta
+      - uid: mondoo-okta-security-trusted-origins-https-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-trusted-origins-https-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-trusted-origins-https-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all active trusted origins in Okta are configured to use HTTPS rather than HTTP.
@@ -2598,16 +2696,34 @@ queries:
                b. Update the **Origin URL** to use `https://` instead of `http://`.
                c. Select **Save**.
             4. If the underlying application does not yet support HTTPS, configure TLS on the application first, then update the trusted origin.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_trusted_origin" "example" {
+              active = true
+              name   = "Example Origin"
+              origin = "https://app.example.com"
+              scopes = ["CORS", "REDIRECT"]
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/API_Trusted-Origins.htm
         title: Trusted Origins
   - uid: mondoo-okta-security-trusted-origins-https-api
     filters: asset.platform == "okta-org"
     mql: okta.trustedOrigins.where(status == "ACTIVE").all(origin == /^https:\/\//)
-  # No Terraform variants: not yet implemented. `okta_policy_rule_signon`
-  # (with `mfa_required = true`) is the candidate resource. Add HCL / plan /
-  # state variants and an `id: terraform` remediation in a follow-up.
-  # No Terraform remediation: rides with variants — see above.
+  - uid: mondoo-okta-security-trusted-origins-https-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.where( nameLabel == "okta_trusted_origin" ).all( arguments['origin'] == /^https:\/\// )
+  - uid: mondoo-okta-security-trusted-origins-https-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
+    mql: |
+      terraform.plan.resourceChanges.where( type == "okta_trusted_origin" ).all( change.after['origin'] == /^https:\/\// )
+  - uid: mondoo-okta-security-trusted-origins-https-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_trusted_origin/ )
+    mql: |
+      terraform.state.resources.where( type == "okta_trusted_origin" ).all( values['origin'] == /^https:\/\// )
   - uid: mondoo-okta-security-signon-requires-mfa
     title: Ensure sign-on policy rules require MFA
     impact: 90
@@ -2624,6 +2740,18 @@ queries:
         tags:
           mondoo.com/filter-title: Okta Organization
           mondoo.com/filter-icon: okta
+      - uid: mondoo-okta-security-signon-requires-mfa-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-signon-requires-mfa-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-okta-security-signon-requires-mfa-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that active sign-on policy rules require multi-factor authentication (MFA) for user sign-in.
@@ -2663,6 +2791,16 @@ queries:
             6. Select **Save**.
 
             Repeat for all active sign-on policy rules to ensure comprehensive MFA enforcement.
+        - id: terraform
+          desc: |
+            ```hcl
+            resource "okta_policy_rule_signon" "require_mfa" {
+              policy_id    = okta_policy_signon.default.id
+              name         = "Require MFA"
+              status       = "ACTIVE"
+              mfa_required = true   # newer provider versions use `factor_required = true`
+            }
+            ```
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/policies/configure-signon-policy.htm
         title: Configure Sign-On Policies
@@ -2678,6 +2816,18 @@ queries:
   # against the live tenant is the source of truth.
   # No Terraform remediation: same reason — guidance limited to TF-managed
   # users would be misleading.
+  - uid: mondoo-okta-security-signon-requires-mfa-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
+    mql: |
+      terraform.resources.where( nameLabel == "okta_policy_rule_signon" ).all( arguments['mfa_required'] == /var/ || arguments['mfa_required'] == true || arguments['factor_required'] == true )
+  - uid: mondoo-okta-security-signon-requires-mfa-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( providerName == /okta/ )
+    mql: |
+      terraform.plan.resourceChanges.where( type == "okta_policy_rule_signon" ).all( change.after['mfa_required'] == true || change.after['factor_required'] == true )
+  - uid: mondoo-okta-security-signon-requires-mfa-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains( type == /okta_policy_rule_signon/ )
+    mql: |
+      terraform.state.resources.where( type == "okta_policy_rule_signon" ).all( values['mfa_required'] == true || values['factor_required'] == true )
   - uid: mondoo-okta-security-limit-org-admins
     title: Limit the number of organization admins
     impact: 80


### PR DESCRIPTION
## Summary
Five parents in `content/mondoo-okta-security.mql.yaml` previously carried `# No Terraform variants: not yet implemented` comments listing a candidate Okta TF resource (left behind by #2458 as documented follow-up work). This PR delivers that follow-up — each parent now has full `terraform-hcl` / `terraform-plan` / `terraform-state` variants plus an `id: terraform` remediation block with example HCL.

| check | resource | argument |
|---|---|---|
| `okta-mfa-access` | `okta_policy_mfa_default` / `okta_policy_factor_enrollment` | resource exists |
| `okta-enforce-session-lifetime` | `okta_policy_rule_signon` | `session_idle <= 120`, `session_lifetime <= 1440` |
| `threatinsight-action-block` | `okta_threat_insight_settings` | `action = "block"` |
| `trusted-origins-https` | `okta_trusted_origin` | `origin` matches `^https://` |
| `signon-requires-mfa` | `okta_policy_rule_signon` | `mfa_required = true` (or the newer `factor_required` argument) |

The two remaining `# No Terraform variants:` comments — `limit-super-admins` and `limit-org-admins` — are intentionally untouched. Counting role assignments across the org has no clean Terraform analog: per-user `okta_user_admin_roles` HCL would only see TF-managed grants and miss admin assignments made via the API or Admin Console, so the runtime check against the live tenant remains the source of truth.

Policy version stays at `2.3.0`.

## Test plan
- [x] `cnspec policy lint content/mondoo-okta-security.mql.yaml` → valid policy bundle(s)
- [x] `inspect-policies.py` reports the 5 newly-equipped parents now satisfy `{console, terraform}`; only the two documented count-based gaps remain
- [ ] Run `cnspec scan terraform-hcl <fixture>` against a small fixture containing each new resource type and confirm the variants evaluate correctly
- [ ] Spot-check rendered remediation Markdown in the UI for the 5 parents (especially `signon-requires-mfa` because the HCL note about the deprecated `mfa_required` vs newer `factor_required` argument is non-trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)