### PR TITLE
:bug: Tolerate `desc: |-` and multi-fence configs in terraform remediation validator

### DIFF
--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -110,7 +110,7 @@ def extract_hcl_blocks(content: str, filepath: Path) -> list[HclBlock]:
         return result
 
     pattern = re.compile(
-        r"- id: terraform\s*\n\s+desc: \|\s*\n(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
+        r"- id: terraform\s*\n\s+desc: \|-?\s*\n(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
         re.DOTALL,
     )
     blocks = []
@@ -120,14 +120,25 @@ def extract_hcl_blocks(content: str, filepath: Path) -> list[HclBlock]:
         tf_line = content[: match.start()].count("\n") + 1
         uid = find_uid_for_line(tf_line)
 
+        # A single terraform remediation desc may split one logical config
+        # across multiple ```hcl``` fences interleaved with prose. Concatenate
+        # them so tflint sees the complete configuration, not fragments where
+        # a `data` source in one fence appears "unused" in isolation.
+        fences = []
+        first_line = None
         for fence in re.finditer(r"```hcl\s*\n(.*?)```", desc_block, re.DOTALL):
             block = fence.group(1).strip()
-            if block:
+            if not block:
+                continue
+            if first_line is None:
                 code_offset = desc_start + fence.start(1)
-                line_number = content[:code_offset].count("\n") + 1
-                blocks.append(HclBlock(
-                    code=block, line=line_number, uid=uid, file=filepath,
-                ))
+                first_line = content[:code_offset].count("\n") + 1
+            fences.append(block)
+
+        if fences:
+            blocks.append(HclBlock(
+                code="\n\n".join(fences), line=first_line, uid=uid, file=filepath,
+            ))
     return blocks
 
 


### PR DESCRIPTION
## Summary
Two robustness fixes to `content/validation/validate_terraform_remediation.py`:

1. **Regex tolerates both `desc: |` and `desc: |-`.** Today the regex only matches the literal block scalar (`desc: |`). YAML `desc: |-` (strip-trailing-newlines) is equally valid and is used in downstream repos that vendor this validator (e.g. `cnspec-enterprise-policies`, where ~85% of terraform remediation blocks were being silently skipped). Adding `-?` accepts both. cnspec content uses `desc: |` exclusively today, so this is preventive.

2. **Concatenate multi-fence terraform descs before lint.** Authors sometimes split one logical Terraform config across multiple ```hcl``` fences interleaved with explanatory prose. Validating each fence standalone produces false-positive `terraform_unused_declarations` errors when a `data` source defined in one fence is consumed in a sibling fence. There are **25** such multi-fence descs in current content — they pass standalone today, but the change protects against the failure mode going forward.

## Validation
```
$ python3 content/validation/validate_terraform_remediation.py
939 passed, 0 failed
```

## Test plan
- [ ] CI: `validate-terraform` job passes
- [ ] Run locally on a representative target (`python3 content/validation/validate_terraform_remediation.py aws`) — should still report 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)