### PR TITLE
🧹 add concurrency group for edge release

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -9,6 +9,10 @@ on:
 env:
   REGISTRY: docker.io
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Make sure edge releases don't add up. We only build the latest one and cancel any in progress