### PR TITLE
:memo: Improve K8s and Linux policy remediation prose

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -173,6 +173,7 @@ deanonymize
 deauth
 debconf
 decryptable
+dentries
 desiredv
 detokenize
 devtmpfs
@@ -304,6 +305,7 @@ igmp
 iis
 ikev
 imds
+inodes
 insertafter
 intransit
 iommu

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -1458,7 +1458,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1477,7 +1477,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1527,7 +1527,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1546,7 +1546,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1593,7 +1593,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1612,7 +1612,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1659,7 +1659,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1678,7 +1678,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1725,7 +1725,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1744,7 +1744,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1791,7 +1791,7 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1810,7 +1810,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1857,7 +1857,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1876,7 +1876,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/docker.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1923,7 +1923,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -1942,7 +1942,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -1989,7 +1989,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2008,7 +2008,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2055,7 +2055,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2074,7 +2074,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2121,7 +2121,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2140,7 +2140,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2187,7 +2187,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2206,7 +2206,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2253,7 +2253,7 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2272,7 +2272,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2319,7 +2319,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2338,7 +2338,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /run/containerd/containerd.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2385,7 +2385,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2404,7 +2404,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2451,7 +2451,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2470,7 +2470,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2517,7 +2517,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2536,7 +2536,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2583,7 +2583,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2602,7 +2602,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2649,7 +2649,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2668,7 +2668,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2715,7 +2715,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2734,7 +2734,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2781,7 +2781,7 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        Check for the existence of `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2800,7 +2800,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Ensure workloads do not have `hostPath.path: /var/run/crio/crio.sock` setting in the `volumes`:
+        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
 
         ```yaml
         ---
@@ -2850,7 +2850,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2864,7 +2864,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -2914,7 +2914,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2928,7 +2928,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -2978,7 +2978,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -2992,7 +2992,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3042,7 +3042,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3056,7 +3056,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3106,7 +3106,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3120,7 +3120,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3170,7 +3170,7 @@ queries:
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `allowPrivilegeEscalation: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3184,7 +3184,7 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Ensure `allowPrivilegeEscalation` is set to `false` or not present in the `securityContext`:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3233,6 +3233,38 @@ queries:
         - Compliance with security best practices and organizational policies may be compromised.
 
         By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+      audit: |
+        A DaemonSet container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true`. The following manifest shows the violating configuration:
+
+        ```yaml
+        ---
+        apiVersion: apps/v1
+        kind: DaemonSet
+        spec:
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: true
+        ```
+      remediation: |
+        Set `allowPrivilegeEscalation` to `false` in every container's `securityContext`, or remove the field so it defaults to `false`. The following DaemonSet manifest applies the safe configuration:
+
+        ```yaml
+        ---
+        apiVersion: apps/v1
+        kind: DaemonSet
+        spec:
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: false
+        ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
         title: Configure a Security Context for a Pod or Container
@@ -3271,7 +3303,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3285,7 +3317,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3297,7 +3329,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3347,7 +3379,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3361,7 +3393,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3373,7 +3405,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3423,7 +3455,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3437,7 +3469,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3449,7 +3481,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3499,7 +3531,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3513,7 +3545,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3525,7 +3557,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3575,7 +3607,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3589,7 +3621,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3601,7 +3633,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3651,7 +3683,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3665,7 +3697,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3677,7 +3709,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3727,7 +3759,7 @@ queries:
 
         By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
       audit: |
-        Check for the existence of `privileged: true` setting in the `securityContext`:
+        A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -3741,7 +3773,7 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from the container spec:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -3753,7 +3785,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
 
-        Or explicitly set `privileged` to `false`:
+        Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
@@ -3804,7 +3836,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3818,7 +3850,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3868,7 +3900,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3882,7 +3914,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3932,7 +3964,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3946,7 +3978,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -3996,7 +4028,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4010,7 +4042,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4060,7 +4092,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4074,7 +4106,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4124,7 +4156,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4138,7 +4170,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4188,7 +4220,7 @@ queries:
 
         By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `readOnlyRootFilesystem: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4202,7 +4234,7 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Ensure `readOnlyRootFilesystem` is set to `true` in the `securityContext`:
+        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4260,7 +4292,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4274,7 +4306,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4288,7 +4320,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4302,7 +4334,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4357,7 +4389,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4371,7 +4403,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4385,7 +4417,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4399,7 +4431,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4453,7 +4485,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4467,7 +4499,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4481,7 +4513,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4495,7 +4527,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4549,7 +4581,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4563,7 +4595,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4577,7 +4609,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4591,7 +4623,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4646,7 +4678,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4660,7 +4692,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4674,7 +4706,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4688,7 +4720,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4742,7 +4774,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4756,7 +4788,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4770,7 +4802,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4784,7 +4816,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4838,7 +4870,7 @@ queries:
 
         By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
       audit: |
-        Check for the existence of `runAsNonRoot: true` setting in the `securityContext`:
+        Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4852,7 +4884,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4866,7 +4898,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `runAsNonRoot` is set to `true` in the `securityContext`:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -4880,7 +4912,7 @@ queries:
                 runAsNonRoot: true
         ```
 
-        It is also possible to set it for all containers at the Pod level:
+        The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
@@ -4929,7 +4961,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -4942,7 +4974,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -4990,7 +5022,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5003,7 +5035,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5051,7 +5083,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5064,7 +5096,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5112,7 +5144,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5125,7 +5157,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5173,7 +5205,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5186,7 +5218,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5235,7 +5267,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5248,7 +5280,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5297,7 +5329,7 @@ queries:
 
         By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostNetwork: true` setting in `spec`:
+        A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
@@ -5310,7 +5342,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostNetwork` is set to `false` or not present in `spec`:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         ---
@@ -5358,7 +5390,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5370,7 +5402,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5417,7 +5449,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5429,7 +5461,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5476,7 +5508,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5488,7 +5520,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5535,7 +5567,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5547,7 +5579,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5594,7 +5626,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5606,7 +5638,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5653,7 +5685,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5665,7 +5697,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5713,7 +5745,7 @@ queries:
 
         By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostPID: true` setting in `spec`:
+        A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5725,7 +5757,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostPID` is set to `false` or not present in `spec`:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5773,7 +5805,7 @@ queries:
 
         By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5785,7 +5817,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5833,7 +5865,7 @@ queries:
 
         By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5845,7 +5877,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5893,7 +5925,7 @@ queries:
 
         By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5905,7 +5937,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5941,7 +5973,7 @@ queries:
       desc: |
         Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -5953,7 +5985,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -5990,7 +6022,7 @@ queries:
       desc: |
         Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -6002,7 +6034,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -6039,7 +6071,7 @@ queries:
       desc: |
         Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -6051,7 +6083,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -6088,7 +6120,7 @@ queries:
       desc: |
         Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
       audit: |
-        Check for the existence of `hostIPC: true` setting in `spec`:
+        A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
         apiVersion: v1
@@ -6100,7 +6132,7 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Ensure `hostIPC` is set to `false` or not present in `spec`:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
 
         ```yaml
         apiVersion: v1
@@ -6782,7 +6814,7 @@ queries:
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
         Avoid using rolling tags like `latest` or `master` as they can change over time.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6795,7 +6827,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6845,7 +6877,7 @@ queries:
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
         Avoid using rolling tags like `latest` or `master` as they can change over time.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6858,7 +6890,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6908,7 +6940,7 @@ queries:
         It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
         Avoid using rolling tags like `latest` or `master` as they can change over time.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6921,7 +6953,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6981,7 +7013,7 @@ queries:
 
         By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -6994,7 +7026,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7054,7 +7086,7 @@ queries:
 
         By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7067,7 +7099,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7127,7 +7159,7 @@ queries:
 
         By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7140,7 +7172,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7200,7 +7232,7 @@ queries:
 
         By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
       audit: |
-        Check for the existence of `imagePullPolicy: Always` and ensure `image` uses either a tag or a digest (SHA):
+        Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7213,7 +7245,7 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Ensure `imagePullPolicy` is set to `Always` and ensure `image` uses either a tag or a digest (SHA):
+        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7263,7 +7295,7 @@ queries:
 
         By ensuring that pods define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7278,7 +7310,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7330,7 +7362,7 @@ queries:
 
         By ensuring that CronJobs define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7345,7 +7377,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7397,7 +7429,7 @@ queries:
 
         By ensuring that StatefulSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7412,7 +7444,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7464,7 +7496,7 @@ queries:
 
         By ensuring that Deployments define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7479,7 +7511,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7531,7 +7563,7 @@ queries:
 
         By ensuring that Jobs define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7546,7 +7578,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7598,7 +7630,7 @@ queries:
 
         By ensuring that ReplicaSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7613,7 +7645,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7665,7 +7697,7 @@ queries:
 
         By ensuring that DaemonSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of CPU resources in `limits`:
+        Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7680,7 +7712,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Define the required resources for CPU `limits` in the manifest:
+        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7732,7 +7764,7 @@ queries:
 
         By ensuring that pods define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7747,7 +7779,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7790,7 +7822,7 @@ queries:
       desc: |
         Kubernetes pod configurations should set memory limits for containers defined in the manifest. This prevents the pod from exhausting the host's resources in case of an application malfunction or an attack.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7805,7 +7837,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7859,7 +7891,7 @@ queries:
 
         By ensuring that StatefulSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7874,7 +7906,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7928,7 +7960,7 @@ queries:
 
         By ensuring that Deployments define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7943,7 +7975,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -7997,7 +8029,7 @@ queries:
 
         By ensuring that Jobs define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8012,7 +8044,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8066,7 +8098,7 @@ queries:
 
         By ensuring that ReplicaSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8081,7 +8113,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8135,7 +8167,7 @@ queries:
 
         By ensuring that DaemonSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
       audit: |
-        Check for the existence of memory resources in `limits`:
+        Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8150,7 +8182,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Define the required resources for memory `limits` in the manifest:
+        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -1845,17 +1845,17 @@ queries:
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        Allowing containers to access the Docker socket can lead to significant security risks:
 
         - Containers can create or control other containers on the host, potentially escalating privileges.
         - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
         - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
         A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2307,17 +2307,17 @@ queries:
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Allowing containers to access the containerd socket can lead to significant security risks:
 
         - Containers can create or control other containers on the host, potentially escalating privileges.
         - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
         - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
         A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -134,3 +134,34 @@ queries:
         Optimizing system resources: By monitoring memory usage, you can identify which programs or processes are using the most memory and make decisions about how to allocate system resources. For example, you might decide to close a memory-intensive program to free up memory for other programs that you're currently using.
 
         Overall, monitoring memory usage is important for maintaining system performance, avoiding crashes and freezes, identifying memory leaks, and optimizing system resources.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Identify the processes consuming the most memory:
+
+            ```bash
+            ps -eo pid,user,%mem,%cpu,rss,command --sort=-%mem | head -20
+            ```
+
+            Inspect memory and swap usage at a glance:
+
+            ```bash
+            free -h
+            ```
+
+            Free up memory by addressing the largest consumers:
+
+            ```bash
+            # Restart a memory-leaking service to release retained memory
+            systemctl restart <service-name>
+
+            # Drop cached pages, dentries, and inodes (kernel will repopulate as needed)
+            sync && echo 3 > /proc/sys/vm/drop_caches
+
+            # Stop or remove non-essential workloads pinning memory
+            systemctl stop <service-name>
+            ```
+
+            For persistent pressure, right-size the workload. Tune service memory limits with `MemoryHigh=` and `MemoryMax=` in systemd unit files, add swap, or scale the host's RAM.


### PR DESCRIPTION
## Summary

- Add audit and remediation blocks to two checks that were missing them:
  - `mondoo-kubernetes-security-daemonset-allowprivilegeescalation` — adds matching `audit` and `remediation` examples in line with the existing replicaset/deployment variants.
  - `linux-operational-policy-memory-usage` — adds a CLI remediation (process inspection, cache drop, service-limit tuning) mirroring the existing `linux-operational-policy-disk-usage` structure.
- Rewrite ~165 fragment-style audit/remediation introductions across `mondoo-kubernetes-security.mql.yaml` as complete sentences. The old prose like `Check for the existence of \`hostPath.path: /var/run/docker.sock\` setting in the \`volumes\`:` becomes `A pod \`volumes\` list that mounts \`/var/run/docker.sock\` as a \`hostPath\` triggers this check, as shown in the manifest below:`, and similarly for the matching remediation prose across the docker.sock, containerd.sock, crio.sock, allowPrivilegeEscalation, privileged, readOnlyRootFilesystem, runAsNonRoot, hostNetwork, hostPID, hostIPC, imagePullPolicy, CPU-limit, and memory-limit checks.

## Test plan

- [x] `cnspec policy lint content/mondoo-kubernetes-security.mql.yaml content/mondoo-linux-operational-policy.mql.yaml` → valid policy bundle(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)