### PR TITLE
:sparkles: Add 5 Tailscale checks built on mql#7376

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -79,6 +79,7 @@ breakglass
 bsdutils
 btmp
 bucketpolicychanges
+BYOD
 cbc
 cbt
 ccmp

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.0.1
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -45,11 +45,18 @@ policies:
           - uid: mondoo-tailscale-security-devices-key-expiry-enabled
           - uid: mondoo-tailscale-security-devices-client-up-to-date
           - uid: mondoo-tailscale-security-devices-no-tailnet-lock-errors
+          - uid: mondoo-tailscale-security-device-approval-required
+          - uid: mondoo-tailscale-security-devices-auto-updates-enabled
+          - uid: mondoo-tailscale-security-devices-key-duration-capped
       - title: Tailscale Users
         checks:
           - uid: mondoo-tailscale-security-no-users-pending-approval
           - uid: mondoo-tailscale-security-admin-owner-roles-limited
           - uid: mondoo-tailscale-security-no-idle-users
+          - uid: mondoo-tailscale-security-user-approval-required
+      - title: Tailscale ACL Policy
+        checks:
+          - uid: mondoo-tailscale-security-acl-no-allow-all
     scoring_system: highest impact
 queries:
   - uid: mondoo-tailscale-security-devices-authorized
@@ -442,3 +449,242 @@ queries:
     refs:
       - url: https://tailscale.com/kb/1138/user-management
         title: Tailscale user management documentation
+  - uid: mondoo-tailscale-security-device-approval-required
+    title: Ensure new devices require admin approval to join the tailnet
+    impact: 70
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+    mql: |
+      tailscale.deviceApprovalRequired == true
+    docs:
+      desc: |
+        This check ensures that the tailnet requires administrators to manually approve every new device before it can connect. With device approval enforced, an attacker who steals a user's credentials cannot silently enroll a new endpoint into the tailnet.
+
+        **Why this matters**
+
+        When device approval is not required, any successful authentication produces a connected device immediately:
+          •  Phished credentials translate directly into network access from an attacker-controlled machine.
+          •  There is no human review step that could catch unfamiliar device names, locations, or platforms.
+          •  Compromised personal devices can join a corporate tailnet without IT visibility.
+
+        Manual device approval provides:
+          •  An explicit out-of-band review point for every new endpoint joining the network.
+          •  An audit trail that ties device join events to administrator decisions.
+          •  A natural choke point for enforcing device-posture and BYOD policies.
+
+        Risk mitigation
+          •  Enable device approval for the tailnet so new devices appear as pending until reviewed.
+          •  Pair device approval with notifications so administrators see new requests promptly.
+          •  Combine with tag-based ACLs so an unapproved device cannot reach sensitive resources even briefly.
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
+
+            1. Go to the [Tailscale admin console settings](https://login.tailscale.com/admin/settings/general).
+            2. Locate the **Device approval** section.
+            3. Enable **Manually approve new devices**.
+            4. Save the change.
+    refs:
+      - url: https://tailscale.com/kb/1099/device-approval
+        title: Tailscale device approval documentation
+  - uid: mondoo-tailscale-security-user-approval-required
+    title: Ensure new users require admin approval to join the tailnet
+    impact: 70
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+    mql: |
+      tailscale.userApprovalRequired == true
+    docs:
+      desc: |
+        This check ensures that the tailnet requires administrators to manually approve every new user before they can join. With user approval enforced, identity-provider misconfigurations and overly broad SSO scopes cannot grant immediate tailnet access.
+
+        **Why this matters**
+
+        When user approval is not required, anyone who can sign in through the configured identity provider lands inside the tailnet:
+          •  Misconfigured SSO groups or relaxed allowlists translate directly into network membership.
+          •  Former employees retained in the IdP for legitimate reasons may inadvertently retain Tailscale access.
+          •  There is no review step where an administrator confirms the new account is expected.
+
+        Manual user approval provides:
+          •  A human review checkpoint between identity provisioning and network access.
+          •  An audit trail that ties user join events to administrator decisions.
+          •  A safety net when IdP integrations or SCIM rules drift from intent.
+
+        Risk mitigation
+          •  Enable user approval so new users appear as pending until an administrator reviews them.
+          •  Configure notifications so administrators are alerted to new approval requests.
+          •  Document the approval criteria so reviewers consistently apply the same access standard.
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
+
+            1. Go to the [Tailscale admin console settings](https://login.tailscale.com/admin/settings/general).
+            2. Locate the **User approval** section.
+            3. Enable **Manually approve new users**.
+            4. Save the change.
+    refs:
+      - url: https://tailscale.com/kb/1239/user-approval
+        title: Tailscale user approval documentation
+  - uid: mondoo-tailscale-security-devices-auto-updates-enabled
+    title: Ensure devices have automatic Tailscale client updates enabled
+    impact: 60
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-id-ra-1
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/soc2-2017: soc2-control-cc7-1-2
+    mql: |
+      tailscale.devicesAutoUpdatesEnabled == true
+    docs:
+      desc: |
+        This check ensures that the tailnet is configured to automatically update the Tailscale client on devices. Automatic updates close the window between disclosure of a Tailscale client vulnerability and rollout of the fix across the fleet.
+
+        **Why this matters**
+
+        When automatic client updates are off, every device has to be patched manually:
+          •  Vulnerabilities in the Tailscale client itself remain exploitable on out-of-date endpoints.
+          •  Devices belonging to users who rarely sign in or who run headless agents can drift far behind the latest release.
+          •  Manual patch rollouts depend on user action that may never happen, leaving long-tail exposure.
+
+        Automatic updates provide:
+          •  A consistent, fleet-wide patch baseline maintained by the platform itself.
+          •  Reduced operational burden compared to chasing individual users to update.
+          •  Faster mean time to remediation for client-side vulnerabilities.
+
+        Risk mitigation
+          •  Enable automatic updates at the tailnet level so all eligible devices opt in by default.
+          •  Use the per-device check to spot endpoints that need attention even when auto-updates are on.
+          •  Subscribe to Tailscale security advisories so the team knows when a critical update has shipped.
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
+
+            1. Go to the [Tailscale admin console settings](https://login.tailscale.com/admin/settings/general).
+            2. Locate the **Auto-updates** section.
+            3. Enable automatic updates for the tailnet.
+            4. Save the change.
+    refs:
+      - url: https://tailscale.com/kb/1067/update
+        title: Tailscale client auto-update documentation
+  - uid: mondoo-tailscale-security-devices-key-duration-capped
+    title: Ensure tailnet device key duration is set to 180 days or less
+    impact: 70
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-g
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/soc2-2017: soc2-control-cc6-1-9
+    mql: |
+      tailscale.devicesKeyDurationDays > 0 && tailscale.devicesKeyDurationDays <= 180
+    docs:
+      desc: |
+        This check ensures that the tailnet's default device key duration is set to a finite, reasonable value of 180 days or less. A short key duration limits the useful lifetime of a stolen device credential.
+
+        **Why this matters**
+
+        Device keys are long-lived credentials. The longer they remain valid, the larger the impact of a single compromise:
+          •  A stolen key with a multi-year lifetime grants attackers persistent access until the device is manually revoked.
+          •  Forgotten or unmanaged devices accumulate stale-but-valid credentials that no human is monitoring.
+          •  Compliance frameworks expect cryptographic credentials to be rotated on a defined schedule.
+
+        Capping the duration at 180 days or less provides:
+          •  A regular forced re-authentication cadence that proves the user still controls the device.
+          •  An automatic upper bound on how long a leaked key can be abused before it expires on its own.
+          •  Alignment with common credential rotation expectations in security frameworks.
+
+        Risk mitigation
+          •  Set the tailnet device key duration to 180 days or less, choosing a shorter window for higher-risk environments.
+          •  Avoid setting the duration to 0, which disables expiry entirely.
+          •  Use the per-device key expiry check to catch devices where expiry has been individually disabled.
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
+
+            1. Go to the [Tailscale admin console settings](https://login.tailscale.com/admin/settings/general).
+            2. Locate the **Device key duration** section.
+            3. Set the duration to a value of 180 days or less.
+            4. Save the change.
+    refs:
+      - url: https://tailscale.com/kb/1028/key-expiry
+        title: Tailscale key expiry documentation
+  - uid: mondoo-tailscale-security-acl-no-allow-all
+    title: Ensure tailnet ACL policy does not contain blanket allow-all rules
+    impact: 90
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/soc2-2017: soc2-control-cc6-1-3
+    mql: |
+      tailscale.aclPolicy.acls.none(
+        _['action'] == "accept" &&
+        _['src'].contains("*") &&
+        _['dst'].contains("*:*")
+      )
+    docs:
+      desc: |
+        This check ensures that the tailnet ACL policy does not contain a rule that accepts traffic from every source to every destination on every port. Tailscale's default starter policy includes such a rule, and it must be removed before the policy provides any meaningful network segmentation.
+
+        **Why this matters**
+
+        A rule with `src: ["*"]`, `dst: ["*:*"]`, and `action: "accept"` reduces the entire ACL to a permissive flat network:
+          •  Any compromised device can pivot to every other device, service, and port.
+          •  The principle of least privilege is not enforced anywhere on the tailnet.
+          •  Tag-based segmentation, group restrictions, and per-service rules added later are masked by the catch-all and provide no protection.
+          •  Network-level audit findings will show that no segmentation exists despite the presence of an ACL file.
+
+        Removing the catch-all and replacing it with explicit rules provides:
+          •  Per-group and per-tag scoping so only the intended principals can reach each service.
+          •  A meaningful default-deny posture for everything not expressly allowed.
+          •  Clear documentation of which workloads are allowed to communicate.
+
+        Risk mitigation
+          •  Replace any `accept` rule whose source is `*` and destination is `*:*` with explicit per-group or per-tag allow rules.
+          •  Use Tailscale's policy tests to confirm that intended access still works after tightening the ACL.
+          •  Adopt a least-privilege baseline where every new rule names specific sources, destinations, and ports.
+      remediation:
+        - id: console
+          desc: |
+            **Using Tailscale Admin Console**
+
+            1. Go to the [Tailscale admin console access controls](https://login.tailscale.com/admin/acls/file).
+            2. Open the policy file editor.
+            3. Remove or scope down any `acls` entry whose `src` is `["*"]`, `dst` is `["*:*"]`, and `action` is `"accept"`.
+            4. Replace it with explicit per-group, per-tag, or per-service rules that grant only the access each group needs.
+            5. Use the **Preview** button and the policy `tests` block to confirm the intended access still works.
+            6. Save the policy.
+    refs:
+      - url: https://tailscale.com/kb/1018/acls
+        title: Tailscale ACL policy documentation
+      - url: https://tailscale.com/kb/1192/tailnet-policy
+        title: Writing a tailnet policy file


### PR DESCRIPTION
## Summary

Adds five new checks to the Tailscale security policy, exercising the new tailnet-level settings and `aclPolicy` resource introduced in [mondoohq/mql#7376](https://github.com/mondoohq/mql/pull/7376):

| Check | MQL | Impact |
|---|---|---|
| `device-approval-required` | `tailscale.deviceApprovalRequired == true` | 70 |
| `user-approval-required` | `tailscale.userApprovalRequired == true` | 70 |
| `devices-auto-updates-enabled` | `tailscale.devicesAutoUpdatesEnabled == true` | 60 |
| `devices-key-duration-capped` | `tailscale.devicesKeyDurationDays > 0 && <= 180` | 70 |
| `acl-no-allow-all` | no `acls` rule with `src ["*"]`, `dst ["*:*"]`, `action accept` | 90 |

The first four are tailnet-level setting checks that complement the existing per-device state checks (`devices-authorized`, `devices-key-expiry-enabled`, `devices-client-up-to-date`). The fifth catches the default Tailscale starter ACL — `{"action": "accept", "src": ["*"], "dst": ["*:*"]}` — which nullifies any tailnet-wide segmentation if it's left in place.

A new "Tailscale ACL Policy" group is added for the ACL check; the four setting checks slot into the existing Devices and Users groups.

## Test plan

- [x] `cnspec policy lint content/mondoo-tailscale-security.mql.yaml` passes
- [x] Each new check renders in `inspect-policies.py` with the required `console` remediation
- [ ] CI lint + spell check
- [ ] Live verification once mql#7376 ships in a cnquery release that cnspec consumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)