### PR TITLE
🧹 Resolve deprecated MQL field usages in policies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -658,6 +658,7 @@ vrf
 vtpm
 vtproto
 vty
+vulns
 vzdump
 wafv
 wazuh

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -732,7 +732,7 @@ queries:
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
-      aws.eks.cluster.encryptionConfig != empty
+      aws.eks.cluster.encryptionKmsKey != null
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_eks_cluster")
     mql: |
@@ -891,8 +891,8 @@ queries:
   - uid: mondoo-aws-security-eks-cluster-private-controlplane-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
-      aws.eks.cluster.resourcesVpcConfig.endpointPrivateAccess == true
-      aws.eks.cluster.resourcesVpcConfig.endpointPublicAccess == false
+      aws.eks.cluster.endpointPrivateAccess == true
+      aws.eks.cluster.endpointPublicAccess == false
   - uid: mondoo-aws-security-eks-cluster-private-controlplane-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_eks_cluster")
     mql: |
@@ -5257,11 +5257,11 @@ queries:
     filters: |
       asset.platform == "aws-rds-dbcluster"
     mql: |
-      aws.rds.dbcluster.securityGroups.none(
+      aws.rds.dbcluster.securityGroups.where(
         vpc.routeTables.where(
           routeEntries.any(gatewayId == /igw-/ && destinationCidrBlock == "0.0.0.0/0")
-        )
-      )
+        ).length > 0
+      ).length == 0
   - uid: mondoo-aws-security-rds-cluster-public-access-check-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_rds_cluster")
     mql: |
@@ -5430,11 +5430,11 @@ queries:
       asset.platform == "aws-rds-dbinstance"
     mql: |
       aws.rds.dbinstance.publiclyAccessible == false ||
-      aws.rds.dbinstance.securityGroups.none(
+      aws.rds.dbinstance.securityGroups.where(
         vpc.routeTables.where(
           routeEntries.any(gatewayId == /igw-/ && destinationCidrBlock == "0.0.0.0/0")
-        )
-      )
+        ).length > 0
+      ).length == 0
   - uid: mondoo-aws-security-rds-instance-public-access-check-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains( nameLabel == "aws_db_instance" )
     mql: terraform.resources.where( nameLabel == "aws_db_instance" ).all( arguments.publicly_accessible != true )
@@ -11364,7 +11364,7 @@ queries:
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
       aws.cloudtrail.trail.isMultiRegionTrail == true
-      aws.cloudtrail.trail.status["IsLogging"] == true
+      aws.cloudtrail.trail.isLogging == true
   - uid: mondoo-aws-security-cloud-trail-multi-region-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudtrail")
     mql: terraform.resources.where(nameLabel == "aws_cloudtrail").any(arguments.is_multi_region_trail == true)
@@ -17035,7 +17035,7 @@ queries:
         title: AWS Documentation - Encryption for backups in AWS Backup
   - uid: mondoo-aws-security-backup-vault-encrypted-aws
     filters: asset.platform == "aws"
-    mql: aws.backup.vaults.all(encryptionKeyArn != empty)
+    mql: aws.backup.vaults.all(encryptionKey != null)
   - uid: mondoo-aws-security-backup-vault-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_backup_vault")
     mql: |
@@ -19229,9 +19229,9 @@ queries:
     mql: |
       aws.guardduty.detectors.length > 0 &&
       aws.guardduty.detectors.all(
-        features.where(
-          _['Name'] == /S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING/
-        ).all(_['Status'] == "ENABLED")
+        featureConfigurations.where(
+          name == /S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING/
+        ).all(status == "ENABLED")
       )
   - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_guardduty_detector_feature")
@@ -20938,7 +20938,7 @@ queries:
   - uid: mondoo-aws-security-timestream-database-encrypted-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.timestream.liveanalytics.databases.all(kmsKeyId != empty)
+      aws.timestream.liveanalytics.databases.all(kmsKey != null)
   - uid: mondoo-aws-security-timestream-database-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_timestreamwrite_database")
     mql: |
@@ -22571,7 +22571,7 @@ queries:
     filters: asset.platform == "aws-lambda-function"
     mql: |
       if (aws.lambda.function.environment.length > 0) {
-        aws.lambda.function.kmsKeyArn != "" && aws.lambda.function.kmsKeyArn != empty
+        aws.lambda.function.kmsKey != null
       }
   - uid: mondoo-aws-security-lambda-env-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_function")
@@ -40244,7 +40244,7 @@ queries:
   - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-aws
     filters: asset.platform == "aws-cloudtrail-trail" && aws.cloudtrail.trail.isMultiRegionTrail == true
     mql: |
-      aws.cloudtrail.trail.cloudWatchLogsLogGroupArn != "" && aws.cloudtrail.trail.cloudWatchLogsLogGroupArn != empty
+      aws.cloudtrail.trail.logGroup != null
   - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudtrail")
     mql: |
@@ -49628,8 +49628,8 @@ queries:
   - uid: mondoo-aws-security-cloudtrail-insights-enabled-aws
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
-      aws.cloudtrail.trail.insightSelectors.any(_['InsightType'] == "ApiCallRateInsight") &&
-      aws.cloudtrail.trail.insightSelectors.any(_['InsightType'] == "ApiErrorRateInsight")
+      aws.cloudtrail.trail.insightSelectorEntries.any(insightType == "ApiCallRateInsight") &&
+      aws.cloudtrail.trail.insightSelectorEntries.any(insightType == "ApiErrorRateInsight")
   - uid: mondoo-aws-security-cloudtrail-insights-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudtrail")
     mql: |
@@ -49761,7 +49761,7 @@ queries:
     mql: |
       aws.securityhub.hubs.length > 0 &&
       aws.securityhub.hubs.all(
-        enabledStandards.length > 0
+        standardSubscriptions.length > 0
       )
   - uid: mondoo-aws-security-securityhub-standards-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_securityhub_account")

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -6338,7 +6338,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForServers.enabled == true
+      azure.subscription.cloudDefender.forServers.enabled == true
   - uid: mondoo-azure-security-defender-for-servers-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -6465,7 +6465,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForAppServices.enabled == true
+      azure.subscription.cloudDefender.forAppServices.enabled == true
   - uid: mondoo-azure-security-defender-for-app-services-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -6592,7 +6592,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForSqlDatabases.enabled == true
+      azure.subscription.cloudDefender.forSqlDatabases.enabled == true
   - uid: mondoo-azure-security-defender-for-sql-databases-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -6719,7 +6719,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForStorageAccounts.enabled == true
+      azure.subscription.cloudDefender.forStorageAccounts.enabled == true
   - uid: mondoo-azure-security-defender-for-storage-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -6846,7 +6846,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForKeyVaults.enabled == true
+      azure.subscription.cloudDefender.forKeyVaults.enabled == true
   - uid: mondoo-azure-security-defender-for-keyvault-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -6973,7 +6973,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForContainers.enabled == true
+      azure.subscription.cloudDefender.forContainers.enabled == true
   - uid: mondoo-azure-security-defender-for-containers-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -7100,7 +7100,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForResourceManager.enabled == true
+      azure.subscription.cloudDefender.forResourceManager.enabled == true
   - uid: mondoo-azure-security-defender-for-resource-manager-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -13223,7 +13223,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForCosmosDb.enabled == true
+      azure.subscription.cloudDefender.forCosmosDb.enabled == true
   - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -13363,7 +13363,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForOpenSourceDatabases.enabled == true
+      azure.subscription.cloudDefender.forOpenSourceDatabases.enabled == true
   - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |
@@ -17974,7 +17974,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.cloudDefender.defenderForSqlServersOnMachines.enabled == true
+      azure.subscription.cloudDefender.forSqlServersOnMachines.enabled == true
   - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_security_center_subscription_pricing")
     mql: |

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -148,7 +148,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      digitalocean.droplets.all(vpcUuid != "")
+      digitalocean.droplets.all(vpc != null)
     docs:
       desc: |
         This check ensures that every Droplet is attached to a Virtual Private Cloud (VPC).
@@ -789,7 +789,7 @@ queries:
   - uid: mondoo-digitalocean-security-lb-in-vpc-digitalocean
     filters: asset.platform == "digitalocean"
     mql: |
-      digitalocean.loadBalancers.all(vpcUuid != "")
+      digitalocean.loadBalancers.all(vpc != null)
   - uid: mondoo-digitalocean-security-lb-in-vpc-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_loadbalancer")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -1675,7 +1675,7 @@ queries:
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
-    mql: gcp.bigquery.dataset.kmsName != empty
+    mql: gcp.bigquery.dataset.kmsKey != null
   - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -1818,7 +1818,7 @@ queries:
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
-    mql: gcp.bigquery.dataset.tables.all(kmsName != empty)
+    mql: gcp.bigquery.dataset.tables.all(kmsKey != null)
   - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -1944,7 +1944,7 @@ queries:
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
-    mql: gcp.bigquery.dataset.models.all(kmsName != empty)
+    mql: gcp.bigquery.dataset.models.all(kmsKey != null)
   - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -9890,7 +9890,7 @@ queries:
   - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-gcp
     filters: asset.platform == 'gcp-logging-bucket'
     mql: |
-      gcp.project.loggingservice.bucket.cmekSettings != empty
+      gcp.project.loggingservice.bucket.kmsKey != null
   - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_logging_project_bucket_config')
@@ -10111,7 +10111,7 @@ queries:
   - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-gcp
     filters: asset.platform == 'gcp-pubsub-topic'
     mql: |
-      gcp.project.pubsubService.topic.config().kmsKeyName != ""
+      gcp.project.pubsubService.topic.config.kmsKey != null
   - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_pubsub_topic')
@@ -13861,7 +13861,7 @@ queries:
         title: Creating and accessing secrets
   - uid: mondoo-gcp-security-secretmanager-cmek-encryption-gcp
     filters: asset.platform == 'gcp-secretmanager-secret'
-    mql: gcp.project.secretmanager.secret.customerManagedEncryption != empty
+    mql: gcp.project.secretmanager.secret.kmsKeys != empty
   - uid: mondoo-gcp-security-secretmanager-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_secret_manager_secret')

--- a/content/querypacks/mondoo-azure-inventory.mql.yaml
+++ b/content/querypacks/mondoo-azure-inventory.mql.yaml
@@ -102,7 +102,7 @@ queries:
     docs:
       desc: |
         This query retrieves data for Microsoft Defender for Cloud
-    mql: azure.subscription.cloudDefender { defenderForServers defenderForContainers securityContacts { name notificationSources }  }
+    mql: azure.subscription.cloudDefender { forServers forContainers securityContacts { name notificationSources }  }
 
   - uid: mondoo-asset-inventory-azure-storageAccounts
     title: Azure Storage accounts

--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -252,7 +252,7 @@ queries:
         id
         name
         state
-        vcnId
+        vcn { id }
         ingressSecurityRules
         egressSecurityRules
         created

--- a/content/querypacks/mondoo-shodan-inventory.mql.yaml
+++ b/content/querypacks/mondoo-shodan-inventory.mql.yaml
@@ -95,7 +95,7 @@ packs:
           desc: Returns known vulnerabilities (CVEs) associated with services on the host.
         filters: asset.platform == "shodan-host"
         mql: |
-          shodan.host.vulns
+          shodan.host.vulns { * }
       - uid: mondoo-shodan-inventory-nsrecords
         title: Shodan info about DNS NS records
         docs:

--- a/content/querypacks/mondoo-shodan-inventory.mql.yaml
+++ b/content/querypacks/mondoo-shodan-inventory.mql.yaml
@@ -95,7 +95,7 @@ packs:
           desc: Returns known vulnerabilities (CVEs) associated with services on the host.
         filters: asset.platform == "shodan-host"
         mql: |
-          shodan.host.vulnerabilities
+          shodan.host.vulns
       - uid: mondoo-shodan-inventory-nsrecords
         title: Shodan info about DNS NS records
         docs:


### PR DESCRIPTION
## Summary

- Migrates 35 query usages off deprecated cnquery fields to their typed replacements across `mondoo-aws-security`, `mondoo-azure-security`, `mondoo-gcp-security`, `mondoo-digitalocean-security`, plus the Azure/OCI/Shodan inventory packs.
- Rewrites two AWS RDS public-access checks from `securityGroups.none(...)` to `securityGroups.where(...).length == 0`, because `aws.vpc.routetable`'s `@defaults("id routes.length")` causes `all`/`none` to pull the deprecated `routes` symbol into the compiled query even when the predicate uses `routeEntries`.
- After this change, `cnspec policy lint ./content` reports `valid policy bundle(s)` with only 3 residual warnings (see below).

### Replacements applied

| Provider | Old | New |
| --- | --- | --- |
| AWS | `aws.eks.cluster.encryptionConfig` | `aws.eks.cluster.encryptionKmsKey` |
| AWS | `aws.eks.cluster.resourcesVpcConfig.endpoint*Access` | `aws.eks.cluster.endpoint*Access` |
| AWS | `aws.cloudtrail.trail.status["IsLogging"]` | `aws.cloudtrail.trail.isLogging` |
| AWS | `aws.cloudtrail.trail.cloudWatchLogsLogGroupArn` | `aws.cloudtrail.trail.logGroup` |
| AWS | `aws.cloudtrail.trail.insightSelectors._['InsightType']` | `aws.cloudtrail.trail.insightSelectorEntries.insightType` |
| AWS | `aws.backup.vault.encryptionKeyArn` | `aws.backup.vault.encryptionKey` |
| AWS | `aws.guardduty.detector.features._['Name'/'Status']` | `aws.guardduty.detector.featureConfigurations.name/status` |
| AWS | `aws.timestream.liveanalytics.database.kmsKeyId` | `aws.timestream.liveanalytics.database.kmsKey` |
| AWS | `aws.lambda.function.kmsKeyArn` | `aws.lambda.function.kmsKey` |
| AWS | `aws.securityhub.hub.enabledStandards` | `aws.securityhub.hub.standardSubscriptions` |
| Azure | `cloudDefender.defenderForX.enabled` (×10) | `cloudDefender.forX.enabled` |
| GCP | `bigqueryService.{dataset,table,model}.kmsName` | `kmsKey` |
| GCP | `loggingservice.bucket.cmekSettings` | `kmsKey` |
| GCP | `pubsubService.topic.config().kmsKeyName` | `config.kmsKey` |
| GCP | `secretmanagerService.secret.customerManagedEncryption` | `kmsKeys` |
| DigitalOcean | `droplet.vpcUuid != ""`, `loadBalancer.vpcUuid != ""` | `vpc != null` |
| OCI inventory | `securityList.vcnId` | `securityList.vcn { id }` |
| Shodan inventory | `shodan.host.vulnerabilities` | `shodan.host.vulns` |

### Not addressed in this PR

Three `mondoo-m365-security` queries still use `microsoft.devicemanagement.deviceconfiguration.properties` / `microsoft.domaindnsrecord.properties`. These have no typed replacement in the shipped ms365 v13.0.7 schema — `properties` is the only path to the underlying Graph data. The `@maturity("deprecated")` marker has already been reverted on cnquery `main`, so these warnings clear on the next ms365 provider bump without policy changes.

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` — no deprecation warnings
- [x] `cnspec policy lint content/mondoo-azure-security.mql.yaml` — no deprecation warnings
- [x] `cnspec policy lint content/mondoo-gcp-security.mql.yaml` — no deprecation warnings
- [x] `cnspec policy lint content/mondoo-digitalocean-security.mql.yaml` — no deprecation warnings
- [x] `cnspec policy lint content/querypacks/mondoo-{azure,oci,shodan}-inventory.mql.yaml` — no deprecation warnings
- [x] `cnspec policy lint ./content` — `valid policy bundle(s)`; only the 3 ms365 `properties` warnings remain
- [ ] Spot-check that the rewritten RDS public-access checks behave the same on a live `aws-rds-dbcluster` / `aws-rds-dbinstance` asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)