### PR TITLE
✨ support enforcing individual lint rules via --strict-rule

### DIFF
--- a/apps/cnspec/cmd/policy.go
+++ b/apps/cnspec/cmd/policy.go
@@ -53,6 +53,7 @@ func init() {
 	// lint
 	policyLintCmd.Flags().StringP("output", "o", "cli", "Set the output format: compact, sarif")
 	policyLintCmd.Flags().String("output-file", "", "Set the output file")
+	policyLintCmd.Flags().StringSlice("strict-rule", nil, "Treat warnings from these rule IDs as errors (repeatable). Use 'all' to promote every warning to an error.")
 	policyCmd.AddCommand(policyLintCmd)
 
 	// fmt
@@ -648,6 +649,9 @@ var policyLintCmd = &cobra.Command{
 		if err := viper.BindPFlag("output-file", cmd.Flags().Lookup("output-file")); err != nil {
 			return err
 		}
+		if err := viper.BindPFlag("strict-rule", cmd.Flags().Lookup("strict-rule")); err != nil {
+			return err
+		}
 		return nil
 	},
 	Run: runPolicyLint,
@@ -672,6 +676,10 @@ func runPolicyLint(cmd *cobra.Command, args []string) {
 	}, files...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not lint bundle files")
+	}
+
+	if strictRules := viper.GetStringSlice("strict-rule"); len(strictRules) > 0 {
+		result.PromoteWarnings(strictRules)
 	}
 
 	out := os.Stdout

--- a/internal/bundle/lint_results_cli.go
+++ b/internal/bundle/lint_results_cli.go
@@ -72,6 +72,43 @@ func (r *Results) HasWarning() bool {
 	return false
 }
 
+// StrictRuleAll is the sentinel value that promotes every warning entry to an
+// error, regardless of its rule ID.
+const StrictRuleAll = "all"
+
+// PromoteWarnings rewrites warning-level entries to error-level for the given
+// rule IDs. The sentinel "all" promotes every warning. Unknown rule IDs are
+// silently ignored so CI configs stay portable across cnspec versions that
+// add or remove rules.
+func (r *Results) PromoteWarnings(ruleIDs []string) {
+	if r == nil || len(ruleIDs) == 0 {
+		return
+	}
+
+	promoteAll := false
+	selected := make(map[string]struct{}, len(ruleIDs))
+	for _, id := range ruleIDs {
+		if id == StrictRuleAll {
+			promoteAll = true
+			continue
+		}
+		selected[id] = struct{}{}
+	}
+
+	for i := range r.Entries {
+		if r.Entries[i].Level != LevelWarning {
+			continue
+		}
+		if promoteAll {
+			r.Entries[i].Level = LevelError
+			continue
+		}
+		if _, ok := selected[r.Entries[i].RuleID]; ok {
+			r.Entries[i].Level = LevelError
+		}
+	}
+}
+
 func (r *Results) ToCli() []byte {
 	// lets not render the result table if no findings are present
 	if r == nil || len(r.Entries) == 0 {

--- a/internal/bundle/lint_results_cli_test.go
+++ b/internal/bundle/lint_results_cli_test.go
@@ -62,4 +62,3 @@ func TestResults_PromoteWarnings(t *testing.T) {
 		assert.NotPanics(t, func() { r.PromoteWarnings([]string{StrictRuleAll}) })
 	})
 }
-

--- a/internal/bundle/lint_results_cli_test.go
+++ b/internal/bundle/lint_results_cli_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResults_PromoteWarnings(t *testing.T) {
+	newResults := func() *Results {
+		return &Results{
+			Entries: []*Entry{
+				{RuleID: "query-deprecated-symbol", Level: LevelWarning},
+				{RuleID: "query-unassigned", Level: LevelWarning},
+				{RuleID: "query-uid", Level: LevelError},
+			},
+		}
+	}
+
+	t.Run("named rule promotes only matching warnings", func(t *testing.T) {
+		r := newResults()
+		r.PromoteWarnings([]string{"query-deprecated-symbol"})
+		assert.Equal(t, LevelError, r.Entries[0].Level, "matched warning is promoted")
+		assert.Equal(t, LevelWarning, r.Entries[1].Level, "unmatched warning stays a warning")
+		assert.Equal(t, LevelError, r.Entries[2].Level, "pre-existing error is unchanged")
+	})
+
+	t.Run("all promotes every warning", func(t *testing.T) {
+		r := newResults()
+		r.PromoteWarnings([]string{StrictRuleAll})
+		assert.Equal(t, LevelError, r.Entries[0].Level)
+		assert.Equal(t, LevelError, r.Entries[1].Level)
+		assert.Equal(t, LevelError, r.Entries[2].Level)
+	})
+
+	t.Run("unknown rule id is a no-op", func(t *testing.T) {
+		r := newResults()
+		r.PromoteWarnings([]string{"does-not-exist"})
+		assert.Equal(t, LevelWarning, r.Entries[0].Level)
+		assert.Equal(t, LevelWarning, r.Entries[1].Level)
+		assert.Equal(t, LevelError, r.Entries[2].Level)
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		r := newResults()
+		r.PromoteWarnings(nil)
+		assert.True(t, r.HasWarning())
+	})
+
+	t.Run("mixed all and named keeps all-promotion semantics", func(t *testing.T) {
+		r := newResults()
+		r.PromoteWarnings([]string{"query-deprecated-symbol", StrictRuleAll})
+		assert.Equal(t, LevelError, r.Entries[0].Level)
+		assert.Equal(t, LevelError, r.Entries[1].Level)
+	})
+
+	t.Run("nil receiver does not panic", func(t *testing.T) {
+		var r *Results
+		assert.NotPanics(t, func() { r.PromoteWarnings([]string{StrictRuleAll}) })
+	})
+}
+


### PR DESCRIPTION
Some rules are warnings, like the recently introduced rule that checks
if you are using deprecated fields or resources in your queries.

We want to give users the option to turn these rules from warnings into
enforcing rules i.e. there is an error instead of just a warning. This
is useful in CI/CDs which are then stopped, to enforce these rules.

Usage:

```
cnspec policy lint ./content --strict-rule query-deprecated-symbol

cnspec policy lint ./content --strict-rule all

cnspec policy lint ./content --strict-rule query-deprecated-symbol --strict-rule query-unassigned
```