### PR TITLE
:sparkles: Add Terraform variants to 6 Azure + GCP checks

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -15983,9 +15983,6 @@ queries:
         values.encryption != null &&
         values.encryption.any(_['key_vault_key_id'] != null && _['key_vault_key_id'] != "")
       )
-  # No Terraform variants: azurerm_monitor_diagnostic_setting targets resources by string-encoded
-  # target_resource_id, so MQL cannot reliably filter diagnostic settings to those scoped at Batch
-  # accounts without parsing reference strings. Revisit if a target-resource-type filter is added.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled
     title: Ensure Azure Batch accounts have diagnostic settings enabled
     impact: 60
@@ -16002,6 +15999,18 @@ queries:
         tags:
           mondoo.com/filter-title: Azure Batch Account
           mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that diagnostic settings are enabled on Azure Batch accounts, providing visibility into job execution, authentication events, and configuration changes through centralized logging.
@@ -16105,6 +16114,24 @@ queries:
       asset.platform == "azure-batch-account"
     mql: |
       azure.subscription.batchService.account.diagnosticSettings.length > 0
+  - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_batch_account")
+    mql: |
+      terraform.resources.where(nameLabel == "azurerm_monitor_diagnostic_setting").any(
+        arguments['target_resource_id'].contains("azurerm_batch_account")
+      )
+  - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_monitor_diagnostic_setting").any(
+        change.after['target_resource_id'] != empty
+      )
+  - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_batch_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_monitor_diagnostic_setting").any(
+        values['target_resource_id'].contains("/batchAccounts/")
+      )
   - uid: mondoo-azure-security-batch-private-endpoints-configured
     title: Ensure Azure Batch accounts have private endpoint connections configured
     impact: 70
@@ -27006,9 +27033,6 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['retention_policy_in_days'] != null && values['retention_policy_in_days'] > 0
       )
-  # No Terraform variants: azurerm_container_registry does not expose a dedicated
-  # keyRotationEnabled flag. Auto-rotation is implied by referencing a Key Vault key URI without a
-  # version, which cannot be reliably detected from the resource configuration alone.
   - uid: mondoo-azure-security-acr-encryption-key-rotation
     title: Ensure ACR encryption key auto-rotation is enabled
     impact: 60
@@ -27025,6 +27049,18 @@ queries:
         tags:
           mondoo.com/filter-title: Azure Subscription
           mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Container Registry instances with customer-managed key encryption have automatic key rotation enabled. Key rotation ensures that encryption keys are periodically updated, limiting the impact of a compromised key.
@@ -27069,6 +27105,30 @@ queries:
             ```
 
             A versionless key URI has the form `https://<vault>.vault.azure.net/keys/<keyName>` (no version suffix).
+        - id: terraform
+          desc: |
+            Reference the Key Vault key by its versionless identifier so the registry tracks the latest key version automatically:
+
+            ```hcl
+            resource "azurerm_container_registry" "example" {
+              name                = "exampleregistry"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              sku                 = "Premium"
+
+              identity {
+                type         = "UserAssigned"
+                identity_ids = [azurerm_user_assigned_identity.example.id]
+              }
+
+              encryption {
+                key_vault_key_id   = azurerm_key_vault_key.example.versionless_id
+                identity_client_id = azurerm_user_assigned_identity.example.client_id
+              }
+            }
+            ```
+
+            Use `versionless_id` rather than `id` — auto-rotation requires the URI to omit the key version.
         - id: bicep
           desc: |
             Key rotation is managed through Azure Key Vault key versioning. Configure the registry encryption to use a key URI without a version to enable automatic rotation:
@@ -27108,6 +27168,38 @@ queries:
         encryption.status == "enabled"
       ).all(
         encryption.keyRotationEnabled == true
+      )
+  - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
+    mql: |
+      terraform.resources.where(nameLabel == "azurerm_container_registry").where(
+        blocks.where(type == "encryption") != empty
+      ).all(
+        blocks.where(type == "encryption").all(
+          arguments['key_vault_key_id'].contains("versionless_id") ||
+          arguments['key_vault_key_id'] == /^https:\/\/[^\/]+\/keys\/[^\/]+\/?$/
+        )
+      )
+  - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_container_registry")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_container_registry").where(
+        change.after.encryption != null && change.after.encryption.length > 0
+      ).all(
+        change.after.encryption.all(
+          _['key_vault_key_id'] == null ||
+          _['key_vault_key_id'] == /^https:\/\/[^\/]+\/keys\/[^\/]+\/?$/
+        )
+      )
+  - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_container_registry")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_container_registry").where(
+        values.encryption != null && values.encryption.length > 0
+      ).all(
+        values.encryption.all(
+          _['key_vault_key_id'] == /^https:\/\/[^\/]+\/keys\/[^\/]+\/?$/
+        )
       )
   - uid: mondoo-azure-security-storage-encryption-scope-cmk
     title: Ensure storage encryption scopes use customer-managed keys
@@ -29910,10 +30002,6 @@ queries:
         values['monitoring'] == empty ||
         values['monitoring'].all(_['alerts_for_all_job_failures_enabled'] != false)
       )
-  # No Terraform variants: backup policies are separate Terraform resources (e.g.
-  # azurerm_backup_policy_vm) that reference the vault via recovery_vault_name. Verifying that
-  # every vault has at least one policy requires cross-resource correlation by string-encoded
-  # references that MQL cannot resolve reliably from Terraform configuration alone.
   - uid: mondoo-azure-security-recovery-vault-backup-policies
     title: Ensure Recovery Services Vaults have backup policies
     impact: 60
@@ -29930,6 +30018,18 @@ queries:
         tags:
           mondoo.com/filter-title: Azure Subscription
           mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have at least one backup policy configured. Backup policies define the schedule, retention, and scope of backup operations.
@@ -29996,6 +30096,28 @@ queries:
               --vm <VMResourceId> \
               --policy-name <PolicyName>
             ```
+        - id: terraform
+          desc: |
+            Define a backup policy alongside the vault. For Azure VM backups:
+
+            ```hcl
+            resource "azurerm_backup_policy_vm" "example" {
+              name                = "example-vm-backup-policy"
+              resource_group_name = azurerm_resource_group.example.name
+              recovery_vault_name = azurerm_recovery_services_vault.example.name
+
+              backup {
+                frequency = "Daily"
+                time      = "23:00"
+              }
+
+              retention_daily {
+                count = 30
+              }
+            }
+            ```
+
+            Use `azurerm_backup_policy_file_share` for Azure Files workloads and `azurerm_backup_policy_vm_workload` for SQL Server or SAP HANA backups.
         - id: bicep
           desc: |
             Backup policies are configured as child resources of the vault. Example for a VM backup policy:
@@ -30038,6 +30160,30 @@ queries:
       azure.subscription.recoveryServices.vaults.all(
         backupPolicies.length > 0
       )
+  - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
+    mql: |
+      terraform.resources.where(
+        nameLabel == "azurerm_backup_policy_vm" ||
+        nameLabel == "azurerm_backup_policy_vm_workload" ||
+        nameLabel == "azurerm_backup_policy_file_share"
+      ).length > 0
+  - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_recovery_services_vault")
+    mql: |
+      terraform.plan.resourceChanges.where(
+        type == "azurerm_backup_policy_vm" ||
+        type == "azurerm_backup_policy_vm_workload" ||
+        type == "azurerm_backup_policy_file_share"
+      ).length > 0
+  - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_recovery_services_vault")
+    mql: |
+      terraform.state.resources.where(
+        type == "azurerm_backup_policy_vm" ||
+        type == "azurerm_backup_policy_vm_workload" ||
+        type == "azurerm_backup_policy_file_share"
+      ).length > 0
   - uid: mondoo-azure-security-recovery-vault-critical-op-alerts
     title: Ensure Recovery Vaults alert on critical operations
     impact: 70

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -16124,11 +16124,12 @@ queries:
       terraform.resources.where(nameLabel == "azurerm_monitor_diagnostic_setting").any(
         arguments['target_resource_id'] == /^(data\.)?azurerm_batch_account\./
       )
-  # Plan: hybrid. When target_resource_id is "(known after apply)" — null in the plan JSON because
-  # it references another resource being created in the same plan — we pass under the filter's
-  # benefit-of-the-doubt (a batch_account is also being created here). When target_resource_id is
-  # a resolved literal string, we require it to contain /batchAccounts/. The state variant is
-  # authoritative once the apply has resolved every reference.
+  # When the check runs against a Terraform plan: target_resource_id resolves to "(known after
+  # apply)" — null in the plan JSON — when it references another resource being created in the
+  # same plan, so we pass under the filter's benefit-of-the-doubt (a batch_account is also being
+  # created here). When target_resource_id is a resolved literal string, we require it to contain
+  # /batchAccounts/. Running against Terraform state is authoritative once the apply has resolved
+  # every reference.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
     mql: |
@@ -30066,7 +30067,7 @@ queries:
         3. Go to **Backup policies** under **Manage**.
         4. Verify that at least one backup policy exists.
 
-        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are presence-only — they verify that at least one `azurerm_backup_policy_vm`, `azurerm_backup_policy_vm_workload`, or `azurerm_backup_policy_file_share` resource is declared when a vault is, but they do not correlate each policy back to a specific vault via `recovery_vault_name`. A configuration with multiple vaults where only one has an associated policy will still pass the Terraform variant. The Azure runtime variant (`-azure`) enforces the strict per-vault check and is authoritative.
+        **When this check runs against Terraform:** The Terraform version of this check is presence-only — it verifies that at least one `azurerm_backup_policy_vm`, `azurerm_backup_policy_vm_workload`, or `azurerm_backup_policy_file_share` resource is declared when a vault is, but it does not correlate each policy back to a specific vault via `recovery_vault_name`. A configuration with multiple vaults where only one has an associated policy still passes against Terraform HCL, plan, or state. The Azure runtime check enforces the strict per-vault rule and is authoritative.
       remediation:
         - id: portal
           desc: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -16114,19 +16114,21 @@ queries:
       asset.platform == "azure-batch-account"
     mql: |
       azure.subscription.batchService.account.diagnosticSettings.length > 0
-  # HCL: substring heuristic on target_resource_id. cnquery's HCL parser flattens references like
-  # azurerm_batch_account.example.id to the dotted string "azurerm_batch_account.example.id", so this
-  # matches that. It can false-positive on a literal target_resource_id string that happens to contain
-  # the substring; it would not match an attacker-controlled comment because comments are stripped.
+  # HCL: anchored regex on the flattened reference string. cnquery's HCL parser turns a reference
+  # like azurerm_batch_account.example.id into the dotted string "azurerm_batch_account.example.id"
+  # (or "data.azurerm_batch_account.example.id" for data-source references). The regex requires the
+  # exact resource type followed by a dot, so a hypothetical azurerm_batch_account_pool wouldn't pass.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_batch_account")
     mql: |
       terraform.resources.where(nameLabel == "azurerm_monitor_diagnostic_setting").any(
-        arguments['target_resource_id'].contains("azurerm_batch_account")
+        arguments['target_resource_id'] == /^(data\.)?azurerm_batch_account\./
       )
-  # Plan: weaker than the state variant. target_resource_id resolves to "(known after apply)" — null
-  # in the plan JSON — when it references another resource being created in the same plan, so we can
-  # only assert the field is set. State sees the resolved ARM ID and can match /batchAccounts/.
+  # Plan: presence-only. target_resource_id resolves to "(known after apply)" — null in the plan
+  # JSON — when it references another resource being created in the same plan, so we cannot assert
+  # the target type at plan time. The check passes for any non-empty target_resource_id, including
+  # one targeting an unrelated resource type. The Azure runtime variant (-azure) and the state
+  # variant inspect the resolved ARM ID and are authoritative.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -16124,16 +16124,17 @@ queries:
       terraform.resources.where(nameLabel == "azurerm_monitor_diagnostic_setting").any(
         arguments['target_resource_id'] == /^(data\.)?azurerm_batch_account\./
       )
-  # Plan: presence-only. target_resource_id resolves to "(known after apply)" — null in the plan
-  # JSON — when it references another resource being created in the same plan, so we cannot assert
-  # the target type at plan time. The check passes for any non-empty target_resource_id, including
-  # one targeting an unrelated resource type. The Azure runtime variant (-azure) and the state
-  # variant inspect the resolved ARM ID and are authoritative.
+  # Plan: hybrid. When target_resource_id is "(known after apply)" — null in the plan JSON because
+  # it references another resource being created in the same plan — we pass under the filter's
+  # benefit-of-the-doubt (a batch_account is also being created here). When target_resource_id is
+  # a resolved literal string, we require it to contain /batchAccounts/. The state variant is
+  # authoritative once the apply has resolved every reference.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
     mql: |
       terraform.plan.resourceChanges.where(type == "azurerm_monitor_diagnostic_setting").any(
-        change.after['target_resource_id'] != empty
+        change.after['target_resource_id'] == null ||
+        change.after['target_resource_id'].contains("/batchAccounts/")
       )
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_batch_account")

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -27183,10 +27183,13 @@ queries:
         blocks.where(type == "encryption") != empty
       ).all(
         blocks.where(type == "encryption").all(
-          arguments['key_vault_key_id'].contains("versionless_id") ||
+          arguments['key_vault_key_id'] == /\.versionless_id$/ ||
           arguments['key_vault_key_id'] == /^https:\/\/[^\/]+\/keys\/[^\/]+\/?$/
         )
       )
+  # Plan: a null key_vault_key_id is treated as passing because the value resolves to "(known after
+  # apply)" — null in the plan JSON — when it references a Key Vault key being created in the same
+  # plan. State sees the resolved URI and rejects versioned ones outright.
   - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_container_registry")
     mql: |
@@ -30059,6 +30062,8 @@ queries:
         2. Select a vault.
         3. Go to **Backup policies** under **Manage**.
         4. Verify that at least one backup policy exists.
+
+        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are presence-only — they verify that at least one `azurerm_backup_policy_vm`, `azurerm_backup_policy_vm_workload`, or `azurerm_backup_policy_file_share` resource is declared when a vault is, but they do not correlate each policy back to a specific vault via `recovery_vault_name`. A configuration with multiple vaults where only one has an associated policy will still pass the Terraform variant. The Azure runtime variant (`-azure`) enforces the strict per-vault check and is authoritative.
       remediation:
         - id: portal
           desc: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -16114,12 +16114,19 @@ queries:
       asset.platform == "azure-batch-account"
     mql: |
       azure.subscription.batchService.account.diagnosticSettings.length > 0
+  # HCL: substring heuristic on target_resource_id. cnquery's HCL parser flattens references like
+  # azurerm_batch_account.example.id to the dotted string "azurerm_batch_account.example.id", so this
+  # matches that. It can false-positive on a literal target_resource_id string that happens to contain
+  # the substring; it would not match an attacker-controlled comment because comments are stripped.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_batch_account")
     mql: |
       terraform.resources.where(nameLabel == "azurerm_monitor_diagnostic_setting").any(
         arguments['target_resource_id'].contains("azurerm_batch_account")
       )
+  # Plan: weaker than the state variant. target_resource_id resolves to "(known after apply)" — null
+  # in the plan JSON — when it references another resource being created in the same plan, so we can
+  # only assert the field is set. State sees the resolved ARM ID and can match /batchAccounts/.
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
     mql: |
@@ -30160,6 +30167,10 @@ queries:
       azure.subscription.recoveryServices.vaults.all(
         backupPolicies.length > 0
       )
+  # Presence-only: verifies that at least one backup policy resource is declared when a vault is.
+  # Does not correlate each policy back to a specific vault via recovery_vault_name, so a config
+  # with two vaults and only one policy would still pass. Per-vault correlation requires a
+  # cross-resource reference walk that this MQL does not perform.
   - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8950,7 +8950,7 @@ queries:
           - Prefer Workload Identity Federation or Google-managed keys over user-managed keys to avoid rotation requirements entirely.
           - Maintain an inventory of all service account keys with their creation dates and intended use.
 
-        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are advisory. They look for a `time_rotating` resource with `rotation_days <= 90` in the same configuration as a `google_service_account_key`, and require the rotator's resource name to contain one of `sa_key`, `service_account`, or `key_rotation` (matching the documented remediation pattern). They do not verify that the rotator is actually wired to the key via `lifecycle.replace_triggered_by`, so a same-named rotator used for a different purpose would still satisfy the check, and a properly-wired rotator with an unconventional name would fail. The GCP runtime variant (`-gcp`) inspects the actual `validAfterTime` of the live key and is authoritative.
+        **When this check runs against Terraform:** The Terraform version of this check is advisory. It looks for a `time_rotating` resource with `rotation_days <= 90` in the same configuration as a `google_service_account_key`, and requires the rotator's resource name to contain one of `sa_key`, `service_account`, or `key_rotation` (matching the documented remediation pattern). It does not verify that the rotator is actually wired to the key via `lifecycle.replace_triggered_by`, so a same-named rotator used for a different purpose still satisfies the check, and a properly-wired rotator with an unconventional name fails. The GCP runtime check inspects the actual `validAfterTime` of the live key and is authoritative.
       remediation:
         - id: terraform
           desc: |
@@ -9015,11 +9015,11 @@ queries:
   # Loose correlation: when any google_service_account_key is declared, we require a time_rotating
   # resource whose name suggests a service-account-key purpose AND whose rotation_days <= 90. The
   # name filter (sa_key, service_account, key_rotation substrings) catches the documented
-  # remediation pattern (resource "time_rotating" "sa_key_rotation" { ... }) and common variants,
-  # so an unrelated time_rotating for certificate or token rotation does not satisfy this check.
-  # Users with non-conforming names will see false negatives — see the desc note. rotation_days is
-  # a number per the time provider schema, so <= 90 is well-defined. The runtime variant against
-  # -gcp inspects the actual validAfterTime and is authoritative.
+  # remediation pattern (resource "time_rotating" "sa_key_rotation" { ... }) and common name
+  # choices, so an unrelated time_rotating for certificate or token rotation does not satisfy this
+  # check. Users with non-conforming names will see false negatives — see the desc note.
+  # rotation_days is a number per the time provider schema, so <= 90 is well-defined. The GCP
+  # runtime check inspects the actual validAfterTime and is authoritative.
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8950,7 +8950,7 @@ queries:
           - Prefer Workload Identity Federation or Google-managed keys over user-managed keys to avoid rotation requirements entirely.
           - Maintain an inventory of all service account keys with their creation dates and intended use.
 
-        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are advisory. They look for any `time_rotating` resource with `rotation_days <= 90` in the same configuration as a `google_service_account_key`, but they do not verify that the rotator is actually wired to the key via `lifecycle.replace_triggered_by`. An unrelated `time_rotating` (for example, one used to rotate a TLS certificate) will satisfy the check. The GCP runtime variant (`-gcp`) inspects the actual `validAfterTime` of the live key and is authoritative.
+        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are advisory. They look for a `time_rotating` resource with `rotation_days <= 90` in the same configuration as a `google_service_account_key`, and require the rotator's resource name to contain one of `sa_key`, `service_account`, or `key_rotation` (matching the documented remediation pattern). They do not verify that the rotator is actually wired to the key via `lifecycle.replace_triggered_by`, so a same-named rotator used for a different purpose would still satisfy the check, and a properly-wired rotator with an unconventional name would fail. The GCP runtime variant (`-gcp`) inspects the actual `validAfterTime` of the live key and is authoritative.
       remediation:
         - id: terraform
           desc: |
@@ -9012,28 +9012,39 @@ queries:
       gcp.project.iam.serviceAccount.keys.where(keyType == "USER_MANAGED").all(
         validAfterTime > time.now - 90 * time.day
       )
-  # Loose correlation: when any google_service_account_key is declared, we require some time_rotating
-  # resource with rotation_days <= 90 in the same config. We do not verify that the key's
-  # lifecycle.replace_triggered_by actually references this rotator, so a stray time_rotating used
-  # for an unrelated purpose would also pass. rotation_days is a number per the time provider schema,
-  # so the <= 90 numeric comparison is well-defined. The runtime variant against -gcp catches the
-  # actual validAfterTime, which is the authoritative check.
+  # Loose correlation: when any google_service_account_key is declared, we require a time_rotating
+  # resource whose name suggests a service-account-key purpose AND whose rotation_days <= 90. The
+  # name filter (sa_key, service_account, key_rotation substrings) catches the documented
+  # remediation pattern (resource "time_rotating" "sa_key_rotation" { ... }) and common variants,
+  # so an unrelated time_rotating for certificate or token rotation does not satisfy this check.
+  # Users with non-conforming names will see false negatives — see the desc note. rotation_days is
+  # a number per the time provider schema, so <= 90 is well-defined. The runtime variant against
+  # -gcp inspects the actual validAfterTime and is authoritative.
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
     mql: |
-      terraform.resources.where(nameLabel == 'time_rotating').any(
+      terraform.resources.where(
+        nameLabel == 'time_rotating' &&
+        labels[1] == /(sa_key|service_account|key_rotation)/
+      ).any(
         arguments['rotation_days'] != null && arguments['rotation_days'] <= 90
       )
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-plan
     filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_service_account_key')
     mql: |
-      terraform.plan.resourceChanges.where(type == 'time_rotating').any(
+      terraform.plan.resourceChanges.where(
+        type == 'time_rotating' &&
+        name == /(sa_key|service_account|key_rotation)/
+      ).any(
         change.after.rotation_days != null && change.after.rotation_days <= 90
       )
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-state
     filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_service_account_key')
     mql: |
-      terraform.state.resources.where(type == 'time_rotating').any(
+      terraform.state.resources.where(
+        type == 'time_rotating' &&
+        name == /(sa_key|service_account|key_rotation)/
+      ).any(
         values.rotation_days != null && values.rotation_days <= 90
       )
   - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8866,7 +8866,13 @@ queries:
         type == 'google_org_policy_policy' &&
         change.after.name != null &&
         change.after.name.contains('iam.automaticIamGrantsForDefaultServiceAccounts')
-      ).length > 0
+      ).any(
+        change.after.spec != null &&
+        change.after.spec.any(
+          _['rules'] != null &&
+          _['rules'].any(_['enforce'] == 'TRUE' || _['enforce'] == true)
+        )
+      )
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-state
     filters: |
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
@@ -8882,7 +8888,13 @@ queries:
         type == 'google_org_policy_policy' &&
         values.name != null &&
         values.name.contains('iam.automaticIamGrantsForDefaultServiceAccounts')
-      ).length > 0
+      ).any(
+        values.spec != null &&
+        values.spec.any(
+          _['rules'] != null &&
+          _['rules'].any(_['enforce'] == 'TRUE' || _['enforce'] == true)
+        )
+      )
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days
     title: Ensure service account keys are rotated within 90 days
     impact: 70
@@ -8995,6 +9007,11 @@ queries:
       gcp.project.iam.serviceAccount.keys.where(keyType == "USER_MANAGED").all(
         validAfterTime > time.now - 90 * time.day
       )
+  # Loose correlation: when any google_service_account_key is declared, we require some time_rotating
+  # resource with rotation_days <= 90 in the same config. We do not verify that the key's
+  # lifecycle.replace_triggered_by actually references this rotator, so a stray time_rotating used
+  # for an unrelated purpose would also pass. The runtime variant against -gcp catches the actual
+  # validAfterTime, which is the authoritative check.
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8833,6 +8833,9 @@ queries:
       gcp.project.iam.serviceAccount.email == /^\d+-compute@developer\.gserviceaccount\.com$/ || gcp.project.iam.serviceAccount.email == /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
     mql: |
       gcp.project.iam.serviceAccount.disabled == true
+  # Two-branch alternation: google_project_organization_policy is the legacy v1 resource (uses a
+  # boolean_policy block), google_org_policy_policy is the v2 successor (uses spec.rules.enforce).
+  # The check passes when either form enforces iam.automaticIamGrantsForDefaultServiceAccounts.
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_project_organization_policy' || nameLabel == 'google_org_policy_policy')
@@ -9012,8 +9015,9 @@ queries:
   # Loose correlation: when any google_service_account_key is declared, we require some time_rotating
   # resource with rotation_days <= 90 in the same config. We do not verify that the key's
   # lifecycle.replace_triggered_by actually references this rotator, so a stray time_rotating used
-  # for an unrelated purpose would also pass. The runtime variant against -gcp catches the actual
-  # validAfterTime, which is the authoritative check.
+  # for an unrelated purpose would also pass. rotation_days is a number per the time provider schema,
+  # so the <= 90 numeric comparison is well-defined. The runtime variant against -gcp catches the
+  # actual validAfterTime, which is the authoritative check.
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8946,6 +8946,8 @@ queries:
           - Use Cloud Monitoring alerts to detect keys approaching the rotation deadline.
           - Prefer Workload Identity Federation or Google-managed keys over user-managed keys to avoid rotation requirements entirely.
           - Maintain an inventory of all service account keys with their creation dates and intended use.
+
+        **Note on Terraform variants:** The Terraform HCL, plan, and state variants of this check are advisory. They look for any `time_rotating` resource with `rotation_days <= 90` in the same configuration as a `google_service_account_key`, but they do not verify that the rotator is actually wired to the key via `lifecycle.replace_triggered_by`. An unrelated `time_rotating` (for example, one used to rotate a TLS certificate) will satisfy the check. The GCP runtime variant (`-gcp`) inspects the actual `validAfterTime` of the live key and is authoritative.
       remediation:
         - id: terraform
           desc: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8735,6 +8735,18 @@ queries:
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
           mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that default Compute Engine and App Engine service accounts are disabled when not needed. Default service accounts are automatically created with overly broad permissions (Editor role) and should be disabled or replaced with custom service accounts following the principle of least privilege.
@@ -8821,6 +8833,56 @@ queries:
       gcp.project.iam.serviceAccount.email == /^\d+-compute@developer\.gserviceaccount\.com$/ || gcp.project.iam.serviceAccount.email == /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
     mql: |
       gcp.project.iam.serviceAccount.disabled == true
+  - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_project_organization_policy' || nameLabel == 'google_org_policy_policy')
+    mql: |
+      terraform.resources.where(
+        nameLabel == 'google_project_organization_policy' &&
+        arguments['constraint'] == 'iam.automaticIamGrantsForDefaultServiceAccounts'
+      ).any(
+        blocks.where(type == 'boolean_policy').any(arguments['enforced'] == true)
+      ) ||
+      terraform.resources.where(
+        nameLabel == 'google_org_policy_policy' &&
+        arguments['name'].contains('iam.automaticIamGrantsForDefaultServiceAccounts')
+      ).any(
+        blocks.where(type == 'spec').any(
+          blocks.where(type == 'rules').any(arguments['enforce'] == 'TRUE' || arguments['enforce'] == true)
+        )
+      )
+  - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
+    mql: |
+      terraform.plan.resourceChanges.where(
+        type == 'google_project_organization_policy' &&
+        change.after.constraint == 'iam.automaticIamGrantsForDefaultServiceAccounts'
+      ).any(
+        change.after.boolean_policy != null &&
+        change.after.boolean_policy.any(_['enforced'] == true)
+      ) ||
+      terraform.plan.resourceChanges.where(
+        type == 'google_org_policy_policy' &&
+        change.after.name != null &&
+        change.after.name.contains('iam.automaticIamGrantsForDefaultServiceAccounts')
+      ).length > 0
+  - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
+    mql: |
+      terraform.state.resources.where(
+        type == 'google_project_organization_policy' &&
+        values.constraint == 'iam.automaticIamGrantsForDefaultServiceAccounts'
+      ).any(
+        values.boolean_policy != null &&
+        values.boolean_policy.any(_['enforced'] == true)
+      ) ||
+      terraform.state.resources.where(
+        type == 'google_org_policy_policy' &&
+        values.name != null &&
+        values.name.contains('iam.automaticIamGrantsForDefaultServiceAccounts')
+      ).length > 0
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days
     title: Ensure service account keys are rotated within 90 days
     impact: 70
@@ -8837,6 +8899,18 @@ queries:
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
           mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that user-managed service account keys are rotated at least every 90 days. Long-lived credentials that are not regularly rotated increase the window of opportunity for an attacker to use compromised credentials without detection.
@@ -8921,6 +8995,24 @@ queries:
       gcp.project.iam.serviceAccount.keys.where(keyType == "USER_MANAGED").all(
         validAfterTime > time.now - 90 * time.day
       )
+  - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
+    mql: |
+      terraform.resources.where(nameLabel == 'time_rotating').any(
+        arguments['rotation_days'] != null && arguments['rotation_days'] <= 90
+      )
+  - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_service_account_key')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'time_rotating').any(
+        change.after.rotation_days != null && change.after.rotation_days <= 90
+      )
+  - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_service_account_key')
+    mql: |
+      terraform.state.resources.where(type == 'time_rotating').any(
+        values.rotation_days != null && values.rotation_days <= 90
+      )
   - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys
     title: Ensure there are no disabled service account keys left undeleted
     impact: 50
@@ -8937,6 +9029,18 @@ queries:
         tags:
           mondoo.com/filter-title: GCP IAM Service Account
           mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that disabled service account keys are deleted rather than left in a disabled state. Disabled keys represent unnecessary credential material that can be re-enabled and should be fully removed to reduce the attack surface.
@@ -9007,6 +9111,24 @@ queries:
     filters: asset.platform == 'gcp-iam-service-account'
     mql: |
       gcp.project.iam.serviceAccount.keys.none(disabled == true)
+  - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_key')
+    mql: |
+      terraform.resources.where(nameLabel == 'google_service_account_key').all(
+        arguments['disabled'] == null || arguments['disabled'] == false
+      )
+  - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_service_account_key')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_service_account_key').all(
+        change.after.disabled == null || change.after.disabled == false
+      )
+  - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_service_account_key')
+    mql: |
+      terraform.state.resources.where(type == 'google_service_account_key').all(
+        values.disabled == null || values.disabled == false
+      )
   - uid: mondoo-gcp-security-logging-bucket-retention-30-days
     title: Ensure Cloud Logging log buckets have at least 30-day retention
     impact: 60


### PR DESCRIPTION
## Summary

Adds Terraform HCL/plan/state variants to six previously-deferred Azure and GCP checks where the underlying schema makes it feasible. Each check that gains a variant also gains the corresponding `id: terraform` remediation if it was missing.

### Azure (3 checks)

- **`batch-diagnostic-settings-enabled`** — matches `azurerm_monitor_diagnostic_setting` resources whose `target_resource_id` references a Batch account (HCL: cnquery's parser converts the reference to a dotted string, so we match `"azurerm_batch_account"`; plan/state: substring match against `/batchAccounts/` in the resolved ARM ID).
- **`acr-encryption-key-rotation`** — detects whether the Key Vault key URI is versionless (HCL: `versionless_id` reference; plan/state: regex against the resolved URI without a version segment). Adds a missing `id: terraform` remediation block.
- **`recovery-vault-backup-policies`** — existence check for `azurerm_backup_policy_*` resources alongside vaults. Adds a missing `id: terraform` remediation block.

### GCP (3 IAM checks)

- **`iam-default-service-accounts-disabled`** — verifies that the `iam.automaticIamGrantsForDefaultServiceAccounts` org policy is enforced via either `google_project_organization_policy` (legacy) or `google_org_policy_policy` (current).
- **`iam-service-account-keys-rotated-90-days`** — verifies a `time_rotating` resource with `rotation_days <= 90` is declared when `google_service_account_key` resources are present (matches the documented Terraform remediation pattern).
- **`iam-no-disabled-service-account-keys`** — flags `google_service_account_key` resources where `disabled = true` is set explicitly.

### Skipped (existing "No Terraform variants" comments retained)

Four Azure checks the user asked about have no Terraform analog under the current `azurerm` provider schema, and the existing in-file comments documenting why are still accurate:

- `aks-wireguard-transit-encryption` — `azurerm_kubernetes_cluster` doesn't expose `transitEncryptionType`.
- `app-service-ssh-disabled` — SSH availability is determined by the container image, not by a property on `azurerm_linux_web_app` / `azurerm_windows_web_app`.
- `recovery-vault-enhanced-security` — `azurerm_recovery_services_vault` doesn't expose `securitySettings.enhancedSecurityState`.
- `frontdoor-origin-https` — the runtime check requires `httpPort == 0`, but the `azurerm_cdn_frontdoor_origin` schema validates `http_port` as `1..65535` so the runtime intent isn't expressible.

## Test plan

- [x] `cnspec policy lint content/mondoo-azure-security.mql.yaml content/mondoo-gcp-security.mql.yaml` — passes
- [ ] CI lint + spell check
- [ ] Spot-check that scanning a sample HCL config with a versionless ACR key passes the new variant
- [ ] Spot-check that scanning a sample HCL config without an `automaticIamGrantsForDefaultServiceAccounts` org policy fails the new variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)