### PR TITLE
:pencil2: Ignore .claude/ working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 
 # claude local config
 settings.local.json
+.claude/
 
 # python
 __pycache__/


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` so local Claude Code state (settings overrides, worktrees, etc.) doesn't leak in.
- `settings.local.json` was already covered by basename match; this widens to the whole tree.

## Test plan

- [x] Verified no `.claude/*` files are currently tracked (`git ls-files | grep ^.claude/` is empty).