### PR TITLE
:sparkles: Move 28 Azure checks to fine-grained per-resource platforms

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -24890,7 +24890,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-datafactory-public-access-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Data Factory
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-hcl
         tags:
@@ -24970,11 +24970,9 @@ queries:
         title: Azure Data Factory managed virtual network and private endpoints
   - uid: mondoo-azure-security-datafactory-public-access-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-datafactory"
     mql: |
-      azure.subscription.dataFactory.factories.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.dataFactory.factory.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |
@@ -25007,7 +25005,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-datafactory-cmk-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Data Factory
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-hcl
         tags:
@@ -25107,11 +25105,9 @@ queries:
         title: Encrypt Azure Data Factory with customer-managed keys
   - uid: mondoo-azure-security-datafactory-cmk-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-datafactory"
     mql: |
-      azure.subscription.dataFactory.factories.all(
-        encryption != empty
-      )
+      azure.subscription.dataFactory.factory.encryption != empty
   - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |
@@ -25144,7 +25140,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-datafactory-managed-identity-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Data Factory
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-datafactory-managed-identity-terraform-hcl
         tags:
@@ -25228,11 +25224,9 @@ queries:
         title: Managed identity for Azure Data Factory
   - uid: mondoo-azure-security-datafactory-managed-identity-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-datafactory"
     mql: |
-      azure.subscription.dataFactory.factories.all(
-        identity != empty
-      )
+      azure.subscription.dataFactory.factory.identity != empty
   - uid: mondoo-azure-security-datafactory-managed-identity-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |
@@ -25265,7 +25259,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-synapse-public-access-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Synapse Workspace
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-public-access-disabled-terraform-hcl
         tags:
@@ -25358,11 +25352,9 @@ queries:
         title: Azure Synapse Analytics managed private endpoints
   - uid: mondoo-azure-security-synapse-public-access-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-synapse-workspace"
     mql: |
-      azure.subscription.synapse.workspaces.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.synapse.workspace.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-synapse-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_synapse_workspace")
     mql: |
@@ -25395,7 +25387,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-synapse-managed-vnet-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Synapse Workspace
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-managed-vnet-terraform-hcl
         tags:
@@ -25492,11 +25484,9 @@ queries:
         title: Azure Synapse Analytics managed workspace virtual network
   - uid: mondoo-azure-security-synapse-managed-vnet-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-synapse-workspace"
     mql: |
-      azure.subscription.synapse.workspaces.all(
-        managedVirtualNetwork == "default"
-      )
+      azure.subscription.synapse.workspace.managedVirtualNetwork == "default"
   - uid: mondoo-azure-security-synapse-managed-vnet-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_synapse_workspace")
     mql: |
@@ -25529,7 +25519,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-synapse-aad-only-auth-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Synapse Workspace
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-aad-only-auth-terraform-hcl
         tags:
@@ -25631,11 +25621,9 @@ queries:
         title: Azure AD authentication with Azure Synapse Analytics
   - uid: mondoo-azure-security-synapse-aad-only-auth-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-synapse-workspace"
     mql: |
-      azure.subscription.synapse.workspaces.all(
-        azureADOnlyAuthentication == true
-      )
+      azure.subscription.synapse.workspace.azureADOnlyAuthentication == true
   - uid: mondoo-azure-security-synapse-aad-only-auth-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_synapse_workspace")
     mql: |
@@ -25671,7 +25659,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-synapse-cmk-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Synapse Workspace
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-synapse-cmk-encryption-terraform-hcl
         tags:
@@ -25780,11 +25768,9 @@ queries:
         title: Azure Synapse Analytics workspace encryption
   - uid: mondoo-azure-security-synapse-cmk-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-synapse-workspace"
     mql: |
-      azure.subscription.synapse.workspaces.all(
-        encryption != empty
-      )
+      azure.subscription.synapse.workspace.encryption != empty
   - uid: mondoo-azure-security-synapse-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_synapse_workspace")
     mql: |
@@ -25817,7 +25803,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-admin-user-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-admin-user-disabled-terraform-hcl
         tags:
@@ -25910,11 +25896,9 @@ queries:
         title: Authenticate with an Azure container registry
   - uid: mondoo-azure-security-acr-admin-user-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        adminUserEnabled == false
-      )
+      azure.subscription.containerRegistry.registry.adminUserEnabled == false
   - uid: mondoo-azure-security-acr-admin-user-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -25947,7 +25931,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-public-access-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-public-access-disabled-terraform-hcl
         tags:
@@ -26040,11 +26024,9 @@ queries:
         title: Configure public IP network rules
   - uid: mondoo-azure-security-acr-public-access-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.containerRegistry.registry.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-acr-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26077,7 +26059,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-content-trust-enabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-content-trust-enabled-terraform-hcl
         tags:
@@ -26168,11 +26150,9 @@ queries:
         title: Content trust in Azure Container Registry
   - uid: mondoo-azure-security-acr-content-trust-enabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        policies.trustPolicyEnabled == true
-      )
+      azure.subscription.containerRegistry.registry.policies.trustPolicyEnabled == true
   - uid: mondoo-azure-security-acr-content-trust-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26205,7 +26185,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-cmk-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-cmk-encryption-terraform-hcl
         tags:
@@ -26334,11 +26314,9 @@ queries:
         title: Encrypt registry using a customer-managed key
   - uid: mondoo-azure-security-acr-cmk-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        encryption.status == "enabled"
-      )
+      azure.subscription.containerRegistry.registry.encryption.status == "enabled"
   - uid: mondoo-azure-security-acr-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26371,7 +26349,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-network-default-deny-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-network-default-deny-terraform-hcl
         tags:
@@ -26470,11 +26448,9 @@ queries:
         title: Configure public IP network rules
   - uid: mondoo-azure-security-acr-network-default-deny-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        networkRuleSet.defaultAction == "Deny"
-      )
+      azure.subscription.containerRegistry.registry.networkRuleSet.defaultAction == "Deny"
   - uid: mondoo-azure-security-acr-network-default-deny-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26512,7 +26488,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-private-endpoints-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-private-endpoints-terraform-hcl
         tags:
@@ -26635,11 +26611,9 @@ queries:
         title: Connect privately to an Azure container registry using Azure Private Link
   - uid: mondoo-azure-security-acr-private-endpoints-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        privateEndpointConnections.length > 0
-      )
+      azure.subscription.containerRegistry.registry.privateEndpointConnections.length > 0
   - uid: mondoo-azure-security-acr-private-endpoints-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_private_endpoint")
     mql: |
@@ -26678,7 +26652,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-quarantine-policy-enabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-quarantine-policy-enabled-terraform-hcl
         tags:
@@ -26765,11 +26739,9 @@ queries:
         title: Quarantine pattern for Azure Container Registry
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        policies.quarantinePolicyEnabled == true
-      )
+      azure.subscription.containerRegistry.registry.policies.quarantinePolicyEnabled == true
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26802,7 +26774,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-export-policy-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-export-policy-disabled-terraform-hcl
         tags:
@@ -26894,11 +26866,9 @@ queries:
         title: Data exfiltration protection for Azure Container Registry
   - uid: mondoo-azure-security-acr-export-policy-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        policies.exportPolicyEnabled == false
-      )
+      azure.subscription.containerRegistry.registry.policies.exportPolicyEnabled == false
   - uid: mondoo-azure-security-acr-export-policy-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -26931,7 +26901,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-retention-policy-enabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-retention-policy-enabled-terraform-hcl
         tags:
@@ -27021,11 +26991,9 @@ queries:
         title: Set a retention policy for untagged manifests
   - uid: mondoo-azure-security-acr-retention-policy-enabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry"
     mql: |
-      azure.subscription.containerRegistry.registries.all(
-        policies.retentionPolicyEnabled == true
-      )
+      azure.subscription.containerRegistry.registry.policies.retentionPolicyEnabled == true
   - uid: mondoo-azure-security-acr-retention-policy-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -27058,7 +27026,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-acr-encryption-key-rotation-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Container Registry
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-hcl
         tags:
@@ -27173,13 +27141,10 @@ queries:
         title: Rotate a customer-managed key
   - uid: mondoo-azure-security-acr-encryption-key-rotation-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-registry" &&
+      azure.subscription.containerRegistry.registry.encryption.status == "enabled"
     mql: |
-      azure.subscription.containerRegistry.registries.where(
-        encryption.status == "enabled"
-      ).all(
-        encryption.keyRotationEnabled == true
-      )
+      azure.subscription.containerRegistry.registry.encryption.keyRotationEnabled == true
   - uid: mondoo-azure-security-acr-encryption-key-rotation-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_registry")
     mql: |
@@ -27229,7 +27194,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-storage-encryption-scope-cmk-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Storage Account
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-encryption-scope-cmk-terraform-hcl
         tags:
@@ -27338,12 +27303,10 @@ queries:
         title: Encryption scopes for Blob storage
   - uid: mondoo-azure-security-storage-encryption-scope-cmk-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.accounts.all(
-        encryptionScopes.where(state == "Enabled").all(
-          source == "Microsoft.KeyVault"
-        )
+      azure.subscription.storage.account.encryptionScopes.where(state == "Enabled").all(
+        source == "Microsoft.KeyVault"
       )
   - uid: mondoo-azure-security-storage-encryption-scope-cmk-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_encryption_scope")
@@ -27377,7 +27340,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Storage Account
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-terraform-hcl
         tags:
@@ -27470,12 +27433,10 @@ queries:
         title: Enable infrastructure encryption for double encryption
   - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-storage-account"
     mql: |
-      azure.subscription.storage.accounts.all(
-        encryptionScopes.where(state == "Enabled").all(
-          requireInfrastructureEncryption == true
-        )
+      azure.subscription.storage.account.encryptionScopes.where(state == "Enabled").all(
+        requireInfrastructureEncryption == true
       )
   - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_encryption_scope")
@@ -29069,7 +29030,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-soft-delete-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-soft-delete-terraform-hcl
         tags:
@@ -29168,12 +29129,10 @@ queries:
         title: Soft delete for Azure Backup
   - uid: mondoo-azure-security-recovery-vault-soft-delete-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        securitySettings.softDeleteState == "Enabled" ||
-        securitySettings.softDeleteState == "AlwaysOn"
-      )
+      azure.subscription.recoveryServices.vault.securitySettings.softDeleteState == "Enabled" ||
+      azure.subscription.recoveryServices.vault.securitySettings.softDeleteState == "AlwaysOn"
   - uid: mondoo-azure-security-recovery-vault-soft-delete-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |
@@ -29206,7 +29165,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-immutability-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-immutability-terraform-hcl
         tags:
@@ -29304,12 +29263,10 @@ queries:
         title: Immutable vault for Azure Backup
   - uid: mondoo-azure-security-recovery-vault-immutability-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        securitySettings.immutabilityState == "Unlocked" ||
-        securitySettings.immutabilityState == "Locked"
-      )
+      azure.subscription.recoveryServices.vault.securitySettings.immutabilityState == "Unlocked" ||
+      azure.subscription.recoveryServices.vault.securitySettings.immutabilityState == "Locked"
   - uid: mondoo-azure-security-recovery-vault-immutability-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |
@@ -29345,7 +29302,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-enhanced-security-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
     docs:
       desc: |
@@ -29416,12 +29373,10 @@ queries:
         title: Security features for protecting Azure Backup
   - uid: mondoo-azure-security-recovery-vault-enhanced-security-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        securitySettings.enhancedSecurityState == "Enabled" ||
-        securitySettings.enhancedSecurityState == "AlwaysOn"
-      )
+      azure.subscription.recoveryServices.vault.securitySettings.enhancedSecurityState == "Enabled" ||
+      azure.subscription.recoveryServices.vault.securitySettings.enhancedSecurityState == "AlwaysOn"
   - uid: mondoo-azure-security-recovery-vault-public-access-disabled
     title: Ensure Recovery Services Vaults disable public access
     impact: 80
@@ -29436,7 +29391,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-public-access-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-public-access-disabled-terraform-hcl
         tags:
@@ -29527,11 +29482,9 @@ queries:
         title: Create and use private endpoints for Azure Backup
   - uid: mondoo-azure-security-recovery-vault-public-access-disabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.recoveryServices.vault.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-recovery-vault-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |
@@ -29564,7 +29517,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-private-endpoints-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-private-endpoints-terraform-hcl
         tags:
@@ -29686,11 +29639,9 @@ queries:
         title: Create and use private endpoints for Azure Backup
   - uid: mondoo-azure-security-recovery-vault-private-endpoints-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        privateEndpointConnections.length > 0
-      )
+      azure.subscription.recoveryServices.vault.privateEndpointConnections.length > 0
   - uid: mondoo-azure-security-recovery-vault-private-endpoints-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_private_endpoint")
     mql: |
@@ -29729,7 +29680,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-cmk-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-cmk-encryption-terraform-hcl
         tags:
@@ -29849,12 +29800,10 @@ queries:
         title: Encryption of backup data using customer-managed keys
   - uid: mondoo-azure-security-recovery-vault-cmk-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        encryption.infrastructureEncryption == "Enabled" &&
-        encryption.keyVaultKeyUri != empty
-      )
+      azure.subscription.recoveryServices.vault.encryption.infrastructureEncryption == "Enabled"
+      azure.subscription.recoveryServices.vault.encryption.keyVaultKeyUri != empty
   - uid: mondoo-azure-security-recovery-vault-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |
@@ -29888,7 +29837,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-terraform-hcl
         tags:
@@ -29989,11 +29938,9 @@ queries:
         title: Monitor Azure Backup with Azure Monitor
   - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        monitoringSettings.alertsForAllJobFailures == "Enabled"
-      )
+      azure.subscription.recoveryServices.vault.monitoringSettings.alertsForAllJobFailures == "Enabled"
   - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |
@@ -30030,7 +29977,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-backup-policies-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-backup-policies-terraform-hcl
         tags:
@@ -30171,11 +30118,9 @@ queries:
         title: Prepare to back up Azure VMs
   - uid: mondoo-azure-security-recovery-vault-backup-policies-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        backupPolicies.length > 0
-      )
+      azure.subscription.recoveryServices.vault.backupPolicies.length > 0
   # Presence-only: verifies that at least one backup policy resource is declared when a vault is.
   # Does not correlate each policy back to a specific vault via recovery_vault_name, so a config
   # with two vaults and only one policy would still pass. Per-vault correlation requires a
@@ -30218,7 +30163,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Recovery Services Vault
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-terraform-hcl
         tags:
@@ -30319,11 +30264,9 @@ queries:
         title: Monitor Azure Backup with Azure Monitor
   - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vaults.all(
-        monitoringSettings.alertsForCriticalOperations == "Enabled"
-      )
+      azure.subscription.recoveryServices.vault.monitoringSettings.alertsForCriticalOperations == "Enabled"
   - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -29802,7 +29802,7 @@ queries:
     filters: |
       asset.platform == "azure-recovery-services-vault"
     mql: |
-      azure.subscription.recoveryServices.vault.encryption.infrastructureEncryption == "Enabled"
+      azure.subscription.recoveryServices.vault.encryption.infrastructureEncryption == "Enabled" &&
       azure.subscription.recoveryServices.vault.encryption.keyVaultKeyUri != empty
   - uid: mondoo-azure-security-recovery-vault-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_recovery_services_vault")


### PR DESCRIPTION
## Summary

Builds on [mql#7372](https://github.com/mondoohq/mql/pull/7372) and the singular-resource init functions added in mondoohq/mql#7262 to move per-resource Azure checks off the broad `asset.platform == "azure"` filter and onto the platform that cnspec discovery actually emits for the resource.

Each converted check now:

- Filters on `asset.platform == "azure-<resource>"` so it runs once per discovered asset.
- Drops the `azure.subscription.<svc>.<plural>.all(...)` wrapper in favor of the singular accessor (e.g. `azure.subscription.containerRegistry.registry.<field>`), which the init function resolves from the asset's ARM id.
- Renames its variant `filter-title` from "Azure Subscription" to the matching resource ("Azure Container Registry", "Azure Data Factory", "Azure Synapse Workspace", "Azure Recovery Services Vault", "Azure Storage Account").

### What moved

- **ACR (10)** → `azure-container-registry`
- **Data Factory (3)** → `azure-datafactory`
- **Synapse (4)** → `azure-synapse-workspace`
- **Recovery Services Vault (9)** → `azure-recovery-services-vault`
- **Storage encryption scopes (2)** → `azure-storage-account`

### What stayed broad

The other 59 `asset.platform == "azure"` checks are either subscription-level concerns (Defender pricing, RBAC, activity log, security contacts, log profiles) or target resource types without a per-asset platform yet (firewall, app gateway, VPN gateway, Databricks, log analytics, managed HSM, service bus, event hubs, function apps, compute disks, public IP, network interface, private DNS, frontdoor).

## Test plan

- [x] `cnspec policy lint content/mondoo-azure-security.mql.yaml` passes
- [x] `python3 content/validation/validate_remediation_commands.py azure` passes (260/260)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)