### PR TITLE
:sparkles: Add 2 AWS checks built on mql#7331 (DocDB public access, OpenSearch custom endpoint cert expiry)

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -302,6 +302,7 @@ policies:
           - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled
           - uid: mondoo-aws-security-opensearch-cmk-encryption
           - uid: mondoo-aws-security-opensearch-auto-software-update
+          - uid: mondoo-aws-security-opensearch-custom-endpoint-certificate-valid
       - title: AWS KMS Key
         checks:
           - uid: mondoo-aws-security-rotation-customer-created-cmks-enabled
@@ -502,6 +503,7 @@ policies:
           - uid: mondoo-aws-security-documentdb-cluster-log-export
           - uid: mondoo-aws-security-documentdb-no-default-security-groups
           - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade
+          - uid: mondoo-aws-security-documentdb-instance-public-access-check
       - title: AWS Glue
         checks:
           - uid: mondoo-aws-security-glue-job-security-configuration
@@ -24768,6 +24770,164 @@ queries:
       cloudformation.template.resources.where(type == "AWS::DocDB::DBInstance").all(
       properties['AutoMinorVersionUpgrade'] == true
       )
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check
+    title: Ensure DocumentDB instances are not publicly accessible
+    impact: 90
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/soc2-2017: soc2-control-cc6-6-1
+    variants:
+      - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-documentdb-instance-public-access-check-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon DocumentDB instances are not configured as publicly accessible. A publicly accessible DocumentDB instance is reachable from outside its VPC: AWS resolves its endpoint to a public IP address, and any client whose security group rules permit traffic on the cluster port can reach it from the internet.
+
+        **Why this matters**
+
+        - DocumentDB instances often hold sensitive application data such as user records, session state, and business records that should never be reachable from arbitrary internet hosts.
+        - Public reachability multiplies the attack surface: brute-force authentication attempts, vulnerability scans, and exploits targeting Amazon DocumentDB's MongoDB-compatible protocol can all reach the instance directly.
+        - Compliance frameworks including PCI DSS, HIPAA, and ISO 27001 require databases handling regulated data to be deployed behind network boundaries that prevent direct public access.
+
+        DocumentDB instances should be deployed in private subnets and reached only through bastion hosts, VPC peering, AWS PrivateLink, or VPN/Direct Connect.
+
+        **Risk mitigation**
+
+        - **Network boundary protection:** Removing public accessibility eliminates the most direct path for unauthorized access.
+        - **Reduced attack surface:** Internet-borne reconnaissance and brute-force attempts no longer reach the database tier.
+        - **Compliance alignment:** Satisfies network-segmentation requirements for regulated workloads.
+      remediation:
+        - id: console
+          desc: |
+            To ensure DocumentDB instances are not publicly accessible using the AWS Console:
+
+            1. Navigate to the **Amazon DocumentDB Console** and choose **Clusters**.
+            2. Select the cluster that contains the affected instance and open the **Instances** tab.
+            3. Select the instance and choose **Modify**.
+            4. Under **Network settings**, set **Publicly accessible** to **No**.
+            5. Choose **Continue** and apply the change immediately or during the next maintenance window.
+            6. Confirm the instance is in a private subnet, and that its security group allows traffic only from authorized sources.
+        - id: cli
+          desc: |
+            To ensure DocumentDB instances are not publicly accessible using the AWS CLI, list instances and their public-access status:
+
+            ```bash
+            aws docdb describe-db-instances \
+              --query "DBInstances[*].{Id:DBInstanceIdentifier,Public:PubliclyAccessible,SubnetGroup:DBSubnetGroup.DBSubnetGroupName}"
+            ```
+
+            DocumentDB does not expose a `modify-db-instance` flag for `PubliclyAccessible`. Resolve the finding by replacing the instance and ensuring the cluster's subnet group covers only private subnets:
+
+            ```bash
+            aws docdb describe-db-subnet-groups \
+              --db-subnet-group-name <subnet-group-name> \
+              --query "DBSubnetGroups[0].Subnets[*].SubnetIdentifier"
+            ```
+
+            If any of those subnets are public, create a new private subnet group and modify the cluster to use it:
+
+            ```bash
+            aws docdb create-db-subnet-group \
+              --db-subnet-group-name private-docdb \
+              --db-subnet-group-description "Private subnets for DocumentDB" \
+              --subnet-ids <private-subnet-1> <private-subnet-2>
+
+            aws docdb modify-db-cluster \
+              --db-cluster-identifier <cluster-id> \
+              --apply-immediately
+            ```
+
+            Then delete and recreate the affected instance with the private subnet group in place:
+
+            ```bash
+            aws docdb delete-db-instance --db-instance-identifier <db-instance-id>
+            aws docdb create-db-instance \
+              --db-instance-identifier <db-instance-id> \
+              --db-cluster-identifier <cluster-id> \
+              --db-instance-class <class> \
+              --engine docdb
+            ```
+        - id: terraform
+          desc: |
+            To ensure DocumentDB instances are not publicly accessible in Terraform, set `publicly_accessible = false` on `aws_docdb_cluster_instance`:
+
+            ```hcl
+            resource "aws_docdb_cluster_instance" "example" {
+              identifier         = "example-instance"
+              cluster_identifier = aws_docdb_cluster.example.id
+              instance_class     = "db.t3.medium"
+              publicly_accessible = false
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure DocumentDB instances are not publicly accessible in CloudFormation, set `PubliclyAccessible: false` on `AWS::DocDB::DBInstance`:
+
+            ```yaml
+            Resources:
+              DocDBInstance:
+                Type: "AWS::DocDB::DBInstance"
+                Properties:
+                  DBInstanceIdentifier: "example-instance"
+                  DBClusterIdentifier: !Ref DocDBCluster
+                  DBInstanceClass: "db.t3.medium"
+                  PubliclyAccessible: false
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.networking.html
+        title: Amazon DocumentDB - Network security
+      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/docdb/modify-db-instance.html
+        title: AWS CLI Command Reference - docdb modify-db-instance
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
+    filters: asset.platform == "aws"
+    mql: aws.documentdb.instances.all(publiclyAccessible == false)
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_docdb_cluster_instance").all(
+      arguments.publicly_accessible != true
+      )
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_docdb_cluster_instance").all(
+      change.after.publicly_accessible != true
+      )
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_docdb_cluster_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_docdb_cluster_instance").all(
+      values.publicly_accessible != true
+      )
+  - uid: mondoo-aws-security-documentdb-instance-public-access-check-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::DocDB::DBInstance")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::DocDB::DBInstance").all(
+      properties['PubliclyAccessible'] != true
+      )
   - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced
     title: Ensure Cognito user pools enforce multi-factor authentication
     impact: 90
@@ -27487,6 +27647,123 @@ queries:
       cloudformation.template.resources.where(type == "AWS::OpenSearchService::Domain").all(
       properties['SoftwareUpdateOptions'] != empty && properties['SoftwareUpdateOptions']['AutoSoftwareUpdateEnabled'] == true
       )
+  # No Terraform variants: Certificate expiry is runtime telemetry from ACM (`notAfter` timestamp on the resolved `aws.acm.certificate`). Terraform stores only the certificate ARN under `aws_opensearch_domain.domain_endpoint_options.custom_endpoint_certificate_arn` and cannot represent the cert's validity window.
+  # No CloudFormation variants: same reason — `AWS::OpenSearchService::Domain.DomainEndpointOptions.CustomEndpointCertificateArn` is just an ARN reference and cannot expose the cert expiry timestamp.
+  - uid: mondoo-aws-security-opensearch-custom-endpoint-certificate-valid
+    title: Ensure OpenSearch domain custom endpoint certificate is not expiring
+    impact: 70
+    tags:
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
+    variants:
+      - uid: mondoo-aws-security-opensearch-custom-endpoint-certificate-valid-aws
+        tags:
+          mondoo.com/filter-title: AWS OpenSearch Domain
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that when an Amazon OpenSearch Service domain exposes a custom endpoint, the ACM certificate backing that endpoint is not expired and is not expiring within the next 30 days. Custom endpoints serve client traffic over HTTPS using a customer-supplied ACM certificate; once the certificate's `notAfter` timestamp passes, clients with strict TLS validation will refuse to connect.
+
+        **Why this matters**
+
+        - An expired TLS certificate causes outright service unavailability for any client that performs proper validation. Even auto-renewed certs require lead time on the OpenSearch endpoint to take effect.
+        - Certificates that are within days of expiry leave little room to recover from rotation problems, ACM validation failures, or DNS changes that block re-issuance.
+        - A long-running expired certificate signals broken certificate lifecycle management, which often correlates with similar gaps on other endpoints in the account.
+
+        AWS Certificate Manager will renew certificates issued by ACM automatically when the domain validation records remain in place; certificates imported into ACM must be rotated manually before expiry.
+
+        **Risk mitigation**
+
+        - **Service availability:** Renewing certificates well before expiry prevents TLS handshake failures that take the endpoint offline.
+        - **Certificate hygiene:** Surfacing expiring certificates drives the lifecycle discipline that protects every other certificate in the account.
+        - **Compliance:** Satisfies cryptographic-key-management requirements that demand proactive certificate renewal.
+      remediation:
+        - id: console
+          desc: |
+            To ensure an OpenSearch domain's custom endpoint certificate is not expiring using the AWS Console:
+
+            1. Navigate to the **AWS Certificate Manager Console** and locate the certificate referenced by the OpenSearch domain's custom endpoint.
+            2. If the certificate is ACM-issued, confirm the DNS or email domain validation records are still in place so ACM can renew automatically. Renew or re-issue the certificate if it is close to expiry.
+            3. If the certificate was imported, request a new certificate from your CA and import it into ACM.
+            4. Open the **Amazon OpenSearch Service Console** and select the affected domain.
+            5. Choose **Actions**, then **Edit security configuration**, and under **Custom endpoint** select the renewed certificate.
+            6. Apply the change and wait for the domain to finish processing the configuration update.
+        - id: cli
+          desc: |
+            To ensure an OpenSearch domain's custom endpoint certificate is not expiring using the AWS CLI, identify the certificate ARN currently in use by the domain:
+
+            ```bash
+            aws opensearch describe-domain \
+              --domain-name <domain-name> \
+              --query "DomainStatus.DomainEndpointOptions.{Custom:CustomEndpointEnabled,Endpoint:CustomEndpoint,CertArn:CustomEndpointCertificateArn}"
+            ```
+
+            Inspect the certificate's expiry timestamp:
+
+            ```bash
+            aws acm describe-certificate \
+              --certificate-arn <certificate-arn> \
+              --query "Certificate.{Domain:DomainName,Status:Status,NotAfter:NotAfter,RenewalEligibility:RenewalEligibility}"
+            ```
+
+            If the certificate is ACM-issued and renewable, request renewal:
+
+            ```bash
+            aws acm renew-certificate --certificate-arn <certificate-arn>
+            ```
+
+            If the certificate must be replaced, request a new one and update the OpenSearch domain to use it:
+
+            ```bash
+            aws opensearch update-domain-config \
+              --domain-name <domain-name> \
+              --domain-endpoint-options CustomEndpointEnabled=true,CustomEndpoint=<endpoint>,CustomEndpointCertificateArn=<new-certificate-arn>
+            ```
+        - id: terraform
+          desc: |
+            To ensure an OpenSearch domain's custom endpoint certificate is not expiring in Terraform, point `domain_endpoint_options.custom_endpoint_certificate_arn` at a renewed ACM certificate and apply the change:
+
+            ```hcl
+            resource "aws_opensearch_domain" "example" {
+              domain_name = "example"
+
+              domain_endpoint_options {
+                custom_endpoint_enabled         = true
+                custom_endpoint                 = "search.example.com"
+                custom_endpoint_certificate_arn = aws_acm_certificate.opensearch.arn
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure an OpenSearch domain's custom endpoint certificate is not expiring in CloudFormation, point `DomainEndpointOptions.CustomEndpointCertificateArn` at a renewed ACM certificate and apply the change:
+
+            ```yaml
+            Resources:
+              OpenSearchDomain:
+                Type: "AWS::OpenSearchService::Domain"
+                Properties:
+                  DomainName: "example"
+                  DomainEndpointOptions:
+                    CustomEndpointEnabled: true
+                    CustomEndpoint: "search.example.com"
+                    CustomEndpointCertificateArn: !Ref OpenSearchCertificate
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/customendpoint.html
+        title: Amazon OpenSearch Service - Custom endpoints
+      - url: https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
+        title: AWS Certificate Manager - Managed renewal
+  - uid: mondoo-aws-security-opensearch-custom-endpoint-certificate-valid-aws
+    filters: asset.platform == "aws-opensearch-domain"
+    mql: |
+      aws.opensearch.domain.customEndpointEnabled == false ||
+        aws.opensearch.domain.customEndpointCertificate.notAfter > time.now + 30 * time.day
   - uid: mondoo-aws-security-neptune-cluster-cmk-encryption
     title: Ensure Neptune DB clusters are encrypted with a customer-managed KMS key
     impact: 70


### PR DESCRIPTION
## Summary

Adds two checks that lean on the new internet-exposure / certificate fields exposed in [mondoohq/mql#7331](https://github.com/mondoohq/mql/pull/7331).

### `mondoo-aws-security-documentdb-instance-public-access-check` (impact 90)

Fails when an `aws.documentdb.instance` has `publiclyAccessible == true`. Mirrors the established RDS / Redshift / Timestream public-access pattern. Full Terraform HCL/plan/state and CloudFormation variants on `aws_docdb_cluster_instance` / `AWS::DocDB::DBInstance`.

```mql
aws.documentdb.instances.all(publiclyAccessible == false)
```

The CLI remediation reflects a DocumentDB quirk: `aws docdb modify-db-instance` has no `--publicly-accessible` flag. To fix a finding, migrate the cluster's subnet group to private subnets and recreate the affected instance.

### `mondoo-aws-security-opensearch-custom-endpoint-certificate-valid` (impact 70)

Fails when an OpenSearch domain has a custom endpoint enabled and the backing ACM certificate is expired or expires within 30 days. Built on the new `aws.opensearch.domain.customEndpointEnabled` and `customEndpointCertificate()` typed ref.

```mql
aws.opensearch.domain.customEndpointEnabled == false ||
  aws.opensearch.domain.customEndpointCertificate.notAfter > time.now + 30 * time.day
```

AWS-only variant. YAML comments document why no Terraform / CloudFormation variants are possible: cert expiry is runtime telemetry from ACM, and IaC stores only the cert ARN. Terraform and CloudFormation remediation snippets are still included because the fix at the IaC layer is to point the cert ARN at a renewed certificate.

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` passes
- [x] `python3 content/validation/validate_remediation_commands.py aws` — all CLI invocations PASS, zero failures
- [ ] Interactive: `cnspec scan aws -f content/mondoo-aws-security.mql.yaml --policy-id mondoo-aws-security` against an account that has at least one DocumentDB cluster and one OpenSearch domain with a custom endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)