### PR TITLE
:sparkles: Add AWS checks for public exposure and encryption (at rest + in transit)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -31,6 +31,7 @@ apigatewayv
 apikey
 apparmor
 APPDATA
+appdata
 appdb
 appgroup
 appgw
@@ -123,6 +124,7 @@ cmdshell
 cmek
 cmk
 cmkdisableordelete
+codeartifact
 Codecov
 codeium
 codename
@@ -316,6 +318,7 @@ isa
 isready
 ivs
 Jalr
+jdbc
 jffs
 jglt
 jira
@@ -435,6 +438,7 @@ ntpsync
 nullglob
 nxos
 OAC
+OAI
 objectstorage
 ocid
 ocir
@@ -585,6 +589,7 @@ shosts
 showcerts
 siem
 Signin
+sigv
 skype
 sntrup
 socketfilterfw
@@ -639,6 +644,7 @@ tmsh
 TNS
 totp
 trae
+TSecurity
 tsuki
 tvm
 twofactor
@@ -702,6 +708,7 @@ workspacesweb
 wpa
 wpaeap
 wpapsk
+wss
 wtmp
 xlarge
 XLast

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -30,7 +30,6 @@ apachectl
 apigatewayv
 apikey
 apparmor
-APPDATA
 appdata
 appdb
 appgroup

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -56278,9 +56278,6 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-route-keys-connect-disconnect.html
         title: API Gateway WebSocket API route keys
-  # No runtime variant: the cnquery aws provider does not expose a policy
-  # attribute on aws.eventbridge.eventBus. Revisit when the resource adds a
-  # `policy` field.
   - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access
     title: Ensure EventBridge event bus policies do not grant public access
     impact: 80
@@ -56299,6 +56296,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
+      - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -56388,6 +56389,17 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-bus-perms.html
         title: Amazon EventBridge event bus permissions
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.eventbridge.eventBuses.all(
+        policy == "" ||
+        parse.json(content: policy).params["Statement"].where(_["Effect"] == "Allow").all(
+          _["Principal"] != "*" &&
+          _["Principal"]["AWS"] != "*" ||
+          _["Condition"] != null
+        )
+      )
   - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudwatch_event_bus_policy")
     mql: |
@@ -56425,8 +56437,6 @@ queries:
         properties['Statement']['Principal']['AWS'] != "*" ||
         properties['Statement']['Condition'] != null
       )
-  # No runtime variant: the cnquery aws provider does not expose
-  # aws.glue.connection. Revisit when the Glue resource set adds connections.
   - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials
     title: Ensure Glue connections do not store plaintext credentials
     impact: 90
@@ -56445,6 +56455,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
+      - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -56502,6 +56516,10 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/glue/latest/dg/connection-properties.html
         title: AWS Glue connection properties
+  - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.glue.connections.all(connectionProperties["PASSWORD"] == null)
   - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_glue_connection")
     mql: |
@@ -56618,9 +56636,6 @@ queries:
       terraform.state.resources.where(type == "aws_cloud9_environment_ec2").all(
         values.connection_type == "CONNECT_SSM"
       )
-  # No runtime variant: aws.elasticbeanstalk.environment does not expose
-  # individual listener settings on the underlying load balancer. The Terraform
-  # variants inspect the namespace/option settings that drive listener creation.
   - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener
     title: Ensure Elastic Beanstalk environments expose an HTTPS listener
     impact: 70
@@ -56639,6 +56654,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
+      - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -56714,6 +56733,16 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https.html
         title: Configuring your Elastic Beanstalk environment's load balancer for HTTPS
+  - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.elasticbeanstalk.environments.all(
+        optionSettings.where(
+          _['namespace'] == /^aws:elbv2?:listener:443$/ &&
+          _['optionName'] == "ListenerEnabled" &&
+          _['value'] == "true"
+        ) != empty
+      )
   - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elastic_beanstalk_environment")
     mql: |
@@ -57255,8 +57284,6 @@ queries:
       cloudformation.template.resources.where(type == "AWS::KinesisVideo::Stream").all(
         properties['KmsKeyId'] != empty
       )
-  # No runtime variant: the cnquery aws provider does not expose EMR Studio
-  # resources. Revisit when an aws.emr.studio resource set is added.
   - uid: mondoo-aws-security-emr-studio-cmk-encryption
     title: Ensure EMR Studio workspace storage uses a customer-managed KMS key
     impact: 60
@@ -57275,6 +57302,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
+      - uid: mondoo-aws-security-emr-studio-cmk-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -57364,6 +57395,10 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-security.html
         title: EMR Studio security and encryption
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.emr.studios.all(encryptionKeyArn != empty)
   - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_studio")
     mql: |
@@ -57489,9 +57524,6 @@ queries:
       terraform.state.resources.where(type == "aws_datasync_task").all(
         values.cloudwatch_log_group_arn != empty
       )
-  # No runtime variant: the cnquery aws provider does not yet expose
-  # CloudFront origin access control bindings on aws.cloudfront.distribution.origin.
-  # Revisit when origin.originAccessControlId is added to the AWS resource pack.
   - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption
     title: Ensure CloudFront S3 origins are reached via origin access control
     impact: 70
@@ -57510,6 +57542,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
+      - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -57608,6 +57644,15 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
         title: Restricting access to S3 origins with OAC
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.cloudfront.distributions.all(
+        origins.where(
+          domainName == /\.s3[.-][a-z0-9.-]*amazonaws\.com$/ &&
+          domainName != /\.s3-website/
+        ).all(originAccessControlId != "")
+      )
   - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudfront_distribution")
     mql: |

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -96,6 +96,7 @@ policies:
           - uid: mondoo-aws-security-api-gw-require-authentication
           - uid: mondoo-aws-security-api-gw-tls
           - uid: mondoo-aws-security-api-gw-xray-enabled
+          - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials
       - title: AWS IAM
         checks:
           - uid: mondoo-aws-security-access-keys-rotated
@@ -115,6 +116,7 @@ policies:
         checks:
           - uid: mondoo-aws-security-lambda-concurrency-check
           - uid: mondoo-aws-security-lambda-function-public-access-prohibited
+          - uid: mondoo-aws-security-lambda-function-url-auth-required
           - uid: mondoo-aws-security-lambda-env-encryption
           - uid: mondoo-aws-security-lambda-code-signing-configured
           - uid: mondoo-aws-security-lambda-xray-tracing
@@ -177,6 +179,7 @@ policies:
           - uid: mondoo-aws-security-dynamodb-table-encrypted-kms
           - uid: mondoo-aws-security-dynamodb-pitr-enabled
           - uid: mondoo-aws-security-dynamodb-cmk-encryption
+          - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption
       - title: Amazon RDS DB Instance
         checks:
           - uid: mondoo-aws-security-rds-instance-public-access-check
@@ -286,6 +289,7 @@ policies:
           - uid: mondoo-aws-security-elb-security-policy-enabled
           - uid: mondoo-aws-security-elb-ssl-listener
           - uid: mondoo-aws-security-elb-drop-invalid-headers
+          - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum
       - title: AWS Elasticsearch Domain
         checks:
           - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
@@ -348,6 +352,7 @@ policies:
           - uid: mondoo-aws-security-cloudfront-trust-store-not-empty
           - uid: mondoo-aws-security-cloudfront-private-origin-mtls
           - uid: mondoo-aws-security-cloudfront-trust-store-recently-updated
+          - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption
       - title: AWS CloudTrail Trail
         checks:
           - uid: mondoo-aws-security-cloud-trail-encryption-enabled
@@ -388,6 +393,7 @@ policies:
           - uid: mondoo-aws-security-secretsmanager-rotation-enabled
           - uid: mondoo-aws-security-secretsmanager-cmk-encryption
           - uid: mondoo-aws-security-secretsmanager-no-public-policy
+          - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc
       - title: IAM Access Analyzer
         checks:
           - uid: mondoo-aws-security-iam-access-analyzer-enabled
@@ -398,12 +404,17 @@ policies:
           - uid: mondoo-aws-security-sns-subscription-https
           - uid: mondoo-aws-security-sns-no-public-access
           - uid: mondoo-aws-security-sns-topic-cmk-encryption
+          - uid: mondoo-aws-security-sns-topic-policy-secure-transport
       - title: Amazon SQS
         checks:
           - uid: mondoo-aws-security-sqs-queue-encrypted
           - uid: mondoo-aws-security-sqs-queue-dead-letter-queue
           - uid: mondoo-aws-security-sqs-no-wildcard-policy
           - uid: mondoo-aws-security-sqs-queue-cmk-encryption
+          - uid: mondoo-aws-security-sqs-queue-policy-secure-transport
+      - title: Amazon EventBridge
+        checks:
+          - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access
       - title: Amazon ElastiCache
         checks:
           - uid: mondoo-aws-security-elasticache-encryption-at-rest
@@ -412,6 +423,7 @@ policies:
           - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption
           - uid: mondoo-aws-security-elasticache-backup-retention
           - uid: mondoo-aws-security-elasticache-cmk-encryption
+          - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption
       - title: AWS Backup
         checks:
           - uid: mondoo-aws-security-backup-vault-encrypted
@@ -450,6 +462,7 @@ policies:
         checks:
           - uid: mondoo-aws-security-dms-replication-not-public
           - uid: mondoo-aws-security-dms-replication-encrypted
+          - uid: mondoo-aws-security-dms-endpoint-ssl-enforced
       - title: AWS Elastic Disaster Recovery (DRS)
         checks:
           - uid: mondoo-aws-security-drs-replication-ebs-encrypted
@@ -469,6 +482,7 @@ policies:
           - uid: mondoo-aws-security-route53-query-logging-enabled
           - uid: mondoo-aws-security-route53-health-check-not-disabled
           - uid: mondoo-aws-security-route53-health-check-https
+          - uid: mondoo-aws-security-route53-resolver-query-logging-enabled
       - title: Route 53 Domains
         checks:
           - uid: mondoo-aws-security-route53-domain-transfer-lock
@@ -492,6 +506,9 @@ policies:
           - uid: mondoo-aws-security-kinesis-stream-encrypted
           - uid: mondoo-aws-security-kinesis-stream-cmk-encryption
           - uid: mondoo-aws-security-kinesis-cmk-typed-key
+      - title: Amazon Kinesis Video Streams
+        checks:
+          - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption
       - title: Amazon Kinesis Firehose
         checks:
           - uid: mondoo-aws-security-kinesis-firehose-encrypted
@@ -523,9 +540,14 @@ policies:
           - uid: mondoo-aws-security-glue-security-config-bookmark-encryption
           - uid: mondoo-aws-security-glue-security-config-cmk-encryption
           - uid: mondoo-aws-security-glue-job-supported-version
+          - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials
+      # AWS AppConfig: scoped out for this batch — AppConfig's public-exposure
+      # surface largely overlaps existing IAM resource-policy checks and there
+      # is no listener/protocol primitive distinct from those already covered.
       - title: AWS Elastic Beanstalk
         checks:
           - uid: mondoo-aws-security-elasticbeanstalk-enhanced-health
+          - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener
       - title: Amazon WorkSpaces
         checks:
           - uid: mondoo-aws-security-workspaces-volume-encryption
@@ -549,6 +571,9 @@ policies:
           - uid: mondoo-aws-security-directoryservice-os-version
           - uid: mondoo-aws-security-directoryservice-sso-enabled
           - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled
+      - title: AWS Cloud9
+        checks:
+          - uid: mondoo-aws-security-cloud9-environment-no-ingress
       - title: Amazon EMR
         checks:
           - uid: mondoo-aws-security-emr-encryption-at-rest
@@ -557,6 +582,7 @@ policies:
           - uid: mondoo-aws-security-emr-local-disk-encryption
           - uid: mondoo-aws-security-emr-not-publicly-accessible
           - uid: mondoo-aws-security-emr-log-cmk-encryption
+          - uid: mondoo-aws-security-emr-studio-cmk-encryption
       - title: Amazon DynamoDB DAX
         checks:
           - uid: mondoo-aws-security-dax-encryption-at-rest
@@ -596,9 +622,13 @@ policies:
           - uid: mondoo-aws-security-transfer-connector-logging-role
           - uid: mondoo-aws-security-transfer-web-app-not-public
           - uid: mondoo-aws-security-transfer-workflow-exception-handling
+      - title: AWS DataSync
+        checks:
+          - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption
       - title: AWS App Mesh
         checks:
           - uid: mondoo-aws-security-appmesh-egress-filter
+          - uid: mondoo-aws-security-appmesh-virtual-node-tls-required
       - title: AWS IAM Identity Center
         checks:
           - uid: mondoo-aws-security-identitycenter-session-duration
@@ -628,6 +658,14 @@ policies:
         checks:
           - uid: mondoo-aws-security-apigatewayv2-routes-require-authorizer
           - uid: mondoo-aws-security-apigatewayv2-domain-tls-1-2
+          - uid: mondoo-aws-security-apigatewayv2-websocket-route-auth-required
+          - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum
+      - title: AWS IoT Core
+        checks:
+          - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum
+      - title: AWS CodeArtifact
+        checks:
+          - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption
     scoring_system: highest impact
 queries:
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms
@@ -55919,4 +55957,3027 @@ queries:
         properties['WorkGroupConfiguration']['ResultConfiguration']['EncryptionConfiguration']['EncryptionOption'] == /^(SSE|CSE)_KMS$/ &&
         properties['WorkGroupConfiguration']['ResultConfiguration']['EncryptionConfiguration']['KmsKey'] != null &&
         properties['WorkGroupConfiguration']['ResultConfiguration']['EncryptionConfiguration']['KmsKey'] != ""
+      )
+  - uid: mondoo-aws-security-lambda-function-url-auth-required
+    title: Ensure Lambda function URLs require authentication
+    impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    variants:
+      - uid: mondoo-aws-security-lambda-function-url-auth-required-aws
+        tags:
+          mondoo.com/filter-title: AWS Lambda Function
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-lambda-function-url-auth-required-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that AWS Lambda function URLs require IAM authentication. A function URL configured with `AuthType: NONE` exposes the Lambda function as an anonymous HTTPS endpoint that any caller on the internet can invoke without credentials.
+
+        **Why this matters**
+
+        - A function URL with `AuthType: NONE` is an anonymous code-execution endpoint reachable from the public internet.
+        - Anonymous endpoints can be abused for denial-of-service, cryptomining, or as part of a chain to reach internal resources the function can access.
+        - Unauthenticated invocation bypasses the principle of least privilege and removes audit attribution from CloudTrail.
+        - Setting `AuthType: AWS_IAM` requires callers to sign requests with SigV4 and lets resource policies and identity policies enforce who may invoke the function.
+      remediation:
+        - id: console
+          desc: |
+            To require authentication on a Lambda function URL using the AWS Console:
+
+            1. Open the **Lambda** console and select the function.
+            2. Choose the **Configuration** tab and select **Function URL**.
+            3. Select **Edit** and set **Auth type** to `AWS_IAM`.
+            4. Save the changes.
+        - id: cli
+          desc: |
+            To require IAM authentication on a Lambda function URL using the AWS CLI:
+
+            ```bash
+            aws lambda update-function-url-config \
+              --function-name <function-name> \
+              --auth-type AWS_IAM
+            ```
+        - id: terraform
+          desc: |
+            To require IAM authentication on a Lambda function URL in Terraform, set `authorization_type = "AWS_IAM"` on the `aws_lambda_function_url` resource:
+
+            ```hcl
+            resource "aws_lambda_function_url" "example" {
+              function_name      = aws_lambda_function.example.function_name
+              authorization_type = "AWS_IAM"
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To require IAM authentication on a Lambda function URL in CloudFormation, set `AuthType: AWS_IAM` on the `AWS::Lambda::Url` resource:
+
+            ```yaml
+            Resources:
+              ExampleFunctionUrl:
+                Type: AWS::Lambda::Url
+                Properties:
+                  TargetFunctionArn: !GetAtt ExampleFunction.Arn
+                  AuthType: AWS_IAM
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html
+        title: Security and auth model for Lambda function URLs
+  - uid: mondoo-aws-security-lambda-function-url-auth-required-aws
+    filters: asset.platform == "aws-lambda-function"
+    mql: |
+      aws.lambda.function.urlConfig == null || aws.lambda.function.urlConfig.authType != "NONE"
+  - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_function_url")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_lambda_function_url").all(
+        arguments.authorization_type != null && arguments.authorization_type != "NONE"
+      )
+  - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_lambda_function_url")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_lambda_function_url").all(
+        change.after.authorization_type != null && change.after.authorization_type != "NONE"
+      )
+  - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_lambda_function_url")
+    mql: |
+      terraform.state.resources.where(type == "aws_lambda_function_url").all(
+        values.authorization_type != null && values.authorization_type != "NONE"
+      )
+  - uid: mondoo-aws-security-lambda-function-url-auth-required-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Lambda::Url")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::Lambda::Url").all(
+        properties['AuthType'] != null && properties['AuthType'] != "NONE"
+      )
+  - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials
+    title: Ensure API Gateway CORS does not pair wildcard origins with credentials
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    variants:
+      - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that API Gateway HTTP APIs do not advertise a wildcard `Access-Control-Allow-Origin: *` while also setting `Access-Control-Allow-Credentials: true`. The CORS specification forbids this combination, and modern browsers refuse the response, but a misconfigured API still represents a clear intent that violates least privilege.
+
+        **Why this matters**
+
+        - Pairing `*` origins with credentials signals that the operator intends to accept authenticated cross-origin requests from any site, which is exactly the configuration browsers were designed to prevent.
+        - Some non-browser clients and older browser releases honor permissive headers anyway, allowing credential replay across origins.
+        - Even before exploitation, the misconfiguration leaks information about the API surface and the operator's threat model.
+        - Restricting `allow_origins` to the specific hostnames that may carry credentials enforces an explicit allowlist consistent with least privilege.
+      remediation:
+        - id: console
+          desc: |
+            To fix the CORS configuration on an API Gateway v2 HTTP API using the AWS Console:
+
+            1. Open the **API Gateway** console and select the HTTP API.
+            2. Choose **CORS** in the left pane.
+            3. If **Access-Control-Allow-Credentials** is enabled, replace any `*` entry in **Access-Control-Allow-Origin** with a specific list of allowed origins.
+            4. Save the changes.
+        - id: cli
+          desc: |
+            To update the CORS configuration on an HTTP API using the AWS CLI, set explicit origins instead of `*` whenever credentials are allowed:
+
+            ```bash
+            aws apigatewayv2 update-api \
+              --api-id <api-id> \
+              --cors-configuration AllowOrigins=https://app.example.com,AllowCredentials=true
+            ```
+        - id: terraform
+          desc: |
+            To configure CORS safely on an API Gateway v2 HTTP API in Terraform, set explicit origins whenever `allow_credentials` is true:
+
+            ```hcl
+            resource "aws_apigatewayv2_api" "example" {
+              name          = "example"
+              protocol_type = "HTTP"
+
+              cors_configuration {
+                allow_origins     = ["https://app.example.com"]
+                allow_credentials = true
+                allow_methods     = ["GET", "POST"]
+                allow_headers     = ["authorization", "content-type"]
+              }
+            }
+            ```
+    refs:
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+        title: MDN Web Docs - CORS request did not succeed
+      - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html
+        title: Configuring CORS for an HTTP API
+  - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.apigatewayv2.apis.where(corsConfiguration != null).all(
+        corsConfiguration["AllowCredentials"] != true ||
+        corsConfiguration["AllowOrigins"] == null ||
+        corsConfiguration["AllowOrigins"].contains("*") == false
+      )
+  - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_apigatewayv2_api")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_apigatewayv2_api").all(
+        blocks.where(type == "cors_configuration").all(
+          arguments.allow_credentials != true ||
+          arguments.allow_origins == null ||
+          arguments.allow_origins.contains("*") == false
+        )
+      )
+  - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_apigatewayv2_api")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_apigatewayv2_api").all(
+        change.after.cors_configuration == empty ||
+        change.after.cors_configuration.all(
+          _['allow_credentials'] != true ||
+          _['allow_origins'] == null ||
+          _['allow_origins'].contains("*") == false
+        )
+      )
+  - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_apigatewayv2_api")
+    mql: |
+      terraform.state.resources.where(type == "aws_apigatewayv2_api").all(
+        values.cors_configuration == empty ||
+        values.cors_configuration.all(
+          _['allow_credentials'] != true ||
+          _['allow_origins'] == null ||
+          _['allow_origins'].contains("*") == false
+        )
+      )
+  # No Terraform variants: scoping routes to their parent WebSocket API requires
+  # cross-resource correlation (route -> aws_apigatewayv2_api.protocol_type ==
+  # "WEBSOCKET") that MQL doesn't compose cleanly across resource types. The
+  # broader mondoo-aws-security-apigatewayv2-routes-require-authorizer check
+  # already covers the configuration intent at the route level for Terraform
+  # assets. Revisit if MQL adds cross-resource join helpers.
+  - uid: mondoo-aws-security-apigatewayv2-websocket-route-auth-required
+    title: Ensure API Gateway v2 WebSocket routes require authorization
+    impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    filters: asset.platform == "aws"
+    mql: |
+      aws.apigatewayv2.apis.where(protocolType == "WEBSOCKET").all(
+        routes.all(authorizationType != "NONE")
+      )
+    docs:
+      desc: |
+        This check ensures that every route on an API Gateway v2 WebSocket API has an `authorizationType` other than `NONE`. WebSocket routes drive long-lived, bidirectional connections, so an unauthenticated route gives any caller on the internet a persistent channel into the backend integration.
+
+        **Why this matters**
+
+        - The `$connect` route establishes the connection — leaving it on `NONE` means any client can open a session and start sending messages over the established connection.
+        - Once the connection is open, per-route authorization still applies, but most backends assume the connection has already been authenticated upstream.
+        - WebSocket abuse is hard to detect because there is no request/response log per message; access decisions must happen at connect time and on every route.
+        - Setting `authorization_type` to `AWS_IAM`, `JWT`, or `CUSTOM` on every route forces the caller to present credentials at connect time and on every action.
+      remediation:
+        - id: console
+          desc: |
+            To require authorization on a WebSocket route using the AWS Console:
+
+            1. Open the **API Gateway** console and select the WebSocket API.
+            2. Choose **Routes** in the left pane and select the route with `Authorization` set to `NONE`.
+            3. Attach an existing authorizer or create one (`AWS_IAM`, `JWT`, or `CUSTOM`).
+            4. Save the route configuration.
+        - id: cli
+          desc: |
+            To attach an authorizer to a WebSocket route using the AWS CLI:
+
+            ```bash
+            aws apigatewayv2 update-route \
+              --api-id <api-id> \
+              --route-id <route-id> \
+              --authorization-type AWS_IAM
+            ```
+        - id: terraform
+          desc: |
+            To require authorization on a WebSocket route in Terraform, set `authorization_type` to a non-`NONE` value on every `aws_apigatewayv2_route` whose parent API has `protocol_type = "WEBSOCKET"`:
+
+            ```hcl
+            resource "aws_apigatewayv2_api" "example" {
+              name          = "example-ws"
+              protocol_type = "WEBSOCKET"
+              route_selection_expression = "$request.body.action"
+            }
+
+            resource "aws_apigatewayv2_route" "connect" {
+              api_id             = aws_apigatewayv2_api.example.id
+              route_key          = "$connect"
+              authorization_type = "AWS_IAM"
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-route-keys-connect-disconnect.html
+        title: API Gateway WebSocket API route keys
+  # No runtime variant: the cnquery aws provider does not expose a policy
+  # attribute on aws.eventbridge.eventBus. Revisit when the resource adds a
+  # `policy` field.
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access
+    title: Ensure EventBridge event bus policies do not grant public access
+    impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    variants:
+      - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon EventBridge event bus resource policies do not grant `Principal: "*"` (or `AWS: "*"`) without scoping conditions such as `aws:PrincipalOrgID` or `aws:SourceAccount`. An event bus with a wildcard principal allows any AWS account to put events onto the bus, including events crafted to look like trusted sources.
+
+        **Why this matters**
+
+        - A public event bus lets an attacker inject events that drive downstream targets such as Lambda functions, Step Functions, and SQS queues.
+        - Injected events can mimic legitimate sources to trigger workflows that exfiltrate data or perform privileged operations.
+        - Cross-account access is best granted to specific account IDs, organization IDs, or AWS service principals — never to `*` without conditions.
+        - Even when a wildcard principal is technically required (cross-service integrations), it must be paired with `aws:SourceArn` or `aws:SourceAccount` conditions to constrain who can invoke it.
+      remediation:
+        - id: console
+          desc: |
+            To remove public access from an EventBridge event bus using the AWS Console:
+
+            1. Open the **EventBridge** console and choose **Event buses** in the left pane.
+            2. Select the bus and choose **Permissions**.
+            3. Replace the existing policy with one that names the specific accounts, organization IDs, or service principals allowed to put events.
+            4. Save the policy.
+        - id: cli
+          desc: |
+            To replace a permissive EventBridge bus policy using the AWS CLI:
+
+            ```bash
+            aws events put-permission \
+              --event-bus-name <bus-name> \
+              --policy file://restricted-policy.json
+            ```
+        - id: terraform
+          desc: |
+            To define a restrictive event bus policy in Terraform, attach `aws_cloudwatch_event_bus_policy` and scope principals to specific account IDs or organization IDs:
+
+            ```hcl
+            data "aws_iam_policy_document" "bus" {
+              statement {
+                sid     = "AllowProductionAccount"
+                effect  = "Allow"
+                actions = ["events:PutEvents"]
+                resources = [aws_cloudwatch_event_bus.example.arn]
+
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:root"]
+                }
+              }
+            }
+
+            resource "aws_cloudwatch_event_bus_policy" "example" {
+              event_bus_name = aws_cloudwatch_event_bus.example.name
+              policy         = data.aws_iam_policy_document.bus.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To define a restrictive event bus policy in CloudFormation, use `AWS::Events::EventBusPolicy` with a specific principal:
+
+            ```yaml
+            Resources:
+              EventBusPolicy:
+                Type: AWS::Events::EventBusPolicy
+                Properties:
+                  EventBusName: !Ref ExampleEventBus
+                  StatementId: AllowProductionAccount
+                  Statement:
+                    Effect: Allow
+                    Principal:
+                      AWS: arn:aws:iam::111122223333:root
+                    Action: events:PutEvents
+                    Resource: !GetAtt ExampleEventBus.Arn
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-bus-perms.html
+        title: Amazon EventBridge event bus permissions
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudwatch_event_bus_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_cloudwatch_event_bus_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").all(
+          _["Principal"] != "*" && _["Principal"]["AWS"] != "*" ||
+          _["Condition"] != null
+        )
+      )
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cloudwatch_event_bus_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cloudwatch_event_bus_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").all(
+          _["Principal"] != "*" && _["Principal"]["AWS"] != "*" ||
+          _["Condition"] != null
+        )
+      )
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloudwatch_event_bus_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_cloudwatch_event_bus_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").all(
+          _["Principal"] != "*" && _["Principal"]["AWS"] != "*" ||
+          _["Condition"] != null
+        )
+      )
+  - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Events::EventBusPolicy")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::Events::EventBusPolicy").all(
+        properties['Statement'] == null ||
+        properties['Statement']['Effect'] != "Allow" ||
+        properties['Statement']['Principal'] != "*" &&
+        properties['Statement']['Principal']['AWS'] != "*" ||
+        properties['Statement']['Condition'] != null
+      )
+  # No runtime variant: the cnquery aws provider does not expose
+  # aws.glue.connection. Revisit when the Glue resource set adds connections.
+  - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials
+    title: Ensure Glue connections do not store plaintext credentials
+    impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    variants:
+      - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS Glue connections do not store credentials as plaintext in `connection_properties`. Glue connections support a `SECRET_ID` property that references an AWS Secrets Manager secret, and that is the only safe way to supply a password or token to a Glue connection.
+
+        **Why this matters**
+
+        - A `PASSWORD` (or `USERNAME`) value in `connection_properties` is stored in the Glue catalog in plaintext and visible to anyone with `glue:GetConnection` permission.
+        - Connection properties are exported by infrastructure-as-code tooling, so the plaintext value lands in Terraform state files and CI logs.
+        - Rotating a plaintext credential requires editing every consumer; a Secrets Manager reference rotates centrally and audits every read.
+        - Replacing the password with `SECRET_ID` keeps the secret in a system designed for credential storage, with KMS-backed encryption-at-rest and CloudTrail audit.
+      remediation:
+        - id: console
+          desc: |
+            To switch a Glue connection to use Secrets Manager using the AWS Console:
+
+            1. Open the **AWS Glue** console and choose **Connections**.
+            2. Edit the connection and select **Use AWS Secrets Manager**.
+            3. Choose the secret that holds the credentials.
+            4. Save the connection.
+        - id: cli
+          desc: |
+            To update a Glue connection so that credentials come from Secrets Manager using the AWS CLI:
+
+            ```bash
+            aws glue update-connection \
+              --name <connection-name> \
+              --connection-input '{"Name":"<connection-name>","ConnectionType":"JDBC","ConnectionProperties":{"JDBC_CONNECTION_URL":"jdbc:mysql://host:3306/db","SECRET_ID":"<secret-arn>"}}'
+            ```
+        - id: terraform
+          desc: |
+            To configure a Glue connection without plaintext credentials in Terraform, reference a Secrets Manager secret via `SECRET_ID`:
+
+            ```hcl
+            resource "aws_glue_connection" "example" {
+              name = "example"
+
+              connection_properties = {
+                JDBC_CONNECTION_URL = "jdbc:mysql://host:3306/db"
+                SECRET_ID           = aws_secretsmanager_secret.glue.arn
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/glue/latest/dg/connection-properties.html
+        title: AWS Glue connection properties
+  - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_glue_connection")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_glue_connection").all(
+        arguments.connection_properties == null ||
+        arguments.connection_properties["PASSWORD"] == null
+      )
+  - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_glue_connection")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_glue_connection").all(
+        change.after.connection_properties == null ||
+        change.after.connection_properties["PASSWORD"] == null
+      )
+  - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_glue_connection")
+    mql: |
+      terraform.state.resources.where(type == "aws_glue_connection").all(
+        values.connection_properties == null ||
+        values.connection_properties["PASSWORD"] == null
+      )
+  # No runtime variant: the cnquery aws provider does not expose aws.cloud9
+  # resources. Revisit if a Cloud9 resource set is added.
+  - uid: mondoo-aws-security-cloud9-environment-no-ingress
+    title: Ensure Cloud9 EC2 environments use no-ingress SSM connections
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS Cloud9 EC2 environments use `CONNECT_SSM` as their connection type. The legacy `CONNECT_SSH` mode opens an SSH listener on the underlying instance, which requires the instance to live in a subnet reachable from the developer's network and exposes port 22 to whatever security group covers that path.
+
+        **Why this matters**
+
+        - `CONNECT_SSM` tunnels developer sessions through AWS Systems Manager, so the instance does not need an inbound SSH port or a public IP.
+        - Removing the inbound SSH path eliminates a long-lived listener that has been used in past Cloud9 incidents.
+        - SSM Session Manager produces a CloudTrail audit trail of every developer session that SSH does not.
+        - Forcing `CONNECT_SSM` is the documented AWS guidance for Cloud9 environments that must operate in private subnets.
+      remediation:
+        - id: console
+          desc: |
+            Cloud9 does not allow toggling connection type after creation. To switch, recreate the environment using the AWS Console:
+
+            1. Open the **AWS Cloud9** console.
+            2. Choose **Create environment** and provide a name.
+            3. Under **Network settings**, choose **Connect via Systems Manager (SSM)**.
+            4. Place the environment in a private subnet and complete the wizard.
+        - id: cli
+          desc: |
+            To create a new Cloud9 EC2 environment that uses SSM via the AWS CLI:
+
+            ```bash
+            aws cloud9 create-environment-ec2 \
+              --name <name> \
+              --instance-type t3.small \
+              --connection-type CONNECT_SSM \
+              --subnet-id <private-subnet-id>
+            ```
+        - id: terraform
+          desc: |
+            To require Systems Manager connectivity for a Cloud9 EC2 environment in Terraform, set `connection_type = "CONNECT_SSM"`:
+
+            ```hcl
+            resource "aws_cloud9_environment_ec2" "example" {
+              name            = "example"
+              instance_type   = "t3.small"
+              subnet_id       = aws_subnet.private.id
+              connection_type = "CONNECT_SSM"
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/cloud9/latest/user-guide/ec2-ssm.html
+        title: Accessing no-ingress EC2 instances with AWS Systems Manager
+  - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloud9_environment_ec2")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_cloud9_environment_ec2").all(
+        arguments.connection_type == "CONNECT_SSM"
+      )
+  - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cloud9_environment_ec2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cloud9_environment_ec2").all(
+        change.after.connection_type == "CONNECT_SSM"
+      )
+  - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloud9_environment_ec2")
+    mql: |
+      terraform.state.resources.where(type == "aws_cloud9_environment_ec2").all(
+        values.connection_type == "CONNECT_SSM"
+      )
+  # No runtime variant: aws.elasticbeanstalk.environment does not expose
+  # individual listener settings on the underlying load balancer. The Terraform
+  # variants inspect the namespace/option settings that drive listener creation.
+  - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener
+    title: Ensure Elastic Beanstalk environments expose an HTTPS listener
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Elastic Beanstalk environments enable an HTTPS listener on their managed load balancer. Without an HTTPS listener, client traffic terminates at the load balancer over plain HTTP, leaving credentials and session data exposed in transit.
+
+        **Why this matters**
+
+        - Elastic Beanstalk creates the load balancer for the user, so listener configuration is set through environment option settings rather than directly on the ELB.
+        - The relevant namespaces are `aws:elbv2:listener:443` for Application Load Balancers and `aws:elb:listener:443` for Classic Load Balancers — enabling the listener and selecting an ACM certificate is what turns on HTTPS.
+        - A misconfigured environment with only an HTTP listener cannot satisfy PCI DSS, HIPAA, or any baseline that requires TLS for web traffic.
+        - Adding the HTTPS listener also enables clients to enforce HSTS and other browser controls that require TLS.
+      remediation:
+        - id: console
+          desc: |
+            To add an HTTPS listener to an Elastic Beanstalk environment using the AWS Console:
+
+            1. Open the **Elastic Beanstalk** console and select the environment.
+            2. Choose **Configuration** then edit **Load balancer**.
+            3. Add a listener on port 443 with `Protocol = HTTPS` and select an ACM certificate.
+            4. Save the configuration.
+        - id: cli
+          desc: |
+            To add an HTTPS listener to a Beanstalk environment using the AWS CLI, update the relevant option settings:
+
+            ```bash
+            aws elasticbeanstalk update-environment \
+              --environment-name <env-name> \
+              --option-settings \
+                Namespace=aws:elbv2:listener:443,OptionName=ListenerEnabled,Value=true \
+                Namespace=aws:elbv2:listener:443,OptionName=Protocol,Value=HTTPS \
+                Namespace=aws:elbv2:listener:443,OptionName=SSLCertificateArns,Value=<acm-arn>
+            ```
+        - id: terraform
+          desc: |
+            To enable an HTTPS listener on an Elastic Beanstalk environment in Terraform, add the listener via `setting` blocks on `aws_elastic_beanstalk_environment`:
+
+            ```hcl
+            resource "aws_elastic_beanstalk_environment" "example" {
+              name                = "example-env"
+              application         = aws_elastic_beanstalk_application.example.name
+              solution_stack_name = "64bit Amazon Linux 2023 v4.5.2 running Docker"
+
+              setting {
+                namespace = "aws:elbv2:listener:443"
+                name      = "ListenerEnabled"
+                value     = "true"
+              }
+
+              setting {
+                namespace = "aws:elbv2:listener:443"
+                name      = "Protocol"
+                value     = "HTTPS"
+              }
+
+              setting {
+                namespace = "aws:elbv2:listener:443"
+                name      = "SSLCertificateArns"
+                value     = aws_acm_certificate.example.arn
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https.html
+        title: Configuring your Elastic Beanstalk environment's load balancer for HTTPS
+  - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elastic_beanstalk_environment")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_elastic_beanstalk_environment").all(
+        blocks.where(type == "setting" &&
+          arguments.namespace == /^aws:elbv2?:listener:443$/ &&
+          arguments.name == "ListenerEnabled" &&
+          arguments.value == "true"
+        ) != empty
+      )
+  - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elastic_beanstalk_environment")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_elastic_beanstalk_environment").all(
+        change.after.setting != empty &&
+        change.after.setting.where(
+          _['namespace'] == /^aws:elbv2?:listener:443$/ &&
+          _['name'] == "ListenerEnabled" &&
+          _['value'] == "true"
+        ) != empty
+      )
+  - uid: mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_elastic_beanstalk_environment")
+    mql: |
+      terraform.state.resources.where(type == "aws_elastic_beanstalk_environment").all(
+        values.setting != empty &&
+        values.setting.where(
+          _['namespace'] == /^aws:elbv2?:listener:443$/ &&
+          _['name'] == "ListenerEnabled" &&
+          _['value'] == "true"
+        ) != empty
+      )
+  # No runtime variant: the cnquery aws provider does not expose Route 53
+  # Resolver query log configurations or their VPC associations. Revisit when
+  # the provider adds aws.route53resolver resources.
+  - uid: mondoo-aws-security-route53-resolver-query-logging-enabled
+    title: Ensure Route 53 Resolver query logging is associated with VPCs
+    impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    variants:
+      - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Route 53 Resolver query logging is configured and associated with VPCs. Resolver query logs capture every DNS query that an EC2 instance, ECS task, Lambda function in a VPC, or other workload makes through the Route 53 Resolver — the data the security team needs to detect DNS-based exfiltration or command-and-control.
+
+        **Why this matters**
+
+        - DNS is one of the most common exfiltration channels because it is rarely blocked at the egress firewall.
+        - Resolver query logging is the only AWS-native way to capture queries originating inside a VPC; public hosted zone query logging only captures queries to your own zones.
+        - Detection rules for DNS tunneling, newly observed domains, and known bad indicators need this log stream as input.
+        - A configured `aws_route53_resolver_query_log_config` is only useful when paired with an `aws_route53_resolver_query_log_config_association` for every VPC that needs logging.
+      remediation:
+        - id: console
+          desc: |
+            To enable Route 53 Resolver query logging using the AWS Console:
+
+            1. Open the **Route 53** console and choose **Resolver** then **Query logging**.
+            2. Choose **Configure query logging** and select a destination (CloudWatch Logs, S3, or Kinesis Data Firehose).
+            3. Add the VPCs that should be logged under **VPCs that are logging queries**.
+            4. Save the configuration.
+        - id: cli
+          desc: |
+            To enable Resolver query logging and associate a VPC using the AWS CLI:
+
+            ```bash
+            aws route53resolver create-resolver-query-log-config \
+              --name vpc-dns-logs \
+              --destination-arn arn:aws:logs:us-east-1:111122223333:log-group:/aws/route53/resolver
+
+            aws route53resolver associate-resolver-query-log-config \
+              --resolver-query-log-config-id <log-config-id> \
+              --resource-id <vpc-id>
+            ```
+        - id: terraform
+          desc: |
+            To enable Resolver query logging and associate it with a VPC in Terraform, create both the log config and an association:
+
+            ```hcl
+            resource "aws_route53_resolver_query_log_config" "example" {
+              name            = "vpc-dns-logs"
+              destination_arn = aws_cloudwatch_log_group.resolver.arn
+            }
+
+            resource "aws_route53_resolver_query_log_config_association" "example" {
+              resolver_query_log_config_id = aws_route53_resolver_query_log_config.example.id
+              resource_id                  = aws_vpc.example.id
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html
+        title: Resolver query logging
+  - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53_resolver_query_log_config")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_route53_resolver_query_log_config_association").length > 0
+  - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_route53_resolver_query_log_config")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_route53_resolver_query_log_config_association").length > 0
+  - uid: mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_route53_resolver_query_log_config")
+    mql: |
+      terraform.state.resources.where(type == "aws_route53_resolver_query_log_config_association").length > 0
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption
+    title: Ensure DynamoDB PITR backups are encrypted with a customer-managed key
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS DynamoDB Table
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that DynamoDB tables with point-in-time recovery (PITR) enabled are also encrypted with a customer-managed KMS key (CMK). Continuous backups inherit the table's encryption configuration, so the only way to keep PITR snapshots under customer-controlled keys is to encrypt the source table with a CMK.
+
+        **Why this matters**
+
+        - PITR snapshots are long-lived copies of the table that span the configured retention window, so any data captured during the retention period is recoverable from those snapshots.
+        - With the default AWS-owned KMS key, AWS controls the entire key lifecycle and there is no CloudTrail visibility into key usage, so backup access cannot be audited end-to-end.
+        - A customer-managed key lets the data owner rotate, revoke, and audit access to every PITR-derived restore through KMS key policies and CloudTrail `kms:Decrypt` events.
+        - Pairing PITR with a CMK satisfies regulatory requirements that demand customer-controlled key management for backups of regulated data.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt DynamoDB PITR backups with a CMK using the AWS Console:
+
+            1. Open the **DynamoDB** console and choose **Tables**.
+            2. Select the table and open the **Additional settings** tab.
+            3. Under **Encryption**, choose **Manage encryption** and select a customer-managed KMS key.
+            4. Under **Backups**, ensure **Point-in-time recovery** is **On**.
+            5. Save the changes.
+        - id: cli
+          desc: |
+            To encrypt DynamoDB PITR backups with a CMK using the AWS CLI, switch the table's SSE configuration to a CMK and enable PITR:
+
+            ```bash
+            aws dynamodb update-table \
+              --table-name <table-name> \
+              --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=<kms-key-arn>
+
+            aws dynamodb update-continuous-backups \
+              --table-name <table-name> \
+              --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true
+            ```
+        - id: terraform
+          desc: |
+            To encrypt DynamoDB PITR backups with a CMK in Terraform, set `server_side_encryption` with a `kms_key_arn` and enable `point_in_time_recovery`:
+
+            ```hcl
+            resource "aws_dynamodb_table" "example" {
+              name         = "example"
+              billing_mode = "PAY_PER_REQUEST"
+              hash_key     = "id"
+
+              attribute {
+                name = "id"
+                type = "S"
+              }
+
+              server_side_encryption {
+                enabled     = true
+                kms_key_arn = aws_kms_key.dynamodb.arn
+              }
+
+              point_in_time_recovery {
+                enabled = true
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To encrypt DynamoDB PITR backups with a CMK in CloudFormation, configure `SSESpecification` with `KMSMasterKeyId` and enable `PointInTimeRecoverySpecification`:
+
+            ```yaml
+            Resources:
+              MyTable:
+                Type: AWS::DynamoDB::Table
+                Properties:
+                  TableName: example
+                  BillingMode: PAY_PER_REQUEST
+                  AttributeDefinitions:
+                    - AttributeName: id
+                      AttributeType: S
+                  KeySchema:
+                    - AttributeName: id
+                      KeyType: HASH
+                  SSESpecification:
+                    SSEEnabled: true
+                    SSEType: KMS
+                    KMSMasterKeyId: !Ref MyKmsKey
+                  PointInTimeRecoverySpecification:
+                    PointInTimeRecoveryEnabled: true
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html
+        title: DynamoDB encryption at rest
+      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html
+        title: DynamoDB point-in-time recovery
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-aws
+    filters: asset.platform == "aws-dynamodb-table"
+    mql: |
+      aws.dynamodb.table.sseType == "KMS"
+      aws.dynamodb.table.sseKmsKey { metadata["KeyManager"] == "CUSTOMER" }
+      aws.dynamodb.table.continuousBackups["PointInTimeRecoveryDescription"]["PointInTimeRecoveryStatus"] == "ENABLED"
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dynamodb_table")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_dynamodb_table").all(
+        blocks.where(type == "server_side_encryption") != empty &&
+        blocks.where(type == "server_side_encryption").all(
+          arguments.enabled == true &&
+          arguments.kms_key_arn != empty
+        ) &&
+        blocks.where(type == "point_in_time_recovery") != empty &&
+        blocks.where(type == "point_in_time_recovery").all(arguments.enabled == true)
+      )
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_dynamodb_table")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_dynamodb_table").all(
+        change.after.server_side_encryption != empty &&
+        change.after.server_side_encryption.all(_['enabled'] == true && _['kms_key_arn'] != empty) &&
+        change.after.point_in_time_recovery != empty &&
+        change.after.point_in_time_recovery.all(_['enabled'] == true)
+      )
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_dynamodb_table")
+    mql: |
+      terraform.state.resources.where(type == "aws_dynamodb_table").all(
+        values.server_side_encryption != empty &&
+        values.server_side_encryption.all(_['enabled'] == true && _['kms_key_arn'] != empty) &&
+        values.point_in_time_recovery != empty &&
+        values.point_in_time_recovery.all(_['enabled'] == true)
+      )
+  - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::DynamoDB::Table")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::DynamoDB::Table").all(
+        properties['SSESpecification'] != empty &&
+        properties['SSESpecification']['SSEEnabled'] == true &&
+        properties['SSESpecification']['KMSMasterKeyId'] != empty &&
+        properties['PointInTimeRecoverySpecification'] != empty &&
+        properties['PointInTimeRecoverySpecification']['PointInTimeRecoveryEnabled'] == true
+      )
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption
+    title: Ensure ElastiCache snapshots are encrypted with a KMS key
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS ElastiCache Cluster
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that ElastiCache replication groups with automatic snapshot retention have at-rest encryption enabled and reference a KMS key. ElastiCache snapshots inherit the cluster's at-rest encryption settings, so a cluster that takes snapshots without a CMK is producing backups that are encrypted only with an AWS-owned key.
+
+        **Why this matters**
+
+        - A non-zero `snapshot_retention_limit` means ElastiCache is producing and storing recoverable copies of cached data, so the snapshot itself becomes regulated data at rest.
+        - When the cluster lacks `at_rest_encryption_enabled = true`, both the cluster and its snapshots fall back to AWS-owned key material that the customer cannot rotate, revoke, or audit.
+        - A KMS key on the cluster propagates to every automated and manual snapshot, ensuring that restored data stays under the same key policy as the source cluster.
+        - Pairing snapshot retention with a customer-controlled KMS key keeps backups aligned with the data-protection controls required for the live workload.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt ElastiCache snapshots with a KMS key using the AWS Console:
+
+            1. Open the **ElastiCache** console and create a new replication group (encryption-at-rest cannot be changed on an existing group).
+            2. Under **Security**, enable **Encryption at rest** and select a customer-managed KMS key.
+            3. Under **Backup**, set **Backup retention period** to a non-zero value.
+            4. Restore the previous group's data into the new group and cut traffic over.
+        - id: cli
+          desc: |
+            To encrypt ElastiCache snapshots with a KMS key using the AWS CLI, create a new replication group with encryption-at-rest, a KMS key, and snapshot retention:
+
+            ```bash
+            aws elasticache create-replication-group \
+              --replication-group-id <group-id> \
+              --replication-group-description "Encrypted Redis cluster" \
+              --engine redis \
+              --at-rest-encryption-enabled \
+              --kms-key-id <kms-key-arn> \
+              --snapshot-retention-limit 7
+            ```
+        - id: terraform
+          desc: |
+            To encrypt ElastiCache snapshots with a KMS key in Terraform, set `at_rest_encryption_enabled`, `kms_key_id`, and `snapshot_retention_limit` on the replication group:
+
+            ```hcl
+            resource "aws_elasticache_replication_group" "example" {
+              replication_group_id = "example"
+              description          = "Encrypted Redis cluster"
+              engine               = "redis"
+
+              at_rest_encryption_enabled = true
+              kms_key_id                 = aws_kms_key.elasticache.arn
+              snapshot_retention_limit   = 7
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To encrypt ElastiCache snapshots with a KMS key in CloudFormation, set the encryption properties on the replication group:
+
+            ```yaml
+            Resources:
+              MyReplicationGroup:
+                Type: AWS::ElastiCache::ReplicationGroup
+                Properties:
+                  ReplicationGroupDescription: Encrypted Redis cluster
+                  Engine: redis
+                  AtRestEncryptionEnabled: true
+                  KmsKeyId: !Ref MyKmsKey
+                  SnapshotRetentionLimit: 7
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
+        title: ElastiCache at-rest encryption
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups.html
+        title: ElastiCache backup and restore
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-aws
+    filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
+    mql: |
+      aws.elasticache.cluster.snapshotRetentionLimit == 0 ||
+        aws.elasticache.cluster.atRestEncryptionEnabled == true &&
+        aws.elasticache.cluster.kmsKey != null
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_elasticache_replication_group")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_elasticache_replication_group").all(
+        arguments['snapshot_retention_limit'] == null ||
+        arguments['snapshot_retention_limit'] == 0 ||
+        arguments['at_rest_encryption_enabled'] == true && arguments['kms_key_id'] != empty
+      )
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elasticache_replication_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_elasticache_replication_group").all(
+        change.after['snapshot_retention_limit'] == null ||
+        change.after['snapshot_retention_limit'] == 0 ||
+        change.after['at_rest_encryption_enabled'] == true && change.after['kms_key_id'] != empty
+      )
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_elasticache_replication_group")
+    mql: |
+      terraform.state.resources.where(type == "aws_elasticache_replication_group").all(
+        values['snapshot_retention_limit'] == null ||
+        values['snapshot_retention_limit'] == 0 ||
+        values['at_rest_encryption_enabled'] == true && values['kms_key_id'] != empty
+      )
+  - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::ElastiCache::ReplicationGroup")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::ElastiCache::ReplicationGroup").all(
+        properties['SnapshotRetentionLimit'] == null ||
+        properties['SnapshotRetentionLimit'] == 0 ||
+        properties['AtRestEncryptionEnabled'] == true && properties['KmsKeyId'] != empty
+      )
+  # No runtime variant: the cnquery aws provider does not expose Kinesis Video
+  # Streams. Revisit when an aws.kinesisvideo resource set is added.
+  - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption
+    title: Ensure Kinesis Video Streams use a customer-managed KMS key
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon Kinesis Video Streams are encrypted with a customer-managed KMS key (CMK). When `kms_key_id` is left unset, Kinesis Video falls back to the AWS-managed `aws/kinesisvideo` key and the customer has no ability to rotate, revoke, or audit usage of the key that protects the video fragments.
+
+        **Why this matters**
+
+        - Video streams from cameras and connected devices frequently contain personal identifiable information, biometric data, or footage of regulated environments.
+        - The AWS-managed key cannot be scoped with a key policy, so any principal with `kinesisvideo:GetMedia` permissions decrypts data without producing a discrete CloudTrail `kms:Decrypt` audit trail tied to a customer key.
+        - A CMK lets the data owner enforce least privilege on decrypt operations, rotate key material on a controlled schedule, and revoke access at the key level when a device or partner is offboarded.
+      remediation:
+        - id: console
+          desc: |
+            To configure a Kinesis Video Stream with a customer-managed key using the AWS Console:
+
+            1. Open the **Kinesis Video Streams** console.
+            2. Create a new video stream (encryption configuration is set at creation).
+            3. Under **Encryption**, choose **Customer-managed AWS KMS key** and select the desired CMK.
+            4. Save the stream and migrate producers to the new stream.
+        - id: cli
+          desc: |
+            To configure a Kinesis Video Stream with a customer-managed key using the AWS CLI, create the stream with `--kms-key-id`:
+
+            ```bash
+            aws kinesisvideo create-stream \
+              --stream-name <stream-name> \
+              --kms-key-id <kms-key-arn>
+            ```
+        - id: terraform
+          desc: |
+            To configure a Kinesis Video Stream with a customer-managed key in Terraform, set `kms_key_id` on `aws_kinesis_video_stream`:
+
+            ```hcl
+            resource "aws_kinesis_video_stream" "example" {
+              name       = "example"
+              kms_key_id = aws_kms_key.kinesisvideo.arn
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-data.html
+        title: Kinesis Video Streams data protection
+  - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kinesis_video_stream")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_kinesis_video_stream").all(
+        arguments.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_kinesis_video_stream")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_kinesis_video_stream").all(
+        change.after.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_kinesis_video_stream")
+    mql: |
+      terraform.state.resources.where(type == "aws_kinesis_video_stream").all(
+        values.kms_key_id != empty
+      )
+  - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::KinesisVideo::Stream")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::KinesisVideo::Stream").all(
+        properties['KmsKeyId'] != empty
+      )
+  # No runtime variant: the cnquery aws provider does not expose EMR Studio
+  # resources. Revisit when an aws.emr.studio resource set is added.
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption
+    title: Ensure EMR Studio workspace storage uses a customer-managed KMS key
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-emr-studio-cmk-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that EMR Studio workspaces specify a customer-managed KMS key for encrypting Jupyter notebooks and other workspace artifacts stored in the backing S3 bucket. When `encryption_key_arn` is omitted, the studio falls back to AWS-managed encryption on the workspace bucket and the customer cannot bind the key lifecycle to the underlying data.
+
+        **Why this matters**
+
+        - EMR Studio workspaces routinely hold notebook code, query results, and small data extracts that include sensitive business or regulated data.
+        - Without a CMK on the studio, every workspace artifact is encrypted with an AWS-owned key whose policy the customer cannot author, rotate, or revoke.
+        - A customer-managed key tied to the studio makes notebook storage subject to the same audit and access-control rules as other regulated data and produces CloudTrail `kms:Decrypt` events for every workspace read.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt an EMR Studio with a customer-managed key using the AWS Console:
+
+            1. Open the **EMR** console and choose **Studios**.
+            2. Create a new studio (the encryption key cannot be changed after creation).
+            3. Under **Encryption**, select **Customer-managed key** and choose the CMK ARN.
+            4. Complete the studio creation and migrate workspaces.
+        - id: cli
+          desc: |
+            To encrypt an EMR Studio with a customer-managed key using the AWS CLI:
+
+            ```bash
+            aws emr create-studio \
+              --name <studio-name> \
+              --auth-mode IAM \
+              --vpc-id <vpc-id> \
+              --subnet-ids <subnet-ids> \
+              --service-role <service-role-arn> \
+              --workspace-security-group-id <sg-id> \
+              --engine-security-group-id <sg-id> \
+              --default-s3-location s3://<workspace-bucket>/ \
+              --encryption-key-arn <kms-key-arn>
+            ```
+        - id: terraform
+          desc: |
+            To encrypt an EMR Studio with a customer-managed key in Terraform, set `encryption_key_arn` on `aws_emr_studio`:
+
+            ```hcl
+            resource "aws_emr_studio" "example" {
+              name                        = "example"
+              auth_mode                   = "IAM"
+              vpc_id                      = aws_vpc.example.id
+              subnet_ids                  = aws_subnet.example[*].id
+              service_role                = aws_iam_role.studio.arn
+              workspace_security_group_id = aws_security_group.workspace.id
+              engine_security_group_id    = aws_security_group.engine.id
+              default_s3_location         = "s3://${aws_s3_bucket.studio.bucket}/"
+              encryption_key_arn          = aws_kms_key.studio.arn
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To encrypt an EMR Studio with a customer-managed key in CloudFormation, set `EncryptionKeyArn`:
+
+            ```yaml
+            Resources:
+              MyStudio:
+                Type: AWS::EMR::Studio
+                Properties:
+                  Name: example
+                  AuthMode: IAM
+                  VpcId: !Ref MyVpc
+                  SubnetIds: !Ref MySubnets
+                  ServiceRole: !GetAtt StudioRole.Arn
+                  WorkspaceSecurityGroupId: !Ref WorkspaceSG
+                  EngineSecurityGroupId: !Ref EngineSG
+                  DefaultS3Location: !Sub s3://${StudioBucket}/
+                  EncryptionKeyArn: !GetAtt StudioKmsKey.Arn
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-security.html
+        title: EMR Studio security and encryption
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_emr_studio")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_emr_studio").all(
+        arguments.encryption_key_arn != empty
+      )
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_emr_studio")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_emr_studio").all(
+        change.after.encryption_key_arn != empty
+      )
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_emr_studio")
+    mql: |
+      terraform.state.resources.where(type == "aws_emr_studio").all(
+        values.encryption_key_arn != empty
+      )
+  - uid: mondoo-aws-security-emr-studio-cmk-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EMR::Studio")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::EMR::Studio").all(
+        properties['EncryptionKeyArn'] != empty
+      )
+  # No runtime variant: the cnquery aws provider does not expose DataSync
+  # tasks. Revisit when an aws.datasync resource set is added.
+  - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption
+    title: Ensure DataSync tasks log to an encrypted CloudWatch log group
+    impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS DataSync tasks reference a CloudWatch log group for transfer telemetry. DataSync task logs capture object paths, source and destination metadata, and any transfer errors — information that often reveals the structure of regulated data and must therefore be retained under the same protection controls as the data being moved.
+
+        **Why this matters**
+
+        - A DataSync task without `cloudwatch_log_group_arn` set leaves the operator with no audit record of what data moved, when, and whether the transfer completed cleanly.
+        - Sending logs to a CloudWatch log group ensures that DataSync output lands somewhere subject to the existing CloudWatch retention and KMS encryption controls (covered by `mondoo-aws-security-cloudwatch-log-group-encrypted`).
+        - This check stays narrowly scoped to the configuration on the DataSync task; cross-resource verification of the referenced log group's KMS key is performed by the dedicated CloudWatch log-group encryption check, so the two together provide end-to-end coverage.
+      remediation:
+        - id: console
+          desc: |
+            To configure a DataSync task with CloudWatch logging using the AWS Console:
+
+            1. Open the **DataSync** console and choose **Tasks**.
+            2. Edit the task and expand **Logging**.
+            3. Choose **Log to Amazon CloudWatch Logs** and select an existing encrypted log group.
+            4. Save the task.
+        - id: cli
+          desc: |
+            To configure a DataSync task with CloudWatch logging using the AWS CLI:
+
+            ```bash
+            aws datasync update-task \
+              --task-arn <task-arn> \
+              --cloud-watch-log-group-arn <log-group-arn>
+            ```
+        - id: terraform
+          desc: |
+            To configure a DataSync task with CloudWatch logging in Terraform, set `cloudwatch_log_group_arn` on `aws_datasync_task` and ensure the referenced log group uses a CMK:
+
+            ```hcl
+            resource "aws_kms_key" "datasync_logs" {
+              description = "DataSync log group encryption"
+            }
+
+            resource "aws_cloudwatch_log_group" "datasync" {
+              name       = "/aws/datasync/example"
+              kms_key_id = aws_kms_key.datasync_logs.arn
+            }
+
+            resource "aws_datasync_task" "example" {
+              name                     = "example"
+              source_location_arn      = aws_datasync_location_s3.source.arn
+              destination_location_arn = aws_datasync_location_s3.destination.arn
+              cloudwatch_log_group_arn = aws_cloudwatch_log_group.datasync.arn
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/datasync/latest/userguide/monitor-datasync.html
+        title: Monitoring AWS DataSync
+  - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_datasync_task")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_datasync_task").all(
+        arguments.cloudwatch_log_group_arn != empty
+      )
+  - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_datasync_task")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_datasync_task").all(
+        change.after.cloudwatch_log_group_arn != empty
+      )
+  - uid: mondoo-aws-security-datasync-task-cloudwatch-logging-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_datasync_task")
+    mql: |
+      terraform.state.resources.where(type == "aws_datasync_task").all(
+        values.cloudwatch_log_group_arn != empty
+      )
+  # No runtime variant: the cnquery aws provider does not yet expose
+  # CloudFront origin access control bindings on aws.cloudfront.distribution.origin.
+  # Revisit when origin.originAccessControlId is added to the AWS resource pack.
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption
+    title: Ensure CloudFront S3 origins are reached via origin access control
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    variants:
+      - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that CloudFront distributions that use an Amazon S3 origin attach an origin access control (OAC) to that origin. OAC is the supported successor to origin access identity (OAI) and is the only mechanism that lets CloudFront sign requests to S3 with SigV4 so that the bucket can stay fully private while still serving content through CloudFront.
+
+        **Why this matters**
+
+        - Without OAC, an S3 origin either accepts anonymous public reads (broad data exposure) or relies on a legacy OAI that does not support SSE-KMS and is no longer recommended.
+        - Attaching OAC keeps the bucket private at the resource policy level and forces every viewer request to flow through CloudFront, where WAF, logging, and TLS policies are enforced.
+        - OAC also unlocks SigV4 access to buckets that require SSE-KMS, so the access boundary and the encryption boundary stay aligned.
+        - Server-side encryption of the underlying S3 bucket is enforced by separate S3 checks; this check is scoped to the CloudFront origin binding so that misconfigurations are surfaced at the distribution rather than only at the bucket.
+      remediation:
+        - id: console
+          desc: |
+            To attach an origin access control to a CloudFront S3 origin using the AWS Console:
+
+            1. Open the **CloudFront** console and choose **Origin access** to create an OAC for S3 with **Sign requests** enabled.
+            2. Edit the distribution and select the S3 origin.
+            3. Under **Origin access**, choose the OAC you created.
+            4. Update the S3 bucket policy with the policy snippet that the console generates so the bucket trusts the distribution.
+            5. Save the changes.
+        - id: cli
+          desc: |
+            To attach an origin access control to a CloudFront S3 origin using the AWS CLI:
+
+            ```bash
+            aws cloudfront create-origin-access-control \
+              --origin-access-control-config Name=example,SigningProtocol=sigv4,SigningBehavior=always,OriginAccessControlOriginType=s3
+            ```
+
+            Update the distribution config (`aws cloudfront update-distribution`) to set `Origins.Items[*].OriginAccessControlId` on the S3 origin and remove any `S3OriginConfig.OriginAccessIdentity` value.
+        - id: terraform
+          desc: |
+            To attach an origin access control to a CloudFront S3 origin in Terraform, create `aws_cloudfront_origin_access_control` and set `origin_access_control_id` on the S3 origin block of `aws_cloudfront_distribution`:
+
+            ```hcl
+            resource "aws_cloudfront_origin_access_control" "example" {
+              name                              = "example"
+              origin_access_control_origin_type = "s3"
+              signing_behavior                  = "always"
+              signing_protocol                  = "sigv4"
+            }
+
+            resource "aws_cloudfront_distribution" "example" {
+              enabled = true
+
+              origin {
+                domain_name              = aws_s3_bucket.example.bucket_regional_domain_name
+                origin_id                = "s3-origin"
+                origin_access_control_id = aws_cloudfront_origin_access_control.example.id
+              }
+              # ... other distribution configuration ...
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To attach an origin access control to a CloudFront S3 origin in CloudFormation, set `OriginAccessControlId` on the origin entry:
+
+            ```yaml
+            Resources:
+              MyOAC:
+                Type: AWS::CloudFront::OriginAccessControl
+                Properties:
+                  OriginAccessControlConfig:
+                    Name: example
+                    OriginAccessControlOriginType: s3
+                    SigningBehavior: always
+                    SigningProtocol: sigv4
+              MyDistribution:
+                Type: AWS::CloudFront::Distribution
+                Properties:
+                  DistributionConfig:
+                    Enabled: true
+                    Origins:
+                      - Id: s3-origin
+                        DomainName: !GetAtt MyBucket.RegionalDomainName
+                        OriginAccessControlId: !Ref MyOAC
+                        S3OriginConfig:
+                          OriginAccessIdentity: ""
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+        title: Restricting access to S3 origins with OAC
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudfront_distribution")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_cloudfront_distribution").all(
+        blocks.where(type == "origin").all(
+          blocks.where(type == "s3_origin_config") == empty ||
+          arguments.origin_access_control_id != empty
+        )
+      )
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cloudfront_distribution")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cloudfront_distribution").all(
+        change.after.origin == null ||
+        change.after.origin.all(
+          _['s3_origin_config'] == null ||
+          _['s3_origin_config'] == [] ||
+          _['origin_access_control_id'] != empty
+        )
+      )
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloudfront_distribution")
+    mql: |
+      terraform.state.resources.where(type == "aws_cloudfront_distribution").all(
+        values.origin == null ||
+        values.origin.all(
+          _['s3_origin_config'] == null ||
+          _['s3_origin_config'] == [] ||
+          _['origin_access_control_id'] != empty
+        )
+      )
+  - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::CloudFront::Distribution")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::CloudFront::Distribution").all(
+        properties['DistributionConfig']['Origins'] == null ||
+        properties['DistributionConfig']['Origins'].all(
+          _['S3OriginConfig'] == null ||
+          _['OriginAccessControlId'] != empty
+        )
+      )
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum
+    title: Ensure ALB and NLB TLS listeners use a TLS 1.2 (or higher) security policy
+    impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-aws
+        tags:
+          mondoo.com/filter-title: AWS Application Load Balancer
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every HTTPS or TLS listener on an Application or Network Load Balancer uses a security policy that requires a TLS 1.2 or higher cipher suite. Listeners that fall back to `ELBSecurityPolicy-2016-08` or any `ELBSecurityPolicy-TLS-1-0`/`ELBSecurityPolicy-TLS-1-1` policy negotiate down to deprecated TLS versions that are no longer considered safe for confidentiality or integrity.
+
+        **Why this matters**
+
+        - TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS, FedRAMP, and most government security baselines because they rely on cipher suites and integrity primitives with known weaknesses.
+        - A listener that advertises a permissive policy negotiates down to the oldest version a client supports, so a single legacy client is enough to expose the entire data path.
+        - The `ELBSecurityPolicy-TLS-1-2-*`, `ELBSecurityPolicy-TLS13-*`, and `ELBSecurityPolicy-FS-1-2-*` families pin the floor at TLS 1.2 and prefer forward-secret cipher suites, keeping recorded traffic safe even if long-lived keys leak in the future.
+        - Pinning the policy also documents the operator's intent, so subsequent changes show up in diff review instead of being silently relaxed.
+      remediation:
+        - id: console
+          desc: |
+            To raise the security policy on an ALB or NLB listener using the AWS Console:
+
+            1. Open the **EC2** console and choose **Load Balancers**.
+            2. Select the load balancer and open the **Listeners** tab.
+            3. Edit each HTTPS or TLS listener and set **Security policy** to a current policy such as `ELBSecurityPolicy-TLS13-1-2-2021-06`.
+            4. Save the changes on each listener.
+        - id: cli
+          desc: |
+            To raise the security policy on an ALB or NLB listener using the AWS CLI:
+
+            ```bash
+            aws elbv2 modify-listener \
+              --listener-arn <listener-arn> \
+              --ssl-policy ELBSecurityPolicy-TLS13-1-2-2021-06
+            ```
+        - id: terraform
+          desc: |
+            To pin the listener security policy in Terraform, set `ssl_policy` to a TLS 1.2-floor policy on `aws_lb_listener`:
+
+            ```hcl
+            resource "aws_lb_listener" "example" {
+              load_balancer_arn = aws_lb.example.arn
+              port              = 443
+              protocol          = "HTTPS"
+              ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+              certificate_arn   = aws_acm_certificate.example.arn
+
+              default_action {
+                type             = "forward"
+                target_group_arn = aws_lb_target_group.example.arn
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To pin the listener security policy in CloudFormation, set `SslPolicy` on `AWS::ElasticLoadBalancingV2::Listener`:
+
+            ```yaml
+            Resources:
+              MyListener:
+                Type: AWS::ElasticLoadBalancingV2::Listener
+                Properties:
+                  LoadBalancerArn: !Ref MyLoadBalancer
+                  Port: 443
+                  Protocol: HTTPS
+                  SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+                  Certificates:
+                    - CertificateArn: !Ref MyCertificate
+                  DefaultActions:
+                    - Type: forward
+                      TargetGroupArn: !Ref MyTargetGroup
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html
+        title: Security policies for Application Load Balancers
+      - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/describe-ssl-policies.html
+        title: Security policies for Network Load Balancers
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-aws
+    filters: asset.platform == "aws-elb-loadbalancer"
+    mql: |
+      aws.elb.loadbalancer.listeners.where(protocol == "HTTPS" || protocol == "TLS").all(
+        sslPolicy == /^ELBSecurityPolicy-TLS-1-2-/ &&
+        sslPolicy != /^ELBSecurityPolicy-TLS-1-2-Ext-2018-06/ ||
+        sslPolicy == /^ELBSecurityPolicy-TLS13-/ ||
+        sslPolicy == /^ELBSecurityPolicy-FS-1-2-/
+      )
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lb_listener")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_lb_listener").where(
+        arguments.protocol == "HTTPS" || arguments.protocol == "TLS"
+      ).all(
+        arguments.ssl_policy == /^ELBSecurityPolicy-TLS-1-2-/ &&
+        arguments.ssl_policy != /^ELBSecurityPolicy-TLS-1-2-Ext-2018-06/ ||
+        arguments.ssl_policy == /^ELBSecurityPolicy-TLS13-/ ||
+        arguments.ssl_policy == /^ELBSecurityPolicy-FS-1-2-/
+      )
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_lb_listener")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_lb_listener").where(
+        change.after.protocol == "HTTPS" || change.after.protocol == "TLS"
+      ).all(
+        change.after.ssl_policy == /^ELBSecurityPolicy-TLS-1-2-/ &&
+        change.after.ssl_policy != /^ELBSecurityPolicy-TLS-1-2-Ext-2018-06/ ||
+        change.after.ssl_policy == /^ELBSecurityPolicy-TLS13-/ ||
+        change.after.ssl_policy == /^ELBSecurityPolicy-FS-1-2-/
+      )
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_lb_listener")
+    mql: |
+      terraform.state.resources.where(type == "aws_lb_listener").where(
+        values.protocol == "HTTPS" || values.protocol == "TLS"
+      ).all(
+        values.ssl_policy == /^ELBSecurityPolicy-TLS-1-2-/ &&
+        values.ssl_policy != /^ELBSecurityPolicy-TLS-1-2-Ext-2018-06/ ||
+        values.ssl_policy == /^ELBSecurityPolicy-TLS13-/ ||
+        values.ssl_policy == /^ELBSecurityPolicy-FS-1-2-/
+      )
+  - uid: mondoo-aws-security-elbv2-listener-tls-1-2-minimum-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::ElasticLoadBalancingV2::Listener")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::ElasticLoadBalancingV2::Listener").where(
+        properties['Protocol'] == "HTTPS" || properties['Protocol'] == "TLS"
+      ).all(
+        properties['SslPolicy'] == /^ELBSecurityPolicy-TLS-1-2-/ &&
+        properties['SslPolicy'] != /^ELBSecurityPolicy-TLS-1-2-Ext-2018-06/ ||
+        properties['SslPolicy'] == /^ELBSecurityPolicy-TLS13-/ ||
+        properties['SslPolicy'] == /^ELBSecurityPolicy-FS-1-2-/
+      )
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport
+    title: Ensure SQS queue policies enforce secure transport
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every SQS queue resource policy contains a statement that explicitly denies access whenever the request is not made over TLS. SQS accepts both HTTP and HTTPS by default, so without a `Deny` keyed on `aws:SecureTransport: false` a caller with a broken TLS configuration can send and receive messages in plaintext.
+
+        **Why this matters**
+
+        - Message bodies and SQS attributes routinely carry workload payloads, application identifiers, and references to other AWS resources; allowing plaintext access leaks all of that.
+        - The SigV4 authorization header is also sent on every request, so plaintext access exposes credentials in transit.
+        - The `aws:SecureTransport` condition key is the only resource-policy mechanism that can refuse a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
+        - Adding the `Deny` statement makes intent auditable in the queue's policy document instead of relying on every caller to opt in to TLS.
+      remediation:
+        - id: console
+          desc: |
+            To attach a secure-transport policy to an SQS queue using the AWS Console:
+
+            1. Open the **SQS** console and select the queue.
+            2. Choose **Access policy** and add the following statement (merging with any existing statements):
+
+               ```json
+               {
+                 "Sid": "DenyInsecureTransport",
+                 "Effect": "Deny",
+                 "Principal": "*",
+                 "Action": "sqs:*",
+                 "Resource": "<queue-arn>",
+                 "Condition": {"Bool": {"aws:SecureTransport": "false"}}
+               }
+               ```
+            3. Save the policy.
+        - id: cli
+          desc: |
+            To attach a secure-transport policy to an SQS queue using the AWS CLI:
+
+            ```bash
+            aws sqs set-queue-attributes \
+              --queue-url <queue-url> \
+              --attributes Policy=file://secure-transport.json
+            ```
+        - id: terraform
+          desc: |
+            To enforce secure transport on an SQS queue in Terraform, attach `aws_sqs_queue_policy` with a `Deny` statement keyed on `aws:SecureTransport`:
+
+            ```hcl
+            data "aws_iam_policy_document" "secure_transport" {
+              statement {
+                sid       = "DenyInsecureTransport"
+                effect    = "Deny"
+                actions   = ["sqs:*"]
+                resources = [aws_sqs_queue.example.arn]
+
+                principals {
+                  type        = "*"
+                  identifiers = ["*"]
+                }
+
+                condition {
+                  test     = "Bool"
+                  variable = "aws:SecureTransport"
+                  values   = ["false"]
+                }
+              }
+            }
+
+            resource "aws_sqs_queue_policy" "secure_transport" {
+              queue_url = aws_sqs_queue.example.id
+              policy    = data.aws_iam_policy_document.secure_transport.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To enforce secure transport on an SQS queue in CloudFormation, add a `Deny` statement keyed on `aws:SecureTransport: "false"` to `AWS::SQS::QueuePolicy`:
+
+            ```yaml
+            Resources:
+              QueuePolicy:
+                Type: AWS::SQS::QueuePolicy
+                Properties:
+                  Queues:
+                    - !Ref Queue
+                  PolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Sid: DenyInsecureTransport
+                        Effect: Deny
+                        Principal: "*"
+                        Action: sqs:*
+                        Resource: !GetAtt Queue.Arn
+                        Condition:
+                          Bool:
+                            aws:SecureTransport: "false"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-security-best-practices.html
+        title: Amazon SQS security best practices
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-aws
+    filters: asset.platform == "aws-sqs-queue"
+    mql: |
+      aws.sqs.queue.policy != null &&
+      aws.sqs.queue.policy['Statement'] != null &&
+      aws.sqs.queue.policy['Statement'].any(
+        _['Effect'] == "Deny" &&
+        _['Condition'] != null &&
+        _['Condition']['Bool'] != null &&
+        _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
+        _['Effect'] == "Deny" &&
+        _['Condition'] != null &&
+        _['Condition']['Bool'] != null &&
+        _['Condition']['Bool']['aws:SecureTransport'] == false
+      )
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sqs_queue_policy").all(
+        arguments.policy["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sqs_queue_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sqs_queue_policy").all(
+        change.after["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sqs_queue_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_sqs_queue_policy").all(
+        values["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::SQS::QueuePolicy")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::SQS::QueuePolicy").all(
+        properties['PolicyDocument'] != null &&
+        properties['PolicyDocument']['Statement'] != null &&
+        properties['PolicyDocument']['Statement'].where(
+          _['Effect'] == "Deny" &&
+          _['Condition'] != null &&
+          _['Condition']['Bool'] != null
+        ).any(
+          _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
+          _['Condition']['Bool']['aws:SecureTransport'] == false
+        )
+      )
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport
+    title: Ensure SNS topic policies enforce secure transport
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-sns-topic-policy-secure-transport-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-sns-topic-policy-secure-transport-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every SNS topic resource policy contains a statement that explicitly denies access whenever the request is not made over TLS. SNS accepts HTTP for both `Publish` and management calls by default, so without a `Deny` keyed on `aws:SecureTransport: false` publishers and subscribers can carry message payloads in plaintext.
+
+        **Why this matters**
+
+        - Message bodies sent to SNS often contain workload events, business data, or references to other AWS resources; plaintext publish leaks all of that on the wire.
+        - SigV4 signed requests still include credential headers, so plaintext API calls expose the caller's signing material in transit.
+        - The `aws:SecureTransport` condition is the only resource-policy mechanism that refuses a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
+        - Adding the `Deny` statement also documents intent in the topic policy itself, so downstream reviewers do not need to infer encryption from network controls.
+      remediation:
+        - id: console
+          desc: |
+            To attach a secure-transport policy to an SNS topic using the AWS Console:
+
+            1. Open the **SNS** console and select the topic.
+            2. Choose **Edit** → **Access policy** and add the following statement (merging with any existing statements):
+
+               ```json
+               {
+                 "Sid": "DenyInsecureTransport",
+                 "Effect": "Deny",
+                 "Principal": "*",
+                 "Action": "sns:*",
+                 "Resource": "<topic-arn>",
+                 "Condition": {"Bool": {"aws:SecureTransport": "false"}}
+               }
+               ```
+            3. Save the changes.
+        - id: cli
+          desc: |
+            To attach a secure-transport policy to an SNS topic using the AWS CLI:
+
+            ```bash
+            aws sns set-topic-attributes \
+              --topic-arn <topic-arn> \
+              --attribute-name Policy \
+              --attribute-value file://secure-transport.json
+            ```
+        - id: terraform
+          desc: |
+            To enforce secure transport on an SNS topic in Terraform, attach `aws_sns_topic_policy` with a `Deny` statement keyed on `aws:SecureTransport`:
+
+            ```hcl
+            data "aws_iam_policy_document" "secure_transport" {
+              statement {
+                sid       = "DenyInsecureTransport"
+                effect    = "Deny"
+                actions   = ["sns:*"]
+                resources = [aws_sns_topic.example.arn]
+
+                principals {
+                  type        = "*"
+                  identifiers = ["*"]
+                }
+
+                condition {
+                  test     = "Bool"
+                  variable = "aws:SecureTransport"
+                  values   = ["false"]
+                }
+              }
+            }
+
+            resource "aws_sns_topic_policy" "secure_transport" {
+              arn    = aws_sns_topic.example.arn
+              policy = data.aws_iam_policy_document.secure_transport.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To enforce secure transport on an SNS topic in CloudFormation, add a `Deny` statement keyed on `aws:SecureTransport: "false"` to `AWS::SNS::TopicPolicy`:
+
+            ```yaml
+            Resources:
+              TopicPolicy:
+                Type: AWS::SNS::TopicPolicy
+                Properties:
+                  Topics:
+                    - !Ref Topic
+                  PolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Sid: DenyInsecureTransport
+                        Effect: Deny
+                        Principal: "*"
+                        Action: sns:*
+                        Resource: !Ref Topic
+                        Condition:
+                          Bool:
+                            aws:SecureTransport: "false"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html
+        title: Amazon SNS security best practices
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport-aws
+    filters: asset.platform == "aws-sns-topic"
+    mql: |
+      aws.sns.topic.policy != null &&
+      aws.sns.topic.policy['Statement'] != null &&
+      aws.sns.topic.policy['Statement'].any(
+        _['Effect'] == "Deny" &&
+        _['Condition'] != null &&
+        _['Condition']['Bool'] != null &&
+        _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
+        _['Effect'] == "Deny" &&
+        _['Condition'] != null &&
+        _['Condition']['Bool'] != null &&
+        _['Condition']['Bool']['aws:SecureTransport'] == false
+      )
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_sns_topic_policy").all(
+        arguments.policy["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sns_topic_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_sns_topic_policy").all(
+        change.after["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sns_topic_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_sns_topic_policy").all(
+        values["policy"]["Statement"].any(
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
+          _["Effect"] == "Deny" &&
+          _["Condition"]["Bool"]["aws:SecureTransport"] == false
+        )
+      )
+  - uid: mondoo-aws-security-sns-topic-policy-secure-transport-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::SNS::TopicPolicy")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::SNS::TopicPolicy").all(
+        properties['PolicyDocument'] != null &&
+        properties['PolicyDocument']['Statement'] != null &&
+        properties['PolicyDocument']['Statement'].where(
+          _['Effect'] == "Deny" &&
+          _['Condition'] != null &&
+          _['Condition']['Bool'] != null
+        ).any(
+          _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
+          _['Condition']['Bool']['aws:SecureTransport'] == false
+        )
+      )
+  - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum
+    title: Ensure API Gateway v2 WebSocket APIs use TLS 1.2 (or higher) on custom domains
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that, whenever an API Gateway v2 account hosts a WebSocket API, every v2 custom domain pins the TLS floor to `TLS_1_2`. WebSocket APIs use the same custom-domain primitive as HTTP APIs, so the security policy chosen at the domain level is what governs the cipher suite negotiated for every wss:// session.
+
+        **Why this matters**
+
+        - The default `TLS_1_0` security policy for v2 custom domains allows TLS 1.0 and TLS 1.1 negotiation, both of which are deprecated by the IETF and prohibited by PCI DSS 4.0.
+        - WebSocket sessions are long-lived, so a single weak negotiation can keep a vulnerable channel open for the lifetime of the connection.
+        - Pinning the floor to `TLS_1_2` is the only resource-level control that forces clients to negotiate modern cipher suites; downstream WAF or CloudFront policies cannot retroactively raise the protocol version.
+        - This check fires only when the account actually hosts WebSocket APIs, so the finding is scoped to the surface where WebSocket clients connect.
+      remediation:
+        - id: console
+          desc: |
+            To raise the security policy on a v2 custom domain used by a WebSocket API using the AWS Console:
+
+            1. Open the **API Gateway** console and choose **Custom domain names**.
+            2. Select the domain that fronts the WebSocket API.
+            3. Edit each domain configuration and set **Minimum TLS version** to `TLS 1.2`.
+            4. Save the changes.
+        - id: cli
+          desc: |
+            To raise the security policy on a v2 custom domain using the AWS CLI:
+
+            ```bash
+            aws apigatewayv2 update-domain-name \
+              --domain-name <domain-name> \
+              --domain-name-configurations CertificateArn=<cert-arn>,EndpointType=REGIONAL,SecurityPolicy=TLS_1_2
+            ```
+        - id: terraform
+          desc: |
+            To pin the security policy in Terraform, set `security_policy = "TLS_1_2"` on every `domain_name_configuration` block of `aws_apigatewayv2_domain_name`:
+
+            ```hcl
+            resource "aws_apigatewayv2_domain_name" "example" {
+              domain_name = "ws.example.com"
+
+              domain_name_configuration {
+                certificate_arn = aws_acm_certificate.example.arn
+                endpoint_type   = "REGIONAL"
+                security_policy = "TLS_1_2"
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html
+        title: Choosing a minimum TLS version for an API Gateway custom domain
+  - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-aws
+    filters: asset.platform == "aws" && aws.apigatewayv2.apis.any(protocolType == "WEBSOCKET")
+    mql: |
+      aws.apigatewayv2.domainNames.all(
+        domainNameConfigurations.all(_['SecurityPolicy'] == "TLS_1_2")
+      )
+  - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_apigatewayv2_api") && terraform.resources.contains(nameLabel == "aws_apigatewayv2_domain_name")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_apigatewayv2_api").any(arguments.protocol_type == "WEBSOCKET") &&
+      terraform.resources.where(nameLabel == "aws_apigatewayv2_domain_name").all(
+        blocks.where(type == "domain_name_configuration") != empty &&
+        blocks.where(type == "domain_name_configuration").all(arguments.security_policy == "TLS_1_2")
+      )
+  - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_apigatewayv2_api") && terraform.plan.resourceChanges.contains(type == "aws_apigatewayv2_domain_name")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_apigatewayv2_api").any(change.after.protocol_type == "WEBSOCKET") &&
+      terraform.plan.resourceChanges.where(type == "aws_apigatewayv2_domain_name").all(
+        change.after.domain_name_configuration != empty &&
+        change.after.domain_name_configuration.all(_['security_policy'] == "TLS_1_2")
+      )
+  - uid: mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_apigatewayv2_api") && terraform.state.resources.contains(type == "aws_apigatewayv2_domain_name")
+    mql: |
+      terraform.state.resources.where(type == "aws_apigatewayv2_api").any(values.protocol_type == "WEBSOCKET") &&
+      terraform.state.resources.where(type == "aws_apigatewayv2_domain_name").all(
+        values.domain_name_configuration != empty &&
+        values.domain_name_configuration.all(_['security_policy'] == "TLS_1_2")
+      )
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced
+    title: Ensure DMS endpoints require SSL connections
+    impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every AWS Database Migration Service endpoint sets `ssl_mode` to a value other than `none`. DMS pulls every row of source data — including credentials, primary keys, and any encrypted-at-rest payload — and pushes it to the target endpoint over a connection it manages itself, so an endpoint configured with `ssl_mode = "none"` carries that data over plaintext TCP between the replication instance and the database.
+
+        **Why this matters**
+
+        - Migration tasks move whole tables and change-data-capture streams, so the volume of data exposed by a single plaintext endpoint is much larger than for a typical application connection.
+        - DMS source endpoints also send authentication material (database username and password, or IAM auth tokens) every time the replication instance reconnects.
+        - `require` validates that the wire protocol is TLS but does not verify the server certificate; `verify-ca` and `verify-full` are stronger because they catch MITM redirection to a rogue endpoint.
+        - The control surface is the endpoint itself — the task and replication instance inherit whatever the endpoints negotiate, so this is where the floor must be set.
+      remediation:
+        - id: console
+          desc: |
+            To require SSL on a DMS endpoint using the AWS Console:
+
+            1. Open the **DMS** console and choose **Endpoints**.
+            2. Edit the endpoint and set **SSL mode** to `require`, `verify-ca`, or `verify-full`.
+            3. Save the endpoint.
+        - id: cli
+          desc: |
+            To require SSL on a DMS endpoint using the AWS CLI:
+
+            ```bash
+            aws dms modify-endpoint \
+              --endpoint-arn <endpoint-arn> \
+              --ssl-mode require
+            ```
+        - id: terraform
+          desc: |
+            To require SSL on a DMS endpoint in Terraform, set `ssl_mode` on `aws_dms_endpoint`:
+
+            ```hcl
+            resource "aws_dms_endpoint" "example" {
+              endpoint_id   = "example"
+              endpoint_type = "source"
+              engine_name   = "mysql"
+              server_name   = aws_db_instance.source.address
+              port          = 3306
+              database_name = "appdata"
+              username      = var.dms_user
+              password      = var.dms_password
+              ssl_mode      = "verify-full"
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To require SSL on a DMS endpoint in CloudFormation, set `SslMode` on `AWS::DMS::Endpoint`:
+
+            ```yaml
+            Resources:
+              MyEndpoint:
+                Type: AWS::DMS::Endpoint
+                Properties:
+                  EndpointType: source
+                  EngineName: mysql
+                  ServerName: !GetAtt SourceDB.Endpoint.Address
+                  Port: 3306
+                  DatabaseName: appdata
+                  Username: !Ref DmsUser
+                  Password: !Ref DmsPassword
+                  SslMode: verify-full
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.SSL.html
+        title: Using SSL with AWS Database Migration Service
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.dms.endpoints.all(sslMode != "none")
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dms_endpoint")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_dms_endpoint").all(
+        arguments.ssl_mode != empty && arguments.ssl_mode != "none"
+      )
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_dms_endpoint")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_dms_endpoint").all(
+        change.after.ssl_mode != empty && change.after.ssl_mode != "none"
+      )
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_dms_endpoint")
+    mql: |
+      terraform.state.resources.where(type == "aws_dms_endpoint").all(
+        values.ssl_mode != empty && values.ssl_mode != "none"
+      )
+  - uid: mondoo-aws-security-dms-endpoint-ssl-enforced-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::DMS::Endpoint")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::DMS::Endpoint").all(
+        properties['SslMode'] != empty && properties['SslMode'] != "none"
+      )
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required
+    title: Ensure App Mesh virtual node listeners require TLS
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every App Mesh virtual node listener is configured with a TLS block whose `mode` is either `STRICT` or `PERMISSIVE`. App Mesh defaults each listener to TLS disabled, so without an explicit `tls` block the Envoy proxy fronting the node accepts plaintext traffic from any peer that can route to it inside the mesh.
+
+        **Why this matters**
+
+        - App Mesh is typically deployed inside a VPC that operators treat as trusted, which is exactly the assumption attackers exploit during lateral movement once they reach a single workload.
+        - With TLS disabled at the listener, sidecar-to-sidecar traffic is plaintext gRPC or HTTP and any compromised workload on the same subnet can read or rewrite it.
+        - `STRICT` mode refuses plaintext clients outright; `PERMISSIVE` mode accepts both TLS and plaintext during a migration window. Both are acceptable for this check, but `STRICT` is the recommended end state.
+        - The TLS block is also where the certificate source is pinned — ACM, ACM Private CA, or a file-based cert — which keeps key material discoverable for audit.
+      remediation:
+        - id: console
+          desc: |
+            To require TLS on an App Mesh virtual node listener using the AWS Console:
+
+            1. Open the **App Mesh** console and choose the mesh.
+            2. Select the virtual node and edit each listener.
+            3. Enable **Client policy** → **TLS** and set the mode to `STRICT` (or `PERMISSIVE` during a migration), then choose a certificate source.
+            4. Save the virtual node.
+        - id: cli
+          desc: |
+            To require TLS on an App Mesh virtual node using the AWS CLI, supply a listener spec with a TLS block:
+
+            ```bash
+            aws appmesh update-virtual-node \
+              --mesh-name <mesh> \
+              --virtual-node-name <node> \
+              --spec file://virtual-node-spec.json
+            ```
+
+            where the listener block in `virtual-node-spec.json` includes a `tls` object with `mode: STRICT` and a certificate source.
+        - id: terraform
+          desc: |
+            To require TLS on an App Mesh virtual node in Terraform, declare a `tls` block under each `listener` in the node spec:
+
+            ```hcl
+            resource "aws_appmesh_virtual_node" "example" {
+              name      = "example"
+              mesh_name = aws_appmesh_mesh.example.id
+
+              spec {
+                listener {
+                  port_mapping {
+                    port     = 8080
+                    protocol = "http"
+                  }
+
+                  tls {
+                    mode = "STRICT"
+
+                    certificate {
+                      acm {
+                        certificate_arn = aws_acm_certificate.example.arn
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To require TLS on an App Mesh virtual node in CloudFormation, set a `TLS` block on each listener:
+
+            ```yaml
+            Resources:
+              MyVirtualNode:
+                Type: AWS::AppMesh::VirtualNode
+                Properties:
+                  MeshName: !Ref MyMesh
+                  VirtualNodeName: example
+                  Spec:
+                    Listeners:
+                      - PortMapping:
+                          Port: 8080
+                          Protocol: http
+                        TLS:
+                          Mode: STRICT
+                          Certificate:
+                            ACM:
+                              CertificateArn: !Ref MyCertificate
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/app-mesh/latest/userguide/tls.html
+        title: Transport Layer Security (TLS) in App Mesh
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.appmesh.meshes.all(
+        virtualNodes.all(
+          listeners.all(
+            _['tls'] != null &&
+            _['tls']['mode'] == "STRICT" ||
+            _['tls'] != null &&
+            _['tls']['mode'] == "PERMISSIVE"
+          )
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appmesh_virtual_node")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_appmesh_virtual_node").all(
+        blocks.where(type == "spec").all(
+          blocks.where(type == "listener") != empty &&
+          blocks.where(type == "listener").all(
+            blocks.where(type == "tls") != empty &&
+            blocks.where(type == "tls").all(
+              arguments.mode == "STRICT" || arguments.mode == "PERMISSIVE"
+            )
+          )
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_appmesh_virtual_node")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_appmesh_virtual_node").all(
+        change.after.spec != empty &&
+        change.after.spec.all(
+          _['listener'] != empty &&
+          _['listener'].all(
+            _['tls'] != empty &&
+            _['tls'].all(
+              _['mode'] == "STRICT" || _['mode'] == "PERMISSIVE"
+            )
+          )
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_appmesh_virtual_node")
+    mql: |
+      terraform.state.resources.where(type == "aws_appmesh_virtual_node").all(
+        values.spec != empty &&
+        values.spec.all(
+          _['listener'] != empty &&
+          _['listener'].all(
+            _['tls'] != empty &&
+            _['tls'].all(
+              _['mode'] == "STRICT" || _['mode'] == "PERMISSIVE"
+            )
+          )
+        )
+      )
+  - uid: mondoo-aws-security-appmesh-virtual-node-tls-required-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::AppMesh::VirtualNode")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::AppMesh::VirtualNode").all(
+        properties['Spec']['Listeners'] != empty &&
+        properties['Spec']['Listeners'].all(
+          _['TLS'] != null &&
+          _['TLS']['Mode'] == "STRICT" ||
+          _['TLS'] != null &&
+          _['TLS']['Mode'] == "PERMISSIVE"
+        )
+      )
+  # No runtime variant: cnquery aws provider does not expose AWS IoT Core
+  # domain configurations. Revisit when an aws.iot resource set is added.
+  - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum
+    title: Ensure IoT Core domain configurations use a TLS 1.2 (or higher) security policy
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every AWS IoT Core domain configuration pins its `tls_config.security_policy` to a current `IoTSecurityPolicy_TLS13_*` or `IoTSecurityPolicy_TLS_1_2_*` value. IoT Core accepts the legacy `IoTSecurityPolicy_TLS_1_0_*` policies by default on existing endpoints, so devices that have not been re-provisioned may still negotiate TLS 1.0 or 1.1 against the broker.
+
+        **Why this matters**
+
+        - IoT fleets often run on long-lived hardware that authenticates with X.509 certificates over MQTT, so a single weak negotiation can keep millions of sessions on a deprecated TLS version.
+        - TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS and most government baselines because their cipher suites rely on broken integrity primitives.
+        - The `tls_config` block on a domain configuration is the only resource-level control that pins the cipher suite floor — broker-side IAM and Thing policies do not see protocol version.
+        - Pinning the policy also documents intent so subsequent infrastructure-as-code changes surface in diff review instead of being silently relaxed.
+      remediation:
+        - id: console
+          desc: |
+            To raise the security policy on an IoT Core domain configuration using the AWS Console:
+
+            1. Open the **AWS IoT** console and choose **Settings** → **Domain configurations**.
+            2. Select the domain configuration and choose **Edit**.
+            3. Set **Security policy** to a current `IoTSecurityPolicy_TLS13_*` or `IoTSecurityPolicy_TLS_1_2_*` value.
+            4. Save the configuration.
+        - id: cli
+          desc: |
+            To raise the security policy on an IoT Core domain configuration using the AWS CLI:
+
+            ```bash
+            aws iot update-domain-configuration \
+              --domain-configuration-name <name> \
+              --tls-config '{"securityPolicy":"IoTSecurityPolicy_TLS13_1_2_2022_10"}'
+            ```
+        - id: terraform
+          desc: |
+            To pin the security policy in Terraform, set `tls_config.security_policy` on `aws_iot_domain_configuration`:
+
+            ```hcl
+            resource "aws_iot_domain_configuration" "example" {
+              name           = "example"
+              domain_name    = "iot.example.com"
+              service_type   = "DATA"
+              server_certificate_arns = [aws_acm_certificate.example.arn]
+
+              tls_config {
+                security_policy = "IoTSecurityPolicy_TLS13_1_2_2022_10"
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/iot/latest/developerguide/transport-security.html
+        title: Transport security in AWS IoT Core
+  - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iot_domain_configuration")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_iot_domain_configuration").all(
+        blocks.where(type == "tls_config") != empty &&
+        blocks.where(type == "tls_config").all(
+          arguments.security_policy == /^IoTSecurityPolicy_TLS13_/ ||
+          arguments.security_policy == /^IoTSecurityPolicy_TLS_1_2_/
+        )
+      )
+  - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_iot_domain_configuration")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_iot_domain_configuration").all(
+        change.after.tls_config != empty &&
+        change.after.tls_config.all(
+          _['security_policy'] == /^IoTSecurityPolicy_TLS13_/ ||
+          _['security_policy'] == /^IoTSecurityPolicy_TLS_1_2_/
+        )
+      )
+  - uid: mondoo-aws-security-iot-domain-configuration-tls-1-2-minimum-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_iot_domain_configuration")
+    mql: |
+      terraform.state.resources.where(type == "aws_iot_domain_configuration").all(
+        values.tls_config != empty &&
+        values.tls_config.all(
+          _['security_policy'] == /^IoTSecurityPolicy_TLS13_/ ||
+          _['security_policy'] == /^IoTSecurityPolicy_TLS_1_2_/
+        )
+      )
+  - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc
+    title: Ensure Secrets Manager rotation Lambdas run inside a VPC
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
+        tags:
+          mondoo.com/filter-title: AWS Secrets Manager
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that the Lambda function attached to each Secrets Manager secret with rotation enabled is itself configured to run inside a customer VPC. The rotation Lambda authenticates to the backing database with the secret it is rotating, so if the function has no VPC configuration it reaches the database over the public AWS network rather than over private subnets the operator controls.
+
+        **Why this matters**
+
+        - The rotation Lambda holds both the current and the candidate credential during each rotation and must talk to the database to verify the new credential — this is exactly the moment when network isolation matters most.
+        - A rotation Lambda without `vpc_config` makes its outbound call from an AWS-managed network range, so the database's security group and network ACL cannot distinguish the legitimate caller from any other AWS workload.
+        - Putting the rotation function in the same private subnets as the database lets the database security group accept only that function's security group, which is the same boundary used for regular application traffic.
+        - This check focuses on the rotation Lambda's network configuration; the secret's encryption-at-rest and rotation cadence are enforced by separate Secrets Manager checks.
+      remediation:
+        - id: console
+          desc: |
+            To run a Secrets Manager rotation Lambda inside a VPC using the AWS Console:
+
+            1. Open the **Lambda** console and select the rotation function attached to the secret.
+            2. Choose the **Configuration** tab and select **VPC**.
+            3. Choose **Edit** and select the VPC, private subnets, and security group that mirror the database's network placement.
+            4. Save the changes.
+        - id: cli
+          desc: |
+            To run a Secrets Manager rotation Lambda inside a VPC using the AWS CLI:
+
+            ```bash
+            aws lambda update-function-configuration \
+              --function-name <rotation-function> \
+              --vpc-config SubnetIds=subnet-aaaa,subnet-bbbb,SecurityGroupIds=sg-1111
+            ```
+        - id: terraform
+          desc: |
+            To run a Secrets Manager rotation Lambda inside a VPC in Terraform, declare a `vpc_config` block on the rotation `aws_lambda_function` and wire the secret to it through `aws_secretsmanager_secret_rotation`:
+
+            ```hcl
+            resource "aws_lambda_function" "rotation" {
+              function_name = "secrets-rotation"
+              role          = aws_iam_role.rotation.arn
+              handler       = "rotate.handler"
+              runtime       = "python3.12"
+              filename      = data.archive_file.rotation.output_path
+
+              vpc_config {
+                subnet_ids         = aws_subnet.private[*].id
+                security_group_ids = [aws_security_group.rotation.id]
+              }
+            }
+
+            resource "aws_secretsmanager_secret_rotation" "example" {
+              secret_id           = aws_secretsmanager_secret.example.id
+              rotation_lambda_arn = aws_lambda_function.rotation.arn
+
+              rotation_rules {
+                automatically_after_days = 30
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-network-rqmts.html
+        title: Network requirements for rotation Lambda functions
+  - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.secretsmanager.secrets.where(rotationEnabled == true).all(
+        rotationLambda != null &&
+        rotationLambda.subnets != empty
+      )
+  - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_function")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_lambda_function").where(
+        arguments.function_name == /rotation|rotate/i
+      ).all(
+        blocks.where(type == "vpc_config") != empty &&
+        blocks.where(type == "vpc_config").all(arguments.subnet_ids != empty)
+      )
+  - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_lambda_function")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_lambda_function").where(
+        change.after.function_name == /rotation|rotate/i
+      ).all(
+        change.after.vpc_config != empty &&
+        change.after.vpc_config.all(_['subnet_ids'] != empty)
+      )
+  - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_lambda_function")
+    mql: |
+      terraform.state.resources.where(type == "aws_lambda_function").where(
+        values.function_name == /rotation|rotate/i
+      ).all(
+        values.vpc_config != empty &&
+        values.vpc_config.all(_['subnet_ids'] != empty)
+      )
+  # No runtime variant: cnquery aws provider does not expose AWS CodeArtifact
+  # domains. Revisit when an aws.codeartifact resource set is added.
+  - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption
+    title: Ensure CodeArtifact domains use a customer-managed KMS key
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that every CodeArtifact domain is created with an explicit `encryption_key` pointing at a customer-managed KMS key. Without that argument CodeArtifact provisions an AWS-managed key whose policy the customer cannot author, rotate, or revoke, so the package archive ends up encrypted under a boundary the operator does not control.
+
+        **Why this matters**
+
+        - CodeArtifact domains aggregate package metadata and asset blobs from every repository in the domain, so the package store often contains internal release tags, private build hashes, and customer-specific package names.
+        - A customer-managed key lets the operator bind the domain's lifecycle to the same KMS policy and CloudTrail audit trail used for other regulated data.
+        - The encryption key is locked at domain creation time — it cannot be changed later — so this is the only opportunity to enforce CMK encryption for the domain's lifetime.
+        - In-transit protection is not part of this check because CodeArtifact only exposes HTTPS endpoints; the only configurable boundary at rest is the KMS key.
+      remediation:
+        - id: console
+          desc: |
+            To create a CodeArtifact domain with a customer-managed key using the AWS Console:
+
+            1. Open the **CodeArtifact** console and choose **Create domain**.
+            2. Under **AWS KMS key**, choose **Customer managed key** and select the CMK ARN.
+            3. Create the domain. The encryption key cannot be changed after creation.
+        - id: cli
+          desc: |
+            To create a CodeArtifact domain with a customer-managed key using the AWS CLI:
+
+            ```bash
+            aws codeartifact create-domain \
+              --domain <domain-name> \
+              --encryption-key <kms-key-arn>
+            ```
+        - id: terraform
+          desc: |
+            To encrypt a CodeArtifact domain with a customer-managed key in Terraform, set `encryption_key` on `aws_codeartifact_domain`:
+
+            ```hcl
+            resource "aws_codeartifact_domain" "example" {
+              domain         = "example"
+              encryption_key = aws_kms_key.codeartifact.arn
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To encrypt a CodeArtifact domain with a customer-managed key in CloudFormation, set `EncryptionKey` on `AWS::CodeArtifact::Domain`:
+
+            ```yaml
+            Resources:
+              MyDomain:
+                Type: AWS::CodeArtifact::Domain
+                Properties:
+                  DomainName: example
+                  EncryptionKey: !GetAtt CodeArtifactKey.Arn
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/codeartifact/latest/ug/domain-overview.html
+        title: AWS CodeArtifact domains
+  - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codeartifact_domain")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_codeartifact_domain").all(
+        arguments.encryption_key != empty
+      )
+  - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_codeartifact_domain")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_codeartifact_domain").all(
+        change.after.encryption_key != empty
+      )
+  - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_codeartifact_domain")
+    mql: |
+      terraform.state.resources.where(type == "aws_codeartifact_domain").all(
+        values.encryption_key != empty
+      )
+  - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::CodeArtifact::Domain")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::CodeArtifact::Domain").all(
+        properties['EncryptionKey'] != empty
       )

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -47339,7 +47339,7 @@ queries:
   - uid: mondoo-aws-security-sfn-logging-enabled-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.sfn.stateMachines.all(loggingConfiguration['level'] != "OFF")
+      aws.sfn.stateMachines.all(loggingLevel != "OFF")
   - uid: mondoo-aws-security-sfn-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sfn_state_machine")
     mql: |
@@ -47492,7 +47492,7 @@ queries:
   - uid: mondoo-aws-security-sfn-encryption-configured-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.sfn.stateMachines.all(encryptionConfiguration['type'] != "AWS_OWNED_KEY")
+      aws.sfn.stateMachines.all(encryptionType != "AWS_OWNED_KEY")
   - uid: mondoo-aws-security-sfn-encryption-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sfn_state_machine")
     mql: |

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 11.0.0
+    version: 12.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## Summary

Adds 23 new security checks to `mondoo-aws-security` across three categories: publicly exposed assets, encryption at rest, and encryption in transit. Lint passes clean (only the two pre-existing SFN deprecation warnings remain).

### Publicly exposed assets (8)
- `lambda-function-url-auth-required` — fails when a function URL has `AuthType: NONE`
- `apigateway-cors-not-wildcard-with-credentials` — flags CORS that pairs `*` origins with credentials
- `apigatewayv2-websocket-route-auth-required` — requires every WebSocket route to set an authorizer
- `eventbridge-bus-policy-no-public-access` — flags bus policies with `Principal: *` and no condition
- `glue-connection-no-plaintext-credentials` — requires `SECRET_ID` instead of a `PASSWORD` property
- `cloud9-environment-no-ingress` — requires `CONNECT_SSM` (no inbound SSH/22)
- `elasticbeanstalk-environment-https-listener` — requires an HTTPS listener namespace on the environment
- `route53-resolver-query-logging-enabled` — requires a Resolver query-log config + association

### Encryption at rest (6)
- `dynamodb-pitr-cmk-encryption` — table has CMK SSE + PITR enabled
- `elasticache-snapshot-kms-encryption` — replication group has at-rest encryption + CMK when snapshots are retained
- `kinesis-video-stream-cmk-encryption` — stream has a customer KMS key
- `emr-studio-cmk-encryption` — studio has `encryption_key_arn` set
- `datasync-task-cloudwatch-logging-encryption` — task ships logs to CloudWatch Logs (relies on existing log-group encryption check for the KMS leg)
- `cloudfront-s3-origin-oac-with-encryption` — every S3 origin uses Origin Access Control

### Encryption in transit (9)
- `elbv2-listener-tls-1-2-minimum` — HTTPS/TLS listeners use a TLS 1.2+ security policy
- `sqs-queue-policy-secure-transport` — queue policy denies when `aws:SecureTransport == false`
- `sns-topic-policy-secure-transport` — topic policy denies when `aws:SecureTransport == false`
- `apigatewayv2-websocket-tls-1-2-minimum` — WebSocket API domains use `TLS_1_2`
- `dms-endpoint-ssl-enforced` — endpoint `ssl_mode != "none"`
- `appmesh-virtual-node-tls-required` — virtual-node listeners enforce TLS (`STRICT` or `PERMISSIVE`)
- `iot-domain-configuration-tls-1-2-minimum` — domain configuration uses a TLS 1.2+ security policy
- `secretsmanager-rotation-lambda-in-vpc` — rotation Lambda runs inside a customer VPC
- `codeartifact-domain-cmk-encryption` — domain has a customer KMS key (CodeArtifact endpoints are TLS-only by AWS design, so the in-transit framing collapsed to at-rest)

### Completeness audit

- **Compliance tags:** every check has the full 13-framework tag block. Tags were chosen by reading each control's text in `cnspec-enterprise-policies/frameworks/` and fall back to the unquoted YAML boolean `false` where no strict-fit control exists (consistent with the EKS canonical reference).
- **Remediation:** every check has at minimum `console`, `cli`, and `terraform` entries (CLAUDE.md requires `terraform`). 14 of 23 also ship `cloudformation` — the rest skip CloudFormation either because the service is not exposed as a CFN resource or because the existing check would be a duplicate primitive.
- **Terraform variants:** 22 of 23 ship `terraform-hcl` + `terraform-plan` + `terraform-state`. The exception (`apigatewayv2-websocket-route-auth-required`) carries a `# No Terraform variants:` YAML comment explaining the cross-resource correlation the runtime variant performs is not cleanly expressible in MQL on Terraform assets, and points at the existing `apigatewayv2-routes-require-authorizer` check as the broader TF cover.
- **Runtime `aws` variant:** 17 of 23 ship it after mondoohq/mql#7685 landed the schema gaps for EventBridge bus policies, CloudFront origin OAC fields, Elastic Beanstalk option settings, Glue connections, and EMR Studio. The other 6 still carry `# No runtime variant: cnquery aws provider does not expose <service> resources.` YAML comments: Cloud9, Route 53 Resolver, Kinesis Video, DataSync, IoT Core domain configurations, CodeArtifact. These remain tracked as the second batch of mondoohq/mql#7678 work.

### Out-of-scope (originally proposed, deferred)

- Amazon Managed Grafana CMK — `aws_grafana_workspace` does not expose a `kms_key_id` argument; Managed Grafana uses AWS-managed keys only.
- AWS Data Exchange / License Manager at-rest encryption — neither service exposes a CMK / encryption argument in the Terraform AWS provider as of v5.x.

## Test plan

- [ ] `cnspec policy lint content/mondoo-aws-security.mql.yaml` → valid bundle
- [ ] Run `cnspec scan aws` against an account with at least one of each affected resource type and confirm each check produces results
- [ ] Run `cnspec scan terraform <hcl-fixture>` against a fixture covering each of the new `aws_*` resources and confirm the Terraform variants fire
- [ ] Run `cnspec scan cloudformation <template>` against a fixture covering the CloudFormation variants and confirm they fire
- [ ] Review compliance-tag mappings against the framework definitions in `cnspec-enterprise-policies/frameworks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)