### PR TITLE
:broom: Replace deprecated MQL fields/resources in cloud SQL/cache checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -5245,7 +5245,7 @@ queries:
     mql: |
       aws.rds.dbcluster.securityGroups.none(
         vpc.routeTables.where(
-          routes.any(GatewayId == /igw-/ && DestinationCidrBlock == "0.0.0.0/0")
+          routeEntries.any(gatewayId == /igw-/ && destinationCidrBlock == "0.0.0.0/0")
         )
       )
   - uid: mondoo-aws-security-rds-cluster-public-access-check-terraform-hcl
@@ -5418,7 +5418,7 @@ queries:
       aws.rds.dbinstance.publiclyAccessible == false ||
       aws.rds.dbinstance.securityGroups.none(
         vpc.routeTables.where(
-          routes.any(GatewayId == /igw-/ && DestinationCidrBlock == "0.0.0.0/0")
+          routeEntries.any(gatewayId == /igw-/ && destinationCidrBlock == "0.0.0.0/0")
         )
       )
   - uid: mondoo-aws-security-rds-instance-public-access-check-terraform-hcl
@@ -12774,7 +12774,7 @@ queries:
         title: AWS Documentation - OpenSearch controls
   - uid: mondoo-aws-security-opensearch-in-vpc-aws
     filters: asset.platform == "aws-opensearch-domain"
-    mql: aws.opensearch.domain.vpcId != ""
+    mql: aws.opensearch.domain.vpc != empty
   - uid: mondoo-aws-security-opensearch-in-vpc-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_opensearch_domain")
     mql: |
@@ -27517,7 +27517,7 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.kinesis.streams.all(
-        encryptionType == "KMS" && keyId != /alias\/aws\/kinesis/
+        encryptionType == "KMS" && kmsKey.keyManager == "CUSTOMER"
       )
   - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kinesis_stream")
@@ -27670,7 +27670,7 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.kinesis.firehoseDeliveryStreams.all(
-        encryption['Status'] == "ENABLED"
+        serverSideEncryption.status == "ENABLED"
       )
   - uid: mondoo-aws-security-kinesis-firehose-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kinesis_firehose_delivery_stream")
@@ -32002,7 +32002,7 @@ queries:
         title: Amazon SageMaker - Give SageMaker Hosted Endpoints Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-model-vpc-configured-aws
     filters: asset.platform == "aws"
-    mql: aws.sagemaker.models.all(vpcConfig != empty)
+    mql: aws.sagemaker.models.all(vpc != empty)
   - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_model")
     mql: |
@@ -32258,7 +32258,7 @@ queries:
         title: Amazon SageMaker - Give SageMaker Training Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
     filters: asset.platform == "aws"
-    mql: aws.sagemaker.trainingJobs.all(vpcConfig != empty)
+    mql: aws.sagemaker.trainingJobs.all(vpc != empty)
   # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); there is no `aws_sagemaker_processing_job` Terraform resource that carries `enable_network_isolation`.
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation
     title: Ensure SageMaker processing jobs have network isolation enabled
@@ -32479,7 +32479,7 @@ queries:
         title: Amazon SageMaker - Give SageMaker Processing Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured-aws
     filters: asset.platform == "aws"
-    mql: aws.sagemaker.processingJobs.all(vpcConfig != empty)
+    mql: aws.sagemaker.processingJobs.all(vpc != empty)
   - uid: mondoo-aws-security-sagemaker-domain-kms-encryption
     title: Ensure SageMaker domains are encrypted with a KMS key
     impact: 70

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -20677,7 +20677,7 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.auditingPolicy.state == "Enabled"
+      azure.subscription.sql.server.blobAuditingPolicy.state == "Enabled"
   - uid: mondoo-azure-security-sql-server-audit-on-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_extended_auditing_policy")
     mql: |
@@ -20694,7 +20694,7 @@ queries:
     filters: |
       asset.platform == "azure-sql-server" && azure.subscription.sql.server.databases.any(name != "master")
     mql: |
-      azure.subscription.sql.server.databases.where(name != "master").all(transparentDataEncryption.state == "Enabled")
+      azure.subscription.sql.server.databases.where(name != "master").all(transparentDataEncryptionEnabled)
   - uid: mondoo-azure-security-sql-server-tde-on-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_database")
     mql: |
@@ -20741,9 +20741,9 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.auditingPolicy.state == "Enabled"
-      azure.subscription.sql.server.auditingPolicy.retentionDays >= 30 ||
-       azure.subscription.sql.server.auditingPolicy.retentionDays == 0
+      azure.subscription.sql.server.blobAuditingPolicy.state == "Enabled"
+      azure.subscription.sql.server.blobAuditingPolicy.retentionDays >= 30 ||
+       azure.subscription.sql.server.blobAuditingPolicy.retentionDays == 0
   - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_extended_auditing_policy")
     mql: |
@@ -20769,7 +20769,7 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.threatDetectionPolicy.state == "Enabled"
+      azure.subscription.sql.server.securityAlertPolicyConfig.state == "Enabled"
   - uid: mondoo-azure-security-sql-threat-detection-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_security_alert_policy")
     mql: |
@@ -24537,9 +24537,9 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.auditingPolicy.state == "Enabled"
-      azure.subscription.sql.server.auditingPolicy.retentionDays >= 90 ||
-       azure.subscription.sql.server.auditingPolicy.retentionDays == 0
+      azure.subscription.sql.server.blobAuditingPolicy.state == "Enabled"
+      azure.subscription.sql.server.blobAuditingPolicy.retentionDays >= 90 ||
+       azure.subscription.sql.server.blobAuditingPolicy.retentionDays == 0
   - uid: mondoo-azure-security-sql-audit-retention-90-days-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_extended_auditing_policy")
     mql: |
@@ -24657,8 +24657,8 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.threatDetectionPolicy.state == "Enabled"
-      azure.subscription.sql.server.threatDetectionPolicy.emailAddresses.where(_ != "").length > 0
+      azure.subscription.sql.server.securityAlertPolicyConfig.state == "Enabled"
+      azure.subscription.sql.server.securityAlertPolicyConfig.emailAddresses.where(_ != "").length > 0
   - uid: mondoo-azure-security-sql-threat-alert-emails-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_security_alert_policy")
     mql: |
@@ -24775,8 +24775,8 @@ queries:
     filters: |
       asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.server.threatDetectionPolicy.state == "Enabled"
-      azure.subscription.sql.server.threatDetectionPolicy.disabledAlerts.none(_ != "")
+      azure.subscription.sql.server.securityAlertPolicyConfig.state == "Enabled"
+      azure.subscription.sql.server.securityAlertPolicyConfig.disabledAlerts.none(_ != "")
   - uid: mondoo-azure-security-sql-threat-detection-types-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_security_alert_policy")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8916,11 +8916,11 @@ queries:
   - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
     mql: |
-      gcp.project.redisService.instance.customerManagedKey != ""
+      gcp.project.redisService.instance.kmsKey != empty
   - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-rediscluster
     filters: asset.platform == "gcp-memorystore-rediscluster"
     mql: |
-      gcp.project.redisService.cluster.kmsKey != ""
+      gcp.project.redisService.cluster.cryptoKey != empty
   - uid: mondoo-gcp-security-cloud-redis-cmek-configured-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_redis_instance' || nameLabel == 'google_redis_cluster')


### PR DESCRIPTION
The new lint rule flagged ten queries referencing fields the providers have annotated `@maturity("deprecated")`. Swap each to its current typed accessor:

- AWS Firehose: `encryption['Status']` → `serverSideEncryption.status`
- Azure SQL server/database `auditingPolicy` → `blobAuditingPolicy`
- Azure SQL server `threatDetectionPolicy` →`securityAlertPolicyConfig`
- Azure SQL database `transparentDataEncryption.state == "Enabled"` → `transparentDataEncryptionEnabled` (already a bool)
- GCP Memorystore Redis `instance.customerManagedKey != ""` → `instance.kmsKey != empty`; cluster `kmsKey` → `cryptoKey`