### PR TITLE
Link each policy description to its cnspec docs page

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -32,7 +32,7 @@ policies:
         - BGP route filtering and peer documentation
         - ACL completeness and logging for denied traffic
 
-        Learn more about scanning Arista EOS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/arista).
+        Learn more about scanning Arista EOS in the [cnspec Arista EOS documentation](https://mondoo.com/docs/cnspec/network/arista).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -32,6 +32,8 @@ policies:
         - BGP route filtering and peer documentation
         - ACL completeness and logging for denied traffic
 
+        Learn more about scanning Arista EOS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/arista).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: User Account Security

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -81,7 +81,7 @@ policies:
         - AWS Step Functions
         - AWS Transfer Family
 
-        Learn more about scanning AWS in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/aws).
+        Learn more about scanning AWS in the [cnspec AWS documentation](https://mondoo.com/docs/cnspec/cloud/aws).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -81,6 +81,8 @@ policies:
         - AWS Step Functions
         - AWS Transfer Family
 
+        Learn more about scanning AWS in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/aws).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: AWS General

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -48,6 +48,8 @@ policies:
         - Azure Log Analytics
         - Azure Recovery Services
 
+        Learn more about scanning Azure in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/azure).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Azure Storage

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -48,7 +48,7 @@ policies:
         - Azure Log Analytics
         - Azure Recovery Services
 
-        Learn more about scanning Azure in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/azure).
+        Learn more about scanning Azure in the [cnspec Azure documentation](https://mondoo.com/docs/cnspec/cloud/azure).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -24,6 +24,8 @@ policies:
         - **SSL/TLS profiles**: Client and server profiles, cipher suites, and authentication
         - **Network security**: VLAN source checking, route domain isolation, and SNMP access restrictions
 
+        Learn more about scanning F5 BIG-IP in the [cnspec docs](https://mondoo.com/docs/cnspec/network/bigip).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -24,7 +24,7 @@ policies:
         - **SSL/TLS profiles**: Client and server profiles, cipher suites, and authentication
         - **Network security**: VLAN source checking, route domain isolation, and SNMP access restrictions
 
-        Learn more about scanning F5 BIG-IP in the [cnspec docs](https://mondoo.com/docs/cnspec/network/bigip).
+        Learn more about scanning F5 BIG-IP in the [cnspec F5 BIG-IP documentation](https://mondoo.com/docs/cnspec/network/bigip).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -32,7 +32,7 @@ policies:
         - Routing protocol authentication for BGP and OSPF
         - Disabling source routing and other dangerous features
 
-        Learn more about scanning Cisco IOS-XE in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+        Learn more about scanning Cisco IOS-XE in the [cnspec Cisco IOS-XE documentation](https://mondoo.com/docs/cnspec/network/cisco).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -32,6 +32,8 @@ policies:
         - Routing protocol authentication for BGP and OSPF
         - Disabling source routing and other dangerous features
 
+        Learn more about scanning Cisco IOS-XE in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -31,7 +31,7 @@ policies:
         - Routing protocol authentication for BGP, OSPF, and EIGRP
         - Management plane protection and CDP status
 
-        Learn more about scanning Cisco IOS-XR in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+        Learn more about scanning Cisco IOS-XR in the [cnspec Cisco IOS-XR documentation](https://mondoo.com/docs/cnspec/network/cisco).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -31,6 +31,8 @@ policies:
         - Routing protocol authentication for BGP, OSPF, and EIGRP
         - Management plane protection and CDP status
 
+        Learn more about scanning Cisco IOS-XR in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -34,6 +34,8 @@ policies:
         - BGP and OSPF routing protocol authentication
         - Disabling source routing and unnecessary services
 
+        Learn more about scanning Cisco NX-OS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -34,7 +34,7 @@ policies:
         - BGP and OSPF routing protocol authentication
         - Disabling source routing and unnecessary services
 
-        Learn more about scanning Cisco NX-OS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/cisco).
+        Learn more about scanning Cisco NX-OS in the [cnspec Cisco NX-OS documentation](https://mondoo.com/docs/cnspec/network/cisco).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - Browser integrity checks and bot mitigation
         - Account-level two-factor authentication and access controls
 
+        Learn more about scanning Cloudflare in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/cloudflare).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Zone Security

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - Browser integrity checks and bot mitigation
         - Account-level two-factor authentication and access controls
 
-        Learn more about scanning Cloudflare in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/cloudflare).
+        Learn more about scanning Cloudflare in the [cnspec Cloudflare documentation](https://mondoo.com/docs/cnspec/saas/cloudflare).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -31,7 +31,7 @@ policies:
         - Spaces (object storage) access keys
         - App Platform
 
-        Learn more about scanning DigitalOcean in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/digitalocean).
+        Learn more about scanning DigitalOcean in the [cnspec DigitalOcean documentation](https://mondoo.com/docs/cnspec/cloud/digitalocean).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -31,6 +31,8 @@ policies:
         - Spaces (object storage) access keys
         - App Platform
 
+        Learn more about scanning DigitalOcean in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/digitalocean).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Account

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Multi-stage builds and minimal base images
         - Idiomatic use of package managers such as apt and apk
 
-        Learn more about scanning Dockerfiles in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
+        Learn more about scanning Dockerfiles in the [cnspec Dockerfile documentation](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - Multi-stage builds and minimal base images
         - Idiomatic use of package managers such as apt and apk
 
+        Learn more about scanning Dockerfiles in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Package Management

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Privilege controls and removal of dangerous capabilities
         - Avoidance of secrets and credentials in image layers
 
-        Learn more about scanning Dockerfiles in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
+        Learn more about scanning Dockerfiles in the [cnspec Dockerfile documentation](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - Privilege controls and removal of dangerous capabilities
         - Avoidance of secrets and credentials in image layers
 
+        Learn more about scanning Dockerfiles in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/dockerfiles).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Network Security

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - **Routing security**: BGP and OSPF neighbor change logging and graceful restart
         - **FortiGuard subscriptions**: Active antispam, web filter, and outbreak prevention subscriptions
 
-        Learn more about scanning Fortinet FortiOS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/fortios).
+        Learn more about scanning Fortinet FortiOS in the [cnspec Fortinet FortiOS documentation](https://mondoo.com/docs/cnspec/network/fortios).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
         - **Routing security**: BGP and OSPF neighbor change logging and graceful restart
         - **FortiGuard subscriptions**: Active antispam, web filter, and outbreak prevention subscriptions
 
+        Learn more about scanning Fortinet FortiOS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/fortios).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
         - System and audit logging
         - Privilege escalation controls
 
+        Learn more about scanning FreeBSD in the [cnspec docs](https://mondoo.com/docs/cnspec/os/freebsd).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Kernel and Process Hardening

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - System and audit logging
         - Privilege escalation controls
 
-        Learn more about scanning FreeBSD in the [cnspec docs](https://mondoo.com/docs/cnspec/os/freebsd).
+        Learn more about scanning FreeBSD in the [cnspec FreeBSD documentation](https://mondoo.com/docs/cnspec/os/freebsd).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -54,6 +54,8 @@ policies:
         - Vertex AI
         - VPC Service Controls
 
+        Learn more about scanning Google Cloud in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/gcp).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Cloud Storage

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -54,7 +54,7 @@ policies:
         - Vertex AI
         - VPC Service Controls
 
-        Learn more about scanning Google Cloud in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/gcp).
+        Learn more about scanning Google Cloud in the [cnspec Google Cloud documentation](https://mondoo.com/docs/cnspec/cloud/gcp).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - Issue and pull request templates
         - Support documentation
 
+        Learn more about scanning GitHub in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/github).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: GitHub Repo

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Issue and pull request templates
         - Support documentation
 
-        Learn more about scanning GitHub in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/github).
+        Learn more about scanning GitHub in the [cnspec GitHub documentation](https://mondoo.com/docs/cnspec/saas/github).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Organization-wide security policies and Dependabot settings
         - Webhook and OAuth or GitHub App authorization
 
-        Learn more about scanning GitHub in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/github).
+        Learn more about scanning GitHub in the [cnspec GitHub documentation](https://mondoo.com/docs/cnspec/saas/github).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - Organization-wide security policies and Dependabot settings
         - Webhook and OAuth or GitHub App authorization
 
+        Learn more about scanning GitHub in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/github).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Authentication & Access

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - Branch protection and merge request controls
         - Repository sharing and forking restrictions
 
-        Learn more about scanning GitLab in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/gitlab).
+        Learn more about scanning GitLab in the [cnspec GitLab documentation](https://mondoo.com/docs/cnspec/saas/gitlab).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - Branch protection and merge request controls
         - Repository sharing and forking restrictions
 
+        Learn more about scanning GitLab in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/gitlab).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Group

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -28,7 +28,7 @@ policies:
         - Mobile device and Chrome management
         - Audit logging and reporting configuration
 
-        Learn more about scanning Google Workspace in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/google_workspace).
+        Learn more about scanning Google Workspace in the [cnspec Google Workspace documentation](https://mondoo.com/docs/cnspec/saas/google_workspace).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -28,6 +28,8 @@ policies:
         - Mobile device and Chrome management
         - Audit logging and reporting configuration
 
+        Learn more about scanning Google Workspace in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/google_workspace).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Authentication & Admin Security

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - TLS Certificates
         - Floating IPs and Primary IPs
 
+        Learn more about scanning Hetzner Cloud in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/hetzner).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Servers

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - TLS Certificates
         - Floating IPs and Primary IPs
 
-        Learn more about scanning Hetzner Cloud in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/hetzner).
+        Learn more about scanning Hetzner Cloud in the [cnspec Hetzner Cloud documentation](https://mondoo.com/docs/cnspec/cloud/hetzner).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
         - Protection against SYN floods, land attacks, teardrop, and other network attacks
         - Validity of security feature licenses
 
+        Learn more about scanning Juniper Junos in the [cnspec docs](https://mondoo.com/docs/cnspec/network/junos).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - Protection against SYN floods, land attacks, teardrop, and other network attacks
         - Validity of security feature licenses
 
-        Learn more about scanning Juniper Junos in the [cnspec docs](https://mondoo.com/docs/cnspec/network/junos).
+        Learn more about scanning Juniper Junos in the [cnspec Juniper Junos documentation](https://mondoo.com/docs/cnspec/network/junos).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Labeling standards for selection and ownership
         - Liveness, readiness, and startup probes
 
-        Learn more about scanning Kubernetes in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/kubernetes).
+        Learn more about scanning Kubernetes in the [cnspec Kubernetes documentation](https://mondoo.com/docs/cnspec/cloud/kubernetes).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - Labeling standards for selection and ownership
         - Liveness, readiness, and startup probes
 
+        Learn more about scanning Kubernetes in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/kubernetes).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: CronJobs

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -30,6 +30,8 @@ policies:
         - Secret management and projected service account tokens
         - ImagePullPolicy, signed images, and registry trust
 
+        Learn more about scanning Kubernetes in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/kubernetes).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Kubernetes API Server

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -30,7 +30,7 @@ policies:
         - Secret management and projected service account tokens
         - ImagePullPolicy, signed images, and registry trust
 
-        Learn more about scanning Kubernetes in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/kubernetes).
+        Learn more about scanning Kubernetes in the [cnspec Kubernetes documentation](https://mondoo.com/docs/cnspec/cloud/kubernetes).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -24,7 +24,7 @@ policies:
         - Memory utilization and swap pressure
         - Filesystem inode availability
 
-        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+        Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -24,6 +24,8 @@ policies:
         - Memory utilization and swap pressure
         - Filesystem inode availability
 
+        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - filters: asset.family.contains("linux")

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -30,7 +30,7 @@ policies:
 
         This policy is developed for Red Hat (RHEL), Debian, Ubuntu, and SUSE (SLES) derivative distributions running on x64 architectures. Some checks may be skipped depending on the distribution, installation type, or underlying infrastructure. Guidance broadly assumes operations are performed as the root user; running remediation through `sudo` may produce different results.
 
-        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+        Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -30,6 +30,8 @@ policies:
 
         This policy is developed for Red Hat (RHEL), Debian, Ubuntu, and SUSE (SLES) derivative distributions running on x64 architectures. Some checks may be skipped depending on the distribution, installation type, or underlying infrastructure. Guidance broadly assumes operations are performed as the root user; running remediation through `sudo` may produce different results.
 
+        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Core

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -25,7 +25,7 @@ policies:
         - Access control and source restrictions
         - File permissions on SNMP credential and configuration files
 
-        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+        Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -25,6 +25,8 @@ policies:
         - Access control and source restrictions
         - File permissions on SNMP credential and configuration files
 
+        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: SNMP Server Configuration

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
 
         This policy supports Red Hat, Debian, Ubuntu, and SUSE distributions on x86 and x64 platforms.
 
+        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Secure Boot

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
 
         This policy supports Red Hat, Debian, Ubuntu, and SUSE distributions on x86 and x64 platforms.
 
-        Learn more about scanning Linux in the [cnspec docs](https://mondoo.com/docs/cnspec/os/linux).
+        Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - SharePoint and OneDrive sharing policies
         - Microsoft Teams security and external access
 
-        Learn more about scanning Microsoft 365 in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/m365).
+        Learn more about scanning Microsoft 365 in the [cnspec Microsoft 365 documentation](https://mondoo.com/docs/cnspec/saas/m365).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
         - SharePoint and OneDrive sharing policies
         - Microsoft Teams security and external access
 
+        Learn more about scanning Microsoft 365 in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/m365).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Identity & Access Protection

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -30,6 +30,8 @@ policies:
 
         This policy was tested against Apple macOS 10.15, 11, 12, 13, and 14.
 
+        Learn more about scanning macOS in the [cnspec docs](https://mondoo.com/docs/cnspec/os/mac).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Core

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -30,7 +30,7 @@ policies:
 
         This policy was tested against Apple macOS 10.15, 11, 12, 13, and 14.
 
-        Learn more about scanning macOS in the [cnspec docs](https://mondoo.com/docs/cnspec/os/mac).
+        Learn more about scanning macOS in the [cnspec macOS documentation](https://mondoo.com/docs/cnspec/os/mac).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -25,6 +25,8 @@ policies:
         - Object Storage
         - Virtual Cloud Network (VCN)
 
+        Learn more about scanning Oracle Cloud Infrastructure in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/oci).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Identity and Access Management

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -25,7 +25,7 @@ policies:
         - Object Storage
         - Virtual Cloud Network (VCN)
 
-        Learn more about scanning Oracle Cloud Infrastructure in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/oci).
+        Learn more about scanning Oracle Cloud Infrastructure in the [cnspec Oracle Cloud Infrastructure documentation](https://mondoo.com/docs/cnspec/cloud/oci).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -28,6 +28,8 @@ policies:
         - Application sign-on and authentication policies
         - Threat insight and behavior detection
 
+        Learn more about scanning Okta in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/okta).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Access Control & Administration

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -28,7 +28,7 @@ policies:
         - Application sign-on and authentication policies
         - Threat insight and behavior detection
 
-        Learn more about scanning Okta in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/okta).
+        Learn more about scanning Okta in the [cnspec Okta documentation](https://mondoo.com/docs/cnspec/saas/okta).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - **Decryption policy**: Proper profiles and logging
         - **Routing security**: Virtual router and static route configuration
 
-        Learn more about scanning Palo Alto PAN-OS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/panos).
+        Learn more about scanning Palo Alto PAN-OS in the [cnspec Palo Alto PAN-OS documentation](https://mondoo.com/docs/cnspec/network/panos).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
         - **Decryption policy**: Proper profiles and logging
         - **Routing security**: Virtual router and static route configuration
 
+        Learn more about scanning Palo Alto PAN-OS in the [cnspec docs](https://mondoo.com/docs/cnspec/network/panos).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
 
     groups:

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -44,7 +44,7 @@ policies:
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
 
-        Learn more about scanning Proxmox VE in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/proxmox).
+        Learn more about scanning Proxmox VE in the [cnspec Proxmox VE documentation](https://mondoo.com/docs/cnspec/cloud/proxmox).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     scoring_system: highest impact

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -44,6 +44,8 @@ policies:
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
 
+        Learn more about scanning Proxmox VE in the [cnspec docs](https://mondoo.com/docs/cnspec/cloud/proxmox).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     scoring_system: highest impact
 

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -28,6 +28,8 @@ policies:
 
         This policy uses two configurable properties, `mondooSlackSecurityExternalChannelName` and `mondooSlackSecurityAllowListedDomains`, so you can match the naming and domain conventions in your workspace.
 
+        Learn more about scanning Slack in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/slack).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Slack

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -28,7 +28,7 @@ policies:
 
         This policy uses two configurable properties, `mondooSlackSecurityExternalChannelName` and `mondooSlackSecurityAllowListedDomains`, so you can match the naming and domain conventions in your workspace.
 
-        Learn more about scanning Slack in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/slack).
+        Learn more about scanning Slack in the [cnspec Slack documentation](https://mondoo.com/docs/cnspec/saas/slack).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - Privileged role management for ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN
         - Session and federation settings
 
-        Learn more about scanning Snowflake in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/snowflake).
+        Learn more about scanning Snowflake in the [cnspec Snowflake documentation](https://mondoo.com/docs/cnspec/saas/snowflake).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - Privileged role management for ACCOUNTADMIN, SECURITYADMIN, and SYSADMIN
         - Session and federation settings
 
+        Learn more about scanning Snowflake in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/snowflake).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Identity and Access Management

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - User access controls and ACL configuration
         - Key expiry and rotation
 
-        Learn more about scanning Tailscale in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/tailscale).
+        Learn more about scanning Tailscale in the [cnspec Tailscale documentation](https://mondoo.com/docs/cnspec/saas/tailscale).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - User access controls and ACL configuration
         - Key expiry and rotation
 
+        Learn more about scanning Tailscale in the [cnspec docs](https://mondoo.com/docs/cnspec/saas/tailscale).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Tailscale Devices

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
         - Device hardening and management plane access
         - Controller backup, updates, and management settings
 
-        Learn more about scanning Ubiquiti UniFi in the [cnspec docs](https://mondoo.com/docs/cnspec/network/unifi).
+        Learn more about scanning Ubiquiti UniFi in the [cnspec Ubiquiti UniFi documentation](https://mondoo.com/docs/cnspec/network/unifi).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -26,6 +26,8 @@ policies:
         - Device hardening and management plane access
         - Controller backup, updates, and management settings
 
+        Learn more about scanning Ubiquiti UniFi in the [cnspec docs](https://mondoo.com/docs/cnspec/network/unifi).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Wireless Security

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - UEFI firmware
         - Secure Boot capability
 
-        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+        Learn more about scanning Windows in the [cnspec Windows documentation](https://mondoo.com/docs/cnspec/os/windows).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -27,6 +27,8 @@ policies:
         - UEFI firmware
         - Secure Boot capability
 
+        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - filters: |

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -30,7 +30,7 @@ policies:
 
         This policy was tested against Microsoft Windows 10 Release 20H2 Enterprise and later versions.
 
-        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+        Learn more about scanning Windows in the [cnspec Windows documentation](https://mondoo.com/docs/cnspec/os/windows).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -30,6 +30,8 @@ policies:
 
         This policy was tested against Microsoft Windows 10 Release 20H2 Enterprise and later versions.
 
+        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Core

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -29,6 +29,8 @@ policies:
 
         This policy supports Windows 10 and Windows 11.
 
+        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Secure Boot

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
 
         This policy supports Windows 10 and Windows 11.
 
-        Learn more about scanning Windows in the [cnspec docs](https://mondoo.com/docs/cnspec/os/windows).
+        Learn more about scanning Windows in the [cnspec Windows documentation](https://mondoo.com/docs/cnspec/os/windows).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -24,7 +24,7 @@ policies:
         - Deprecated resource types and arguments
         - Legacy configurations replaced by newer equivalents
 
-        Learn more about scanning Terraform in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/terraform).
+        Learn more about scanning Terraform in the [cnspec Terraform documentation](https://mondoo.com/docs/cnspec/supplychain/terraform).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -24,6 +24,8 @@ policies:
         - Deprecated resource types and arguments
         - Legacy configurations replaced by newer equivalents
 
+        Learn more about scanning Terraform in the [cnspec docs](https://mondoo.com/docs/cnspec/supplychain/terraform).
+
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Terraform Provider Deprecations


### PR DESCRIPTION
## Summary

- Add a "Learn more about scanning *X* in the [cnspec docs](...)" line just before the contributions footer in each policy description that has a provider-specific docs page on https://mondoo.com/docs/cnspec.
- 40 policies updated. Policies without a matching provider docs page (AI security, MCP, EDR, Chef Infra client/server, Phoenix PLCnext, Grafana, DNS, TLS, HTTP, Email) are left unchanged.

## Test plan

- [x] `cnspec policy lint ./content` passes.
- [x] Spot-checked URLs against live docs (cloud/aws, cloud/oci, saas/m365, saas/google_workspace, network/cisco, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)