### PR TITLE
:sparkles: Add compliance tags to GCP Artifact Registry, Vertex AI, Redis security checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -553,6 +553,7 @@ secureboot
 securepassword
 SECURITYADMIN
 securitygroupchanges
+sef
 sentinelagent
 sentineld
 sentinelone

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -27477,6 +27477,20 @@ queries:
   - uid: mondoo-gcp-security-artifact-registry-repository-cmek-encryption
     title: Ensure Artifact Registry repositories are encrypted with CMEK
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-artifact-registry-repository-cmek-encryption-gcp
         tags:
@@ -27578,6 +27592,20 @@ queries:
   - uid: mondoo-gcp-security-artifact-registry-repository-iam-no-public-principals
     title: Ensure Artifact Registry repositories are not publicly accessible
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-gcp-security-artifact-registry-repository-iam-no-public-principals-gcp
         tags:
@@ -27704,6 +27732,20 @@ queries:
   - uid: mondoo-gcp-security-artifact-registry-repository-vulnerability-scanning-enabled
     title: Ensure container repositories have vulnerability scanning enabled
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-8
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: pcidss-requirement-11-3-1
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-gcp-security-artifact-registry-repository-vulnerability-scanning-enabled-gcp
         tags:
@@ -27823,6 +27865,20 @@ queries:
   - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions
     title: Ensure Cloud Build triggers do not store plaintext secrets in substitutions
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-6-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions-gcp
         tags:
@@ -27961,6 +28017,20 @@ queries:
   - uid: mondoo-gcp-security-cloud-build-worker-pool-private
     title: Ensure Cloud Build worker pools run privately with no public egress
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-gcp-security-cloud-build-worker-pool-private-gcp
         tags:
@@ -28095,6 +28165,20 @@ queries:
   - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account
     title: Ensure Cloud Build triggers do not run as the default Compute Engine SA
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-gcp
         tags:
@@ -28203,6 +28287,20 @@ queries:
   - uid: mondoo-gcp-security-dataflow-job-no-public-ips
     title: Ensure Dataflow jobs run on workers with no public IPs
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-gcp-security-dataflow-job-no-public-ips-gcp
         tags:
@@ -28328,6 +28426,20 @@ queries:
   - uid: mondoo-gcp-security-dataflow-job-no-default-service-account
     title: Ensure Dataflow jobs use a custom worker service account
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-gcp-security-dataflow-job-no-default-service-account-gcp
         tags:
@@ -28463,6 +28575,20 @@ queries:
   - uid: mondoo-gcp-security-filestore-instance-cmek-encryption
     title: Ensure Filestore instances are encrypted with CMEK
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-gcp-security-filestore-instance-cmek-encryption-gcp
         tags:
@@ -28579,6 +28705,20 @@ queries:
   - uid: mondoo-gcp-security-firestore-project-iam-no-public-datastore-roles
     title: Ensure project IAM does not grant Datastore roles to public principals
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-gcp-security-firestore-project-iam-no-public-datastore-roles-gcp
         tags:
@@ -28701,6 +28841,20 @@ queries:
   - uid: mondoo-gcp-security-vertexai-custom-job-no-default-service-account
     title: Ensure Vertex AI custom jobs do not run as the default Compute Engine SA
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     filters: asset.platform == 'gcp'
     mql: |
       gcp.project.vertexaiService.customJobs.where(
@@ -28752,6 +28906,20 @@ queries:
   - uid: mondoo-gcp-security-essential-contacts-security-category-configured
     title: Ensure Essential Contacts cover the SECURITY notification category
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-sef-08
+      compliance/dora: dora-art-17
+      compliance/hipaa: hipaa-security-ss164-308-a-6-ii-security-incident-procedures-response-and-reporting
+      compliance/iso-27001-2022: iso-27001-2022-a-5-24
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-rs-co-2
+      compliance/nist-csf-2: nist-csf-2-rs-co-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ir-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
+      compliance/pci-dss-4: pcidss-requirement-12-10-1
+      compliance/soc2-2017: soc2-control-cc7-4-6
+      compliance/vda-isa-5: vda-isa-5-1-6-1
     variants:
       - uid: mondoo-gcp-security-essential-contacts-security-category-configured-gcp
         tags:


### PR DESCRIPTION
## Summary

- Adds the standard 13-framework compliance tag block to the 12 GCP security checks merged in #2513 (Artifact Registry, Cloud Build, Dataflow, Filestore, Firestore, Vertex AI, Essential Contacts).
- Every control UID was verified against the framework YAML in `cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` per `content/CLAUDE.md`. Where no control fits cleanly, the tag is the unquoted YAML boolean `false` instead of a copy from a neighbouring check.
- BSI Grundschutz SYS.1.5 is `false` for every check because the module covers virtual-machine virtualization controls and does not address artifact storage encryption, IAM, vulnerability scanning, or essential contacts. Same outcome the existing `mondoo-gcp-security-instances-are-not-configured-use-default-service-account` already shows for that framework.

### Mappings by category

- **CMEK encryption at rest** (Artifact Registry, Filestore): ISO `a-8-24`, NIST 800-53 `sc-28`, NIST CSF 2 `pr-ds-01`, PCI `3-5-1`, SOC 2 `cc6-1-10`, NIS-2 `21-2-h`, etc.
- **Public-principal IAM exclusion** (repo IAM, project Datastore roles): ISO `a-5-15`, NIST 800-53 `ac-3`, NIST CSF 2 `pr-aa-05`, PCI `7-2-1`, SOC 2 `cc6-1-3`, NIS-2 `21-2-i`.
- **Vulnerability scanning enabled**: ISO `a-8-8`, NIST 800-53 `ra-5`, NIST CSF 1 `de-cm-8`, NIST CSF 2 `id-ra-01`, PCI `11-3-1`, SOC 2 `cc7-1-5`, CSA `tvm-07`, NIS-2 `21-2-e`. HIPAA falls back to `false`.
- **Secrets in Cloud Build substitutions**: ISO `a-5-17` (Authentication information), NIST 800-53 `ia-5`, NIST 800-171 `3-5-10`, PCI `8-6-2` (passwords not hard coded in scripts/configuration files), SOC 2 `cc6-1-9`. CSA, HIPAA, NIS-2, VDA-ISA fall back to `false` — none has a clean fit for "do not store plaintext secrets in build config".
- **Network isolation** (worker pool private, Dataflow no public IPs): ISO `a-8-22`, NIST 800-53 `sc-7`, NIST CSF 1 `pr-ac-5`, NIST CSF 2 `pr-ir-01`, PCI `1-4-1`, SOC 2 `cc6-1-5`, CSA `ivs-03`, VDA-ISA `5-2-7`. HIPAA and NIS-2 fall back to `false` (HIPAA's `312-e-1` is transmission encryption, not segmentation; NIS-2 21(2) has no network-segmentation article).
- **Non-default service account** (Cloud Build, Dataflow, Vertex AI): ISO `a-8-2` (Privileged access rights), NIST 800-53 `ac-6`, NIST CSF 2 `pr-aa-05`, PCI `7-2-1`, SOC 2 `cc6-3-3`, CSA `iam-05`.
- **Essential Contacts SECURITY category**: ISO `a-5-24`, NIST 800-53 `ir-6`, NIST CSF 2 `rs-co-02`, PCI `12-10-1`, SOC 2 `cc7-4-6`, CSA `sef-08` (Points of Contact Maintenance), DORA art-17.

### Borderline calls flagged for review

- Plaintext-secrets check has the most `false` tags (BSI, CSA, HIPAA, NIS-2, VDA-ISA). The regex catches non-cryptographic secrets (tokens, connection strings) so framework-level "key management" / "cryptographic procedures" controls are a poor fit; PCI 8.6.2 is the only framework with explicit "no hard-coded secrets in config" language.
- Network-isolation checks use `false` for HIPAA and NIS-2 because neither has a clean network-segmentation control. The neighbour `mondoo-gcp-security-gke-cluster-network-policy-enabled` uses HIPAA `312-e-1` (Transmission) and NIS-2 `21-2-e` (Vulnerability handling) for these but those mappings don't reflect the underlying control text — flagged in `content/CLAUDE.md` as exactly the pattern to avoid copying.
- HIPAA is `false` for vulnerability scanning. The Security Rule's risk-management addressable specification (`308(a)(1)(ii)(B)`) is about written assessments, not technical scanning.

### Frameworks where every check is `false`

- **BSI Grundschutz SYS.1.5** — module is scoped to VM virtualization; none of the 12 checks fall inside that scope. (Existing GCP checks already follow this pattern.)

## Test plan

- [x] `go run ./apps/cnspec policy lint ./content/mondoo-gcp-security.mql.yaml` passes.
- [x] Every non-`false` UID was confirmed by `grep -nE "uid: <uid>" cnspec-enterprise-policies/frameworks/<framework>.mql.yaml`.
- [x] `false` is the unquoted YAML boolean (the established convention for unmappable controls).

Follow-up to #2513.

[Claude Code](https://claude.com/claude-code) generated this PR.