### PR TITLE
Clarify annotation flag expects KEY=VALUE format

### DIFF
--- a/apps/cnspec/cmd/sbom.go
+++ b/apps/cnspec/cmd/sbom.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	rootCmd.AddCommand(sbomCmd)
 	sbomCmd.Flags().String("asset-name", "", "User-override for the asset name")
-	sbomCmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset") // user-added, editable
+	sbomCmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset in the form KEY=VALUE") // user-added, editable
 	sbomCmd.Flags().StringP("output", "o", "list", "Set output format: "+sbom.AllFormats())
 	sbomCmd.Flags().String("output-target", "", "Set output target to which the SBOM report will be written")
 	sbomCmd.Flags().Bool("with-evidence", false, "Include evidence for each component")

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -65,7 +65,7 @@ func init() {
 		return getPoliciesForCompletion(), cobra.ShellCompDirectiveDefault
 	})
 	_ = scanCmd.Flags().String("asset-name", "", "Override the asset name")
-	_ = scanCmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset") // user-added, editable
+	_ = scanCmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset in the form KEY=VALUE") // user-added, editable
 	_ = scanCmd.Flags().StringToString("props", nil, "Set custom values for properties")
 	_ = scanCmd.Flags().String("trace-id", "", "Set a trace identifier")
 

--- a/docs/cli/cnspec_scan.md
+++ b/docs/cli/cnspec_scan.md
@@ -180,7 +180,7 @@ cnspec scan --inventory-file FILENAME
 ### Options
 
 ```
-      --annotation stringToString     Add an annotation to the asset in this format: key=value. (default [])
+      --annotation stringToString     Add an annotation to the asset in the form KEY=VALUE (default [])
       --asset-name string             User-override for the asset name
       --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd'. (default true)
   -h, --help                          help for scan

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -19,7 +19,7 @@ Available Commands:
   sbom        Scan read SBOM file on disk
 
 Flags:
-      --annotation stringToString     Add an annotation to the asset (default [])
+      --annotation stringToString     Add an annotation to the asset in the form KEY=VALUE (default [])
       --asset-name string             Override the asset name
       --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd' (default true)
   -h, --help                          help for scan


### PR DESCRIPTION
## Summary
- Update `--annotation` flag help text on `scan` and `sbom` commands to specify the expected `KEY=VALUE` form
- Regenerate `docs/cli/cnspec_scan.md` and `test/cli/testdata/cnspec_scan.ct` to match

## Test plan
- [ ] `cnspec scan --help` shows the clarified annotation usage
- [ ] `cnspec sbom --help` shows the clarified annotation usage
- [ ] `make test/go` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)