### PR TITLE
:sparkles: Add GCP checks for public exposure and encryption (at rest + in transit)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -32,6 +32,7 @@ apikey
 apparmor
 APPDATA
 appdb
+appengine
 appgroup
 appgw
 appspot
@@ -179,6 +180,7 @@ detokenize
 devtmpfs
 DGAs
 dhe
+DICOM
 diffie
 directoryservice
 dlp
@@ -233,8 +235,11 @@ faillog
 failovers
 fargate
 FCr
+featurestore
 FEMI
 ffde
+FHIR
+filebase
 fileless
 fileshare
 filestore
@@ -627,6 +632,7 @@ tallylog
 Tbps
 tde
 TDS
+tensorboard
 tfa
 timeadd
 timestream

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -29242,7 +29242,6 @@ queries:
 
             ```hcl
             resource "google_api_gateway_api_config" "default" {
-              provider      = google-beta
               api           = google_api_gateway_api.default.api_id
               api_config_id = "my-config"
 
@@ -29502,7 +29501,6 @@ queries:
 
             ```hcl
             resource "google_workstations_workstation_cluster" "default" {
-              provider               = google-beta
               workstation_cluster_id = "private-cluster"
               network                = google_compute_network.default.id
               subnetwork             = google_compute_subnetwork.default.id
@@ -29877,7 +29875,6 @@ queries:
             }
 
             resource "google_dataflow_flex_template_job" "flex" {
-              provider                = google-beta
               name                    = "flex-pipeline"
               container_spec_gcs_path = "gs://templates/flex-spec.json"
               kms_key_name            = google_kms_crypto_key.dataflow.id
@@ -30230,7 +30227,6 @@ queries:
             }
 
             resource "google_vertex_ai_metadata_store" "default" {
-              provider = google-beta
               name     = "metadata-store"
               region   = "us-central1"
 
@@ -30266,7 +30262,7 @@ queries:
             gcloud ai custom-jobs create \
               --region=REGION \
               --display-name=JOB_NAME \
-              --kms-key-name=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY \
+              --kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY \
               --config=config.yaml
             ```
 
@@ -30276,7 +30272,7 @@ queries:
             gcloud ai tensorboards create \
               --region=REGION \
               --display-name=TENSORBOARD_NAME \
-              --kms-key-name=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
+              --kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
       - url: https://cloud.google.com/vertex-ai/docs/general/cmek

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -235,12 +235,16 @@ policies:
           - uid: mondoo-gcp-security-logging-bucket-locked
           - uid: mondoo-gcp-security-logging-bucket-cmek-encryption
           - uid: mondoo-gcp-security-logging-sinks-configured
+          - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption
       - title: Pub/Sub
         checks:
           - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption
           - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured
           - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible
           - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible
+      - title: Cloud Healthcare API
+        checks:
+          - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption
       - title: Cloud Functions
         checks:
           - uid: mondoo-gcp-security-cloud-functions-ingress-restricted
@@ -249,6 +253,9 @@ policies:
           - uid: mondoo-gcp-security-cloud-functions-cmek-encryption
           - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars
           - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured
+      - title: API Gateway
+        checks:
+          - uid: mondoo-gcp-security-apigateway-config-requires-authentication
       - title: Cloud Run
         checks:
           - uid: mondoo-gcp-security-cloud-run-ingress-restricted
@@ -257,6 +264,10 @@ policies:
           - uid: mondoo-gcp-security-cloud-run-vpc-access-configured
           - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account
           - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption
+      - title: App Engine
+        checks:
+          - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress
+          - uid: mondoo-gcp-security-appengine-handler-secure-always
       - title: Dataproc
         checks:
           - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured
@@ -273,10 +284,14 @@ policies:
           - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions
           - uid: mondoo-gcp-security-cloud-build-worker-pool-private
           - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account
+      - title: Cloud Composer
+        checks:
+          - uid: mondoo-gcp-security-composer-environment-cmek-encryption
       - title: Dataflow
         checks:
           - uid: mondoo-gcp-security-dataflow-job-no-public-ips
           - uid: mondoo-gcp-security-dataflow-job-no-default-service-account
+          - uid: mondoo-gcp-security-dataflow-job-cmek-encryption
       - title: Filestore
         checks:
           - uid: mondoo-gcp-security-filestore-instance-cmek-encryption
@@ -301,12 +316,16 @@ policies:
         checks:
           - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only
           - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow
+      - title: Cloud CDN
+        checks:
+          - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required
       - title: SSL/TLS Policies
         checks:
           - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2
           - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile
           - uid: mondoo-gcp-security-ssl-certificate-not-expired
           - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy
+          - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2
       - title: Cloud NAT
         checks:
           - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping
@@ -355,6 +374,11 @@ policies:
           - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public
           - uid: mondoo-gcp-security-vertexai-custom-job-has-explicit-service-account
           - uid: mondoo-gcp-security-vertexai-custom-job-no-default-service-account
+          - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip
+          - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption
+      - title: Cloud Workstations
+        checks:
+          - uid: mondoo-gcp-security-workstations-cluster-private-cluster
       - title: VPC Service Controls
         checks:
           - uid: mondoo-gcp-security-vpc-sc-access-policies-defined
@@ -29027,3 +29051,1604 @@ queries:
       terraform.state.resources.where(type == 'google_essential_contacts_contact').any(
         values['notification_category_subscriptions'].any(_ == "SECURITY" || _ == "ALL")
       )
+  - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress
+    title: Ensure App Engine applications are protected by IAP or internal-only ingress
+    impact: 30
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-gcp
+        tags:
+          mondoo.com/filter-title: GCP App Engine
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that App Engine workloads intended to be private are protected from arbitrary internet traffic. Workloads should either sit behind Identity-Aware Proxy (IAP) at the project level or be configured to accept only internal or internal-and-load-balancer ingress.
+
+        **Why this matters**
+
+        By default, App Engine services are reachable from the public internet. Many App Engine workloads serve back-office, internal-only, or partner-only functionality and should not be exposed to anonymous traffic:
+
+          - IAP places a Google-managed identity check in front of the application so only authenticated principals from your organization can reach it.
+          - Setting `ingress_traffic_allowed` to `INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY` or `INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB` restricts traffic to internal VPC sources and optionally an internal load balancer, eliminating direct internet exposure.
+          - Public exposure without authentication is a leading cause of credential-harvesting, scraping, and brute-force attacks against App Engine apps.
+
+        If App Engine traffic is left wide open with no IAP and no ingress restriction, the workload's full attack surface is reachable by any host on the internet, regardless of whether application-level authentication is enforced.
+
+        **Risk mitigation**
+          - Enable IAP on the App Engine application and grant access only to the IAM principals that need it.
+          - For workloads that should never accept internet traffic, set `ingress_traffic_allowed` to `INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY` or `INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB`.
+          - Combine network controls with strong application-level authentication and authorization.
+      remediation:
+        - id: terraform
+          desc: |
+            To restrict App Engine ingress in Terraform, set `ingress_traffic_allowed` on the service network settings:
+
+            ```hcl
+            resource "google_app_engine_service_network_settings" "internal" {
+              service = "default"
+
+              network_settings {
+                ingress_traffic_allowed = "INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY"
+              }
+            }
+            ```
+
+            `INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB` is also acceptable when an internal load balancer is required.
+        - id: console
+          desc: |
+            To restrict App Engine ingress using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **App Engine** > **Services**.
+            2. Select the service that should not be publicly reachable.
+            3. Open **Network ingress controls**.
+            4. Set ingress to **Internal only** or **Internal and Cloud Load Balancing**.
+            5. Save.
+
+            To enable IAP for App Engine:
+
+            1. In the Google Cloud Console, go to **Security** > **Identity-Aware Proxy**.
+            2. Locate the App Engine application and toggle IAP on.
+            3. Grant the **IAP-secured Web App User** role only to the principals that should reach the app.
+        - id: cli
+          desc: |
+            To restrict App Engine ingress using the Google Cloud CLI:
+
+            ```bash
+            gcloud app services update SERVICE_NAME --ingress=internal-only
+            ```
+
+            `internal-and-cloud-load-balancing` is also acceptable when an internal load balancer is required.
+    refs:
+      - url: https://cloud.google.com/appengine/docs/standard/application-security
+        title: App Engine application security
+      - url: https://cloud.google.com/iap/docs/enabling-app-engine
+        title: Enabling IAP for App Engine
+  - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.appEngine.application.iap['enabled'] == true
+  - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_app_engine_service_network_settings')
+    mql: |
+      terraform.resources('google_app_engine_service_network_settings').all(
+        blocks.where(type == 'network_settings') != empty &&
+        blocks.where(type == 'network_settings').all(
+          arguments.ingress_traffic_allowed == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY' ||
+          arguments.ingress_traffic_allowed == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB'
+        )
+      )
+  - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_app_engine_service_network_settings')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_app_engine_service_network_settings').all(
+        change.after['network_settings'] != empty &&
+        change.after['network_settings'].all(
+          _['ingress_traffic_allowed'] == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY' ||
+          _['ingress_traffic_allowed'] == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB'
+        )
+      )
+  - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_app_engine_service_network_settings')
+    mql: |
+      terraform.state.resources.where(type == 'google_app_engine_service_network_settings').all(
+        values['network_settings'] != empty &&
+        values['network_settings'].all(
+          _['ingress_traffic_allowed'] == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY' ||
+          _['ingress_traffic_allowed'] == 'INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB'
+        )
+      )
+  # No runtime variant: the cnquery gcp provider does not expose API Gateway resources. Cloud Endpoints (google_endpoints_service) is a related concern that is not covered here; this check focuses on API Gateway.
+  - uid: mondoo-gcp-security-apigateway-config-requires-authentication
+    title: Ensure API Gateway configs reference at least one OpenAPI document
+    impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every `google_api_gateway_api_config` references at least one OpenAPI document. The OpenAPI document is the contract that drives authentication, authorization, and request validation for API Gateway. A config with no OpenAPI document is a configuration error that leaves the API gateway with no enforceable security definitions.
+
+        **Why this matters**
+
+        API Gateway sits in front of backend services and is responsible for authenticating callers, rejecting unauthenticated traffic, and enforcing per-operation policies. Those rules are defined inside the OpenAPI specification referenced by the API config:
+
+          - The OpenAPI document declares `securityDefinitions` (or `components.securitySchemes` in OpenAPI 3) and attaches `security` requirements to each operation.
+          - Without an OpenAPI document attached, API Gateway has no security definitions to enforce, and every backend operation is effectively exposed without authentication.
+          - Public, unauthenticated API surface is one of the most common root causes of cloud data leaks.
+
+        This check verifies the necessary precondition that an OpenAPI document is attached. The contents of the OpenAPI document — whether it actually declares strong authentication on every operation — should be reviewed manually because parsing the embedded spec is out of scope for static configuration analysis.
+
+        **Risk mitigation**
+          - Ensure every API Gateway config references at least one `openapi_documents` entry.
+          - Inside the OpenAPI specification, declare a `securityDefinitions`/`components.securitySchemes` block (for example, Google ID token, API key, or JWT) and attach a `security` requirement to every operation.
+          - Block unauthenticated traffic at the backend (Cloud Run, Cloud Functions) as defense in depth.
+          - For Cloud Endpoints, the equivalent resource is `google_endpoints_service`, which carries the same OpenAPI-spec contract.
+      remediation:
+        - id: terraform
+          desc: |
+            To ensure an API Gateway config has an attached OpenAPI document in Terraform:
+
+            ```hcl
+            resource "google_api_gateway_api_config" "default" {
+              provider      = google-beta
+              api           = google_api_gateway_api.default.api_id
+              api_config_id = "my-config"
+
+              openapi_documents {
+                document {
+                  path     = "spec.yaml"
+                  contents = filebase64("${path.module}/openapi.yaml")
+                }
+              }
+            }
+            ```
+
+            Inside the referenced `openapi.yaml`, declare `securityDefinitions` and attach a `security` requirement to every operation.
+        - id: console
+          desc: |
+            To attach an OpenAPI document to an API Gateway config using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **API Gateway**.
+            2. Open the API and select **Create gateway** or edit the existing config.
+            3. Upload the OpenAPI specification that defines `securityDefinitions` and per-operation `security` requirements.
+            4. Save and deploy.
+        - id: cli
+          desc: |
+            To create an API Gateway config with an OpenAPI document using the Google Cloud CLI:
+
+            ```bash
+            gcloud api-gateway api-configs create CONFIG_ID \
+              --api=API_ID \
+              --openapi-spec=openapi.yaml
+            ```
+
+            Ensure the supplied `openapi.yaml` declares `securityDefinitions` and applies a `security` requirement to every operation.
+    refs:
+      - url: https://cloud.google.com/api-gateway/docs/authentication-method
+        title: API Gateway authentication methods
+      - url: https://cloud.google.com/api-gateway/docs/openapi-overview
+        title: API Gateway OpenAPI overview
+  - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_api_gateway_api_config')
+    mql: |
+      terraform.resources('google_api_gateway_api_config').all(
+        blocks.where(type == 'openapi_documents') != empty
+      )
+  - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_api_gateway_api_config')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_api_gateway_api_config').all(
+        change.after['openapi_documents'] != empty
+      )
+  - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_api_gateway_api_config')
+    mql: |
+      terraform.state.resources.where(type == 'google_api_gateway_api_config').all(
+        values['openapi_documents'] != empty
+      )
+  - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required
+    title: Ensure CDN-enabled backend services require signed URLs
+    impact: 40
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud CDN
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that backend services with Cloud CDN enabled require signed URLs (or signed cookies) for cached responses. When CDN is enabled in front of a private origin, allowing unsigned requests means cached content can be replayed by anyone who guesses or scrapes the URL.
+
+        **Why this matters**
+
+        Cloud CDN caches responses at Google edge locations to reduce latency and origin load. Without signed-URL enforcement, the cached content is reachable by any client that knows or guesses the URL:
+
+          - Cached responses outlive the lifetime of the original authenticated request, which means a single leaked URL can serve content indefinitely.
+          - For CDN backends fronting private user data, premium media, or partner content, lack of signed-URL enforcement is functionally equivalent to making the content public.
+          - Signed URLs and signed cookies bind cached responses to short-lived, cryptographically verifiable tokens so only authorized callers can fetch them.
+
+        Many legitimate Cloud CDN backends are intentionally public (static marketing assets, software downloads). This check is a posture trigger: when CDN is enabled, confirm that signed-URL enforcement is either configured or explicitly waived for a public-content workload.
+
+        **Risk mitigation**
+          - On every CDN-enabled backend service that fronts private content, set `cdn_policy.signed_url_cache_max_age_sec` to a non-zero value.
+          - Provision signing keys with the `google_compute_backend_service_signed_url_key` resource and rotate them regularly.
+          - For workloads that are intentionally public, document the exception and ensure the cache contains no sensitive data.
+      remediation:
+        - id: terraform
+          desc: |
+            To require signed URLs on a CDN-enabled backend service in Terraform:
+
+            ```hcl
+            resource "google_compute_backend_service" "default" {
+              name        = "cdn-backend"
+              protocol    = "HTTP"
+              port_name   = "http"
+              timeout_sec = 10
+              enable_cdn  = true
+
+              cdn_policy {
+                cache_mode                   = "CACHE_ALL_STATIC"
+                signed_url_cache_max_age_sec = 7200
+              }
+            }
+
+            resource "google_compute_backend_service_signed_url_key" "default" {
+              backend_service = google_compute_backend_service.default.name
+              name            = "signing-key"
+              key_value       = var.signing_key_value
+            }
+            ```
+        - id: console
+          desc: |
+            To require signed URLs on a CDN-enabled backend service using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Network services** > **Cloud CDN**.
+            2. Select the CDN-enabled backend service.
+            3. Under **Signed URLs**, add a signing key and set a non-zero signed URL cache max age.
+            4. Save.
+        - id: cli
+          desc: |
+            To add a signed URL key and enable signed-URL caching on a backend service using the Google Cloud CLI:
+
+            ```bash
+            gcloud compute backend-services add-signed-url-key BACKEND_SERVICE_NAME \
+              --key-name=KEY_NAME \
+              --key-file=KEY_FILE
+
+            gcloud compute backend-services update BACKEND_SERVICE_NAME \
+              --signed-url-cache-max-age=7200s
+            ```
+    refs:
+      - url: https://cloud.google.com/cdn/docs/using-signed-urls
+        title: Using signed URLs with Cloud CDN
+      - url: https://cloud.google.com/cdn/docs/using-signed-cookies
+        title: Using signed cookies with Cloud CDN
+  - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.backendServices.where(enableCDN == true).all(
+        cdnPolicy.signedUrlCacheMaxAgeSec > 0
+      )
+  - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_backend_service')
+    mql: |
+      terraform.resources('google_compute_backend_service').where(
+        arguments.enable_cdn == true
+      ).all(
+        blocks.where(type == 'cdn_policy') != empty &&
+        blocks.where(type == 'cdn_policy').all(
+          arguments.signed_url_cache_max_age_sec != null &&
+          arguments.signed_url_cache_max_age_sec != 0
+        )
+      )
+  - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_backend_service')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_backend_service').where(
+        change.after['enable_cdn'] == true
+      ).all(
+        change.after['cdn_policy'] != empty &&
+        change.after['cdn_policy'].all(
+          _['signed_url_cache_max_age_sec'] != null &&
+          _['signed_url_cache_max_age_sec'] != 0
+        )
+      )
+  - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_backend_service')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_backend_service').where(
+        values['enable_cdn'] == true
+      ).all(
+        values['cdn_policy'] != empty &&
+        values['cdn_policy'].all(
+          _['signed_url_cache_max_age_sec'] != null &&
+          _['signed_url_cache_max_age_sec'] != 0
+        )
+      )
+  # No runtime variant: the cnquery gcp provider does not expose Cloud Workstations resources.
+  - uid: mondoo-gcp-security-workstations-cluster-private-cluster
+    title: Ensure Cloud Workstations clusters use a private endpoint
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures Cloud Workstations clusters force clients onto a private endpoint by setting `private_cluster_config.enable_private_endpoint` to `true`. Workstations clusters with a public endpoint are reachable directly from the internet, expanding the attack surface for what is effectively a managed developer VM with broad access to source code, credentials, and downstream services.
+
+        **Why this matters**
+
+        Cloud Workstations is a hosted development environment with first-class IAM, but the cluster's control endpoint behavior is configured at provisioning time and cannot be tightened in place without a redeploy:
+
+          - When the public endpoint is enabled, clients can reach the cluster from any network.
+          - Setting `enable_private_endpoint = true` forces ingress through a private VPC endpoint, requiring callers to be on the connected network (typically through VPN, Cloud Interconnect, or IAP TCP forwarding).
+          - Developer environments commonly hold IDE plugins, credentials, and source checkouts that are valuable targets for credential theft and supply-chain compromise.
+
+        **Risk mitigation**
+          - Set `private_cluster_config.enable_private_endpoint = true` on every Cloud Workstations cluster.
+          - Reach workstations through Cloud VPN, Cloud Interconnect, or IAP-secured TCP forwarding instead of public endpoints.
+          - Restrict the connected VPC's reachable surface with firewall rules and VPC Service Controls.
+      remediation:
+        - id: terraform
+          desc: |
+            To require a private endpoint on a Cloud Workstations cluster in Terraform:
+
+            ```hcl
+            resource "google_workstations_workstation_cluster" "default" {
+              provider               = google-beta
+              workstation_cluster_id = "private-cluster"
+              network                = google_compute_network.default.id
+              subnetwork             = google_compute_subnetwork.default.id
+              location               = "us-central1"
+
+              private_cluster_config {
+                enable_private_endpoint = true
+              }
+            }
+            ```
+        - id: console
+          desc: |
+            To require a private endpoint on a Cloud Workstations cluster using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Cloud Workstations** > **Cluster management**.
+            2. Create a new cluster (the private endpoint setting cannot be flipped on an existing cluster).
+            3. Under **Network**, enable **Private cluster** so the cluster uses a private endpoint.
+            4. Select **Create**.
+        - id: cli
+          desc: |
+            To create a Cloud Workstations cluster with a private endpoint using the Google Cloud CLI:
+
+            ```bash
+            gcloud workstations clusters create CLUSTER_ID \
+              --region=REGION \
+              --network=projects/PROJECT_ID/global/networks/NETWORK \
+              --subnetwork=projects/PROJECT_ID/regions/REGION/subnetworks/SUBNETWORK \
+              --enable-private-endpoint
+            ```
+    refs:
+      - url: https://cloud.google.com/workstations/docs/configure-private-cluster
+        title: Configure a private Cloud Workstations cluster
+  - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_workstations_workstation_cluster')
+    mql: |
+      terraform.resources('google_workstations_workstation_cluster').all(
+        blocks.where(type == 'private_cluster_config') != empty &&
+        blocks.where(type == 'private_cluster_config').all(
+          arguments.enable_private_endpoint == true
+        )
+      )
+  - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_workstations_workstation_cluster')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_workstations_workstation_cluster').all(
+        change.after['private_cluster_config'] != empty &&
+        change.after['private_cluster_config'].all(_['enable_private_endpoint'] == true)
+      )
+  - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_workstations_workstation_cluster')
+    mql: |
+      terraform.state.resources.where(type == 'google_workstations_workstation_cluster').all(
+        values['private_cluster_config'] != empty &&
+        values['private_cluster_config'].all(_['enable_private_endpoint'] == true)
+      )
+  # No runtime variant: the cnquery gcp provider does not expose Vertex AI Workbench (google_workbench_instance) or legacy Notebooks (google_notebooks_instance) resources.
+  - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip
+    title: Ensure Vertex AI Workbench instances do not have public IP addresses
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    variants:
+      - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI Workbench instances (both the current `google_workbench_instance` resource and the legacy `google_notebooks_instance` resource) are provisioned without a public IP address. Workbench instances are managed Jupyter environments that hold notebooks, model artifacts, credentials, and direct access to training data — they are high-value targets that should never accept connections directly from the internet.
+
+        **Why this matters**
+
+        A Workbench instance with a public IP is reachable on the open internet, even when its JupyterLab proxy itself is gated by IAM:
+
+          - Public IPs expand the attack surface to brute-force scanning, vulnerability scanning, and SSRF abuse.
+          - Compromise of a Workbench instance typically yields Google Cloud credentials with broad access to BigQuery, Cloud Storage, and Vertex AI training resources.
+          - Disabling the public IP forces callers to use Private Google Access or IAP TCP forwarding, both of which are gated by IAM.
+
+        **Risk mitigation**
+          - Set `disable_public_ip = true` on `google_workbench_instance` resources.
+          - For legacy `google_notebooks_instance` resources, set `no_public_ip = true`.
+          - Reach Workbench instances through IAP TCP forwarding, the JupyterLab proxy URL, or a private VPC peer.
+      remediation:
+        - id: terraform
+          desc: |
+            To provision a Vertex AI Workbench instance without a public IP in Terraform, use the current `google_workbench_instance` resource:
+
+            ```hcl
+            resource "google_workbench_instance" "default" {
+              name     = "workbench-private"
+              location = "us-central1-a"
+
+              gce_setup {
+                disable_public_ip = true
+              }
+            }
+            ```
+
+            For the legacy `google_notebooks_instance` resource:
+
+            ```hcl
+            resource "google_notebooks_instance" "default" {
+              name         = "notebook-private"
+              location     = "us-central1-a"
+              machine_type = "e2-medium"
+
+              no_public_ip = true
+            }
+            ```
+        - id: console
+          desc: |
+            To disable the public IP on a Vertex AI Workbench instance using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Vertex AI** > **Workbench**.
+            2. Create a new instance (the public-IP setting is set at creation time).
+            3. Expand **Networking** > **Advanced options**.
+            4. Clear **Enable external IP address**.
+            5. Select **Create**.
+        - id: cli
+          desc: |
+            To create a Vertex AI Workbench instance without a public IP using the Google Cloud CLI:
+
+            ```bash
+            gcloud workbench instances create INSTANCE_NAME \
+              --location=LOCATION \
+              --disable-public-ip
+            ```
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/create
+        title: Create a Vertex AI Workbench instance
+      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-network
+        title: Manage Vertex AI Workbench network options
+  - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_workbench_instance' || nameLabel == 'google_notebooks_instance')
+    mql: |
+      terraform.resources('google_workbench_instance').all(
+        blocks.where(type == 'gce_setup') != empty &&
+        blocks.where(type == 'gce_setup').all(arguments.disable_public_ip == true)
+      )
+      terraform.resources('google_notebooks_instance').all(
+        arguments.no_public_ip == true
+      )
+  - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_workbench_instance' || type == 'google_notebooks_instance')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_workbench_instance').all(
+        change.after['gce_setup'] != empty &&
+        change.after['gce_setup'].all(_['disable_public_ip'] == true)
+      )
+      terraform.plan.resourceChanges.where(type == 'google_notebooks_instance').all(
+        change.after['no_public_ip'] == true
+      )
+  - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_workbench_instance' || type == 'google_notebooks_instance')
+    mql: |
+      terraform.state.resources.where(type == 'google_workbench_instance').all(
+        values['gce_setup'] != empty &&
+        values['gce_setup'].all(_['disable_public_ip'] == true)
+      )
+      terraform.state.resources.where(type == 'google_notebooks_instance').all(
+        values['no_public_ip'] == true
+      )
+  # No runtime variant: the cnquery gcp provider does not expose Cloud Composer (google_composer_environment) resources.
+  - uid: mondoo-gcp-security-composer-environment-cmek-encryption
+    title: Ensure Cloud Composer environments are encrypted with CMEK
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Cloud Composer environments are encrypted with a customer-managed encryption key (CMEK). The environment-level CMEK key flows through to the Composer-managed Cloud Storage bucket, the GKE persistent disks, and the Cloud SQL database that back the Airflow control plane and DAG state.
+
+        **Why this matters**
+
+        Cloud Composer environments run Airflow on top of a Google-managed control plane, but the environment itself stores DAGs, Airflow metadata, task logs, and operator state in storage and database services tied to the environment:
+
+          - Without a CMEK, the environment bucket, GKE disks, and Cloud SQL instance are encrypted with Google-managed keys that organizations cannot independently revoke.
+          - Composer DAGs and Airflow Variables often hold connection strings, BigQuery queries, and references to sensitive resources, which makes the environment a high-value target.
+          - CMEK encryption gives the environment a single revocation lever: disabling or destroying the Cloud KMS key blocks decryption across the bucket, disks, and database.
+
+        **Risk mitigation**
+          - Set `config.encryption_config.kms_key_name` on every `google_composer_environment` to a Cloud KMS key that lives in the same region as the environment.
+          - Grant `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key to the Composer, Storage, Compute Engine, and Cloud SQL service agents that operate the environment.
+          - CMEK must be configured at environment creation time; existing environments need to be recreated.
+      remediation:
+        - id: terraform
+          desc: |
+            To require CMEK on a Cloud Composer environment in Terraform, set `config.encryption_config.kms_key_name`:
+
+            ```hcl
+            resource "google_composer_environment" "default" {
+              name   = "composer-cmek"
+              region = "us-central1"
+
+              config {
+                software_config {
+                  image_version = "composer-2-airflow-2"
+                }
+
+                encryption_config {
+                  kms_key_name = google_kms_crypto_key.composer.id
+                }
+              }
+            }
+            ```
+        - id: console
+          desc: |
+            To require CMEK on a Cloud Composer environment using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Composer** > **Environments**.
+            2. Select **Create environment** (CMEK is set at creation time).
+            3. Under **Encryption**, select **Customer-managed encryption key (CMEK)** and pick the Cloud KMS key.
+            4. Complete environment creation.
+        - id: cli
+          desc: |
+            To create a Cloud Composer environment with CMEK using the Google Cloud CLI:
+
+            ```bash
+            gcloud composer environments create ENV_NAME \
+              --location=REGION \
+              --image-version=composer-2-airflow-2 \
+              --kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
+            ```
+    refs:
+      - url: https://cloud.google.com/composer/docs/composer-2/configure-cmek-encryption
+        title: Configure CMEK encryption for Cloud Composer
+  - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_composer_environment')
+    mql: |
+      terraform.resources('google_composer_environment').all(
+        blocks.where(type == 'config') != empty &&
+        blocks.where(type == 'config').all(
+          blocks.where(type == 'encryption_config') != empty &&
+          blocks.where(type == 'encryption_config').all(arguments.kms_key_name != empty)
+        )
+      )
+  - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_composer_environment')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_composer_environment').all(
+        change.after['config'] != empty &&
+        change.after['config'].all(
+          _['encryption_config'] != empty &&
+          _['encryption_config'].all(_['kms_key_name'] != empty)
+        )
+      )
+  - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_composer_environment')
+    mql: |
+      terraform.state.resources.where(type == 'google_composer_environment').all(
+        values['config'] != empty &&
+        values['config'].all(
+          _['encryption_config'] != empty &&
+          _['encryption_config'].all(_['kms_key_name'] != empty)
+        )
+      )
+  - uid: mondoo-gcp-security-dataflow-job-cmek-encryption
+    title: Ensure Cloud Dataflow jobs are encrypted with CMEK
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP Dataflow Job
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Cloud Dataflow jobs run with a customer-managed encryption key (CMEK) configured on the job environment. Dataflow's CMEK setting encrypts the temporary state Dataflow writes to disk during the job — shuffle data, intermediate files in the staging bucket, and worker state in the temporary location.
+
+        **Why this matters**
+
+        Dataflow workers read input, materialize intermediate state, and write output across multiple storage layers. Without a CMEK, every byte of that intermediate state is encrypted with a Google-managed key that organizations cannot independently revoke:
+
+          - Streaming pipelines often process payment data, clickstream events, or telemetry that flows through the job in the clear inside the worker.
+          - The staging and temp buckets that back a job hold serialized pipeline state and intermediate shuffle files that mirror the data the job is processing.
+          - CMEK gives the job a single revocation lever: disabling or destroying the Cloud KMS key blocks further decryption of all of that intermediate state.
+
+        **Risk mitigation**
+          - Set `kms_key_name` on every `google_dataflow_job` and `google_dataflow_flex_template_job` to a Cloud KMS key that lives in the job region.
+          - Grant the Dataflow and Compute Engine service agents `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key.
+          - Ensure the staging and temp Cloud Storage buckets passed to the job are themselves CMEK-encrypted with the same key.
+      remediation:
+        - id: terraform
+          desc: |
+            To require CMEK on Dataflow jobs in Terraform, set `kms_key_name` on the job resource:
+
+            ```hcl
+            resource "google_dataflow_job" "default" {
+              name              = "pipeline"
+              template_gcs_path = "gs://dataflow-templates/latest/Word_Count"
+              temp_gcs_location = "gs://staging-bucket/tmp"
+              kms_key_name      = google_kms_crypto_key.dataflow.id
+            }
+
+            resource "google_dataflow_flex_template_job" "flex" {
+              provider                = google-beta
+              name                    = "flex-pipeline"
+              container_spec_gcs_path = "gs://templates/flex-spec.json"
+              kms_key_name            = google_kms_crypto_key.dataflow.id
+            }
+            ```
+        - id: console
+          desc: |
+            To require CMEK on a Dataflow job using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Dataflow** > **Jobs**.
+            2. Select **Create job from template** or **Create job from flex template**.
+            3. Expand **Optional parameters** > **Encryption**.
+            4. Select **Customer-managed encryption key (CMEK)** and pick the Cloud KMS key.
+            5. Submit the job.
+        - id: cli
+          desc: |
+            To run a Dataflow job with CMEK using the Google Cloud CLI:
+
+            ```bash
+            gcloud dataflow jobs run JOB_NAME \
+              --gcs-location=gs://dataflow-templates/latest/Word_Count \
+              --region=REGION \
+              --dataflow-kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
+            ```
+    refs:
+      - url: https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys
+        title: Use customer-managed encryption keys with Dataflow
+  - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.dataflow.jobs.where(currentState == 'JOB_STATE_RUNNING' || currentState == 'JOB_STATE_PENDING' || currentState == 'JOB_STATE_QUEUED').all(
+        environment['serviceKmsKeyName'] != null && environment['serviceKmsKeyName'] != ''
+      )
+  - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_dataflow_job' || nameLabel == 'google_dataflow_flex_template_job')
+    mql: |
+      terraform.resources('google_dataflow_job').all(
+        arguments.kms_key_name != empty
+      )
+      terraform.resources('google_dataflow_flex_template_job').all(
+        arguments.kms_key_name != empty
+      )
+  - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_dataflow_job' || type == 'google_dataflow_flex_template_job')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_dataflow_job').all(
+        change.after['kms_key_name'] != null && change.after['kms_key_name'] != ''
+      )
+      terraform.plan.resourceChanges.where(type == 'google_dataflow_flex_template_job').all(
+        change.after['kms_key_name'] != null && change.after['kms_key_name'] != ''
+      )
+  - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_dataflow_job' || type == 'google_dataflow_flex_template_job')
+    mql: |
+      terraform.state.resources.where(type == 'google_dataflow_job').all(
+        values['kms_key_name'] != null && values['kms_key_name'] != ''
+      )
+      terraform.state.resources.where(type == 'google_dataflow_flex_template_job').all(
+        values['kms_key_name'] != null && values['kms_key_name'] != ''
+      )
+  # Skipped: Cloud Tasks queue CMEK is configured at the project + location level via the Cloud Tasks API (CmekConfig), not per queue, and is not exposed by either google_cloud_tasks_queue or the cnquery gcp provider. There is no actionable runtime or Terraform check today. Revisit when the Terraform google provider exposes a first-class CmekConfig resource for Cloud Tasks.
+  # Skipped: Storage Transfer Service jobs do not introduce their own CMEK setting — they inherit encryption from the source and destination Cloud Storage buckets. google_storage_transfer_job has no kms_key_name argument and the cnquery gcp provider does not surface transfer jobs. The bucket-level check mondoo-gcp-security-cloud-storage-bucket-cmek-encryption already covers the underlying data.
+  # No runtime variant: the cnquery gcp provider does not expose Cloud Healthcare API resources.
+  - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption
+    title: Ensure Cloud Healthcare datasets are encrypted with CMEK
+    impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Cloud Healthcare datasets are encrypted with a customer-managed encryption key (CMEK). A healthcare dataset is the container for DICOM stores, FHIR stores, and HL7v2 stores, and the dataset-level CMEK flows down to every store inside it.
+
+        **Why this matters**
+
+        Cloud Healthcare datasets hold protected health information (PHI) including imaging studies, clinical records, and messaging traffic — the most regulated category of data in Google Cloud:
+
+          - Without a CMEK, every DICOM image, FHIR resource, and HL7v2 message stored under the dataset is encrypted with a Google-managed key that organizations cannot independently revoke.
+          - CMEK gives the dataset a single revocation lever: disabling or destroying the Cloud KMS key blocks decryption across all stores in the dataset.
+          - HIPAA Security Rule §164.312(a)(2)(iv) requires a documented mechanism for encrypting and decrypting electronic PHI, and customer-managed keys are how organizations document that mechanism on Google Cloud.
+
+        **Risk mitigation**
+          - Set `encryption_spec.kms_key_name` on every `google_healthcare_dataset` to a Cloud KMS key that lives in the same region as the dataset.
+          - Grant the Cloud Healthcare service agent `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key.
+          - Restrict access to the Cloud KMS key with IAM so only the Healthcare service agents and authorized administrators can use it.
+      remediation:
+        - id: terraform
+          desc: |
+            To require CMEK on a Cloud Healthcare dataset in Terraform:
+
+            ```hcl
+            resource "google_healthcare_dataset" "default" {
+              name     = "phi-dataset"
+              location = "us-central1"
+
+              encryption_spec {
+                kms_key_name = google_kms_crypto_key.healthcare.id
+              }
+            }
+            ```
+        - id: console
+          desc: |
+            To require CMEK on a Cloud Healthcare dataset using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Healthcare** > **Datasets**.
+            2. Select **Create dataset** (CMEK is set at creation time).
+            3. Under **Encryption**, select **Customer-managed encryption key (CMEK)** and pick the Cloud KMS key.
+            4. Select **Create**.
+        - id: cli
+          desc: |
+            To create a Cloud Healthcare dataset with CMEK using the Google Cloud CLI:
+
+            ```bash
+            gcloud healthcare datasets create DATASET_ID \
+              --location=REGION \
+              --encryption-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
+            ```
+    refs:
+      - url: https://cloud.google.com/healthcare-api/docs/how-tos/cmek
+        title: Configure Cloud Healthcare API with CMEK
+  - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_healthcare_dataset')
+    mql: |
+      terraform.resources('google_healthcare_dataset').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+  - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_healthcare_dataset')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_healthcare_dataset').all(
+        change.after['encryption_spec'] != empty &&
+        change.after['encryption_spec'].all(_['kms_key_name'] != empty)
+      )
+  - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_healthcare_dataset')
+    mql: |
+      terraform.state.resources.where(type == 'google_healthcare_dataset').all(
+        values['encryption_spec'] != empty &&
+        values['encryption_spec'].all(_['kms_key_name'] != empty)
+      )
+  - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption
+    title: Ensure Cloud Logging project log buckets use CMEK
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP Logging Bucket
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Cloud Logging log bucket configured by `google_logging_project_bucket_config` is encrypted with a customer-managed encryption key (CMEK). Most Cloud Logging sinks route to a log bucket, so requiring CMEK on every project log-bucket config — not just the `_Default` bucket — closes the gap where a custom log bucket created to receive sink output uses Google-managed keys.
+
+        **Why this matters**
+
+        Cross-resource correlation between `google_logging_project_sink` and its destination log bucket is hard to evaluate from a single Terraform module. The simpler, defensible rule is: every log bucket the project provisions through `google_logging_project_bucket_config` must use CMEK. Sinks that route to those buckets are then implicitly covered:
+
+          - Log buckets routinely store audit logs, data-access logs, and policy-violation logs that are valuable to attackers and auditors alike.
+          - The companion runtime check `mondoo-gcp-security-logging-bucket-cmek-encryption` enforces the same property at runtime — this check is the broader Terraform-side guarantee.
+
+        **Risk mitigation**
+          - Set `cmek_settings.kms_key_name` on every `google_logging_project_bucket_config` in the project.
+          - For organization or folder-level sinks that target a log bucket in a different project, run this check against the project that owns the destination bucket.
+          - Grant the Cloud Logging service agent `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the Cloud KMS key.
+      remediation:
+        - id: terraform
+          desc: |
+            To require CMEK on every Cloud Logging project log bucket in Terraform:
+
+            ```hcl
+            resource "google_logging_project_bucket_config" "default" {
+              project        = var.project_id
+              location       = "global"
+              bucket_id      = "audit-bucket"
+              retention_days = 400
+
+              cmek_settings {
+                kms_key_name = google_kms_crypto_key.logging.id
+              }
+            }
+            ```
+        - id: console
+          desc: |
+            To require CMEK on a Cloud Logging log bucket using the Google Cloud Console:
+
+            1. In the Google Cloud Console, go to **Logging** > **Logs Storage**.
+            2. Select the log bucket to update.
+            3. Select **Edit bucket**.
+            4. Under **Encryption**, select **Customer-managed encryption key (CMEK)** and pick the Cloud KMS key.
+            5. Select **Update bucket**.
+        - id: cli
+          desc: |
+            To require CMEK on a Cloud Logging log bucket using the Google Cloud CLI:
+
+            ```bash
+            gcloud logging buckets update BUCKET_ID \
+              --location=LOCATION \
+              --cmek-kms-key-name=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
+            ```
+    refs:
+      - url: https://cloud.google.com/logging/docs/routing/managed-encryption-storage
+        title: Customer-managed encryption keys for Cloud Logging
+  - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-gcp
+    filters: asset.platform == 'gcp-logging-bucket'
+    mql: |
+      gcp.project.loggingservice.bucket.kmsKey != null
+  - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_logging_project_bucket_config')
+    mql: |
+      terraform.resources('google_logging_project_bucket_config').all(
+        blocks.where(type == 'cmek_settings') != empty &&
+        blocks.where(type == 'cmek_settings').all(arguments.kms_key_name != empty)
+      )
+  - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_logging_project_bucket_config')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_logging_project_bucket_config').all(
+        change.after['cmek_settings'] != empty
+      )
+  - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_logging_project_bucket_config')
+    mql: |
+      terraform.state.resources.where(type == 'google_logging_project_bucket_config').all(
+        values['cmek_settings'] != empty
+      )
+  - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption
+    title: Ensure Vertex AI training and runtime assets are encrypted with CMEK
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI training, indexing, and runtime assets that are not already covered by the per-resource CMEK checks — namely Tensorboards, custom training jobs, indexes, index endpoints, metadata stores, and the legacy Feature Store — are encrypted with a customer-managed encryption key (CMEK).
+
+        **Why this matters**
+
+        Vertex AI's CMEK contract is per-resource: each resource ships its own `encryption_spec` block, and a missing block silently falls back to Google-managed encryption that organizations cannot revoke. The endpoint, model, dataset, pipeline-job, and feature-online-store CMEK checks already enforce this on their respective resources; this check rounds out coverage for the remaining first-class Vertex AI surfaces:
+
+          - Tensorboards hold training metrics that can disclose dataset characteristics.
+          - Custom training jobs persist intermediate artifacts in a Google-managed staging bucket whose encryption is set at job submission time.
+          - Indexes and index endpoints back vector search and may encode embeddings of sensitive content.
+          - Metadata stores hold lineage and pipeline metadata across the project.
+          - The legacy Feature Store backs feature serving and online prediction with stored feature values.
+
+        **Risk mitigation**
+          - Set `encryption_spec.kms_key_name` on every `google_vertex_ai_tensorboard`, `google_vertex_ai_metadata_store`, `google_vertex_ai_index`, `google_vertex_ai_index_endpoint`, `google_vertex_ai_featurestore`, and on custom jobs submitted via the API.
+          - Use a Cloud KMS key in the same region as the Vertex AI resource.
+          - Grant the Vertex AI service agent `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the key.
+      remediation:
+        - id: terraform
+          desc: |
+            To require CMEK on Vertex AI training and runtime assets in Terraform, set `encryption_spec` on each resource type:
+
+            ```hcl
+            resource "google_vertex_ai_tensorboard" "default" {
+              display_name = "tensorboard"
+              region       = "us-central1"
+
+              encryption_spec {
+                kms_key_name = google_kms_crypto_key.vertex.id
+              }
+            }
+
+            resource "google_vertex_ai_metadata_store" "default" {
+              provider = google-beta
+              name     = "metadata-store"
+              region   = "us-central1"
+
+              encryption_spec {
+                kms_key_name = google_kms_crypto_key.vertex.id
+              }
+            }
+
+            resource "google_vertex_ai_featurestore" "default" {
+              name   = "featurestore"
+              region = "us-central1"
+
+              encryption_spec {
+                kms_key_name = google_kms_crypto_key.vertex.id
+              }
+            }
+            ```
+
+            `google_vertex_ai_index` and `google_vertex_ai_index_endpoint` accept the same `encryption_spec` block.
+        - id: console
+          desc: |
+            To require CMEK on Vertex AI training and runtime assets using the Google Cloud Console, CMEK must be set at creation time on each resource:
+
+            1. In the Google Cloud Console, go to **Vertex AI** and select the resource type (Tensorboards, Training, Indexes, Feature Store, Metadata).
+            2. Select **Create** for the resource.
+            3. Under **Encryption**, select **Customer-managed encryption key (CMEK)** and pick the Cloud KMS key.
+            4. Complete creation.
+        - id: cli
+          desc: |
+            To submit a Vertex AI custom training job with CMEK using the Google Cloud CLI:
+
+            ```bash
+            gcloud ai custom-jobs create \
+              --region=REGION \
+              --display-name=JOB_NAME \
+              --kms-key-name=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY \
+              --config=config.yaml
+            ```
+
+            For Tensorboards:
+
+            ```bash
+            gcloud ai tensorboards create \
+              --region=REGION \
+              --display-name=TENSORBOARD_NAME \
+              --kms-key-name=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
+            ```
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+        title: Customer-managed encryption keys for Vertex AI
+  - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-gcp
+    filters: asset.platform == 'gcp-project'
+    mql: |
+      gcp.project.vertexai.tensorboards.all(
+        encryptionSpec != empty
+      )
+      gcp.project.vertexai.customJobs.all(
+        encryptionSpec != empty
+      )
+      gcp.project.vertexai.indexes.all(
+        encryptionSpec != empty
+      )
+      gcp.project.vertexai.indexEndpoints.all(
+        encryptionSpec != empty
+      )
+  - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_vertex_ai_tensorboard' || nameLabel == 'google_vertex_ai_metadata_store' || nameLabel == 'google_vertex_ai_featurestore' || nameLabel == 'google_vertex_ai_index' || nameLabel == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.resources('google_vertex_ai_tensorboard').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+      terraform.resources('google_vertex_ai_metadata_store').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+      terraform.resources('google_vertex_ai_featurestore').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+      terraform.resources('google_vertex_ai_index').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+      terraform.resources('google_vertex_ai_index_endpoint').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments.kms_key_name != empty)
+      )
+  - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_vertex_ai_tensorboard' || type == 'google_vertex_ai_metadata_store' || type == 'google_vertex_ai_featurestore' || type == 'google_vertex_ai_index' || type == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_tensorboard').all(
+        change.after['encryption_spec'] != empty
+      )
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_metadata_store').all(
+        change.after['encryption_spec'] != empty
+      )
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_featurestore').all(
+        change.after['encryption_spec'] != empty
+      )
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_index').all(
+        change.after['encryption_spec'] != empty
+      )
+      terraform.plan.resourceChanges.where(type == 'google_vertex_ai_index_endpoint').all(
+        change.after['encryption_spec'] != empty
+      )
+  - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_vertex_ai_tensorboard' || type == 'google_vertex_ai_metadata_store' || type == 'google_vertex_ai_featurestore' || type == 'google_vertex_ai_index' || type == 'google_vertex_ai_index_endpoint')
+    mql: |
+      terraform.state.resources.where(type == 'google_vertex_ai_tensorboard').all(
+        values['encryption_spec'] != empty
+      )
+      terraform.state.resources.where(type == 'google_vertex_ai_metadata_store').all(
+        values['encryption_spec'] != empty
+      )
+      terraform.state.resources.where(type == 'google_vertex_ai_featurestore').all(
+        values['encryption_spec'] != empty
+      )
+      terraform.state.resources.where(type == 'google_vertex_ai_index').all(
+        values['encryption_spec'] != empty
+      )
+      terraform.state.resources.where(type == 'google_vertex_ai_index_endpoint').all(
+        values['encryption_spec'] != empty
+      )
+  # Skipped: Cloud Build worker pool CMEK is configured at the project level via the Cloud Build CmekConfig (projects.locations.updateProjectConfig), not on the worker pool resource. google_cloudbuild_worker_pool has no kms_key_name argument and the cnquery gcp provider does not surface project-level Cloud Build CMEK config. Revisit when the Terraform google provider adds a kms_key_name argument on the worker pool or a first-class Cloud Build CmekConfig resource.
+  - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2
+    title: Ensure HTTPS load balancer target proxies attach a strong SSL policy
+    impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-gcp
+        tags:
+          mondoo.com/filter-title: GCP Compute (Target HTTPS Proxy)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every HTTPS load balancer target proxy attaches an SSL policy that enforces a minimum TLS version of 1.2 (or 1.3) and a profile stronger than `COMPATIBLE`. Existing SSL-policy checks only inspect SSL policies that are defined; they do not catch HTTPS proxies that have no policy attached and therefore inherit GCP's permissive default.
+
+        **Why this matters**
+
+        HTTPS target proxies front public-facing applications behind GCP global and regional HTTPS load balancers. When a target HTTPS proxy has no SSL policy attached, GCP falls back to a default that permits TLS 1.0, TLS 1.1, and cipher suites that include 3DES and CBC-only algorithms. That default has several practical consequences:
+
+          - TLS 1.0 and TLS 1.1 are deprecated by IETF (RFC 8996), PCI DSS, and NIST SP 800-52 Rev 2.
+          - The `COMPATIBLE` profile retains weak cipher suites that enable downgrade and padding-oracle attacks.
+          - Browser vendors have removed support for TLS below 1.2, so allowing it provides no real compatibility benefit but enlarges the attack surface for automated scanners and downgrade tooling.
+          - The SSL policy is the only edge configuration knob that controls cipher and protocol negotiation; relying on the default is equivalent to accepting the weakest settings GCP offers.
+
+        This check tightens the existing `ssl-policy-min-tls-1-2` and `ssl-policy-modern-or-restricted-profile` checks by requiring that every HTTPS proxy actually references a policy, and that the referenced policy meets both the minimum-version and profile bars at the same time.
+
+        **Risk mitigation**
+
+        - Define one or more `google_compute_ssl_policy` resources with `min_tls_version = "TLS_1_2"` (or `TLS_1_3`) and `profile = "MODERN"` or `RESTRICTED`.
+        - Attach a strong policy to every `google_compute_target_https_proxy` and `google_compute_target_ssl_proxy` via `ssl_policy`.
+        - Treat unattached HTTPS proxies as a deployment defect, not a default-acceptable state.
+      remediation:
+        - id: terraform
+          desc: |
+            Bind every target HTTPS proxy to a strong SSL policy via `ssl_policy`:
+
+            ```hcl
+            resource "google_compute_ssl_policy" "modern" {
+              name            = "modern-tls"
+              profile         = "MODERN"
+              min_tls_version = "TLS_1_2"
+            }
+
+            resource "google_compute_target_https_proxy" "https" {
+              name             = "my-https-proxy"
+              url_map          = google_compute_url_map.default.id
+              ssl_certificates = [google_compute_ssl_certificate.cert.id]
+              ssl_policy       = google_compute_ssl_policy.modern.id
+            }
+            ```
+        - id: console
+          desc: |
+            Attach a strong SSL policy to each HTTPS load balancer frontend:
+
+            1. Open **Network services** > **Load balancing** and select the HTTPS load balancer.
+            2. Edit the frontend configuration that holds the target HTTPS proxy.
+            3. Under **SSL policy**, select or create a policy with profile **Modern** or **Restricted** and minimum TLS version **TLS 1.2**.
+            4. Save the frontend and apply changes.
+        - id: cli
+          desc: |
+            Attach an SSL policy to an existing target HTTPS proxy:
+
+            ```bash
+            gcloud compute target-https-proxies update PROXY_NAME \
+              --ssl-policy=POLICY_NAME
+            ```
+
+            Create a strong SSL policy first, if one does not already exist:
+
+            ```bash
+            gcloud compute ssl-policies create POLICY_NAME \
+              --profile=MODERN \
+              --min-tls-version=1.2
+            ```
+    refs:
+      - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+        title: GCP - SSL policies concepts
+      - url: https://cloud.google.com/load-balancing/docs/use-ssl-policies
+        title: GCP - Using SSL policies
+  - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.targetHttpsProxies.all(
+        sslPolicyUrl != "" &&
+        sslPolicy.minTlsVersion == "TLS_1_2" &&
+        sslPolicy.profile != "COMPATIBLE" &&
+        sslPolicy.profile != "CUSTOM"
+      )
+  - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_target_https_proxy')
+    mql: |
+      terraform.resources('google_compute_target_https_proxy').all(
+        arguments['ssl_policy'] != null && arguments['ssl_policy'] != ""
+      )
+      terraform.resources('google_compute_ssl_policy').all(
+        arguments.min_tls_version == "TLS_1_2" || arguments.min_tls_version == "TLS_1_3"
+      )
+      terraform.resources('google_compute_ssl_policy').all(
+        arguments.profile == "MODERN" || arguments.profile == "RESTRICTED"
+      )
+  - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_target_https_proxy')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_target_https_proxy').all(
+        change.after['ssl_policy'] != null && change.after['ssl_policy'] != ""
+      )
+      terraform.plan.resourceChanges.where(type == 'google_compute_ssl_policy').all(
+        change.after['min_tls_version'] == "TLS_1_2" || change.after['min_tls_version'] == "TLS_1_3"
+      )
+      terraform.plan.resourceChanges.where(type == 'google_compute_ssl_policy').all(
+        change.after['profile'] == "MODERN" || change.after['profile'] == "RESTRICTED"
+      )
+  - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_target_https_proxy')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_target_https_proxy').all(
+        values['ssl_policy'] != null && values['ssl_policy'] != ""
+      )
+      terraform.state.resources.where(type == 'google_compute_ssl_policy').all(
+        values['min_tls_version'] == "TLS_1_2" || values['min_tls_version'] == "TLS_1_3"
+      )
+      terraform.state.resources.where(type == 'google_compute_ssl_policy').all(
+        values['profile'] == "MODERN" || values['profile'] == "RESTRICTED"
+      )
+  # No runtime variant: the cnquery gcp provider does not expose per-handler app.yaml configuration on App Engine standard versions. Revisit if gcp.project.appEngineService.version gains a handlers field.
+  - uid: mondoo-gcp-security-appengine-handler-secure-always
+    title: Ensure App Engine standard version handlers require HTTPS
+    impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every URL handler on a `google_app_engine_standard_app_version` requires HTTPS. The Terraform `handlers.security_level` argument should be set to `SECURE_ALWAYS` so App Engine rejects plain HTTP requests and forces clients to use TLS.
+
+        **Why this matters**
+
+        App Engine standard handlers default to `SECURE_DEFAULT` or `SECURE_OPTIONAL`, both of which accept HTTP traffic alongside HTTPS:
+
+          - `SECURE_NEVER` and `SECURE_OPTIONAL` allow plaintext HTTP. Credentials, session cookies, and request bodies travel unprotected over the network and can be intercepted by anyone on the path.
+          - `SECURE_DEFAULT` allows whichever protocol the client uses, so a client that initiates HTTP gets HTTP for the entire session — there is no automatic redirect to HTTPS.
+          - `SECURE_ALWAYS` is the only value that guarantees the handler refuses HTTP and requires TLS for every request.
+
+        This check applies to App Engine standard environment app versions. App Engine flexible environment apps terminate TLS at the load balancer rather than per handler, so this control is enforced at the load balancer for those workloads.
+
+        **Risk mitigation**
+
+        - Set `security_level = "SECURE_ALWAYS"` on every `handlers` block of every `google_app_engine_standard_app_version`.
+        - Roll out the change as a new App Engine version and migrate traffic to it; existing handler configuration cannot be changed in place once a version is deployed.
+        - Pair this control with `appengine-iap-or-vpc-only-ingress` so that workloads also limit who can reach the HTTPS endpoint.
+      remediation:
+        - id: terraform
+          desc: |
+            Require HTTPS on every App Engine standard handler:
+
+            ```hcl
+            resource "google_app_engine_standard_app_version" "default" {
+              version_id = "v1"
+              service    = "default"
+              runtime    = "python39"
+
+              entrypoint {
+                shell = "gunicorn -b :$PORT main:app"
+              }
+
+              deployment {
+                zip {
+                  source_url = "https://storage.googleapis.com/${var.bucket}/${var.object}"
+                }
+              }
+
+              handlers {
+                url_regex      = ".*"
+                security_level = "SECURE_ALWAYS"
+
+                script {
+                  script_path = "auto"
+                }
+              }
+            }
+            ```
+
+            App Engine versions are immutable; deploy a new version with corrected handlers and migrate traffic to it rather than trying to update handlers on an existing version.
+        - id: console
+          desc: |
+            App Engine standard handler `security_level` is set in `app.yaml` at deploy time and cannot be edited from the Google Cloud Console:
+
+            1. Edit `app.yaml` for the service and set `secure: always` on every handler.
+            2. Redeploy the service with `gcloud app deploy` (see the CLI remediation).
+            3. In the Google Cloud Console, go to **App Engine** > **Versions** and migrate traffic to the new version.
+            4. Stop or delete the old, insecure version once traffic has shifted.
+        - id: cli
+          desc: |
+            Add `secure: always` to every handler in `app.yaml` and redeploy:
+
+            ```yaml
+            runtime: python39
+
+            handlers:
+              - url: /.*
+                secure: always
+                script: auto
+            ```
+
+            ```bash
+            gcloud app deploy app.yaml
+            gcloud app services set-traffic SERVICE_NAME --splits=NEW_VERSION=1
+            ```
+    refs:
+      - url: https://cloud.google.com/appengine/docs/standard/reference/app-yaml
+        title: App Engine - app.yaml reference
+      - url: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_standard_app_version
+        title: Terraform - google_app_engine_standard_app_version
+  - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_app_engine_standard_app_version')
+    mql: |
+      terraform.resources('google_app_engine_standard_app_version').all(
+        blocks.where(type == 'handlers').all(
+          arguments.security_level == "SECURE_ALWAYS"
+        )
+      )
+  - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_app_engine_standard_app_version')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_app_engine_standard_app_version').all(
+        change.after['handlers'] != empty &&
+        change.after['handlers'].all(
+          _['security_level'] == "SECURE_ALWAYS"
+        )
+      )
+  - uid: mondoo-gcp-security-appengine-handler-secure-always-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_app_engine_standard_app_version')
+    mql: |
+      terraform.state.resources.where(type == 'google_app_engine_standard_app_version').all(
+        values['handlers'] != empty &&
+        values['handlers'].all(
+          _['security_level'] == "SECURE_ALWAYS"
+        )
+      )
+  # Skipped: Filestore in-transit encryption is not a resource-level configuration. NFSv3 mounts traverse the customer VPC unencrypted at the protocol level; Enterprise tier with Kerberos can encrypt mounts but neither cnquery nor the Terraform google_filestore_instance resource expose Kerberos config. Revisit if Filestore adds a configurable encrypt-in-transit field or if the cnquery gcp provider exposes the underlying network mode in a way that distinguishes private-service-access from a direct, untrusted peering.

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 8.0.0
+    version: 9.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## Summary

Adds 12 new security checks to `mondoo-gcp-security` across three categories. Lint passes clean.

### Publicly exposed assets (5)
- `appengine-iap-or-vpc-only-ingress` — informational (impact 30); alerts when IAP is not enabled at the project
- `apigateway-config-requires-authentication` — config has at least one `openapi_documents` entry
- `cloud-cdn-backend-signed-urls-required` — backends with `enable_cdn = true` require `cdn_policy.signed_url_cache_max_age_sec > 0` plus a signed-URL key
- `workstations-cluster-private-cluster` — `private_cluster_config.enable_private_endpoint = true`
- `vertex-ai-workbench-no-public-ip` — covers both `google_workbench_instance` (`gce_setup.disable_public_ip = true`) and legacy `google_notebooks_instance` (`no_public_ip = true`)

### Encryption at rest — CMEK (5)
- `composer-environment-cmek-encryption`
- `dataflow-job-cmek-encryption` — covers `google_dataflow_job` and `google_dataflow_flex_template_job`
- `healthcare-dataset-cmek-encryption`
- `logging-sink-destination-cmek-encryption` — every `google_logging_project_bucket_config` has `cmek_settings.kms_key_name` (broader than the existing `_Default` log-bucket-CMEK check)
- `vertex-ai-job-cmek-encryption` — covers tensorboards, metadata stores, featurestores, indexes, and index endpoints; complements the existing endpoint/model/dataset/pipeline-job/feature-online-store CMEK checks

### Encryption in transit (2)
- `https-lb-ssl-policy-min-tls-1-2` — every `google_compute_target_https_proxy` references a `google_compute_ssl_policy` whose `min_tls_version in (\"TLS_1_2\", \"TLS_1_3\")` and `profile != \"COMPATIBLE\"`
- `appengine-handler-secure-always` — every `google_app_engine_standard_app_version` handler has `security_level = \"SECURE_ALWAYS\"`

### Completeness audit

- **Compliance tags:** every check has the full 13-framework tag block, mapped by reading the framework YAML in `cnspec-enterprise-policies/frameworks/`. Falls back to the unquoted YAML boolean `false` where no strict-fit control exists.
- **Remediation:** every check has `console`, `cli` (gcloud), and `terraform` entries.
- **Terraform variants:** every check ships `terraform-hcl` + `terraform-plan` + `terraform-state`.
- **Runtime `gcp` variant:** shipped for 5 of 12 checks. The other 7 carry `# No runtime variant: the cnquery gcp provider does not expose <service> resources.` YAML comments — affected services: API Gateway configs, Cloud Workstations, Vertex AI Workbench / Notebooks, Cloud Composer, Cloud Healthcare API, App Engine per-handler config, Vertex AI metadata stores.

### Out-of-scope (originally proposed, deferred)

- **#50, #51, #66, #67, #69, #70** — not selected for this batch.
- **#59 Cloud Tasks queue CMEK** — `google_cloud_tasks_queue` has no `kms_key_name` argument; CMEK is configured per project + location via the Cloud Tasks API and is not Terraform-managed today.
- **#60 Storage Transfer Service CMEK** — `google_storage_transfer_job` has no CMEK argument; transfers inherit encryption from source / destination buckets, which is already covered by `mondoo-gcp-security-cloud-storage-bucket-cmek-encryption`.
- **#64 Cloud Build worker pool CMEK** — `google_cloudbuild_worker_pool` has no CMEK argument; Cloud Build CMEK is configured project-wide via `projects.locations.updateProjectConfig` and is not Terraform-managed.
- **#71 Filestore in-transit encryption** — Filestore mounts traverse the customer VPC over NFSv3; there is no per-resource configurable in-transit encryption flag on `google_filestore_instance`. The existing Filestore CMEK check covers the only resource-level encryption knob.

Each skip is documented in a YAML comment in the policy file so future passes do not re-investigate.

### Known parity gaps (cnquery side)

- API Gateway, Cloud Workstations, Vertex AI Workbench / Notebooks, Cloud Composer, Cloud Healthcare API are not exposed by the cnquery gcp provider.
- App Engine `version` resource exposes `runtime`, `env`, `servingStatus`, `vpcAccessConnector` but no `handlers` list.
- Vertex AI runtime variant covers tensorboards / custom jobs / indexes / index endpoints but skips metadata stores (`metadataStores()` is not surfaced).

## Test plan

- [ ] `cnspec policy lint content/mondoo-gcp-security.mql.yaml` → valid bundle
- [ ] `cnspec scan gcp` against a project with at least one of each affected resource type
- [ ] `cnspec scan terraform <hcl-fixture>` against fixtures covering each new `google_*` resource
- [ ] Review compliance-tag mappings against `cnspec-enterprise-policies/frameworks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)