### PR TITLE
:label: Backfill 6 compliance frameworks across 211 GCP parent checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -63,6 +63,7 @@ backrefs
 backupdr
 bak
 bbb
+bcr
 benbi
 bhttp
 bigfish
@@ -84,6 +85,7 @@ bucketpolicychanges
 BYOD
 cbc
 cbt
+ccc
 ccmp
 Cdm
 cdn
@@ -615,6 +617,7 @@ totp
 trae
 tskey
 tsuki
+tvm
 twofactor
 uefi
 umac

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -363,13 +363,19 @@ queries:
     title: Ensure that instances are not configured to use the default service account
     impact: 95
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
         tags:
@@ -514,13 +520,19 @@ queries:
     title: Ensure instances do not use default service account with full API access
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
         tags:
@@ -678,13 +690,19 @@ queries:
     title: Ensure oslogin is enabled for compute instances
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
         tags:
@@ -821,13 +839,19 @@ queries:
     title: Ensure Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-gcp
         tags:
@@ -950,13 +974,19 @@ queries:
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
         tags:
@@ -1043,13 +1073,19 @@ queries:
     title: Ensure that Cloud Storage buckets enforce public access prevention
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-gcp
         tags:
@@ -1142,13 +1178,19 @@ queries:
     title: Ensure Cloud Storage buckets are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-gcp
         tags:
@@ -1260,13 +1302,19 @@ queries:
     title: Ensure that Cloud Storage buckets have a locked retention policy configured
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-gcp
         tags:
@@ -1378,13 +1426,19 @@ queries:
     title: Ensure that BigQuery datasets are not anonymously or publicly accessible
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-gcp
         tags:
@@ -1525,13 +1579,19 @@ queries:
     title: Ensure a default CMEK is specified for all BigQuery datasets
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
         tags:
@@ -1645,13 +1705,19 @@ queries:
     title: Ensure all BigQuery tables are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
         tags:
@@ -1782,13 +1848,19 @@ queries:
     title: Ensure all BigQuery models are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
         tags:
@@ -1907,13 +1979,19 @@ queries:
     title: Ensure that BigQuery views do not use Legacy SQL
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-gcp
         tags:
@@ -2026,13 +2104,19 @@ queries:
     title: Ensure that BigQuery datasets do not grant domain-wide access
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-gcp
         tags:
@@ -2150,13 +2234,19 @@ queries:
     title: Ensure Cloud SQL MySQL instances are not publicly exposed
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-gcp
         tags:
@@ -2289,13 +2379,19 @@ queries:
     title: Ensure Cloud SQL MySQL connections require SSL/TLS
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-gcp
         tags:
@@ -2440,13 +2536,19 @@ queries:
     title: Ensure 'skip_show_database' flag is enabled for Cloud SQL MySQL
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-gcp
         tags:
@@ -2589,13 +2691,19 @@ queries:
     title: Ensure 'local_infile' flag is disabled for Cloud SQL MySQL
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-gcp
         tags:
@@ -2740,13 +2848,19 @@ queries:
     title: Ensure Cloud SQL PostgreSQL 'log_error_verbosity' is DEFAULT or verbose
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-gcp
         tags:
@@ -2902,13 +3016,19 @@ queries:
     title: Ensure 'log_connections' flag is enabled for Cloud SQL PostgreSQL
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-gcp
         tags:
@@ -3054,13 +3174,19 @@ queries:
     title: Ensure 'log_disconnections' flag is enabled for Cloud SQL PostgreSQL
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-gcp
         tags:
@@ -3211,13 +3337,19 @@ queries:
     title: Ensure public IP addresses are not assigned to VM instances
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
         tags:
@@ -3379,13 +3511,19 @@ queries:
     title: Ensure the default service account is not used on VM instances
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
         tags:
@@ -3563,13 +3701,19 @@ queries:
     title: Ensure "Block Project-Wide SSH Keys" is enabled for VM instances
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
         tags:
@@ -3707,13 +3851,19 @@ queries:
     title: Ensure Confidential VM Service is enabled for all VM instances
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
         tags:
@@ -3883,13 +4033,19 @@ queries:
     title: Ensure Secure Boot is enabled for all VM instances
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
         tags:
@@ -4060,13 +4216,19 @@ queries:
     title: Ensure vTPM is enabled for all VM instances
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
         tags:
@@ -4239,13 +4401,19 @@ queries:
     title: Ensure Integrity Monitoring is enabled for all VM instances
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
         tags:
@@ -4424,13 +4592,19 @@ queries:
     title: Ensure Cloud SQL PostgreSQL instances are not publicly exposed
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-gcp
         tags:
@@ -4577,13 +4751,19 @@ queries:
     title: Ensure Cloud SQL for SQL Server instances are not publicly exposed
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-gcp
         tags:
@@ -4725,13 +4905,19 @@ queries:
     title: Ensure Cloud SQL PostgreSQL connections require SSL/TLS
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-gcp
         tags:
@@ -4877,13 +5063,19 @@ queries:
     title: Ensure Cloud SQL for SQL Server connections require SSL/TLS
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-gcp
         tags:
@@ -5029,13 +5221,19 @@ queries:
     title: Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
         tags:
@@ -5200,13 +5398,19 @@ queries:
     title: Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days
     impact: 30
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
         tags:
@@ -5327,13 +5531,19 @@ queries:
     title: Ensure KMS crypto keys have a destroy scheduled duration of 24h+
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-gcp
         tags:
@@ -5448,13 +5658,19 @@ queries:
     title: Ensure KMS keyrings are not in the global location
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-gcp
         tags:
@@ -5571,13 +5787,19 @@ queries:
     title: Ensure KMS ENCRYPT_DECRYPT crypto keys have automatic rotation configured
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-gcp
         tags:
@@ -5707,13 +5929,19 @@ queries:
     title: Ensure That DNSSEC Is Enabled for Cloud DNS
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
         tags:
@@ -5836,13 +6064,19 @@ queries:
     title: Ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC
     impact: 30
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
         tags:
@@ -5987,13 +6221,19 @@ queries:
     title: Ensure RSASHA1 is not used for the zone-signing key in Cloud DNS
     impact: 30
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-gcp
         tags:
@@ -6136,13 +6376,19 @@ queries:
     title: Ensure DNSSEC uses NSEC3 for authenticated denial-of-existence
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-gcp
         tags:
@@ -6286,13 +6532,19 @@ queries:
     title: Ensure SSH access is restricted from the internet
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-gcp
         tags:
@@ -6443,13 +6695,19 @@ queries:
     title: Ensure RDP access is restricted from the internet
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-gcp
         tags:
@@ -6583,13 +6841,19 @@ queries:
     title: Ensure firewall rules do not allow unrestricted ingress on all protocols
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-gcp
         tags:
@@ -6730,13 +6994,19 @@ queries:
     title: Ensure firewall rules block internet ingress to database ports
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-gcp
         tags:
@@ -6879,13 +7149,19 @@ queries:
     title: Ensure firewall rules do not allow unrestricted internet ingress
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-gcp
         tags:
@@ -7023,13 +7299,19 @@ queries:
     title: Ensure legacy authorization (ABAC) is disabled on GKE clusters
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-gcp
         tags:
@@ -7127,13 +7409,19 @@ queries:
     title: Ensure master authorized networks are enabled on GKE clusters
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-gcp
         tags:
@@ -7236,13 +7524,19 @@ queries:
     title: Ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-gcp
         tags:
@@ -7339,13 +7633,19 @@ queries:
     title: Ensure network policy is enabled on GKE clusters
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-gcp
         tags:
@@ -7454,13 +7754,19 @@ queries:
     title: Ensure Kubernetes alpha features are disabled on GKE clusters
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-gcp
         tags:
@@ -7557,13 +7863,19 @@ queries:
     title: Ensure Workload Identity is enabled on GKE clusters
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-gke-workload-identity-enabled-gcp
         tags:
@@ -7670,13 +7982,19 @@ queries:
     title: Ensure private cluster is enabled on GKE clusters
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-private-cluster-enabled-gcp
         tags:
@@ -7785,13 +8103,19 @@ queries:
     title: Ensure shielded GKE nodes are enabled
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-gcp
         tags:
@@ -7908,13 +8232,19 @@ queries:
     title: Ensure GKE clusters use a release channel for version management
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-release-channel-configured-gcp
         tags:
@@ -8024,13 +8354,19 @@ queries:
     title: Ensure legacy networks do not exist in the project
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-network-not-legacy-gcp
         tags:
@@ -8131,13 +8467,19 @@ queries:
     title: Ensure VPC Flow Logs are enabled on subnetworks
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-gcp
         tags:
@@ -8242,13 +8584,19 @@ queries:
     title: Ensure Private Google Access is enabled on subnetworks
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-gcp
         tags:
@@ -8347,13 +8695,19 @@ queries:
     title: Ensure authentication is enabled for Cloud Redis instances
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-cloud-redis-auth-enabled-memorystore-redis
         tags:
@@ -8457,13 +8811,19 @@ queries:
     title: Ensure Cloud Redis instances are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-redis
         tags:
@@ -8599,13 +8959,19 @@ queries:
     title: Ensure user-managed service account keys are not created
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-gcp
         tags:
@@ -8729,13 +9095,19 @@ queries:
     title: Ensure default Compute Engine and App Engine service accounts are disabled
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-gcp
         tags:
@@ -8908,13 +9280,19 @@ queries:
     title: Ensure service account keys are rotated within 90 days
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-gcp
         tags:
@@ -9057,13 +9435,19 @@ queries:
     title: Ensure there are no disabled service account keys left undeleted
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-2-2
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-gcp
         tags:
@@ -9173,13 +9557,19 @@ queries:
     title: Ensure Cloud Logging log buckets have at least 30-day retention
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-logging-bucket-retention-30-days-gcp
         tags:
@@ -9282,13 +9672,19 @@ queries:
     title: Ensure Cloud Logging log buckets are locked to prevent tampering
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-logging-bucket-locked-gcp
         tags:
@@ -9399,13 +9795,19 @@ queries:
     title: Ensure Cloud Logging log buckets are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-gcp
         tags:
@@ -9513,13 +9915,19 @@ queries:
     title: Ensure Cloud Logging has at least one sink configured for log export
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-logging-sinks-configured-gcp
         tags:
@@ -9616,13 +10024,19 @@ queries:
     title: Ensure Pub/Sub topics are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-gcp
         tags:
@@ -9721,13 +10135,19 @@ queries:
     title: Ensure Pub/Sub subscriptions have an expiration policy configured
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-gcp
         tags:
@@ -9824,13 +10244,19 @@ queries:
     title: Ensure Pub/Sub topics are not anonymously or publicly accessible
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible-terraform-hcl
         tags:
@@ -9941,13 +10367,19 @@ queries:
     title: Ensure Pub/Sub subscriptions are not anonymously or publicly accessible
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible-terraform-hcl
         tags:
@@ -10058,13 +10490,19 @@ queries:
     title: Ensure Cloud Functions do not allow all ingress traffic
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-gcp
         tags:
@@ -10171,13 +10609,19 @@ queries:
     title: Ensure Cloud Functions do not use the default service account
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-gcp
         tags:
@@ -10293,13 +10737,19 @@ queries:
     title: Ensure Cloud Functions have a VPC connector configured
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-gcp
         tags:
@@ -10408,13 +10858,19 @@ queries:
     title: Ensure Cloud Functions use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-gcp
         tags:
@@ -10521,13 +10977,19 @@ queries:
     title: Ensure Cloud Run services do not allow all ingress traffic
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-run-ingress-restricted-gcp
         tags:
@@ -10635,13 +11097,19 @@ queries:
     title: Ensure Cloud Run services use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-run-cmek-encryption-gcp
         tags:
@@ -10748,13 +11216,19 @@ queries:
     title: Ensure Cloud Run services do not use the default service account
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-run-no-default-service-account-gcp
         tags:
@@ -10883,13 +11357,19 @@ queries:
     title: Ensure Cloud Run services have VPC access configured
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-gcp
         tags:
@@ -11000,13 +11480,19 @@ queries:
     title: Ensure Cloud Run jobs do not use the default service account
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-gcp
         tags:
@@ -11145,13 +11631,19 @@ queries:
     title: Ensure Cloud Run jobs use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-gcp
         tags:
@@ -11262,13 +11754,19 @@ queries:
     title: Ensure Dataproc clusters have disk encryption configured with CMEK
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-gcp
         tags:
@@ -11374,13 +11872,19 @@ queries:
     title: Ensure Dataproc clusters use internal IP addresses only
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-gcp
         tags:
@@ -11493,13 +11997,19 @@ queries:
     title: Ensure Dataproc clusters have Shielded VM features enabled
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-gcp
         tags:
@@ -11638,13 +12148,19 @@ queries:
     title: Ensure Dataproc clusters do not use the default service account
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-gcp
         tags:
@@ -11770,13 +12286,19 @@ queries:
     title: Ensure Binary Authorization default rule does not allow all images
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-gcp
         tags:
@@ -11893,13 +12415,19 @@ queries:
     title: Ensure Binary Authorization global policy evaluation is enabled
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-gcp
         tags:
@@ -12003,13 +12531,19 @@ queries:
     title: Ensure API keys have API target restrictions configured
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-gcp
         tags:
@@ -12123,13 +12657,19 @@ queries:
     title: Ensure API keys have application restrictions configured
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-gcp
         tags:
@@ -12265,13 +12805,19 @@ queries:
     title: Ensure API keys have been rotated within 90 days
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-api-keys-not-stale-gcp
         tags:
@@ -12353,13 +12899,19 @@ queries:
     title: Ensure the default network does not exist in the project
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-network-default-deleted-gcp
         tags:
@@ -12479,13 +13031,19 @@ queries:
     title: Ensure DNS logging is enabled for VPC networks
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-gcp
         tags:
@@ -12591,13 +13149,19 @@ queries:
     title: Ensure subnetworks do not use overly broad IP CIDR ranges
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-gcp
         tags:
@@ -12705,13 +13269,19 @@ queries:
     title: Ensure in-transit encryption is enabled for Cloud Memorystore for Redis
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-memorystore-redis
         tags:
@@ -12833,13 +13403,19 @@ queries:
     title: Ensure Cloud Redis instances use the Standard HA tier
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: "false"
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-memorystore-redis
         tags:
@@ -12936,13 +13512,19 @@ queries:
     title: Ensure IAM authentication is enabled for Memorystore Redis Cluster
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-memorystore-rediscluster
         tags:
@@ -13048,13 +13630,19 @@ queries:
     title: Ensure deletion protection is enabled for Memorystore Redis Cluster
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: "false"
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-memorystore-rediscluster
         tags:
@@ -13156,13 +13744,19 @@ queries:
     title: Ensure Secret Manager secrets are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-secretmanager-cmek-encryption-gcp
         tags:
@@ -13309,13 +13903,19 @@ queries:
     title: Ensure Secret Manager secrets have rotation configured
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-secretmanager-rotation-configured-gcp
         tags:
@@ -13444,13 +14044,19 @@ queries:
     title: Ensure Secret Manager secrets do not have overly permissive IAM policies
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-gcp
         tags:
@@ -13600,13 +14206,19 @@ queries:
     title: Ensure IP forwarding is not enabled on compute instances
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-gcp
         tags:
@@ -13713,13 +14325,19 @@ queries:
     title: Ensure interactive serial port access is disabled on compute instances
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-gcp
         tags:
@@ -13842,13 +14460,19 @@ queries:
     title: Ensure Compute Engine disks are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
         tags:
@@ -13957,13 +14581,19 @@ queries:
     title: Ensure external forwarding rules do not forward all ports
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-gcp
         tags:
@@ -14071,13 +14701,19 @@ queries:
     title: Ensure Cloud SQL authorized networks are not overly permissive
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-mysql
         tags:
@@ -14227,13 +14863,19 @@ queries:
     title: Ensure Cloud SQL instances have a password policy enabled
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-gcp-mysql
         tags:
@@ -14369,13 +15011,19 @@ queries:
     title: Ensure Cloud SQL instances are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-gcp-mysql
         tags:
@@ -14494,13 +15142,19 @@ queries:
     title: Ensure GKE cluster has application-layer secrets encryption enabled
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-gke-database-encryption-enabled-gcp
         tags:
@@ -14606,13 +15260,19 @@ queries:
     title: Ensure GKE cluster node pools have Secure Boot enabled
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-gcp
         tags:
@@ -14743,13 +15403,19 @@ queries:
     title: Ensure Cloud Functions do not store secrets in plaintext env vars
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-gcp
         tags:
@@ -14901,13 +15567,19 @@ queries:
     title: Ensure Cloud Functions use a user-managed Artifact Registry repository
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-gcp
         tags:
@@ -15017,13 +15689,19 @@ queries:
     title: Ensure Cloud Armor security policy rules are not in preview-only mode
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-gcp
         tags:
@@ -15133,13 +15811,19 @@ queries:
     title: Ensure Cloud Armor security policy default rule does not allow all traffic
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-gcp
         tags:
@@ -15269,13 +15953,19 @@ queries:
     title: Ensure SSL policies enforce a minimum TLS version of 1.2
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-gcp
         tags:
@@ -15370,13 +16060,19 @@ queries:
     title: Ensure SSL policies use MODERN or RESTRICTED profile
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-gcp
         tags:
@@ -15468,13 +16164,19 @@ queries:
     title: Ensure SSL certificates are not expired or expiring within 30 days
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-ssl-certificate-not-expired-gcp
         tags:
@@ -15566,13 +16268,19 @@ queries:
     title: Ensure Cloud NAT does not use endpoint-independent mapping
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-gcp
         tags:
@@ -15674,13 +16382,19 @@ queries:
     title: Ensure audit logging is enabled for all services
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-audit-logging-enabled-all-services-gcp
         tags:
@@ -15805,13 +16519,19 @@ queries:
     title: Ensure VM external IP access is restricted via organization policy
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-gcp
         tags:
@@ -15934,13 +16654,19 @@ queries:
     title: Ensure serial port access is disabled via organization policy
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
         tags:
@@ -16050,13 +16776,19 @@ queries:
     title: Ensure uniform bucket-level access is enforced via organization policy
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-gcp
         tags:
@@ -16166,13 +16898,19 @@ queries:
     title: Ensure Firestore databases are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-firestore-cmek-encryption-gcp
         tags:
@@ -16274,13 +17012,19 @@ queries:
     title: Ensure Spanner databases are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-spanner-cmek-encryption-gcp
         tags:
@@ -16378,13 +17122,19 @@ queries:
     title: Ensure Bigtable clusters are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-bigtable-cmek-encryption-gcp
         tags:
@@ -16486,13 +17236,19 @@ queries:
     title: Ensure AlloyDB clusters are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-alloydb-cmek-encryption-gcp
         tags:
@@ -16595,13 +17351,19 @@ queries:
     title: Ensure AlloyDB instances do not have public IP addresses
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-alloydb-no-public-ip-gcp
         tags:
@@ -16705,13 +17467,19 @@ queries:
     title: Ensure GKE clusters have Security Posture enabled
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-8
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-security-posture-enabled-gcp
         tags:
@@ -16825,13 +17593,19 @@ queries:
     title: Ensure VPN tunnels use IKE version 2
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
         tags:
@@ -16936,13 +17710,19 @@ queries:
     title: Ensure GKE node pools have an upgrade strategy configured
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-12
       compliance/nist-csf-2: nist-csf-2-pr-ps-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc8-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-gcp
         tags:
@@ -17093,13 +17873,19 @@ queries:
     title: Ensure Cloud SQL instances require Cloud SQL connectors for all connections
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-gcp-mysql
         tags:
@@ -17232,13 +18018,19 @@ queries:
     title: Ensure Backup & DR vault access is restricted
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-backupdr-vault-access-restricted-gcp
         tags:
@@ -17339,13 +18131,19 @@ queries:
     title: Ensure Vertex AI endpoints are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-gcp
         tags:
@@ -17457,13 +18255,19 @@ queries:
     title: Ensure Vertex AI endpoints use Private Service Connect
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
         tags:
@@ -17572,13 +18376,19 @@ queries:
     title: Ensure Vertex AI models are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-vertexai-model-cmek-encryption-gcp
         tags:
@@ -17651,13 +18461,19 @@ queries:
     title: Ensure Vertex AI datasets are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-gcp
         tags:
@@ -17775,13 +18591,19 @@ queries:
     title: Ensure Vertex AI pipeline jobs are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     # NOTE (2026-03-29): Terraform variants not included because Vertex AI pipeline jobs have no
     # corresponding Terraform resource (google_vertex_ai_pipeline_job does not exist in the
     # Terraform Google provider). Pipeline jobs are created via API/SDK only.
@@ -17878,13 +18700,19 @@ queries:
     title: Ensure Vertex AI pipeline jobs use a VPC network
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     # NOTE (2026-03-29): Terraform variants not included because Vertex AI pipeline jobs have no
     # corresponding Terraform resource (google_vertex_ai_pipeline_job does not exist in the
     # Terraform Google provider). Pipeline jobs are created via API/SDK only.
@@ -17971,13 +18799,19 @@ queries:
     title: Ensure Vertex AI pipeline jobs don't use default SA
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     # NOTE (2026-03-29): Terraform variants not included because Vertex AI pipeline jobs have no
     # corresponding Terraform resource (google_vertex_ai_pipeline_job does not exist in the
     # Terraform Google provider). Pipeline jobs are created via API/SDK only.
@@ -18077,13 +18911,19 @@ queries:
     title: Ensure Vertex AI feature online stores use CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-gcp
         tags:
@@ -18207,13 +19047,19 @@ queries:
     title: Ensure firewall rules do not allow unrestricted egress
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-gcp
         tags:
@@ -18337,13 +19183,19 @@ queries:
     title: Ensure egress firewall rules do not allow all ports
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-egress-all-ports-gcp
         tags:
@@ -18472,13 +19324,19 @@ queries:
     title: Ensure legacy metadata endpoints are disabled on GKE nodes
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-gcp
         tags:
@@ -18578,13 +19436,19 @@ queries:
     title: Ensure GKE legacy client authentication is disabled
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-gcp
         tags:
@@ -18697,13 +19561,19 @@ queries:
     title: Ensure GKE node auto-upgrade is enabled
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-12
       compliance/nist-csf-2: nist-csf-2-pr-ps-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-gcp
         tags:
@@ -18801,13 +19671,19 @@ queries:
     title: Ensure GKE node auto-repair is enabled
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-gcp
         tags:
@@ -18905,13 +19781,19 @@ queries:
     title: Ensure GKE nodes use a dedicated service account
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-gke-dedicated-service-account-gcp
         tags:
@@ -19019,13 +19901,19 @@ queries:
     title: Ensure GKE clusters use VPC-native IP aliasing
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-gcp
         tags:
@@ -19121,13 +20009,19 @@ queries:
     title: Ensure GKE nodes use Container-Optimized OS
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-cos-node-image-gcp
         tags:
@@ -19234,13 +20128,19 @@ queries:
     title: Ensure Cloud SQL instances have automated backups enabled
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: "false"
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
         tags:
@@ -19348,13 +20248,19 @@ queries:
     title: Ensure cross-database ownership chaining is disabled
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-gcp
         tags:
@@ -19472,13 +20378,19 @@ queries:
     title: Ensure contained database authentication is disabled
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-gcp
         tags:
@@ -19597,13 +20509,19 @@ queries:
     title: Ensure 'log_lock_waits' is enabled for Cloud SQL PostgreSQL
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-gcp
         tags:
@@ -19720,13 +20638,19 @@ queries:
     title: Ensure firewall rules do not allow full port range access
     impact: 40
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-no-large-port-range-gcp
         tags:
@@ -19850,13 +20774,19 @@ queries:
     title: Ensure default network firewall rules are restricted
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-firewall-default-rules-restricted-gcp
         tags:
@@ -19978,13 +20908,19 @@ queries:
     title: Ensure Compute Engine disks are encrypted with CSEK
     impact: 30
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-gcp
         tags:
@@ -20090,13 +21026,19 @@ queries:
     title: Ensure GKE workload metadata concealment is enabled
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-gcp
         tags:
@@ -20213,13 +21155,19 @@ queries:
     title: Ensure GKE control plane uses a private endpoint
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-gcp
         tags:
@@ -20728,13 +21676,19 @@ queries:
     title: Ensure Cloud Storage buckets have soft delete retention enabled
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
+      compliance/pci-dss-4: false
       compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
         tags:
@@ -20844,13 +21798,19 @@ queries:
     impact: 75
     filters: asset.platform == 'gcp'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
+      compliance/pci-dss-4: false
       compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       gcp.project.storageService.buckets.where(objectRetentionMode != "").all(
         objectRetentionMode == "Enabled"
@@ -20911,13 +21871,19 @@ queries:
     title: Ensure KMS key access justifications exclude customer-initiated support
     impact: 65
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-gcp
         tags:
@@ -21035,13 +22001,19 @@ queries:
     title: Ensure no custom routes send 0.0.0.0/0 to the default internet gateway
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
         tags:
@@ -21154,13 +22126,19 @@ queries:
     title: Ensure PSC service attachments do not accept connections automatically
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
         tags:
@@ -21274,13 +22252,19 @@ queries:
     title: Ensure Cloud SQL users authenticate via Cloud IAM, not built-in passwords
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp
         tags:
@@ -21396,13 +22380,19 @@ queries:
     title: Ensure Target SSL proxies have an explicit SSL policy attached
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
         tags:
@@ -21503,13 +22493,19 @@ queries:
     title: Ensure GKE network policy has a provider specified
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-gke-network-policy-provider-specified-gcp
         tags:
@@ -21638,13 +22634,19 @@ queries:
     impact: 60
     filters: asset.platform == "gcp-gke-cluster"
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       gcp.project.gkeService.cluster.notificationConfig == null ||
       gcp.project.gkeService.cluster.notificationConfig.pubsubEnabled == false ||
@@ -21722,13 +22724,19 @@ queries:
     impact: 75
     filters: asset.platform == 'gcp'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-13
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
+      compliance/pci-dss-4: false
       compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       gcp.project.gkeService.clusters.length == 0 ||
       gcp.project.gkeBackupService.backupPlans.where(
@@ -21806,13 +22814,19 @@ queries:
     title: Ensure Vertex AI index endpoints are not publicly accessible
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
         tags:
@@ -21918,13 +22932,19 @@ queries:
     impact: 80
     filters: asset.platform == 'gcp'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       gcp.project.vertexaiService.customJobs.where(
         state == "JOB_STATE_RUNNING" || state == "JOB_STATE_PENDING" || state == "JOB_STATE_QUEUED"
@@ -22000,13 +23020,19 @@ queries:
     title: Ensure IAP tunnel destination groups do not use overly broad CIDR ranges
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
         tags:
@@ -22113,13 +23139,19 @@ queries:
     impact: 70
     filters: asset.platform == 'gcp'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-12
       compliance/nis-2: false
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: false
       compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       gcp.project.dlpService.jobTriggers.none(
         status != "HEALTHY" ||
@@ -22210,13 +23242,19 @@ queries:
     title: Ensure DLP inspect templates include common credential info types
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-12
       compliance/nis-2: false
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: false
       compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
         tags:
@@ -22366,13 +23404,19 @@ queries:
     title: Ensure Model Armor templates enable prompt injection filtering
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-gcp
         tags:
@@ -22436,13 +23480,19 @@ queries:
     title: Ensure Model Armor templates enable malicious URI filtering
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-23
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-gcp
         tags:
@@ -22503,13 +23553,19 @@ queries:
     title: Ensure Model Armor templates have RAI filters configured
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: false
       compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-filters-gcp
         tags:
@@ -22589,13 +23645,19 @@ queries:
     title: Ensure Model Armor templates have Sensitive Data Protection
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-7-1
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-sdp-enabled-gcp
         tags:
@@ -22666,13 +23728,19 @@ queries:
     title: Ensure Model Armor templates enforce blocking mode
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-blocking-mode-gcp
         tags:
@@ -22733,13 +23801,19 @@ queries:
     title: Ensure Model Armor templates log sanitize operations
     impact: 50
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-model-armor-sanitize-logging-gcp
         tags:
@@ -22798,13 +23872,19 @@ queries:
     title: Ensure Model Armor RAI filters use adequate confidence
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: false
       compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
       compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-confidence-gcp
         tags:
@@ -22887,13 +23967,19 @@ queries:
     title: Ensure SCC notification configs are configured
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-5
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-scc-notification-configs-gcp
         tags:
@@ -22960,13 +24046,19 @@ queries:
     title: Ensure SCC BigQuery exports are configured
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
         tags:
@@ -23033,13 +24125,19 @@ queries:
     title: Ensure AlloyDB instances have audit logging database flags enabled
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-gcp-security-alloydb-audit-logging-flags-gcp
         tags:
@@ -23173,13 +24271,19 @@ queries:
     filters: |
       asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       if (gcp.sql.instance.diskEncryptionConfiguration['kmsKeyName'] != empty) {
         gcp.sql.instance.backupRuns.all(
@@ -23250,13 +24354,19 @@ queries:
     title: Ensure BigQuery AWS and Azure connections use identity federation
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-bigquery-aws-azure-connections-use-identity-federation-gcp
         tags:
@@ -23417,13 +24527,19 @@ queries:
     impact: 60
     filters: asset.platform == 'gcp-bigquery-dataset'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       gcp.project.bigqueryService.connections.where(type == "CLOUD_SQL").all(
         modified != null && modified > time.now - 90 * time.day
@@ -23493,13 +24609,19 @@ queries:
     impact: 80
     filters: asset.platform == 'gcp-bigquery-dataset'
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       gcp.project.bigqueryService.connections.where(type == "CLOUD_RESOURCE").all(
         properties['serviceAccountId'] == null ||
@@ -23587,13 +24709,19 @@ queries:
     title: Ensure Spanner backup schedules use customer-managed encryption
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-spanner-backup-schedule-cmek-encryption-gcp
         tags:
@@ -23725,13 +24853,19 @@ queries:
     title: Ensure Spanner instance and database IAM grant no primitive roles
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-spanner-iam-no-primitive-roles-gcp
         tags:
@@ -23912,13 +25046,19 @@ queries:
     title: Ensure Spanner IAM has no public or anonymous principals
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-spanner-iam-no-public-principals-gcp
         tags:
@@ -24073,13 +25213,19 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances require IAM authentication
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-memorystore-iam-auth-enabled-gcp
         tags:
@@ -24173,13 +25319,19 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances enable in-transit encryption
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gcp-security-memorystore-transit-encryption-enabled-gcp
         tags:
@@ -24269,13 +25421,19 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-memorystore-cmek-encryption-gcp
         tags:
@@ -24373,13 +25531,19 @@ queries:
     title: Ensure Memorystore backup collections are encrypted with CMEK
     impact: 60
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     docs:
       desc: |
         This check ensures that Memorystore backup collections are encrypted with a customer-managed encryption key (CMEK). Backups inherit the CMEK of the source instance — an instance without CMEK produces backups without CMEK, and a CMEK key whose Cloud Storage permissions are misconfigured can leave backups effectively under Google-managed protection.
@@ -24422,13 +25586,19 @@ queries:
     title: Ensure Memorystore Private Service Connect endpoints are not public
     impact: 95
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     docs:
       desc: |
         This check ensures that no Memorystore instance exposes a `PUBLIC_ENDPOINT` Private Service Connect (PSC) attachment. Memorystore PSC connections should always have `connection_type` of `PRIVATE_SERVICE_CONNECT`, which terminates inside a consumer VPC.
@@ -24484,13 +25654,19 @@ queries:
     title: Ensure Memorystore engineConfigs keep protected-mode enabled
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-memorystore-engine-config-protected-mode-gcp
         tags:
@@ -24590,13 +25766,19 @@ queries:
     title: Ensure Memorystore engine version is not a known-vulnerable release
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-08
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     docs:
       desc: |
         This check ensures that Memorystore instances do not run an engine version with publicly disclosed CVEs. The MQL exposes `engineVersion` (for example `valkey-7.5`, `redis-7.2`); this check fails when the version matches a known-vulnerable release for which Memorystore has not yet patched.
@@ -24654,13 +25836,19 @@ queries:
     title: Ensure Datastream streams are encrypted with CMEK
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-gcp
         tags:
@@ -24757,13 +25945,19 @@ queries:
     title: Ensure Datastream profiles avoid static service IP connectivity
     impact: 85
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
         tags:
@@ -24876,13 +26070,19 @@ queries:
     title: Ensure Datastream connection profiles do not use forward SSH connectivity
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
         tags:
@@ -24963,13 +26163,19 @@ queries:
     title: Ensure Datastream source profiles store credentials in Secret Manager
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
         tags:
@@ -25151,13 +26357,19 @@ queries:
     title: Ensure Datastream private-connection routes do not advertise public CIDRs
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-gcp
         tags:
@@ -25262,13 +26474,19 @@ queries:
     title: Ensure Datastream GCS destination buckets are hardened
     impact: 75
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     docs:
       desc: |
         This check ensures that any Cloud Storage bucket used as a Datastream GCS destination has the standard data-tier hardening: uniform bucket-level access enabled, public access prevention enforced, and CMEK configured. It uses the typed `connectionProfile.bucket` cross-reference exposed by the Datastream resource model — the bucket is resolved into the `gcp.project.storageService.bucket` resource, and the same field-level checks already used for general bucket policies are applied.
@@ -25311,13 +26529,19 @@ queries:
     title: Ensure Datastream private connections do not peer the default VPC
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-gcp
         tags:
@@ -25422,13 +26646,19 @@ queries:
     title: Ensure Memorystore for Memcached instances are not on the default VPC
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     variants:
       - uid: mondoo-gcp-security-memcache-instance-not-default-vpc-gcp
         tags:
@@ -25533,13 +26763,19 @@ queries:
     title: Ensure Memorystore for Memcached discovery endpoints are RFC1918 addresses
     impact: 90
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     docs:
       desc: |
         This check ensures that the Memorystore for Memcached auto-discovery endpoint resolves to an address inside RFC1918 (private) space. Memcached has no native auth or TLS, so any address that is reachable from outside the authorized VPC is a direct path to unauthenticated cache reads and writes.
@@ -25571,13 +26807,19 @@ queries:
     title: Ensure Memcached engine version is not a known-vulnerable release
     impact: 70
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-08
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gcp-security-memcache-engine-version-supported-gcp
         tags:
@@ -25668,13 +26910,19 @@ queries:
     title: Ensure Compute Engine snapshot IAM has no public principals
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-public-principals-gcp
         tags:
@@ -25798,13 +27046,19 @@ queries:
     title: Ensure Compute Engine snapshot IAM grants no primitive roles
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-gcp
         tags:
@@ -25931,13 +27185,19 @@ queries:
     title: Ensure Compute Engine custom image IAM has no public principals
     impact: 100
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-image-iam-no-public-principals-gcp
         tags:
@@ -26055,13 +27315,19 @@ queries:
     title: Ensure Compute Engine custom image IAM grants no primitive roles
     impact: 80
     tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
       - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles-gcp
         tags:


### PR DESCRIPTION
## Summary

Brings every parent check in `mondoo-gcp-security.mql.yaml` up to the policy's declared 13-framework universe. Adds `compliance/bsi-grundschutz-sys15`, `csa-cloud-controls-matrix-4`, `dora`, `hipaa`, `pci-dss-4`, and `vda-isa-5` tags to the 211 parent checks that didn't have them. After this PR the audit script reports 0 framework-parity gaps in this policy.

Same shape as #2475 (kubernetes), but at higher scale.

## How mappings were chosen

Each gap-tagged check was categorized by its existing `(iso-27001-2022, nist-csf-2, nist-sp-800-53-rev5)` signature — the team's already-verified anchor. Each combo maps to a 6-framework template derived from the 14 fully-tagged AWS checks (which the team established as the canonical pattern) and verified against control text in `cnspec-enterprise-policies/frameworks/<fw>.mql.yaml`. No tags were copied from neighboring checks per `content/CLAUDE.md`.

| Category | Checks | PCI | CSA CCM-4 | DORA | HIPAA | VDA-ISA-5 | BSI |
|---|---|---|---|---|---|---|---|
| encryption-at-rest | 39 | 3.5.1 | CEK-03 | art-9 | 312(a)(2)(iv) | 5.1.1 | false |
| encryption-in-transit | 12 | 4.2.1 | CEK-04 | art-9 | 312(e)(1) | 5.1.2 | false |
| network-segmentation | 51 | 1.3.1 | IVS-03 | art-9 | 312(e)(1) | 5.2.6 | false |
| audit-logging | 15 | 10.2.1 | LOG-08 | art-10 | 312(b) | 5.2.4 | false |
| iam-authorization | 35 | 7.2.1 | IAM-04 | art-9 | 312(a)(1) | 4.1.1 | false |
| identity-credentials | 20 | 8.3.1 | IAM-02 | art-9 | 312(d) | 4.1.3 | false |
| hardening-config | 14 | 2.2.1 | CCC-06 | art-9 | false | 5.2.1 | false |
| patching | 6 | 6.3.3 | TVM-03 | art-9 | false | 5.2.1 | false |
| backup | 7 | false | BCR-08 | art-12 | 308(a)(7)(ii)(A) | false | false |
| integrity | 8 | false | false | art-9 | 312(c)(1) | false | false |
| dlp / model-armor | 8 | false | false | false | false | false | false |

## Why so many `false` entries on certain rows

Per `content/CLAUDE.md`, **a missing mapping is strictly better than a wrong one**:

- **`bsi-grundschutz-sys15: false` on every check** — BSI-Grundschutz SYS.1.5 is a virtualization-host hardening module. Cloud-resource configuration (the focus of this policy) is out of its scope. Every fully-tagged AWS check uses this same convention.
- **`pci-dss-4: false` on backup, integrity, model-armor** — PCI DSS v4 doesn't have a cardholder-data-aware control for these areas. Best-fit attempts (e.g. mapping backup to a generic incident-response control) would be loose.
- **`hipaa: false` on hardening, patching** — HIPAA Security Rule's technical safeguards don't address configuration baselines or patch cadence; those obligations live in the administrative safeguards, which are policy-level rather than configuration-checkable.
- **`csa: false` on integrity** — Boot-integrity / shielded-VM controls don't have a clean CCM v4 anchor; UEM/AIS controls are about endpoint and application security broadly.

## Diff shape

- `+1,266` lines, `0` deletions, `0` reorders of existing keys.
- New compliance keys are inserted alphabetically within the existing `compliance/*` block; existing keys retain their original order.

## Test plan

- [x] `cnspec policy lint content/mondoo-gcp-security.mql.yaml` → `valid policy bundle(s)`
- [x] Audit script (`audit_compliance_tags.py`) confirms 0 framework-parity gaps after the change
- [x] Spot-checked sample mappings in each category against framework YAML control titles
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)