### PR TITLE
:sparkles: Add MSK replicator external-Kafka TLS check built on mql#7352

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -61,6 +61,7 @@ azurewebsites
 backrefs
 backupdr
 bak
+bbb
 benbi
 bhttp
 bigfish
@@ -96,6 +97,7 @@ certonly
 chage
 chargen
 chatgpt
+cheatsheet
 checkend
 cimv
 claude
@@ -494,6 +496,7 @@ reissuance
 remoteadministrator
 removexattr
 renameat
+replicators
 reprovisioned
 resourced
 respout
@@ -518,6 +521,7 @@ safetensors
 Samepage
 saoudrizwan
 SAs
+Sasl
 savecore
 scandb
 scc

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -554,6 +554,7 @@ policies:
           - uid: mondoo-aws-security-msk-encryption-at-rest
           - uid: mondoo-aws-security-msk-encryption-in-transit
           - uid: mondoo-aws-security-msk-logging-enabled
+          - uid: mondoo-aws-security-msk-replicator-external-kafka-tls
       - title: Amazon Keyspaces
         checks:
           - uid: mondoo-aws-security-keyspaces-cmk-encryption
@@ -32594,6 +32595,100 @@ queries:
     mql: |
       cloudformation.template.resources.where(type == "AWS::MSK::Cluster").all(
       properties['LoggingInfo'] != empty && properties['LoggingInfo']['BrokerLogs'] != empty
+      )
+  # No Terraform variants: The `aws_msk_replicator` Terraform resource only models MSK-to-MSK replication; the external (non-MSK) Apache Kafka cluster shape that exposes `encryption_in_transit.type` is API-only.
+  # No CloudFormation variants: `AWS::MSK::Replicator` likewise lacks the external Apache Kafka cluster shape, so `EncryptionInTransit.Type` cannot be expressed in a template.
+  # No Terraform / CloudFormation remediation: same reason — there is no IaC representation of an external Apache Kafka cluster target to fix.
+  - uid: mondoo-aws-security-msk-replicator-external-kafka-tls
+    title: Ensure MSK replicators encrypt data in transit to external Kafka
+    impact: 80
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/soc2-2017: soc2-control-cc6-7-2
+    variants:
+      - uid: mondoo-aws-security-msk-replicator-external-kafka-tls-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon MSK replicators targeting external (non-MSK) Apache Kafka clusters use TLS for traffic to those external brokers. When a replicator's source or target is an external Apache Kafka cluster, the `EncryptionInTransit.Type` setting controls whether replicated topic data travels over TLS or in plaintext. Only `TLS` ensures that messages crossing the boundary between MSK and the external broker are encrypted.
+
+        **Why this matters**
+
+        - MSK replicators move full topic streams between clusters, so plaintext links carry every replicated message, including sensitive payloads, in the clear.
+        - Traffic to an external Apache Kafka cluster typically traverses VPC peering, Transit Gateway, Direct Connect, or the public internet. Plaintext on any of these paths is exposed to network-level interception.
+        - Compliance frameworks such as PCI DSS, HIPAA, NIST SP 800-53 SC-8, and SOC 2 require encryption of regulated data in transit; Kafka replication is in scope when topics carry such data.
+
+        **Risk mitigation**
+
+        - **Confidentiality:** TLS prevents on-path attackers from reading replicated messages.
+        - **Integrity:** TLS protects against tampering with the replication stream between clusters.
+        - **Compliance:** Satisfies in-transit encryption requirements for regulated topic data.
+      remediation:
+        - id: console
+          desc: |
+            Encryption-in-transit settings on an MSK replicator's external Apache Kafka cluster cannot be changed after creation. Recreate the replicator with TLS:
+
+            1. Navigate to the **Amazon MSK Console** and choose **Replicators**.
+            2. Note the source and target Kafka cluster configuration of the existing replicator.
+            3. Delete the replicator. Replication stops at this point.
+            4. Choose **Create replicator** and configure source and target. For any external Apache Kafka cluster, set **Encryption in transit** to **TLS** and confirm the broker presents a certificate trusted by the configured root CA.
+            5. Verify the new replicator reaches the **RUNNING** state and resume your replication topology.
+        - id: cli
+          desc: |
+            Encryption-in-transit on the external Apache Kafka cluster is set at create time and cannot be updated. Recreate the replicator with `EncryptionInTransit.Type=TLS` for any `ApacheKafkaCluster` source or target.
+
+            Inspect the current configuration:
+
+            ```bash
+            aws kafka describe-replicator --replicator-arn <replicator-arn> \
+              --query "KafkaClusters[].{Alias:KafkaClusterAlias,External:ApacheKafkaCluster.BootstrapServers,EncInTransit:ApacheKafkaCluster.EncryptionInTransit.Type}"
+            ```
+
+            Delete the misconfigured replicator:
+
+            ```bash
+            aws kafka delete-replicator --replicator-arn <replicator-arn>
+            ```
+
+            Recreate the replicator with TLS to the external Apache Kafka cluster. Substitute the appropriate VPC, subnet, security group, and credential settings for your environment:
+
+            ```bash
+            aws kafka create-replicator \
+              --replicator-name <name> \
+              --service-execution-role-arn <role-arn> \
+              --kafka-clusters '[
+                {
+                  "AmazonMskCluster": {"MskClusterArn": "<msk-source-arn>"},
+                  "VpcConfig": {"SubnetIds": ["subnet-aaa"], "SecurityGroupIds": ["sg-aaa"]}
+                },
+                {
+                  "ApacheKafkaCluster": {
+                    "BootstrapServers": "broker1:9092,broker2:9092",
+                    "VpcConfig": {"SubnetIds": ["subnet-bbb"], "SecurityGroupIds": ["sg-bbb"]},
+                    "EncryptionInTransit": {"Type": "TLS"},
+                    "Authentication": {"Type": "SASL_SCRAM", "SaslScram": {"SecretArn": "<secret-arn>"}}
+                  }
+                }
+              ]' \
+              --replication-info-list file://replication-info.json
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-replicator-encryption.html
+        title: Amazon MSK Replicator - Encryption in Transit
+      - url: https://docs.aws.amazon.com/cli/latest/reference/kafka/create-replicator.html
+        title: AWS CLI - kafka create-replicator
+  - uid: mondoo-aws-security-msk-replicator-external-kafka-tls-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.msk.replicators.all(
+        kafkaClusters.where(apacheKafkaBootstrapBrokers != "").all(encryptionInTransitType == "TLS")
       )
   # No Terraform variants: This check follows a CloudTrail trail's `S3BucketName` to the referenced bucket and inspects its public ACL — a cross-resource correlation. The general `s3-bucket-level-public-access-prohibited-bucket` check covers the bucket directly in Terraform.
   - uid: mondoo-aws-security-cloudtrail-s3-bucket-not-public


### PR DESCRIPTION
## Summary

Adds `mondoo-aws-security-msk-replicator-external-kafka-tls` (impact 80), built on the new `aws.msk.replicator.kafkaCluster` fields exposed in [mondoohq/mql#7352](https://github.com/mondoohq/mql/pull/7352).

The check fails when an MSK replicator targets an external (non-MSK) Apache Kafka cluster with `EncryptionInTransitType` anything other than `TLS`. Plaintext replication to an external broker exposes every replicated message — typically across VPC peering, Transit Gateway, Direct Connect, or the public internet — to network-level interception.

MQL:

```mql
aws.msk.replicators.all(
  kafkaClusters.where(apacheKafkaBootstrapBrokers != "").all(encryptionInTransitType == "TLS")
)
```

AWS-only variant. YAML comments document why no Terraform / CloudFormation variants or remediation are included: neither `aws_msk_replicator` (Terraform) nor `AWS::MSK::Replicator` (CloudFormation) models the external Apache Kafka cluster shape that exposes `EncryptionInTransit.Type` — that shape is API-only.

Compliance tags reuse the same control mappings as the existing `mondoo-aws-security-msk-encryption-in-transit` check, since both enforce TLS encryption for Kafka data in transit (ISO 27001 A.8.24, NIST SP 800-53 SC-8, NIST CSF 2 PR.DS-02, SOC 2 CC6.7, etc.).

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` passes
- [x] `python3 content/validation/validate_remediation_commands.py aws` — all 3 CLI invocations (`describe-replicator`, `delete-replicator`, `create-replicator`) PASS
- [ ] Interactive: `cnspec shell aws -c 'aws.msk.replicators { name kafkaClusters { apacheKafkaBootstrapBrokers encryptionInTransitType } }'` against an account with at least one external-Kafka replicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)