### PR TITLE
Skip SMBv1 registry checks when SMB1 feature is disabled

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3663,6 +3663,8 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-client-driver-is-set-to-enabled-disable-driver-recommended
     title: "Ensure SMB v1 client driver is disabled"
     impact: 100
+    filters: |
+      windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3744,6 +3746,8 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-server-is-set-to-disabled
     title: Ensure 'Configure SMB v1 server' is set to 'Disabled'
     impact: 100
+    filters: |
+      windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
       compliance/bsi-grundschutz-sys15: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06


### PR DESCRIPTION
## Summary
- Add SMB1Protocol optional-feature filters to the SMBv1 client and server registry checks.
- Keep the existing registry assertions unchanged when SMBv1 is installed/enabled.
- Avoid flagging Windows hosts where SMBv1 is disabled or absent as an optional feature.

## Validation
- `cnspec run local -c "windows.optionalFeatures.where(name == \"SMB1Protocol\").any(enabled == true)" --ast`
- `cnspec policy lint content/mondoo-windows-security.mql.yaml`
- `git diff --check`
- `make test/lint/content` was attempted; it fails on unrelated provider-schema/content errors in other bundles (arista/cloudflare/tailscale/etc.).
