### PR TITLE
Rewrite policy descriptions to focus on user value

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -69,6 +69,7 @@ bhttp
 bigfish
 bigquery
 bigtable
+BIMI
 binauthz
 blackbox
 blackholes
@@ -271,7 +272,6 @@ gunicorn
 hbdev
 hcloud
 HDFS
-healthinsights
 healthreporting
 Helpdesk
 hetzner
@@ -579,6 +579,7 @@ sqlserver
 srcaddr
 ssbd
 sshusers
+SSID
 ssldir
 ssllabs
 ssltest
@@ -615,7 +616,6 @@ tmsh
 TNS
 totp
 trae
-tskey
 tsuki
 tvm
 twofactor

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -16,16 +16,20 @@ policies:
         email: hello@mondoo.com
     summary: Enforce approved AI coding agents, IDE extensions, MCP servers, and local LLM runtimes
     docs:
-      desc: |-
-        The Mondoo AI Security policy identifies unsanctioned AI tooling on corporate endpoints that could exfiltrate source code, leak credentials, or introduce supply-chain risk. Unapproved coding agents, IDE extensions, and MCP servers can transmit sensitive files to third-party model providers, bypass code-review controls, and create blind spots for security teams.
+      desc: |
+        The Mondoo AI Security policy identifies unsanctioned AI tooling on corporate endpoints that could exfiltrate source code, leak credentials, or introduce supply-chain risk. This policy helps organizations enforce AI governance and detect unauthorized tooling before it can transmit sensitive files to third-party model providers, bypass code-review controls, and create blind spots for security teams.
 
-        This policy validates AI tooling governance across endpoints by:
-          - Detecting unapproved AI coding agents installed as running processes, system packages, or Homebrew packages
-          - Identifying unapproved AI assistant extensions in VS Code
-          - Flagging Model Context Protocol (MCP) servers that aren't on the approved allow-list
-          - Surfacing local LLM runtimes and any LLM ports listening on the network
+        This policy provides security checks across endpoint AI tooling, surfacing unsanctioned components and exposure points:
+
+        - AI coding agents installed as running processes, system packages, or Homebrew packages
+        - AI assistant extensions installed in Visual Studio Code
+        - Model Context Protocol (MCP) servers running outside the approved allow-list
+        - Local large language model runtimes
+        - LLM ports listening on the network
 
         By default, only GitHub Copilot and Claude Code are approved. Customize the allow-lists by overriding the `props` values for your environment.
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Unapproved AI Coding Agents
         filters: |

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -15,23 +15,22 @@ policies:
         email: hello@mondoo.com
     summary: Secure Arista EOS switches and routers
     docs:
-      desc: |-
-        The Mondoo Arista EOS Security policy provides comprehensive security checks for Arista EOS network switches and routers. This policy helps ensure your Arista network infrastructure is properly configured, hardened, and maintained according to security best practices.
+      desc: |
+        The Mondoo Arista EOS Security policy identifies critical misconfigurations on Arista EOS switches and routers that could leave your network infrastructure vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, traffic interception, lateral movement, and disruption of network services.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key areas of Arista EOS configuration, uncovering misconfigurations that could put your network fabric at risk:
 
-        - Validates user authentication, password policies, and privilege management
-        - Ensures proper AAA configuration and multifactor authentication
-        - Verifies secure protocols are used and insecure protocols are disabled
-        - Validates interface configurations and security settings
-        - Ensures proper VLAN configuration and native VLAN protection
-        - Validates SNMP configuration security
-        - Ensures accurate time synchronization for logging and auditing
-        - Validates comprehensive logging configuration
-        - Ensures proper console and remote access controls
-        - Validates security banners, timeouts, and system configuration
-        - Ensures BGP peers have proper route filtering and documentation
-        - Validates ACL completeness and logging for denied traffic
+        - User authentication, password policies, and privilege management
+        - AAA configuration and multifactor authentication
+        - Secure management protocols and removal of insecure cleartext protocols
+        - Interface configuration and VLAN security, including native VLAN protection
+        - SNMP hardening
+        - NTP time synchronization for accurate logging and audit trails
+        - Centralized logging and remote log collection
+        - Console, VTY, and remote access controls with timeouts and ACLs
+        - Security banners and session controls
+        - BGP route filtering and peer documentation
+        - ACL completeness and logging for denied traffic
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -18,7 +18,7 @@ policies:
     summary: Secure AWS EC2, S3, IAM, RDS, Lambda, and more
     docs:
       desc: |
-        The Mondoo AWS Security policy is designed to identify critical misconfigurations that could leave your AWS infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
+        The Mondoo AWS Security policy identifies critical misconfigurations that could leave your AWS infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
         This policy provides security checks across key AWS services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -17,7 +17,7 @@ policies:
     summary: Secure Azure VMs, storage, networking, and IAM
     docs:
       desc: |
-        The Mondoo Azure Security policy is designed to identify critical misconfigurations that could leave your Azure infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
+        The Mondoo Azure Security policy identifies critical misconfigurations that could leave your Azure infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
         This policy provides security checks across key Azure services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -15,14 +15,14 @@ policies:
         email: hello@mondoo.com
     summary: Secure F5 BIG-IP device configurations
     docs:
-      desc: |-
-        The Mondoo F5 BIG-IP Security policy provides security checks for F5 BIG-IP application delivery controllers. This policy helps ensure your BIG-IP infrastructure is properly configured and hardened according to security best practices.
+      desc: |
+        The Mondoo F5 BIG-IP Security policy identifies critical misconfigurations on F5 BIG-IP application delivery controllers that could leave your application traffic vulnerable to interception, downgrade, or unauthorized access. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of TLS downgrade attacks, certificate compromise, and unauthorized administrative access.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key BIG-IP areas, uncovering misconfigurations that could weaken application delivery security:
 
-        - **SSL/TLS Certificates**: Validates that certificates are not expired and use strong cryptographic parameters
-        - **SSL/TLS Profiles**: Ensures client and server SSL profiles use secure cipher suites and proper authentication
-        - **Network Security**: Checks VLAN source checking, route domain isolation, and SNMP access restrictions
+        - **SSL/TLS certificates**: Validity, expiration, and cryptographic strength
+        - **SSL/TLS profiles**: Client and server profiles, cipher suites, and authentication
+        - **Network security**: VLAN source checking, route domain isolation, and SNMP access restrictions
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -15,10 +15,16 @@ policies:
         email: hello@mondoo.com
     summary: Secure Chef Infra Client credentials and installations
     docs:
-      desc: |-
-        Mondoo Chef Infra Client Security identifies insecure Chef Infra Client installations that could expose node credentials, as well as end-of-life client releases that no longer receive security updates per the [Chef Supported Versions documentation](https://docs.chef.io/versions/).
+      desc: |
+        The Mondoo Chef Infra Client Security policy identifies insecure Chef Infra Client installations that could expose node credentials and provide attackers with a path to compromise every system the client manages. This policy helps organizations detect end-of-life client releases that no longer receive security updates and configuration weaknesses that could let an attacker steal client keys, escalate privileges, or pivot from a managed node into the broader Chef-managed estate.
 
-        If you have questions, comments, or have identified ways to improve this policy, please write me at tim@mondoo.com, or reach out in the [Mondoo Slack Community](https://mondoo.link/slack).
+        This policy provides security checks across key Chef Infra Client areas:
+
+        - End-of-life client versions per the [Chef Supported Versions documentation](https://docs.chef.io/versions/)
+        - File permissions on client configuration and credential files
+        - Secure configuration of the client run environment
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Insecure permissions
         filters: |

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -15,13 +15,16 @@ policies:
         email: hello@mondoo.com
     summary: Secure Chef Infra Server components and configurations
     docs:
-      desc: |-
-        Mondoo Chef Infra Server Security identifies several misconfigurations and end-of-life components that allow attackers to expose node information:
-          - Insecure disk permissions on critical directories and configuration files.
-          - End-of-life components installed on the Chef Infra Server such as Push Jobs, Analytics, or Reporting, which no longer receive security updates.
-          - Insecure server settings such as non-secure TLS support or legacy add-on compatibility.
+      desc: |
+        The Mondoo Chef Infra Server Security policy identifies misconfigurations and end-of-life components on Chef Infra Server that could expose node credentials, configuration data, and the keys to your fleet. This policy helps organizations detect and remediate weaknesses before attackers can exploit them to read or alter cookbook content, harvest client keys, or compromise every system the server manages.
 
-        If you have questions, comments, or have identified ways to improve this policy, please write me at tim@mondoo.com, or reach out in the [Mondoo Slack Community](https://mondoo.link/slack).
+        This policy provides security checks across key Chef Infra Server areas:
+
+        - File and directory permissions on critical configuration and key material
+        - End-of-life add-on components such as Push Jobs, Analytics, and Reporting
+        - Insecure server settings, including weak TLS support and legacy add-on compatibility
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: EOL components
         filters: |

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -15,22 +15,22 @@ policies:
         email: hello@mondoo.com
     summary: Secure Cisco IOS-XE routers and switches
     docs:
-      desc: |-
-        The Mondoo Cisco IOS-XE Security policy provides comprehensive security checks for Cisco IOS-XE routers and switches. This policy helps ensure your Cisco IOS-XE infrastructure is properly configured, hardened, and maintained according to security best practices.
+      desc: |
+        The Mondoo Cisco IOS-XE Security policy identifies critical misconfigurations on Cisco IOS-XE routers and switches that could leave your network infrastructure vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, traffic interception, routing manipulation, and disruption of network services.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key areas of Cisco IOS-XE configuration:
 
-        - Validates SSH configuration, version, and key strength
-        - Ensures AAA authentication, authorization, and accounting are enabled
-        - Verifies insecure services (HTTP, BOOTP, DHCP, CDP) are disabled
-        - Validates user account security and password encryption
-        - Ensures proper NTP authentication and time synchronization
-        - Validates logging configuration and remote log collection
-        - Ensures SNMP is hardened with ACLs and strong community strings
-        - Validates VTY, console, and auxiliary line security
-        - Ensures security banners and session timeouts are configured
-        - Validates routing protocol authentication for BGP and OSPF
-        - Ensures source routing and other dangerous features are disabled
+        - SSH configuration, version enforcement, and key strength
+        - AAA authentication, authorization, and accounting
+        - Removal of insecure services such as HTTP, BOOTP, DHCP, and CDP
+        - User account security and password encryption
+        - NTP authentication and time synchronization for accurate logging
+        - Logging configuration and remote log collection
+        - SNMP hardening with ACLs and strong community strings
+        - VTY, console, and auxiliary line security
+        - Security banners and session timeouts
+        - Routing protocol authentication for BGP and OSPF
+        - Disabling source routing and other dangerous features
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -15,21 +15,21 @@ policies:
         email: hello@mondoo.com
     summary: Secure Cisco IOS-XR routers
     docs:
-      desc: |-
-        The Mondoo Cisco IOS-XR Security policy provides comprehensive security checks for Cisco IOS-XR routers and network devices. This policy helps ensure your Cisco IOS-XR infrastructure is properly configured, hardened, and maintained according to security best practices.
+      desc: |
+        The Mondoo Cisco IOS-XR Security policy identifies critical misconfigurations on Cisco IOS-XR routers and core network devices that could leave your service-provider and data-center networks vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, route hijacking, and disruption of carrier-grade services.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key areas of Cisco IOS-XR configuration:
 
-        - Validates SSH configuration and version enforcement
-        - Ensures proper AAA authentication, authorization, and accounting configuration
-        - Verifies NTP authentication and time synchronization
-        - Validates logging and syslog host configuration
-        - Ensures password policies and encryption are enforced
-        - Validates SNMP security and community string hardening
-        - Ensures secure banner configuration for legal notice
-        - Validates console and VTY line access controls
-        - Ensures routing protocol authentication for BGP, OSPF, and EIGRP
-        - Validates management plane protection and CDP status
+        - SSH configuration and version enforcement
+        - AAA authentication, authorization, and accounting
+        - NTP authentication and time synchronization
+        - Logging and syslog host configuration
+        - Password policies and encryption enforcement
+        - SNMP security and community string hardening
+        - Secure banner configuration for legal notice
+        - Console and VTY line access controls
+        - Routing protocol authentication for BGP, OSPF, and EIGRP
+        - Management plane protection and CDP status
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -15,24 +15,24 @@ policies:
         email: hello@mondoo.com
     summary: Secure Cisco NX-OS switches
     docs:
-      desc: |-
-        The Mondoo Cisco NX-OS Security policy provides comprehensive security checks for Cisco NX-OS switches and data center network devices. This policy helps ensure your Cisco Nexus infrastructure is properly configured, hardened, and maintained according to security best practices.
+      desc: |
+        The Mondoo Cisco NX-OS Security policy identifies critical misconfigurations on Cisco Nexus switches running NX-OS that could leave your data-center network vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, east-west traffic interception, fabric tampering, and disruption of data-center workloads.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key areas of Cisco NX-OS configuration:
 
-        - Validates SSH key configuration and algorithm strength
-        - Ensures password strength checking and encryption are enabled
-        - Verifies AAA authentication with TACACS+ or RADIUS integration
-        - Validates user account security and credential management
-        - Ensures proper logging configuration and remote log collection
-        - Validates SNMP security including SNMPv3 enforcement
-        - Ensures NTP time synchronization is configured
-        - Validates boot security including POAP and boot order
-        - Ensures CoPP (Control Plane Policing) is properly configured
-        - Validates VTY and console line security with ACLs and timeouts
-        - Ensures security banners are configured
-        - Validates BGP and OSPF routing protocol authentication
-        - Ensures source routing and unnecessary services are disabled
+        - SSH key configuration and algorithm strength
+        - Password strength checking and encryption
+        - AAA authentication with TACACS+ or RADIUS integration
+        - User account security and credential management
+        - Logging configuration and remote log collection
+        - SNMP security, including SNMPv3 enforcement
+        - NTP time synchronization
+        - Boot security, including POAP and boot order
+        - Control Plane Policing (CoPP) configuration
+        - VTY and console line security with ACLs and timeouts
+        - Security banners
+        - BGP and OSPF routing protocol authentication
+        - Disabling source routing and unnecessary services
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -16,21 +16,15 @@ policies:
     summary: Secure Cloudflare zones, DNS, and account settings
     docs:
       desc: |
-        The Mondoo Cloudflare Security policy identifies misconfigurations in Cloudflare zones and accounts that could weaken your security posture. Improperly configured SSL/TLS settings, disabled security features, or weak access controls can expose your infrastructure to man-in-the-middle attacks, data interception, and unauthorized access.
+        The Mondoo Cloudflare Security policy identifies critical misconfigurations in Cloudflare zones and accounts that could weaken your edge security posture and expose origin infrastructure to attackers. This policy helps organizations detect and remediate weaknesses before they can be exploited, reducing the likelihood of man-in-the-middle attacks, data interception, account compromise, and unauthorized changes to DNS and routing.
 
-        This policy validates critical security controls including SSL/TLS encryption, HTTPS enforcement, Web Application Firewall (WAF) enablement, browser integrity checks, and account-level two-factor authentication.
+        This policy provides security checks across key Cloudflare areas:
 
-        ## Scan a Cloudflare zone
-
-        ```bash
-        cnspec scan cloudflare --zone <zone-name>
-        ```
-
-        ## Scan a Cloudflare account
-
-        ```bash
-        cnspec scan cloudflare --account <account-name>
-        ```
+        - SSL/TLS encryption mode and certificate handling
+        - HTTPS enforcement and HSTS
+        - Web Application Firewall (WAF) and managed rule enablement
+        - Browser integrity checks and bot mitigation
+        - Account-level two-factor authentication and access controls
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -16,9 +16,9 @@ policies:
     summary: Secure DigitalOcean Droplets, Databases, Load Balancers, DOKS, Spaces, and App Platform
     docs:
       desc: |
-        The Mondoo DigitalOcean Security policy identifies critical misconfigurations that could leave your DigitalOcean cloud infrastructure vulnerable to attackers. The policy focuses on security-relevant controls only — hardening against unauthorized access, data exposure, weak cryptography, credential misuse, and exposure to known CVEs through end-of-life software.
+        The Mondoo DigitalOcean Security policy identifies critical misconfigurations that could leave your DigitalOcean cloud infrastructure vulnerable to attackers. This policy focuses on security-relevant controls and helps organizations harden against unauthorized access, data exposure, weak cryptography, credential misuse, and exposure to known CVEs through end-of-life software.
 
-        This policy provides security checks across the following DigitalOcean services:
+        This policy provides security checks across key DigitalOcean services, uncovering misconfigurations that could put critical resources at risk:
 
         - Account identity
         - Droplets (virtual machines)
@@ -30,12 +30,6 @@ policies:
         - Content Delivery Network (CDN)
         - Spaces (object storage) access keys
         - App Platform
-
-        ## Scan a DigitalOcean account
-
-        ```bash
-        cnspec scan digitalocean --token <your-api-token>
-        ```
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -16,17 +16,14 @@ policies:
     summary: Secure DNS against spoofing, poisoning, and hijacking
     docs:
       desc: |
-        The Mondoo DNS Security policy identifies DNS misconfigurations that could expose your domain to spoofing attacks, cache poisoning, or domain hijacking. Improperly configured DNS records can allow attackers to redirect traffic, intercept sensitive communications, or impersonate your organization.
+        The Mondoo DNS Security policy identifies DNS misconfigurations that could expose your domain to spoofing, cache poisoning, and domain hijacking. This policy helps organizations detect and remediate DNS weaknesses before attackers can exploit them to redirect traffic, intercept sensitive communications, or impersonate your organization to customers and partners.
 
-        This policy validates critical DNS security controls including DNSSEC enablement, proper record configurations, and detection of legacy or vulnerable record types.
+        This policy provides security checks across key DNS areas:
 
-        ## Scan a host
-
-        Remotely scan a host's DNS configuration without installing an agent:
-
-        ```bash
-        cnspec scan host <hostname>
-        ```
+        - DNSSEC enablement and validation
+        - Authoritative record configuration for A, AAAA, MX, NS, TXT, and CNAME records
+        - Detection of legacy or vulnerable record types
+        - Record consistency and exposure of internal infrastructure
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -15,14 +15,17 @@ policies:
         email: hello@mondoo.com
     summary: Enforce Dockerfile best practices for reliable, efficient container builds
     docs:
-      desc: |-
-        The Mondoo Dockerfile Best Practices policy identifies patterns in Dockerfiles that lead to bloated images, non-reproducible builds, or unreliable container behavior. These checks complement the Mondoo Dockerfile Security policy by covering operational hygiene rather than direct security vulnerabilities.
+      desc: |
+        The Mondoo Dockerfile Best Practices policy identifies patterns in Dockerfiles that lead to bloated images, non-reproducible builds, and unreliable container behavior. This policy complements the Mondoo Dockerfile Security policy by covering operational hygiene rather than direct security vulnerabilities, helping teams ship smaller, faster, and more predictable container images.
 
-        ## Scan a Dockerfile
+        This policy provides checks across key Dockerfile authoring areas:
 
-        ```bash
-        cnspec scan docker file DOCKERFILE_PATH
-        ```
+        - Image size and layer efficiency
+        - Build reproducibility and deterministic dependency handling
+        - Cache-friendly instruction ordering
+        - Metadata and labeling for traceability
+        - Multi-stage builds and minimal base images
+        - Idiomatic use of package managers such as apt and apk
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -15,16 +15,17 @@ policies:
         email: hello@mondoo.com
     summary: Secure Dockerfiles against insecure build patterns
     docs:
-      desc: |-
-        The Mondoo Dockerfile Security policy identifies insecure patterns in Dockerfiles that could result in vulnerable container images. Insecure Dockerfiles can lead to containers running as root, exposing management ports, disabling certificate validation, or including unnecessary attack surface that enables container escapes and host compromise.
+      desc: |
+        The Mondoo Dockerfile Security policy identifies insecure patterns in Dockerfiles that produce vulnerable container images. This policy helps organizations detect and remediate authoring mistakes before images ship to production, reducing the likelihood of containers running as root, exposed management ports, disabled certificate validation, and unnecessary attack surface that enables container escapes and host compromise.
 
-        This policy validates security best practices including non-root user configuration, secure package management, certificate validation, exposed port restrictions, and privilege controls.
+        This policy provides security checks across key Dockerfile authoring areas:
 
-        ## Scan a Dockerfile
-
-        ```bash
-        cnspec scan docker file DOCKERFILE_PATH
-        ```
+        - Non-root user configuration
+        - Secure package management and pinned dependencies
+        - Certificate and signature validation during builds
+        - Restricted exposed ports and management interfaces
+        - Privilege controls and removal of dangerous capabilities
+        - Avoidance of secrets and credentials in image layers
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -15,42 +15,17 @@ policies:
         email: hello@mondoo.com
     summary: Validate endpoint detection and response deployment
     docs:
-      desc: |-
-        In today's ever-changing world of cybersecurity, it is crucial to ensure the strength of endpoint security. A reliable defense mechanism is the Endpoint Detection and Response (EDR) framework, which provides real-time monitoring, threat identification, and incident response capabilities. However, the effectiveness of this framework depends on the agents' deployment and functionality across organizational endpoints.
+      desc: |
+        The Mondoo Endpoint Detection and Response (EDR) policy verifies that your EDR agents are present, running, and up to date across the endpoint fleet. EDR is only effective when its agents are actually deployed and operational. Gaps in coverage or stale signatures leave endpoints blind to active threats and create silent paths for attackers to gain a foothold and persist.
 
-        In order to strengthen your cyber defenses and stay protected against emerging threats, it is essential to establish a policy that thoroughly confirms the presence and operational status of EDR agents. This policy aims to verify the installation of these critical components and ensure their continuous operation, thereby enhancing our resilience against malicious attacks.
+        This policy helps organizations confirm continuous EDR coverage so that endpoint telemetry, threat detection, and incident response work as designed, closing the visibility gaps that adversaries rely on for initial access, privilege escalation, and lateral movement.
 
-        By implementing this policy, we take a proactive approach to instill confidence in our security posture and reinforce our commitment to safeguarding sensitive data, critical assets, and the integrity of our digital infrastructure.
+        This policy provides checks across key EDR coverage areas:
 
-        Additionally, it is highly recommended that antivirus signatures are updated daily to ensure protection against the latest threats. For instance, Windows Defender signatures can be updated using the following PowerShell command:
-
-        ```powershell
-        Update-MpSignature
-        ```
-
-        ## Local scan
-
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local --policy-bundle mondoo-edr-policy.mql.yaml
-        ```
-
-        ## Remote scan
-
-        Remotely scan a host for endpoint detection and response (EDR) without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Windows hosts require a suitable authentication method such as WinRM or SSH keys.
-
-        ### Scan a remote Windows host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key --policy-bundle mondoo-edr-policy.mql.yaml
-        ```
+        - Presence of supported EDR agents on Windows, Linux, and macOS endpoints
+        - Operational status of the EDR agent and its services
+        - Antivirus and EDR signature freshness
+        - Coverage parity across operating systems and endpoint roles
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -16,15 +16,15 @@ policies:
     summary: Secure email with SPF, DKIM, and DMARC validation
     docs:
       desc: |
-        The Mondoo Email Security policy identifies missing or misconfigured email authentication records that could enable email spoofing, phishing attacks, and business email compromise. Without proper SPF, DKIM, and DMARC configurations, attackers can send fraudulent emails that appear to originate from your domain, potentially leading to credential theft, financial fraud, and reputational damage.
+        The Mondoo Email Security policy identifies missing or misconfigured email authentication that could enable email spoofing, phishing, and business email compromise targeting your domain. This policy helps organizations detect and remediate authentication gaps before attackers can exploit them to send fraudulent mail, steal credentials, defraud customers, or damage brand reputation.
 
-        This policy validates email authentication protocols including Sender Policy Framework (SPF), Domain Keys Identified Mail (DKIM), and Domain-based Message Authentication, Reporting & Conformance (DMARC), as well as supporting DNS configurations.
+        This policy provides security checks across key email authentication areas:
 
-        ### Running the Policy
-
-        ```bash
-        cnspec scan host mondoo.com -f mondoo-email-security.mql.yaml
-        ```
+        - Sender Policy Framework (SPF) record presence and strictness
+        - DomainKeys Identified Mail (DKIM) signing and key strength
+        - Domain-based Message Authentication, Reporting and Conformance (DMARC) policy and alignment
+        - Supporting DNS records and BIMI configuration
+        - Common spoofing-friendly DNS misconfigurations
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -15,37 +15,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure Fortinet FortiOS firewall and FortiGate appliance configurations
     docs:
-      desc: |-
-        The Mondoo Fortinet FortiOS Security policy provides comprehensive security checks for Fortinet FortiOS firewalls and FortiGate appliances. This policy helps ensure your FortiOS infrastructure follows security best practices across firmware management, system hardening, logging, firewall policy, network interfaces, routing, and FortiGuard subscriptions.
+      desc: |
+        The Mondoo Fortinet FortiOS Security policy identifies critical misconfigurations on FortiGate firewalls and FortiOS appliances that could leave your perimeter and internal segmentation vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, policy bypass, traffic interception, and disruption of protected services.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key FortiOS areas:
 
-        - **Firmware Security**: Validates firmware is GA, mature, and running a supported major version
-        - **System Hardening**: Admin session timeouts, non-default management ports, HA configuration
-        - **DNS & NTP**: DNS-over-TLS, NTP synchronization, and server configuration
-        - **Logging & Monitoring**: Implicit deny logging, external log destinations, extended log formats
-        - **Firewall Policy**: No overly permissive rules, UTM/SSL inspection, traffic logging
-        - **Network Interfaces**: Management access restrictions on WAN, no telnet access
-        - **Routing Security**: BGP/OSPF neighbor change logging and graceful restart
-        - **FortiGuard Subscriptions**: Active antispam, web filter, and outbreak prevention subscriptions
-
-        ## Authentication
-
-        Scanning a FortiOS device requires a REST API token.
-
-        ### Generating an API token
-
-        1. Log into the FortiOS web interface
-        2. Navigate to **System > Administrators**
-        3. Click **Create New > REST API Admin**
-        4. Assign an administrator profile with read-only access
-        5. Copy the generated API token
-
-        ### Running a scan
-
-        ```bash
-        cnspec scan fortios --hostname <FORTIOS_HOSTNAME> -t <FORTIOS_TOKEN>
-        ```
+        - **Firmware security**: GA status, maturity, and supported major version
+        - **System hardening**: Admin session timeouts, non-default management ports, and HA configuration
+        - **DNS and NTP**: DNS-over-TLS, NTP synchronization, and trusted server configuration
+        - **Logging and monitoring**: Implicit deny logging, external log destinations, and extended log formats
+        - **Firewall policy hygiene**: Restriction of overly permissive rules, UTM and SSL inspection, and traffic logging
+        - **Network interfaces**: Management access restrictions on WAN and removal of telnet access
+        - **Routing security**: BGP and OSPF neighbor change logging and graceful restart
+        - **FortiGuard subscriptions**: Active antispam, web filter, and outbreak prevention subscriptions
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -15,32 +15,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure FreeBSD access controls, SSH, and services
     docs:
-      desc: |-
-        The Mondoo FreeBSD Security policy identifies misconfigurations that could leave FreeBSD systems vulnerable to unauthorized access, privilege escalation, and data exfiltration. Improperly hardened systems can enable attackers to gain initial access, move laterally across networks, and maintain persistent access to critical infrastructure.
+      desc: |
+        The Mondoo FreeBSD Security policy identifies critical misconfigurations on FreeBSD systems that could leave servers and appliances vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized access, privilege escalation, lateral movement, and persistent compromise of critical FreeBSD infrastructure.
 
-        This policy validates security controls across FreeBSD systems by:
-          - Hardening kernel and process security settings
-          - Identifying dangerous services that should not be running
-          - Ensuring proper SSH server configuration
-          - Hardening network stack kernel parameters
-          - Verifying correct file permissions on sensitive system files
-          - Ensuring users and groups are securely configured
-          - Validating logging configuration
-          - Checking privilege escalation controls
+        This policy provides security checks across key FreeBSD areas:
 
-        ## Remote scan
-
-        Remotely scan a FreeBSD host without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of FreeBSD hosts require authentication such as SSH keys.
-
-        ### Scan a remote FreeBSD host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        - Kernel and process security settings
+        - Removal of dangerous services and unnecessary daemons
+        - SSH server hardening
+        - Network stack kernel parameters
+        - File permissions on sensitive system files
+        - User and group configuration
+        - System and audit logging
+        - Privilege escalation controls
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -17,7 +17,7 @@ policies:
     summary: Secure GCP compute, storage, IAM, and networking
     docs:
       desc: |
-        The Mondoo Google Cloud (GCP) Security policy is designed to identify critical misconfigurations that could leave your Google Cloud infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
+        The Mondoo Google Cloud (GCP) Security policy identifies critical misconfigurations that could leave your Google Cloud infrastructure vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
         This policy provides security checks across key GCP services, uncovering misconfigurations that could put critical resources at risk, particularly those exposed to the public internet:
 

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -16,41 +16,16 @@ policies:
     summary: Validate GitHub repo quality and collaboration practices
     docs:
       desc: |
-        The Mondoo GitHub Repository Best Practices policy validates that GitHub repositories follow operational best practices that help maintain code quality, improve collaboration, and reduce operational risk. Missing documentation, disabled issue tracking, or improper repository configurations can lead to confusion, lost contributions, and difficulty maintaining projects over time.
+        The Mondoo GitHub Repository Best Practices policy identifies GitHub repositories that don't follow operational best practices for sustainable, collaborative software development. This policy helps organizations maintain code quality, smooth onboarding, and predictable contribution workflows, reducing confusion, lost contributions, and the operational drag that comes with unmaintained or under-documented repositories.
 
-        This policy checks repository settings including README presence, license files, code of conduct, contributing guidelines, and support documentation.
+        This policy provides checks across key repository configuration areas:
 
-        ## Authenticating with GitHub
-
-        This policy requires a GitHub personal access token to authenticate with GitHub's API. The personal access token is required regardless of whether you are scanning a public or a private repository. Access to private repositories is determined by the level of access the token cnspec is configured with when it runs.
-
-        ### Create a personal access token
-
-        To create a read-only personal access token, see [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) on GitHub's documentation site.
-
-        ### Configure a GITHUB_TOKEN environment variable
-
-        You supply your personal access token to cnspec using the `GITHUB_TOKEN` environment variable.
-
-        #### Linux / macOS
-
-        ```bash
-        export GITHUB_TOKEN=<your personal access token>
-        ```
-
-        #### Windows
-
-        ```powershell
-        $Env:GITHUB_TOKEN = "<personal-access-token>"
-        ```
-
-        ## Scanning GitHub repositories
-
-        To scan the configuration of a GitHub repository:
-
-        ```bash
-        cnspec scan github repo <ORG_NAME/REPO_NAME>
-        ```
+        - README presence and completeness
+        - License files
+        - Code of conduct
+        - Contributing guidelines
+        - Issue and pull request templates
+        - Support documentation
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -16,51 +16,16 @@ policies:
     summary: Secure GitHub orgs, repos, and supply chain settings
     docs:
       desc: |
-        The Mondoo GitHub Organization Security policy identifies misconfigurations that could expose your GitHub organization to supply chain attacks, unauthorized code changes, and data breaches. Improperly secured organizations can allow attackers to inject malicious code, steal secrets, or compromise the software development lifecycle.
+        The Mondoo GitHub Organization Security policy identifies critical misconfigurations in GitHub organizations that could expose your software development lifecycle to supply chain attacks, unauthorized code changes, and source code theft. This policy helps organizations detect and remediate weaknesses before attackers can exploit them to inject malicious code, harvest secrets, or compromise downstream consumers of your software.
 
-        This policy validates critical security controls including two-factor authentication requirements, default repository permissions, verified domains, and organization-wide security policies.
+        This policy provides security checks across key GitHub organization areas:
 
-        ## Authentication
-
-        Scanning GitHub organizations requires a GitHub personal access token to authenticate with GitHub's API. Access to an organization is determined by the level of access granted to the token.
-
-        ### Create a personal access token
-
-        To create a read-only personal access token, see [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) on GitHub's documentation site.
-
-        ### Configure a GITHUB_TOKEN environment variable
-
-        You supply your personal access token to cnspec using the `GITHUB_TOKEN` environment variable.
-
-        #### Linux / macOS
-
-        ```bash
-        export GITHUB_TOKEN=<your personal access token>
-        ```
-
-        #### Windows
-
-        ```powershell
-        $Env:GITHUB_TOKEN = "<personal-access-token>"
-        ```
-
-        ## Scan a GitHub organization
-
-        To scan the configuration of your GitHub organization, run this command:
-
-        ```bash
-        cnspec scan github org <ORG_NAME>
-        ```
-
-        ## Scan a GitHub organization and all repositories
-
-        cnspec can also scan a GitHub organization and all of its repositories using the `--discover all` flag. To scan your GitHub organization and discover and scan all of the repositories within your organization, run this command:
-
-        ```bash
-        cnspec scan github org <ORG_NAME> --discover all
-        ```
-
-        > Note: Scanning large GitHub organizations may exceed GitHub API rate limits. For more information see [About rate limits](https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28#about-rate-limits) in the GitHub documentation.
+        - Two-factor authentication requirements
+        - Default repository permissions and visibility
+        - Verified domains and SAML SSO enforcement
+        - Member, outside collaborator, and team access controls
+        - Organization-wide security policies and Dependabot settings
+        - Webhook and OAuth or GitHub App authorization
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -16,31 +16,15 @@ policies:
     summary: Secure GitLab groups, projects, and CI/CD pipelines
     docs:
       desc: |
-        The Mondoo GitLab Security policy identifies misconfigurations that could expose your GitLab groups and projects to supply chain attacks, unauthorized code changes, and data breaches. Improperly secured GitLab environments can allow attackers to access private repositories, inject malicious code, or exfiltrate sensitive data.
+        The Mondoo GitLab Security policy identifies critical misconfigurations in GitLab groups and projects that could expose your software development lifecycle to supply chain attacks, unauthorized code changes, and source code theft. This policy helps organizations detect and remediate weaknesses before attackers can exploit them to access private repositories, inject malicious code, or exfiltrate sensitive data and secrets.
 
-        This policy validates critical security controls including group and project visibility settings, two-factor authentication requirements, and access control configurations.
+        This policy provides security checks across key GitLab areas:
 
-        ### Prerequisites
-
-        Remote scans of GitLab require a [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens.html) with access to the group and projects you plan to scan.
-
-        ### Scan a GitLab group and projects
-
-        To scan a GitLab group, set your personal access token and run a scan:
-
-        ```bash
-        export GITLAB_TOKEN=<your personal access token>
-        cnspec scan gitlab --group <group_name>
-        ```
-
-        ### Scan a single GitLab project
-
-        To scan a GitLab project, set your personal access token and run a scan:
-
-        ```bash
-        export GITLAB_TOKEN=<your personal access token>
-        cnspec scan gitlab --group <group_name> --project <project_name>
-        ```
+        - Group and project visibility settings
+        - Two-factor authentication requirements
+        - Member access and role assignments
+        - Branch protection and merge request controls
+        - Repository sharing and forking restrictions
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -16,51 +16,17 @@ policies:
     summary: Secure Google Workspace users, apps, and data sharing
     docs:
       desc: |
-        The Mondoo Google Workspace Security policy identifies misconfigurations that could expose your organization to account takeover, data breaches, and unauthorized access. Google Workspace serves as the productivity and collaboration hub for many organizations, and misconfigurations can enable attackers to access email, documents, and corporate data across connected services.
+        The Mondoo Google Workspace Security policy identifies critical misconfigurations in Google Workspace tenants that could expose your organization to account takeover, data breaches, and unauthorized access across email, drive, and connected services. As the productivity and collaboration hub for many organizations, Workspace misconfigurations give attackers a path to corporate data, customer information, and identity-based access to dozens of downstream applications.
 
-        This policy validates critical security controls including authentication settings, app access restrictions, sharing policies, and administrative configurations.
+        This policy provides security checks across key Google Workspace areas:
 
-        ### Prerequisites
-
-        1. Create/Select a GCP project
-        2. Navigate to the [Google API Console](https://console.cloud.google.com/apis/dashboard).
-        3. Select "Enable APIs and Services" and enable the following APIs:
-          - Admin SDK API
-          - Cloud Identity API
-          - Google Calendar API
-          - Google Drive API
-          - Gmail API
-          - Google People API
-        4. Create a service account for [Google Workspace](https://support.google.com/a/answer/7378726?product_name=UnuFlow&hl=en&visit_id=638041387835615758-4147680582&rd=1&src=supportwidget0&hl=en)
-        5. Create credentials for the service account and download the json file
-        6. Enter the following scopes in Security -> Access and data controls -> API controls, and select [Domain-wide Delegation](https://developers.google.com/workspace/guides/create-credentials#delegate_domain-wide_authority_to_your_service_account)
-
-          - https://www.googleapis.com/auth/admin.chrome.printers.readonly
-          - https://www.googleapis.com/auth/admin.directory.customer.readonly
-          - https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly
-          - https://www.googleapis.com/auth/admin.directory.device.mobile.readonly
-          - https://www.googleapis.com/auth/admin.directory.domain.readonly
-          - https://www.googleapis.com/auth/admin.directory.group.member.readonly
-          - https://www.googleapis.com/auth/admin.directory.group.readonly
-          - https://www.googleapis.com/auth/admin.directory.orgunit.readonly
-          - https://www.googleapis.com/auth/admin.directory.resource.calendar.readonly
-          - https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.alias.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.readonly
-          - https://www.googleapis.com/auth/admin.directory.userschema.readonly
-          - https://www.googleapis.com/auth/admin.reports.audit.readonly
-          - https://www.googleapis.com/auth/admin.reports.usage.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.security
-          - https://www.googleapis.com/auth/cloud-identity.groups.readonly
-
-        ### Run policy
-
-        To run this policy against a Google Workspace customer:
-
-        ```bash
-        export GOOGLEWORKSPACE_CREDENTIALS=$PWD/my-project-123456-1234ea722b12.json
-        cnspec scan google-workspace --customer-id <CUSTOMERID> --impersonated-user-email <EMAIL>
-        ```
+        - User authentication and multi-factor enforcement
+        - Administrative access and role management
+        - Application access and OAuth scope controls
+        - Drive and document sharing policies
+        - Gmail, Calendar, and Meet security settings
+        - Mobile device and Chrome management
+        - Audit logging and reporting configuration
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -16,31 +16,15 @@ policies:
         email: hello@mondoo.com
     docs:
       desc: |
-        The Mondoo Grafana Security policy checks Grafana organizations for security best practices covering service accounts, user roles, datasource configuration, and alerting. It validates that the principle of least privilege is applied, credentials are properly scoped and rotated, and datasource connections follow secure defaults.
+        The Mondoo Grafana Security policy identifies misconfigurations in Grafana organizations that could expose dashboards, datasource credentials, and observability data to unauthorized users. This policy helps organizations apply the principle of least privilege, protect credentials, and detect insecure datasource and alerting configurations before attackers can exploit them to access sensitive telemetry, pivot into connected datastores, or disrupt monitoring.
 
-        ## Remote scan
+        This policy provides security checks across key Grafana areas:
 
-        Remote scans use the cnspec Grafana provider to query the Grafana HTTP API.
-
-        ### Prerequisites
-
-        Create a service account token with Viewer (preferred) or Admin role in your Grafana instance:
-
-        ```bash
-        # Via Grafana API
-        SA_ID=$(curl -s -u admin:admin -H "Content-Type: application/json" \
-          -d '{"name":"cnspec-auditor","role":"Viewer"}' \
-          https://grafana.example.com/api/serviceaccounts | jq -r .id)
-        TOKEN=$(curl -s -u admin:admin -H "Content-Type: application/json" \
-          -d '{"name":"cnspec-token"}' \
-          https://grafana.example.com/api/serviceaccounts/${SA_ID}/tokens | jq -r .key)
-        ```
-
-        ### Scan a Grafana organization
-
-        ```bash
-        cnspec scan grafana --url https://grafana.example.com --token "$TOKEN"
-        ```
+        - Service account scope and lifecycle
+        - User roles, organization membership, and permissions
+        - Datasource configuration and credential handling
+        - Alerting and notification channel configuration
+        - Authentication and session settings
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -16,21 +16,15 @@ policies:
     summary: Secure Hetzner Cloud servers, firewalls, load balancers, certificates, and IP addresses
     docs:
       desc: |
-        The Mondoo Hetzner Cloud Security policy identifies critical misconfigurations that could leave your Hetzner Cloud project vulnerable to attackers. The policy focuses on security-relevant controls only — hardening against unauthorized network access, data exposure in transit, weak cryptography, and exposure to known CVEs through end-of-life software.
+        The Mondoo Hetzner Cloud Security policy identifies critical misconfigurations that could leave your Hetzner Cloud project vulnerable to attackers. This policy focuses on security-relevant controls and helps organizations harden against unauthorized network access, data exposure in transit, weak cryptography, and exposure to known CVEs through end-of-life software.
 
-        This policy provides security checks across the following Hetzner Cloud resources:
+        This policy provides security checks across key Hetzner Cloud resources:
 
         - Cloud Servers
         - Firewalls
         - Load Balancers
         - TLS Certificates
         - Floating IPs and Primary IPs
-
-        ## Scan a Hetzner Cloud project
-
-        ```bash
-        cnspec scan hetzner --token <your-api-token>
-        ```
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -16,17 +16,16 @@ policies:
     summary: Secure HTTP headers against XSS, clickjacking, and more
     docs:
       desc: |
-        The Mondoo HTTP Security policy identifies missing or misconfigured HTTP security headers that could expose web applications to cross-site scripting (XSS), clickjacking, MIME-type sniffing attacks, and information disclosure. Properly configured security headers provide defense-in-depth protection against common web-based attacks.
+        The Mondoo HTTP Security policy identifies missing or misconfigured HTTP security headers that could expose web applications to cross-site scripting, clickjacking, MIME-type sniffing, and information disclosure. This policy helps organizations apply defense-in-depth at the HTTP layer, detecting weaknesses before attackers can exploit them to steal session tokens, hijack user actions, or enumerate sensitive server details.
 
-        This policy validates critical HTTP security headers including Content-Security-Policy, X-Content-Type-Options, Strict-Transport-Security (HSTS), and ensures sensitive server information is not exposed.
+        This policy provides security checks across key HTTP security headers and exposures:
 
-        ## Scan a host
-
-        Remotely scan a host's HTTP configuration without installing an agent:
-
-        ```bash
-        cnspec scan host <fqdn>
-        ```
+        - Content-Security-Policy
+        - Strict-Transport-Security (HSTS)
+        - X-Content-Type-Options
+        - X-Frame-Options and frame-ancestors
+        - Referrer-Policy and Permissions-Policy
+        - Server and technology fingerprinting headers
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -15,19 +15,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure Juniper Junos routers, switches, and firewalls
     docs:
-      desc: |-
-        The Mondoo Juniper Junos Security policy provides security hardening checks for Juniper devices running Junos OS. This policy validates that your Juniper network infrastructure is hardened against common attack vectors and configured in accordance with security standards.
+      desc: |
+        The Mondoo Juniper Junos Security policy identifies critical misconfigurations on Juniper devices running Junos OS that could leave your network and security infrastructure vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, traffic interception, route manipulation, and disruption of protected zones.
 
-        This policy covers the following security areas:
+        This policy provides security checks across key Junos OS areas:
 
         - Root login restrictions, cryptographic algorithm validation, and brute-force protection
         - Authentication enforcement and privilege restriction
-        - Disabling Telnet, FTP, finger, and other cleartext protocols
-        - Default community string removal, access restrictions, and read-only enforcement
+        - Removal of cleartext protocols including Telnet, FTP, and finger
+        - SNMP hardening, including default community removal, access restrictions, and read-only enforcement
         - Centralized syslog with secure transport for tamper-resistant audit trails
         - Policy logging, screen profile enforcement, and untrust zone lockdown
         - Protection against SYN floods, land attacks, teardrop, and other network attacks
-        - Verification that security feature licenses remain valid
+        - Validity of security feature licenses
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -15,32 +15,17 @@ policies:
         email: hello@mondoo.com
     summary: Validate Kubernetes resource limits and labels
     docs:
-      desc: |-
-        The Mondoo Kubernetes Best Practices policy validates that Kubernetes workloads follow operational best practices that help maintain cluster reliability, resource efficiency, and operational consistency. Missing resource requests, improper namespace usage, or inadequate labeling can lead to resource contention, scheduling failures, and difficulty managing workloads at scale.
+      desc: |
+        The Mondoo Kubernetes Best Practices policy identifies Kubernetes workloads that don't follow operational best practices for cluster reliability, resource efficiency, and consistent operations. This policy helps platform and application teams prevent resource contention, scheduling failures, and the operational drag that shows up as outages and on-call pages, addressing issues that aren't security vulnerabilities but still take services down.
 
-        This policy checks workload configurations including resource requests and limits, namespace usage, host aliases, port configurations, and labeling standards across Deployments, DaemonSets, StatefulSets, Jobs, CronJobs, and Pods.
+        This policy provides checks across key workload configuration areas, covering Deployments, DaemonSets, StatefulSets, Jobs, CronJobs, and Pods:
 
-        ## Remote scan
-
-        Remotely scan a Kubernetes cluster without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Kubernetes clusters require a `KUBECONFIG` with access to the cluster you want to scan.
-
-        ### Scan a Kubernetes cluster
-
-        Open a terminal and configure an environment variable with the path to your `KUBECONFIG`:
-
-        ```bash
-        export KUBECONFIG=/path/to/kubeconfig
-        ```
-
-        Run a scan of the Kubernetes cluster:
-
-        ```bash
-        cnspec scan k8s
-        ```
+        - Resource requests and limits
+        - Namespace usage and isolation
+        - Host alias configuration
+        - Container port configuration
+        - Labeling standards for selection and ownership
+        - Liveness, readiness, and startup probes
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -16,32 +16,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure Kubernetes clusters, workloads, and RBAC
     docs:
-      desc: |-
-        The Mondoo Kubernetes Cluster and Workload Security policy identifies misconfigurations that could leave your Kubernetes clusters and workloads vulnerable to attackers. Improperly configured clusters can enable container escapes, privilege escalation, lateral movement between pods, and unauthorized access to sensitive data and secrets. This policy helps organizations detect and remediate security risks before they can be exploited.
+      desc: |
+        The Mondoo Kubernetes Cluster and Workload Security policy identifies critical misconfigurations that could leave your Kubernetes clusters and workloads vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of container escapes, privilege escalation, lateral movement between pods, and unauthorized access to secrets and sensitive data.
 
-        This policy validates security controls across Kubernetes API servers, kubelets, and workloads including Deployments, DaemonSets, StatefulSets, Jobs, CronJobs, and Pods. Key security checks include container privilege restrictions, host namespace isolation, resource limits, network policies, and secure authentication configurations.
+        This policy provides security checks across key Kubernetes components and workload types, including the API server, kubelet, Deployments, DaemonSets, StatefulSets, Jobs, CronJobs, and Pods:
 
-        ## Remote scan
-
-        Remotely scan a Kubernetes cluster without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Kubernetes clusters require a `KUBECONFIG` with access to the cluster you want to scan.
-
-        ### Scan a Kubernetes cluster
-
-        Open a terminal and configure an environment variable with the path to your `KUBECONFIG`:
-
-        ```bash
-        export KUBECONFIG=/path/to/kubeconfig
-        ```
-
-        Run a scan of the Kubernetes cluster:
-
-        ```bash
-        cnspec scan k8s
-        ```
+        - API server authentication, authorization, and admission controls
+        - Kubelet hardening and certificate management
+        - Container privilege restrictions and dropped capabilities
+        - Host namespace isolation and read-only root filesystems
+        - Resource requests and limits to prevent denial of service
+        - Network policies and inter-pod traffic controls
+        - Secret management and projected service account tokens
+        - ImagePullPolicy, signed images, and registry trust
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -15,34 +15,14 @@ policies:
         email: hello@mondoo.com
     summary: Validate Linux server reliability and operations
     docs:
-      desc: |-
-        The Mondoo Linux Server Operational Policy validates that Linux servers follow operational best practices that help maintain system reliability and prevent service disruptions. Resource exhaustion from full disks or memory pressure can lead to application crashes, data corruption, and service outages.
+      desc: |
+        The Mondoo Linux Server Operational Policy identifies operational health issues on Linux servers that could lead to service disruption, data corruption, and unplanned outages. This policy helps operations teams catch resource exhaustion and capacity problems before they cascade into application crashes, dropped writes, and emergency on-call work.
 
-        This policy checks system health indicators including disk usage thresholds and memory utilization to help identify potential issues before they impact services.
+        This policy provides checks across key Linux server health indicators:
 
-        ## Local scan
-
-        Local scans refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a Linux host without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Linux hosts require authentication such as SSH keys.
-
-        ### Scan a remote Linux host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        - Disk usage thresholds across mounted filesystems
+        - Memory utilization and swap pressure
+        - Filesystem inode availability
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -15,48 +15,20 @@ policies:
         email: hello@mondoo.com
     summary: Secure Linux SSH, permissions, kernel, and services
     docs:
-      desc: |-
-        The Mondoo Linux Security policy identifies misconfigurations that could leave Linux systems vulnerable to unauthorized access, privilege escalation, and data exfiltration. Improperly hardened systems can enable attackers to gain initial access, move laterally across networks, and maintain persistent access to critical infrastructure.
+      desc: |
+        The Mondoo Linux Security policy identifies critical misconfigurations on Linux systems that could leave servers vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized access, privilege escalation, lateral movement across networks, and persistent compromise of critical infrastructure.
 
-        This policy validates security controls across Linux systems by:
-          - Identifying problematic services that may be running
-          - Identifying loose permissions on sensitive system configuration files
-          - Ensuring logging and auditing services are properly configured and running
-          - Hardening SSH configurations
-          - Ensure users and groups are securely configured
-          - Identifying misconfigured Kernel networking configurations
-          - Harden various Kernel parameters
+        This policy provides security checks across key areas of Linux server hardening:
 
-        This policy has been developed for Red Hat (RHEL), Debian, Ubuntu, and SUSE (SLES) derivative distributions running on x64 architectures.
-        Some queries may be skipped depending on your particular distribution, installation type, or underlying infrastructure.
-        The overall guidance within this policy broadly assumes that operations are being performed as the root user.
-        Operations performed using sudo instead of the root user may produce unexpected results or fail to make the intended changes to the system.
-        Non-root users may not be able to access certain areas of the system, especially after remediation has been performed. It is advisable to verify
-        root users path integrity and the integrity of any programs being run prior to execution of commands and scripts included in this benchmark.
+        - Identification of problematic services that should not be running
+        - File permissions on sensitive system configuration files
+        - Logging and auditing services
+        - SSH server configuration and key management
+        - User and group security
+        - Kernel networking parameters
+        - Kernel hardening parameters
 
-        ## Local scan
-
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a Linux host without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Linux hosts require authentication such as SSH keys.
-
-        ### Scan a remote Linux host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        This policy is developed for Red Hat (RHEL), Debian, Ubuntu, and SUSE (SLES) derivative distributions running on x64 architectures. Some checks may be skipped depending on the distribution, installation type, or underlying infrastructure. Guidance broadly assumes operations are performed as the root user; running remediation through `sudo` may produce different results.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -16,33 +16,14 @@ policies:
     summary: Secure Linux SNMP community strings and access controls
     docs:
       desc: |
-        The Mondoo Linux Server SNMP Policy identifies insecure SNMP configurations that could expose sensitive system information or enable unauthorized network management access. Misconfigured SNMP services with weak community strings or unauthenticated access can allow attackers to gather reconnaissance data, modify device configurations, or pivot through network infrastructure.
+        The Mondoo Linux Server SNMP Policy identifies insecure SNMP configurations on Linux hosts that could expose system information and enable unauthorized network management access. This policy helps organizations detect and remediate SNMP weaknesses before attackers can exploit them to gather reconnaissance, modify configurations, or pivot through network infrastructure.
 
-        This policy validates SNMP security controls including authentication requirements, community string restrictions, and file permission protections for SNMP credentials.
+        This policy provides security checks across key SNMP configuration areas:
 
-        ## Local scan
-
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a host's SNMP configuration without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Linux hosts require authentication such as SSH keys.
-
-        ### Scan a remote Linux host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        - Authentication requirements and SNMPv3 enforcement
+        - Community string strength and exposure
+        - Access control and source restrictions
+        - File permissions on SNMP credential and configuration files
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -16,33 +16,18 @@ policies:
     summary: Secure Linux workstation access, firewall, and services
     docs:
       desc: |
-        The Mondoo Linux Workstation Security policy identifies misconfigurations that could leave Linux workstations vulnerable to malware, unauthorized access, and data theft. Workstations are often targeted as entry points for attackers due to their exposure to phishing, malicious downloads, and physical access threats.
+        The Mondoo Linux Workstation Security policy identifies critical misconfigurations on Linux workstations that could leave end-user systems vulnerable to malware, unauthorized access, and data theft. Workstations are a frequent first foothold for attackers, with phishing, malicious downloads, and physical access threats all targeting the endpoint. Workstation hardening directly limits what an attacker can do once they get in.
 
-        This policy validates critical security controls including secure boot configuration, disk encryption, firewall settings, screen lock policies, and user authentication. It supports Red Hat, Debian, Ubuntu, and SUSE distributions on x86 and x64 platforms.
+        This policy provides security checks across key Linux workstation areas:
 
-        ## Local scan
+        - Secure Boot configuration
+        - Disk encryption (LUKS) and removable media handling
+        - Host firewall configuration
+        - Screen lock and idle session policies
+        - User authentication and password requirements
+        - Automatic updates and patch posture
 
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a Linux workstation without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Linux hosts require authentication such as SSH keys.
-
-        ### Scan a remote Linux host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        This policy supports Red Hat, Debian, Ubuntu, and SUSE distributions on x86 and x64 platforms.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -15,26 +15,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure Microsoft 365 identity, email, and data sharing
     docs:
-      desc: |-
-        The Mondoo Microsoft 365 Security policy identifies misconfigurations that could expose your organization to account takeover, data breaches, and unauthorized access. Microsoft 365 serves as the productivity hub for many organizations, and misconfigurations can enable attackers to access email, documents, and corporate data across connected services.
+      desc: |
+        The Mondoo Microsoft 365 Security policy identifies critical misconfigurations in Microsoft 365 tenants that could expose your organization to account takeover, data breaches, and unauthorized access across email, documents, and collaboration services. As the productivity hub for many organizations, M365 misconfigurations give attackers a path to corporate data, customer information, and identity-based access to dozens of downstream Microsoft and third-party services.
 
-        This policy validates critical security controls including multi-factor authentication, conditional access policies, password policies, identity protection settings, and administrative access configurations.
+        This policy provides security checks across key Microsoft 365 areas:
 
-        ## Remote scan
-
-        Remotely scan a Microsoft 365 organization without installing an agent.
-
-        ### Installation
-
-        Remote scans of Microsoft 365 require API credentials with access to the organization. Please follow the setup guide to create a Application registration and grant access to it:
-
-        [Microsoft 365 Setup Guide](https://mondoo.com/docs/platform/infra/saas/ms365/ms365-auto/)
-
-        ### Scan a Microsoft 365 organization
-
-        ```bash
-        cnspec scan ms365 --certificate-path <*.pem> --tenant-id <tenant_id> --client-id <client_id> --policy-bundle mondoo-m365-security.mql.yaml
-        ```
+        - Multi-factor authentication enforcement
+        - Conditional Access policies
+        - Password and authentication policies
+        - Identity Protection and risk-based controls
+        - Administrative access and role management
+        - Exchange Online and Defender for Office 365 settings
+        - SharePoint and OneDrive sharing policies
+        - Microsoft Teams security and external access
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -15,34 +15,20 @@ policies:
         email: hello@mondoo.com
     summary: Secure macOS firewall, FileVault, Gatekeeper, and more
     docs:
-      desc: |-
-        The Mondoo macOS Security policy identifies misconfigurations that could leave macOS systems vulnerable to unauthorized access, malware infections, and data exfiltration. Improperly configured macOS systems can expose sensitive data through file sharing services, allow unauthorized remote access, or leave systems susceptible to network-based attacks.
+      desc: |
+        The Mondoo macOS Security policy identifies critical misconfigurations on macOS systems that could leave end-user devices vulnerable to malware, unauthorized access, and data exfiltration. This policy helps organizations detect and remediate hardening gaps before attackers can exploit them to access sensitive data through file sharing services, gain unauthorized remote access, or compromise systems through network-based attacks.
 
-        This policy validates critical security controls including FileVault encryption, firewall settings, Gatekeeper, sharing services, remote access configurations, and network security settings. It was tested against Apple macOS 10.15, 11, 12, 13, and 14.
+        This policy provides security checks across key macOS areas:
 
-        ## Local scan
+        - FileVault full-disk encryption
+        - Application firewall configuration
+        - Gatekeeper and System Integrity Protection
+        - Sharing services such as Screen Sharing, File Sharing, and Remote Login
+        - Remote access configurations
+        - Network security settings and Bluetooth controls
+        - Software update posture
 
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a macOS host without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of macOS hosts require **Remote login** to be enabled in the System Preferences, along with a suitable authentication method such as SSH keys.
-
-        ### Scan a remote macOS host (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        This policy was tested against Apple macOS 10.15, 11, 12, 13, and 14.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -16,22 +16,12 @@ policies:
     summary: Secure Model Context Protocol server configurations
     docs:
       desc: |
-        This policy provides comprehensive security validation for Model Context Protocol (MCP) implementations.
-        It focuses on validating tool definitions, preventing security vulnerabilities, and ensuring proper
-        configuration of MCP servers and clients.
+        The Mondoo Model Context Protocol (MCP) Security policy identifies weaknesses in MCP server and client implementations that could expose AI-integrated systems to prompt injection, data leakage, and abuse of tool capabilities. As MCP becomes the connective tissue between AI agents and enterprise systems, misconfigured tool definitions and unvalidated content can let attackers steer agents into actions that exfiltrate data, execute unintended commands, or expose users to malicious content.
 
-        The policy covers two main areas:
-        1. Content Security: Validates text content for PII, prompt injection, malicious URLs, explicit content, and Unicode attacks
-        2. Schema Validation: Ensures proper structure and validation constraints for tools, prompts, and resources
+        This policy provides security checks across two main areas of MCP implementation:
 
-        Key security controls include:
-        - PII detection and prevention
-        - Prompt injection attack detection
-        - Malicious URL detection
-        - Explicit content filtering
-        - Unicode security validation
-        - Schema completeness validation
-        - Input parameter validation
+        - **Content security**: PII detection, prompt-injection detection, malicious URL detection, explicit content filtering, and Unicode security validation
+        - **Schema validation**: Structure and validation constraints for tools, prompts, and resources, including schema completeness and input parameter validation
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -17,17 +17,13 @@ policies:
     summary: Secure OCI compute, networking, storage, and IAM
     docs:
       desc: |
-        The Mondoo Oracle Cloud Infrastructure (OCI) Security policy identifies critical misconfigurations that could leave your OCI tenancy vulnerable to attackers. This policy covers IAM (Identity and Access Management), Object Storage, and VCN (Virtual Cloud Network) security. It helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, and operational disruptions.
+        The Mondoo Oracle Cloud Infrastructure (OCI) Security policy identifies critical misconfigurations that could leave your OCI tenancy vulnerable to attackers. This policy helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, privilege escalation, and operational disruptions.
 
-        ## Authentication
+        This policy provides security checks across key OCI services, uncovering misconfigurations that could put critical resources at risk:
 
-        Scanning OCI requires API key authentication configured in your OCI CLI config file (`~/.oci/config`).
-
-        ## Scan an OCI tenancy
-
-        ```bash
-        cnspec scan oci
-        ```
+        - Identity and Access Management (IAM)
+        - Object Storage
+        - Virtual Cloud Network (VCN)
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -16,75 +16,17 @@ policies:
     summary: Secure Okta MFA, policies, and identity configurations
     docs:
       desc: |
-        The Mondoo Okta Organization Security policy identifies misconfigurations in Okta organizations that could enable unauthorized access, account takeover, or identity-based attacks. As the central identity provider for many organizations, Okta misconfigurations can have far-reaching security implications, potentially exposing all connected applications and services to compromise.
+        The Mondoo Okta Organization Security policy identifies critical misconfigurations in Okta organizations that could enable unauthorized access, account takeover, and identity-based attacks. As the central identity provider for many organizations, Okta misconfigurations have outsized blast radius, since a single weakness can expose every connected application and downstream service to compromise.
 
-        This policy validates critical security controls including multi-factor authentication requirements, password policies, session management, API security settings, and administrative access configurations. It supports scanning Okta organizations directly as well as Terraform projects using the [Okta Terraform provider](https://registry.terraform.io/providers/okta/okta/latest/docs).
+        This policy provides security checks across key Okta areas, with support for both live Okta organizations and infrastructure managed with the [Okta Terraform provider](https://registry.terraform.io/providers/okta/okta/latest/docs):
 
-        ## Authentication
-
-        Scanning Okta organizations requires an API token to authenticate with Okta's API.
-
-        ### Create an API token
-
-        To create an API token, see [Create an API token](https://developer.okta.com/docs/guides/create-an-api-token/main/) on Okta's documentation site.
-
-        ### Configure an OKTA_TOKEN environment variable
-
-        You supply your API token to cnspec using the `OKTA_TOKEN` environment variable.
-
-        #### Linux / macOS
-
-        ```bash
-        export OKTA_TOKEN=<OKTA_TOKEN>
-        ```
-
-        #### Windows
-        ```powershell
-        $Env:OKTA_TOKEN = "<OKTA_TOKEN>"
-        ```
-
-        ## Scan an Okta organization
-
-        To scan the configuration of an Okta organization all together:
-
-        ```bash
-        cnspec scan okta --organization DOMAIN.okta.com --token $OKTA_TOKEN  -f okta-security-healthinsights.mql.yaml
-        ```
-
-        ## Scan Terraform HCL code managing Okta with the Terraform provider for Okta
-
-        ```bash
-        cnspec scan terraform /path/to/terraform -f okta-security-healthinsights.mql.yaml
-        ```
-
-        ## Scan Terraform plan file Okta with the Terraform provider for Okta
-
-        Generate a Terraform plan.json file to scan:
-
-        ```bash
-        terraform plan -out plan.tfplan
-        terraform show -json plan.tfplan > tfplan.json
-        ```
-
-        Scan Terraform plan file
-
-        ```bash
-        cnspec scan terraform plan /path/to/plan.json -f okta-security-healthinsights.mql.yaml
-        ```
-
-        ## Scan Terraform state file Okta with the Terraform provider for Okta
-
-        Generate a Terraform state.json file to scan:
-
-        ```bash
-        terraform show -json > tfstate.json
-        ```
-
-        Scan Terraform state file:
-
-        ```bash
-        cnspec scan terraform state /path/to/tfstate.json -f okta-security-healthinsights.mql.yaml
-        ```
+        - Multi-factor authentication policies and factor strength
+        - Password policies and lifecycle controls
+        - Session management and timeout settings
+        - API token security and rate limiting
+        - Administrative access and role management
+        - Application sign-on and authentication policies
+        - Threat insight and behavior detection
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -15,19 +15,19 @@ policies:
         email: hello@mondoo.com
     summary: Secure PAN-OS firewalls and Panorama configurations
     docs:
-      desc: |-
-        The Mondoo Palo Alto Networks PAN-OS Security policy provides comprehensive security checks for Palo Alto Networks PAN-OS firewalls and Panorama management platforms. This policy helps ensure your network security infrastructure is properly configured, licensed, and maintained according to security best practices.
+      desc: |
+        The Mondoo Palo Alto Networks PAN-OS Security policy identifies critical misconfigurations on PAN-OS firewalls and Panorama management platforms that could leave your network security infrastructure vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, policy bypass, encrypted threat blindness, and disruption of protected zones.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key PAN-OS areas:
 
-        - **License Management**: Verifies critical security subscriptions are active and not expired
-        - **System Configuration**: Validates operational mode and system parameters
-        - **Zone Security**: Ensures zones have protection profiles, packet buffer protection, and logging
-        - **Security Rule Hygiene**: Validates security rules use App-ID, threat profiles, and logging
-        - **Network Interface Hardening**: Checks interface zone assignment, management profiles, and addressing
-        - **VPN/IPsec Security**: Verifies IKE and IPsec tunnel configurations follow best practices
-        - **Decryption Policy**: Ensures decryption rules have proper profiles and logging
-        - **Routing Security**: Validates virtual router and static route configurations
+        - **License management**: Active and unexpired security subscriptions
+        - **System configuration**: Operational mode and system parameters
+        - **Zone security**: Protection profiles, packet buffer protection, and logging
+        - **Security rule hygiene**: App-ID enforcement, threat profiles, and traffic logging
+        - **Network interfaces**: Zone assignment, management profiles, and addressing
+        - **VPN and IPsec**: IKE and IPsec tunnel configuration
+        - **Decryption policy**: Proper profiles and logging
+        - **Routing security**: Virtual router and static route configuration
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -19,7 +19,14 @@ policies:
     summary: Secure Phoenix PLCnext industrial controllers
     docs:
       desc: |
-        The Phoenix PLCnext Security Policy provides security validation for Phoenix Contact PLCnext industrial automation controllers. This policy checks for secure configurations, firmware versions, and system hardening on PLCnext devices.
+        The Mondoo Phoenix Contact PLCnext Security policy identifies critical misconfigurations on PLCnext industrial automation controllers that could expose operational technology (OT) infrastructure to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized device access, process manipulation, and disruption of physical processes that depend on PLC reliability.
+
+        This policy provides security checks across key PLCnext areas:
+
+        - Secure device configuration
+        - Firmware version and supported releases
+        - Authentication and access controls
+        - System hardening and exposed services
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -16,33 +16,25 @@ policies:
     summary: Secure Proxmox Virtual Environment hypervisor, VM, and container configurations
     docs:
       desc: |
-        The Mondoo Proxmox VE Security policy provides security checks for Proxmox Virtual Environment hypervisors. The policy validates hypervisor configuration, VM and LXC container settings, cluster security, network segmentation, storage encryption, and kernel hardening that is specific to virtualization.
+        The Mondoo Proxmox VE Security policy identifies critical misconfigurations on Proxmox Virtual Environment hypervisors that could leave your virtualization platform vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of unauthorized hypervisor access, VM and container escape, lateral movement across guests, and disruption of every workload running on the host.
 
-        This policy is designed to run alongside the [Mondoo Linux Security](mondoo-linux-security.mql.yaml) policy, which covers the underlying Debian OS hardening. Checks already covered by the Linux baseline (SSH hardening, CIS kernel sysctls, auditd basics, file permissions, unnecessary services) are deliberately NOT duplicated here.
+        This policy runs alongside the [Mondoo Linux Security](mondoo-linux-security.mql.yaml) policy, which covers the underlying Debian OS hardening. Checks already covered by the Linux baseline are not duplicated here.
 
-        This policy covers the following critical security areas:
+        This policy provides security checks across key Proxmox VE areas:
 
-        - **Proxmox Access Control**: Two-factor authentication, Administrator role assignment, user.cfg permissions, Proxmox-adapted SSH root login
-        - **Account Security**: Empty password detection, UID 0 account validation
-        - **Proxmox Firewall**: Cluster firewall enablement, default DROP policy, per-node firewall, rule presence
-        - **TLS Certificates**: Self-signed certificate detection, expiration monitoring
-        - **LXC Container Security**: Unprivileged containers, nesting, AppArmor, per-interface firewall, mknod/FUSE restrictions, resource limits
-        - **QEMU/KVM VM Security**: Spectre/Meltdown mitigations, per-interface firewall, raw QEMU argument restrictions
-        - **Cluster & Migration**: Corosync encryption, live migration encryption
-        - **Network Segmentation**: VLAN usage across VMs and containers
-        - **Storage & Backup Encryption**: Proxmox Backup Server encryption, master key configuration
-        - **Proxmox-specific Hardening**: KSM disable, PCI ACS override prevention, IOMMU, auditd watches on /etc/pve/
-        - **ANSSI-BP-028 Kernel Hardening**: Unprivileged BPF, kexec_load, perf_event_paranoid, TTY line discipline autoload, TCP RFC1337, user namespaces
-        - **Password Policy**: login.defs extensions (PASS_MAX_DAYS, PASS_MIN_DAYS, ENCRYPT_METHOD)
-        - **Cron Security**: Permissions on /etc/crontab, /etc/cron.d, /etc/cron.hourly
-
-        ## Scan a Proxmox VE host
-
-        Install cnspec on the Proxmox VE node, then scan locally:
-
-        ```bash
-        cnspec scan local --policy mondoo-proxmox-security --policy mondoo-linux-security
-        ```
+        - **Proxmox access control**: Two-factor authentication, Administrator role assignment, `user.cfg` permissions, Proxmox-adapted SSH root login
+        - **Account security**: Empty password detection, UID 0 account validation
+        - **Proxmox firewall**: Cluster firewall enablement, default DROP policy, per-node firewall, rule presence
+        - **TLS certificates**: Self-signed certificate detection, expiration monitoring
+        - **LXC container security**: Unprivileged containers, nesting, AppArmor, per-interface firewall, mknod and FUSE restrictions, resource limits
+        - **QEMU/KVM VM security**: Spectre and Meltdown mitigations, per-interface firewall, raw QEMU argument restrictions
+        - **Cluster and migration**: Corosync encryption, live migration encryption
+        - **Network segmentation**: VLAN usage across VMs and containers
+        - **Storage and backup encryption**: Proxmox Backup Server encryption, master key configuration
+        - **Proxmox-specific hardening**: KSM disable, PCI ACS override prevention, IOMMU, auditd watches on `/etc/pve/`
+        - **ANSSI-BP-028 kernel hardening**: Unprivileged BPF, `kexec_load`, `perf_event_paranoid`, TTY line discipline autoload, TCP RFC 1337, user namespaces
+        - **Password policy**: `login.defs` extensions including PASS_MAX_DAYS, PASS_MIN_DAYS, and ENCRYPT_METHOD
+        - **Cron security**: Permissions on `/etc/crontab`, `/etc/cron.d`, `/etc/cron.hourly`
 
         ## References
 
@@ -51,6 +43,8 @@ policies:
         - [BSI SYS.1.5 Virtualisation](https://www.bsi.bund.de/)
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     scoring_system: highest impact
 
     groups:

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -16,67 +16,17 @@ policies:
     summary: Secure Slack workspace access and app permissions
     docs:
       desc: |
-        The Mondoo Slack Team Security policy identifies misconfigurations in Slack workspaces that could expose sensitive communications and enable unauthorized access. Improperly configured Slack workspaces can lead to data leakage, unauthorized channel access, and compromised user accounts through phishing or credential theft.
+        The Mondoo Slack Team Security policy identifies critical misconfigurations in Slack workspaces that could expose sensitive communications to unauthorized access. This policy helps organizations detect and remediate weaknesses before attackers can exploit them to leak data through external sharing, harvest credentials through phishing, or pivot from a compromised account into channels containing secrets, customer data, and operational details.
 
-        This policy validates critical security controls including two-factor authentication requirements, session settings, external sharing policies, and app installation permissions.
+        This policy provides security checks across key Slack workspace areas:
 
-        ### Prerequisites
+        - Two-factor authentication requirements
+        - Session settings and idle timeouts
+        - External sharing and guest access policies
+        - App installation and OAuth permissions
+        - Channel naming patterns and external channel governance
 
-        To run this query pack, you need access to the Slack API. This requires creating a new app in the Slack workspace, so you can retrieve a token.
-
-        1. Sign in to [the Slack website](https://api.slack.com/apps/) and view **Your Apps**.
-        2. Select **Create New App**.
-        3. Select **From scratch**.
-        4. Enter an app name (such as `cnquery`), select the workspace, then select **Create App**.
-        5. In the **Add features & functionality** section, select **Permissions**.
-        6. Scroll to **Scopes** and select **User Token Scopes**.
-
-          Note: Bots are very limited in their access so you must assign user scopes.
-
-        7. Add the required permissions to **User Token Scopes**:
-
-          | OAuth Scope  |
-          | ---- |
-          | [channels:read](https://api.slack.com/scopes/channels:read) |
-          | [groups:read](https://api.slack.com/scopes/groups:read) |
-          | [im:read](https://api.slack.com/scopes/im:read) |
-          | [mpim:read](https://api.slack.com/scopes/mpim:read) |
-          | [team:read](https://api.slack.com/scopes/team:read) |
-          | [usergroups:read](https://api.slack.com/scopes/usergroups:read) |
-          | [users:read](https://api.slack.com/scopes/users:read) |
-
-        8. Scroll up to **OAuth Tokens for Your Workspace** and select **Install to Workspace**.
-        9. Copy the provided **User OAuth Token**. It looks like this: `xoxp-1234567890123-1234567890123-1234567890123-12345cea5ae0d3bed30dca43cb34c2d1`
-
-        ### Run cnspec using this policy
-
-        To run this policy against a Slack workspace:
-
-        ```bash
-        export SLACK_TOKEN=xoxp-TOKEN
-        cnspec scan slack --policy-bundle mondoo-slack-security.mql.yaml
-        ```
-
-        Alternatively, you can use the CLI flag to connect to your Slack workspace:
-
-        ```bash
-        cnspec scan slack --token TOKEN --policy-bundle mondoo-slack-security.mql.yaml
-        ```
-
-        ## Note:
-        You need to set the two properties in this policy to some values that make sense for your organizations.
-        Modify the blocks below as needed:
-
-        ```mql
-          - uid: mondooSlackSecurityExternalChannelName
-            title: Enter your naming pattern for externally shared Slack channels
-            mql: |
-              return /ext|extern|ex_/
-          - uid: mondooSlackSecurityAllowListedDomains
-            title: Enter allowed domains here
-            mql: |
-              return /mondoo.com|example.com/
-        ```
+        This policy uses two configurable properties, `mondooSlackSecurityExternalChannelName` and `mondooSlackSecurityAllowListedDomains`, so you can match the naming and domain conventions in your workspace.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -16,23 +16,15 @@ policies:
     summary: Secure Snowflake accounts, users, and access controls
     docs:
       desc: |
-        The Mondoo Snowflake Security policy identifies misconfigurations in Snowflake accounts that could expose sensitive data or enable unauthorized access. This policy covers identity and access management, password policies, network access controls, and privileged role management.
+        The Mondoo Snowflake Security policy identifies critical misconfigurations in Snowflake accounts that could expose sensitive data and analytics workloads to attackers. This policy helps organizations detect and remediate weaknesses before they can be exploited, reducing the likelihood of unauthorized data access, credential theft, and abuse of privileged roles in your data warehouse.
 
-        ## Authentication
+        This policy provides security checks across key Snowflake areas:
 
-        Scanning a Snowflake account requires key-pair or password authentication.
-
-        ### Using key-pair authentication (recommended)
-
-        ```bash
-        cnspec scan snowflake --account ACCOUNT_IDENTIFIER --user USERNAME --role ACCOUNTADMIN --private-key /path/to/rsa_key.p8
-        ```
-
-        ### Using password authentication
-
-        ```bash
-        cnspec scan snowflake --account ACCOUNT_IDENTIFIER --user USERNAME --role ACCOUNTADMIN --password PASSWORD
-        ```
+        - Identity and access management
+        - Password and key-pair authentication policies
+        - Network access controls and network policies
+        - Privileged role management for ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN
+        - Session and federation settings
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -16,26 +16,15 @@ policies:
     summary: Secure Tailscale tailnet ACLs and device settings
     docs:
       desc: |
-        The Mondoo Tailscale Security policy identifies misconfigurations in Tailscale tailnets that could weaken your zero-trust network security posture. This policy covers device authorization, key management, software updates, and user access controls.
+        The Mondoo Tailscale Security policy identifies critical misconfigurations in Tailscale tailnets that could weaken your zero-trust network posture. This policy helps organizations detect and remediate weaknesses before they can be exploited, reducing the likelihood of unauthorized device access, stale credentials granting persistent network entry, and exposure of services that should remain private to authorized members.
 
-        ## Authentication
+        This policy provides security checks across key Tailscale areas:
 
-        Scanning a Tailscale tailnet requires an API key or OAuth client credentials.
-
-        ### Using an API key
-
-        ```bash
-        export TAILSCALE_API_KEY=tskey-api-...
-        cnspec scan tailscale --tailnet TAILNET_NAME
-        ```
-
-        ### Using OAuth credentials
-
-        ```bash
-        export TAILSCALE_OAUTH_CLIENT_ID=...
-        export TAILSCALE_OAUTH_CLIENT_SECRET=...
-        cnspec scan tailscale --tailnet TAILNET_NAME
-        ```
+        - Device authorization and tagging
+        - Auth key and OAuth client lifecycle
+        - Tailscale client software updates
+        - User access controls and ACL configuration
+        - Key expiry and rotation
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -16,15 +16,15 @@ policies:
     summary: Secure TLS/SSL certificates, ciphers, and protocols
     docs:
       desc: |
-        The Mondoo TLS/SSL Security policy identifies weak or misconfigured TLS/SSL settings that could expose encrypted communications to interception and tampering. Outdated protocols, weak cipher suites, and certificate issues can enable man-in-the-middle attacks, allowing attackers to eavesdrop on sensitive data or inject malicious content into encrypted connections.
+        The Mondoo TLS/SSL Security policy identifies weak or misconfigured TLS/SSL settings that could expose encrypted communications to interception, downgrade, and tampering. This policy helps organizations detect and remediate cryptographic weaknesses before attackers can exploit them in man-in-the-middle attacks to eavesdrop on sensitive data or inject malicious content into encrypted connections.
 
-        This policy validates TLS/SSL configurations including protocol versions, cipher suite strength, certificate validity, key exchange mechanisms, and protection against known vulnerabilities like BEAST and POODLE.
+        This policy provides security checks across key TLS/SSL configuration areas:
 
-        ## Remote scan a host
-
-        ```bash
-        cnspec scan host <fqdn>
-        ```
+        - TLS protocol versions and deprecation of insecure releases
+        - Cipher suite strength and forward secrecy
+        - Certificate validity, chain, and key strength
+        - Key exchange mechanisms
+        - Protection against known vulnerabilities such as BEAST, POODLE, and downgrade attacks
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -16,23 +16,15 @@ policies:
     summary: Secure Ubiquiti UniFi controller and network settings
     docs:
       desc: |
-        The Mondoo Ubiquiti UniFi Security policy identifies misconfigurations in UniFi controllers that could weaken your network security posture. This policy covers wireless security, firewall settings, threat management, device hardening, and controller backup and management settings.
+        The Mondoo Ubiquiti UniFi Security policy identifies critical misconfigurations in UniFi controllers that could weaken your network security posture. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of wireless intrusion, controller compromise, and disruption of network services.
 
-        ## Authentication
+        This policy provides security checks across key UniFi areas:
 
-        Scanning a UniFi controller requires API credentials.
-
-        ### Using an API key
-
-        ```bash
-        cnspec scan unifi --host 192.168.1.1 --api-key YOUR_API_KEY
-        ```
-
-        ### Using username and password
-
-        ```bash
-        cnspec scan unifi --host 192.168.1.1 --user admin --password YOUR_PASSWORD
-        ```
+        - Wireless security and SSID protection
+        - Firewall settings and inter-VLAN policies
+        - Threat management and intrusion prevention
+        - Device hardening and management plane access
+        - Controller backup, updates, and management settings
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -16,13 +16,18 @@ policies:
     summary: Validate Windows 11 hardware and software compatibility
     docs:
       desc: |
-        The Mondoo Microsoft Windows 11 Compatibility policy evaluates whether a Windows workstation meets the necessary requirements for Microsoft Windows 11. This policy assesses the following criteria:
-        - CPU compatibility with supported processors
-        - Minimum RAM requirements (greater than 8GB)
-        - HDD capacity (at least 120GB)
-        - TPM 2.0 support for enhanced security
-        - UEFI firmware requirement
+        The Mondoo Microsoft Windows 11 Compatibility policy evaluates whether a Windows workstation meets the hardware and firmware requirements to run Windows 11. This policy helps organizations plan upgrades and identify devices that need replacement, ensuring teams can move off unsupported Windows releases before security updates end and exposure to known vulnerabilities grows.
+
+        This policy provides checks across the Windows 11 system requirements:
+
+        - CPU compatibility with the supported processor list
+        - Minimum RAM of more than 8 GB
+        - Storage capacity of at least 120 GB
+        - TPM 2.0 support
+        - UEFI firmware
         - Secure Boot capability
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - filters: |
           asset.platform.contains("windows")

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -15,34 +15,20 @@ policies:
         email: hello@mondoo.com
     summary: Secure Windows accounts, firewall, audit, and services
     docs:
-      desc: |-
-        The Mondoo Microsoft Windows Security policy identifies misconfigurations that could leave Windows systems vulnerable to unauthorized access, malware infections, and lateral movement attacks. Improperly configured Windows systems can enable attackers to exploit SMB vulnerabilities, bypass User Account Control (UAC), steal credentials, and establish persistent access.
+      desc: |
+        The Mondoo Microsoft Windows Security policy identifies critical misconfigurations on Windows systems that could leave servers and clients vulnerable to attackers. This policy helps organizations detect and remediate hardening gaps before they can be exploited, reducing the likelihood of SMB-based exploitation, User Account Control (UAC) bypass, credential theft, lateral movement, and persistent compromise.
 
-        This policy validates critical security controls including password policies, Remote Desktop Protocol (RDP) hardening, SMB security settings, UAC configurations, and network access restrictions. It was tested against Microsoft Windows 10 Release 20H2 Enterprise and later versions.
+        This policy provides security checks across key Windows areas:
 
-        ## Local scan
+        - Password policies and account lockout
+        - Remote Desktop Protocol (RDP) hardening
+        - SMB security settings and protocol versions
+        - User Account Control (UAC) configuration
+        - Network access restrictions and anonymous access
+        - Audit policy and event log configuration
+        - Windows Firewall configuration
 
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a Windows host without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Windows hosts require an authentication method such as WinRM or SSH keys.
-
-        ### Scan a remote Windows device (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> -i /path/to/ssh_key
-        ```
+        This policy was tested against Microsoft Windows 10 Release 20H2 Enterprise and later versions.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -16,33 +16,18 @@ policies:
     summary: Secure Windows workstation access, updates, and configs
     docs:
       desc: |
-        The Mondoo Microsoft Windows Workstation Security policy identifies misconfigurations that could leave Windows workstations vulnerable to malware, unauthorized access, and data theft. Workstations are often targeted as entry points for attackers due to their exposure to phishing, malicious downloads, and physical access threats.
+        The Mondoo Microsoft Windows Workstation Security policy identifies critical misconfigurations on Windows workstations that could leave end-user devices vulnerable to malware, unauthorized access, and data theft. Workstations are a frequent first foothold for attackers, with phishing, malicious downloads, and physical access threats all targeting the endpoint. Workstation hardening directly limits what an attacker can do once they get in.
 
-        This policy validates critical security controls including secure boot, BitLocker encryption, antivirus presence, automatic updates, and firewall settings. It supports Windows 10 and Windows 11.
+        This policy provides security checks across key Windows workstation areas:
 
-        ## Local scan
+        - Secure Boot configuration
+        - BitLocker disk encryption
+        - Antivirus and Microsoft Defender presence
+        - Automatic updates and patch posture
+        - Windows Firewall configuration
+        - User Account Control (UAC) and screen lock policies
 
-        Local scan refer to scans of files and operating systems where cnspec is installed.
-
-        To scan the `localhost` against this policy:
-
-        ```bash
-        cnspec scan local
-        ```
-
-        ## Remote scan
-
-        Remotely scan a Windows workstation without installing an agent.
-
-        ### Prerequisites
-
-        Remote scans of Windows hosts require authentication such as SSH keys.
-
-        ### Scan a remote Windows system (SSH authentication)
-
-        ```bash
-        cnspec scan ssh <user>@<IP_ADDRESS> --ask-pass
-        ```
+        This policy supports Windows 10 and Windows 11.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -16,23 +16,13 @@ policies:
     summary: Identify deprecated Terraform providers and configs
     docs:
       desc: |
-        The Terraform HCL Deprecations Policy identifies deprecated Terraform providers and configurations that should be updated to maintain compatibility and security.
+        The Terraform HCL Deprecations policy identifies deprecated Terraform providers and configurations that should be updated to keep infrastructure-as-code maintainable, secure, and compatible with current tooling. This policy helps organizations spot deprecated resources and arguments before they break upgrades, leave behind insecure defaults, or block teams from adopting newer features and CVE fixes shipped in current provider releases.
 
-        ## Scanning Terraform Files
+        This policy provides checks across key Terraform deprecation areas:
 
-        This policy scans Terraform HCL files to identify deprecated providers and configurations.
-
-        ### Scan a Terraform directory
-
-        ```bash
-        cnspec scan terraform /path/to/terraform -f terraform-deprecations.mql.yaml
-        ```
-
-        ### Scan a specific Terraform file
-
-        ```bash
-        cnspec scan terraform main.tf -f terraform-deprecations.mql.yaml
-        ```
+        - Deprecated providers
+        - Deprecated resource types and arguments
+        - Legacy configurations replaced by newer equivalents
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:


### PR DESCRIPTION
## Summary

- Refocus the main `desc` block of every policy on what the policy does for users and the risks it mitigates, following the AWS/Azure/GCP pattern.
- Drop scan/auth/prerequisite sections from policy descriptions; that material belongs in product docs, not in the policy bundle.
- Standardize on lead sentence + risk framing + bulleted service/area list + standard "suggestions" footer across all 51 policies.

51 policy files updated; net -501 lines.

## Test plan

- [x] `cnspec policy lint ./content` passes (after updating local panos provider to 13.4.0, which is what current OSPF queries already require).

🤖 Generated with [Claude Code](https://claude.com/claude-code)