### PR TITLE
:bug: Fix DMS replication MQL using map-style field access

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -20610,7 +20610,7 @@ queries:
   - uid: mondoo-aws-security-dms-replication-not-public-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.dms.replicationInstances.all(_["PubliclyAccessible"] == false)
+      aws.dms.replicationInstances.all(publiclyAccessible == false)
   - uid: mondoo-aws-security-dms-replication-not-public-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dms_replication_instance")
     mql: |
@@ -20727,7 +20727,7 @@ queries:
   - uid: mondoo-aws-security-dms-replication-encrypted-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.dms.replicationInstances.all(_["KmsKeyId"] != "" && _["KmsKeyId"] != empty)
+      aws.dms.replicationInstances.all(kmsKey != empty)
   - uid: mondoo-aws-security-dms-replication-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dms_replication_instance")
     mql: |


### PR DESCRIPTION
## Summary

- `mondoo-aws-security-dms-replication-not-public-aws` and `-encrypted-aws` were using map-style accessors (`_["PubliclyAccessible"]`, `_["KmsKeyId"]`) that aren't supported on `aws.dms.replicationInstance`, breaking bundle compilation.
- Switched to the typed fields: `publiclyAccessible` and `kmsKey != empty`.

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)