### PR TITLE
:label: Add 13-framework compliance tags to all 38 AI-security checks

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -98,6 +98,20 @@ queries:
   - uid: mondoo-ai-security-no-unapproved-ai-processes
     title: No unapproved AI agent processes are running
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     props:
       - uid: mondooAiSecurityApprovedProcesses
         title: Regex matching approved AI process names
@@ -150,6 +164,20 @@ queries:
   - uid: mondoo-ai-security-no-unapproved-ai-packages
     title: No unapproved AI tools installed via package managers
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     props:
       - uid: mondooAiSecurityApprovedPackages
         title: Regex matching approved AI package names
@@ -201,6 +229,20 @@ queries:
     title: No unapproved AI tools installed via Homebrew
     filters: asset.platform == "macos"
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     props:
       - uid: mondooAiSecurityApprovedHomebrewPackages
         title: Regex matching approved Homebrew AI package names
@@ -229,6 +271,20 @@ queries:
   - uid: mondoo-ai-security-no-cursor
     title: Cursor editor is not configured on this endpoint
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       cursor.skills.length == 0 && cursor.mcpServers.length == 0 && cursor.rules.length == 0
     docs:
@@ -266,6 +322,20 @@ queries:
   - uid: mondoo-ai-security-no-windsurf
     title: Windsurf editor is not configured on this endpoint
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       windsurf.skills.length == 0 && windsurf.mcpServers.length == 0 && windsurf.rules.length == 0
     docs:
@@ -301,6 +371,20 @@ queries:
   - uid: mondoo-ai-security-no-goose
     title: Goose AI agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       goose.skills.length == 0 && goose.extensions.length == 0
     docs:
@@ -332,6 +416,20 @@ queries:
   - uid: mondoo-ai-security-no-zed
     title: Zed editor is not configured on this endpoint
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       zed.extensions.length == 0
     docs:
@@ -358,6 +456,20 @@ queries:
   - uid: mondoo-ai-security-no-cline
     title: Cline agent is not configured on this endpoint
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: cline.skills.length == 0
     docs:
       desc: |
@@ -388,6 +500,20 @@ queries:
   - uid: mondoo-ai-security-no-roo
     title: Roo Code agent is not configured on this endpoint
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: roo.skills.length == 0
     docs:
       desc: |
@@ -418,6 +544,20 @@ queries:
   - uid: mondoo-ai-security-no-continuedev
     title: Continue agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: continuedev.skills.length == 0
     docs:
       desc: |
@@ -448,6 +588,20 @@ queries:
   - uid: mondoo-ai-security-no-trae
     title: Trae agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: trae.skills.length == 0
     docs:
       desc: |
@@ -478,6 +632,20 @@ queries:
   - uid: mondoo-ai-security-no-opencode
     title: OpenCode agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: opencode.skills.length == 0
     docs:
       desc: |
@@ -508,6 +676,20 @@ queries:
   - uid: mondoo-ai-security-no-kiro
     title: Kiro agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: kiro.skills.length == 0
     docs:
       desc: |
@@ -538,6 +720,20 @@ queries:
   - uid: mondoo-ai-security-no-pi
     title: Pi agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: pi.skills.length == 0
     docs:
       desc: |
@@ -568,6 +764,20 @@ queries:
   - uid: mondoo-ai-security-no-mistral-vibe
     title: Mistral Vibe is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: mistral.vibe.skills.length == 0
     docs:
       desc: |
@@ -598,6 +808,20 @@ queries:
   - uid: mondoo-ai-security-no-antigravity
     title: Antigravity agent is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: antigravity.skills.length == 0
     docs:
       desc: |
@@ -628,6 +852,20 @@ queries:
   - uid: mondoo-ai-security-no-ibm-bob
     title: IBM Bob is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: ibm.bob.skills.length == 0
     docs:
       desc: |
@@ -658,6 +896,20 @@ queries:
   - uid: mondoo-ai-security-no-openclaw
     title: OpenClaw is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: openclaw.skills.length == 0
     docs:
       desc: |
@@ -688,6 +940,20 @@ queries:
   - uid: mondoo-ai-security-no-snowflake-cortex
     title: Snowflake Cortex Code is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: snowflake.cortex.skills.length == 0
     docs:
       desc: |
@@ -718,6 +984,20 @@ queries:
   - uid: mondoo-ai-security-no-junie
     title: Junie is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: junie.skills.length == 0
     docs:
       desc: |
@@ -748,6 +1028,20 @@ queries:
   - uid: mondoo-ai-security-no-augment
     title: Augment is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: augment.skills.length == 0
     docs:
       desc: |
@@ -778,6 +1072,20 @@ queries:
   - uid: mondoo-ai-security-no-warp
     title: Warp AI terminal is not configured on this endpoint
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: warp.skills.length == 0
     docs:
       desc: |
@@ -808,6 +1116,20 @@ queries:
   - uid: mondoo-ai-security-no-kilocode
     title: Kilo Code is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: kilocode.skills.length == 0
     docs:
       desc: |
@@ -838,6 +1160,20 @@ queries:
   - uid: mondoo-ai-security-no-openhands
     title: OpenHands is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: openhands.skills.length == 0
     docs:
       desc: |
@@ -868,6 +1204,20 @@ queries:
   - uid: mondoo-ai-security-no-qwen-code
     title: Qwen Code is not configured on this endpoint
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: qwen.code.skills.length == 0
     docs:
       desc: |
@@ -901,6 +1251,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-codeium-extension
     title: No Codeium extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)codeium\./
@@ -983,6 +1347,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-tabnine-extension
     title: No Tabnine extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)tabnine\./
@@ -1028,6 +1406,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-supermaven-extension
     title: No Supermaven extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)supermaven\./
@@ -1073,6 +1465,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-continue-extension
     title: No Continue extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)continue\.continue/
@@ -1118,6 +1524,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-cline-extension
     title: No Cline extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)saoudrizwan\.claude-dev|cline\./
@@ -1163,6 +1583,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-cody-extension
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)sourcegraph\.cody/
@@ -1208,6 +1642,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-codex-extension
     title: No OpenAI Codex extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)openai\.codex/
@@ -1253,6 +1701,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-claude-extension
     title: No Claude extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)anthropic\.claude/
@@ -1298,6 +1760,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-cursor-extension
     title: No Cursor-specific extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)cursor\./
@@ -1343,6 +1819,20 @@ queries:
   - uid: mondoo-ai-security-no-vscode-roo-extension
     title: No Roo Code extensions in VS Code-compatible editors
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
         identifier == /(?i)rooveterinaryinc\.roo-cline|roocode\./
@@ -1391,6 +1881,20 @@ queries:
   - uid: mondoo-ai-security-no-unapproved-mcp-servers
     title: No unapproved MCP servers across all AI agents
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     props:
       - uid: mondooAiSecurityApprovedMcpServers
         title: Regex matching approved MCP server names (applies to all agents)
@@ -1461,6 +1965,20 @@ queries:
   - uid: mondoo-ai-security-no-local-llm-runtimes
     title: No local LLM runtimes are running
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       processes.where(
         executable == /(?i)(ollama|llama|lmstudio|lm-studio|localai|gpt4all)/
@@ -1504,6 +2022,20 @@ queries:
   - uid: mondoo-ai-security-no-local-llm-listening-ports
     title: No local LLM inference servers are listening
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-5
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: false
     mql: |
       ports.listening.where(
         port == 11434 || port == 1234 || port == 1337


### PR DESCRIPTION
## Summary

`mondoo-ai-security.mql.yaml` had no compliance tags before this PR. All 38 checks detect unapproved AI tools / agents / VS Code extensions / local LLM runtimes on managed endpoints — i.e. they enforce **software-installation restrictions** (shadow-IT prevention).

## Why a new template (UNAUTHORIZED_SOFTWARE)

The existing HARDENING template (used in proxmox/grafana/AWS/GCP for least-functionality config) doesn't strictly fit this enforcement objective. AI tooling on endpoints is more accurately captured by controls that target *unauthorized software installation and execution*, not *configuration baselines*. Anchored on:

| Framework | Control | Why it fits |
|---|---|---|
| ISO 27001:2022 | A.8.19 | "Installation of software on operational systems" — exact fit |
| NIST CSF 2 | PR.PS-05 | "Installation and execution of unauthorized software are prevented" — exact fit |
| NIST 800-171 | §3.4.8 | "deny-by-exception / permit-by-exception software policy" — exact fit |
| NIST 800-53 | CM-10 | "Software Usage Restrictions" — closer than CM-7 (Least Functionality) |
| SOC2 2017 | CC6.8.1 | "Restricts Application and Software Installation" — exact fit |
| CSA CCM-4 | UEM-02 | "Application and Service Approval" |
| HIPAA | 308(a)(5)(ii)(B) | "Protection from Malicious Software" |
| DORA | Article 9 | "Protection and Prevention" |
| NIS-2 | 21.2(e) | "security in development and maintenance" |
| NIST CSF 1 | DE.CM-5 | "Unauthorized mobile code is detected" |

## Honest `false` mappings

- **`pci-dss-4: false`** — PCI DSS v4 has no cardholder-data-aware control for endpoint AI tooling; 12.3.4 (annual technology review) is policy-level, not a configuration check.
- **`vda-isa-5: false`** — VDA-ISA 5.2.3 covers malware protection, but AI tools aren't strictly malware. 5.2.1 (change management) is also a stretch. `false` per content/CLAUDE.md guidance (missing > wrong).
- **`bsi-grundschutz-sys15: false`** — BSI-SYS15 covers virtualization-host hardening, out of scope for endpoint software restriction.

## Test plan

- [x] `cnspec policy lint content/mondoo-ai-security.mql.yaml` → `valid policy bundle(s)`
- [x] Audit script reports `mondoo-ai-security` at 13 frameworks, 0 gaps
- [x] All 38 check uids explicitly listed in `OVERRIDES` (script fails fast on uncategorized checks)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)