### PR TITLE
:label: Add 13-framework compliance tags to all 10 chef-infra-client checks

### DIFF
--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -49,6 +49,20 @@ queries:
   - uid: etc-chef-directory-permissions
     title: Ensure /etc/chef/ is owned by root with 750 permissions
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       if (file("/etc/chef").exists) {
         file("/etc/chef") {
@@ -111,6 +125,20 @@ queries:
   - uid: var-chef-directory-permissions
     title: Ensure /var/chef/ is owned by root with 750 permissions
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       if (file("/var/chef").exists) {
         file("/var/chef") {
@@ -173,6 +201,20 @@ queries:
   - uid: var-log-chef-directory-permissions
     title: Ensure /var/log/chef/ is owned by root with 750 permissions
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       if (file("/var/log/chef").exists) {
         file("/var/log/chef") {
@@ -236,6 +278,20 @@ queries:
   - uid: client-rb-permissions
     title: Ensure /etc/chef/client.rb is owned by root with 640 permissions
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       if (file("/etc/chef/client.rb").exists) {
         file("/etc/chef/client.rb") {
@@ -300,6 +356,20 @@ queries:
   - uid: client-pem-permissions
     title: Ensure /etc/chef/client.pem is owned by root with 640 permissions
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       if (file("/etc/chef/client.pem").exists) {
         file("/etc/chef/client.pem") {
@@ -369,6 +439,20 @@ queries:
   - uid: validation-pem-not-present
     title: Ensure /etc/chef/validation.pem is not present
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       file("/etc/chef/validation.pem").exists == false
     docs:
@@ -422,6 +506,20 @@ queries:
   - uid: non-eol-infra-client
     title: Ensure a non-EOL Chef Infra Client or Cinc Client release is used
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       command("chef-client -v") {
         stdout == /^(Chef Infra|Cinc) Client: (17|18|19|20|21).*/m
@@ -503,6 +601,20 @@ queries:
   - uid: disable-legacy-encrypted-data-bags
     title: Disable support for less secure Encrypted Data Bag versions
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       if (file("/etc/chef/client.rb").exists) {
         file("/etc/chef/client.rb").content.contains("data_bag_decrypt_minimum_version 3")
@@ -562,6 +674,20 @@ queries:
   - uid: avoid-reporting-tokens-in-config
     title: Avoid storing Automate tokens in the client.rb config
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       if (file("/etc/chef/client.rb").exists) {
         file("/etc/chef/client.rb").content.contains("data_collector.token") == false
@@ -631,6 +757,20 @@ queries:
   - uid: ssl-verification-enabled
     title: Ensure SSL verification is not disabled
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       if (file("/etc/chef/client.rb").exists) {
         file("/etc/chef/client.rb").content.contains("ssl_verify_mode :verify_none") == false


### PR DESCRIPTION
## Summary

`mondoo-chef-infra-client.mql.yaml` had no compliance tags before this PR. Adds the canonical 13-framework set used by AWS / GCP / k8s / proxmox / grafana so this policy can satisfy compliance reporting alongside the rest.

## Per-check categorization

| Category | Checks |
|---|---|
| iam-authorization (5) | etc-chef-directory-permissions, var-chef-directory-permissions, var-log-chef-directory-permissions, client-rb-permissions, client-pem-permissions |
| identity-auth (2) | validation-pem-not-present (stale credential cleanup), avoid-reporting-tokens-in-config (no Automate tokens in client.rb) |
| patching (1) | non-eol-infra-client |
| encryption-at-rest (1) | disable-legacy-encrypted-data-bags (legacy crypto algorithm) |
| encryption-in-transit (1) | ssl-verification-enabled |

Templates derived from #2475 (k8s) / #2478 (GCP) / #2479 (AWS) / #2480 (proxmox) / #2481 (grafana) — verified against control text in `cnspec-enterprise-policies/frameworks/`.

## Test plan

- [x] `cnspec policy lint content/mondoo-chef-infra-client.mql.yaml` → `valid policy bundle(s)`
- [x] Audit script reports `mondoo-chef-infra-client` at 13 frameworks, 0 gaps
- [x] All 10 check uids explicitly listed in `OVERRIDES`
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)