### PR TITLE
:label: Add 13-framework compliance tags to all 11 grafana parent checks

### DIFF
--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -72,6 +72,20 @@ queries:
   - uid: mondoo-grafana-no-admin-service-accounts
     title: Ensure service accounts do not use the Admin role
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     filters: asset.platform == "grafana-org"
     mql: grafana.serviceAccounts.none(role == "Admin")
     docs:
@@ -96,6 +110,20 @@ queries:
   - uid: mondoo-grafana-service-account-tokens-have-expiration
     title: Ensure all service account tokens have an expiration date
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     filters: asset.platform == "grafana-org"
     mql: grafana.serviceAccounts.all(tokens.all(hasExpiration == true))
     docs:
@@ -129,6 +157,20 @@ queries:
   - uid: mondoo-grafana-no-expired-service-account-tokens
     title: Ensure no expired service account tokens exist
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     filters: asset.platform == "grafana-org"
     mql: grafana.serviceAccounts.all(tokens.none(isExpired == true))
     docs:
@@ -159,6 +201,20 @@ queries:
   - uid: mondoo-grafana-disabled-service-accounts-no-tokens
     title: Ensure disabled service accounts have no active tokens
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     filters: asset.platform == "grafana-org"
     mql: |
       grafana.serviceAccounts.where(isDisabled == true).all(
@@ -185,6 +241,20 @@ queries:
   - uid: mondoo-grafana-limit-org-admins
     title: Ensure the number of organization administrators is limited
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     filters: asset.platform == "grafana-org"
     mql: grafana.users.where(role == "Admin").length <= 3
     docs:
@@ -210,6 +280,20 @@ queries:
   - uid: mondoo-grafana-no-default-admin-login
     title: Ensure the default admin login has been changed
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     filters: asset.platform == "grafana-org"
     mql: grafana.users.none(login == "admin" && role == "Admin")
     docs:
@@ -240,6 +324,20 @@ queries:
   - uid: mondoo-grafana-datasources-use-proxy-mode
     title: Ensure datasources use proxy access mode
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     filters: asset.platform == "grafana-org"
     mql: grafana.datasources.all(access == "proxy")
     docs:
@@ -262,6 +360,20 @@ queries:
   - uid: mondoo-grafana-datasources-no-basic-auth
     title: Ensure datasources do not use basic authentication
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     filters: asset.platform == "grafana-org"
     mql: grafana.datasources.none(basicAuth == true)
     docs:
@@ -288,6 +400,20 @@ queries:
   - uid: mondoo-grafana-datasources-use-tls
     title: Ensure datasource connections use TLS
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     filters: asset.platform == "grafana-org"
     mql: |
       grafana.datasources.where(url != "").all(
@@ -325,6 +451,20 @@ queries:
   - uid: mondoo-grafana-notification-policy-has-receiver
     title: Ensure notification policy has a default receiver configured
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     filters: asset.platform == "grafana-org"
     mql: grafana.notificationPolicy.receiver != ""
     docs:
@@ -346,6 +486,20 @@ queries:
   - uid: mondoo-grafana-contact-points-resolve-enabled
     title: Ensure contact points do not disable resolve messages
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     filters: asset.platform == "grafana-org"
     mql: grafana.contactPoints.none(disableResolveMessage == true)
     docs:


### PR DESCRIPTION
## Summary

`mondoo-grafana-security.mql.yaml` had no compliance tags before this PR. Adds the same 13-framework set used by AWS / GCP / k8s / proxmox (#2475, #2478, #2479, #2480) so this policy can satisfy compliance reporting alongside the rest.

## Per-check categorization

Each of the 11 parent checks is **explicitly categorized** (not heuristically) in the backfill script — every uid is in `OVERRIDES` so the script fails fast on unknown checks rather than silently mis-tagging.

| Category | Checks |
|---|---|
| identity-auth (5) | service-account-tokens-have-expiration, no-expired-service-account-tokens, disabled-service-accounts-no-tokens, no-default-admin-login, datasources-no-basic-auth |
| iam-authorization (2) | no-admin-service-accounts, limit-org-admins |
| audit-logging (2) | notification-policy-has-receiver, contact-points-resolve-enabled |
| network-segmentation (1) | datasources-use-proxy-mode (browser → datasource isolation) |
| encryption-in-transit (1) | datasources-use-tls |

## Templates

Same 13-framework templates as the previous four PRs — derived from the 14 fully-tagged AWS checks and verified against control text in `cnspec-enterprise-policies/frameworks/`. `bsi-grundschutz-sys15: false` everywhere because BSI-SYS15 is virtualization-host hardening (out of scope for application-layer Grafana checks).

## Test plan

- [x] `cnspec policy lint content/mondoo-grafana-security.mql.yaml` → `valid policy bundle(s)`
- [x] Audit script reports `mondoo-grafana-security` at 13 frameworks, 0 gaps
- [x] Spot-checked sample mappings (no-default-admin-login → IDENTITY_AUTH; datasources-use-proxy-mode → NET_SEG; notification-policy → AUDIT_LOG)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)