### PR TITLE
:label: Add 13-framework compliance tags to both EDR parent checks

### DIFF
--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -65,6 +65,20 @@ queries:
   - uid: mondoo-edr-policy-ensure-edr-agent-is-installed
     title: Ensure EDR Agent is installed
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-09
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/pci-dss-4: pcidss-requirement-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-edr-policy-ensure-edr-agent-is-installed-macos
         tags:
@@ -114,6 +128,20 @@ queries:
   - uid: mondoo-edr-policy-ensure-edr-agent-is-running
     title: Ensure EDR Agent is running
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-09
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/pci-dss-4: pcidss-requirement-5-3-5
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-edr-policy-ensure-crowdstrike-agent-is-running-macos
         tags:


### PR DESCRIPTION
## Summary

- mondoo-edr-policy had no compliance tags before this PR
- Both parent checks (`ensure-edr-agent-is-installed`, `ensure-edr-agent-is-running`) now carry the canonical 13-framework set
- Mappings target anti-malware / endpoint protection controls (ISO 27001 A.8.7, NIST CSF DE.CM-4 / DE.CM-09, NIST 800-53 SI-3, NIST 800-171 3.14.2, SOC 2 CC6.8.4, CSA CCM UEM-09, HIPAA §164.308(a)(5)(ii)(B), VDA-ISA 5.2.3, DORA Art. 10, NIS-2 Art. 21.2(b))
- PCI DSS 4 split: `5-2-1` (deployed) for the *installed* check, `5-3-5` (actively running) for the *running* check
- `bsi-grundschutz-sys15: false` — SYS.1.5 covers virtualization only and has no malware control

## Test plan

- [x] `cnspec policy lint content/mondoo-edr-policy.mql.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)