### PR TITLE
:sparkles: Add Mondoo Shodan Security policy

### DIFF
--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -1,0 +1,109 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-shodan
+    name: Mondoo Shodan Security
+    version: 1.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: shodan,saas
+    require:
+      - provider: shodan
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    docs:
+      desc: |-
+        The Mondoo Shodan Security policy provides security guidelines for hosts, networks, and IP addresses that are scanned by Shodan, a search engine for internet-connected devices. It confirms Shodan membership status and checks Shodan findings for vulnerabilities and open ports.
+
+        ## Join the community!
+
+        Our goal is to build policies that are simple to deploy, accurate, and actionable.
+
+        If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+    groups:
+      - title: IP address checks
+        filters: asset.platform == "shodan-host"
+        checks:
+          - uid: mondoo-shodan-no-port
+          - uid: mondoo-shodan-vulnerabilities
+      - title: Shodan organization checks
+        filters: asset.platform == "shodan-org"
+        checks:
+          - uid: mondoo-shodan-membership
+    scoring_system: average
+queries:
+  - uid: mondoo-shodan-membership
+    title: Verify Shodan membership
+    impact: 50
+    filters: asset.platform == "shodan-org"
+    mql: shodan.profile.member == true
+    docs:
+      desc: |
+        This check verifies the status and integrity of an organization's or individual's Shodan membership.
+
+        ## Rationale
+
+        The Shodan search engine offers different membership tiers that grant varying levels of access to its features and data. Ensuring that the Shodan membership is active, properly configured, and aligned with the organization's requirements helps maintain access to critical security insights and ensures the effective use of Shodan's capabilities.
+      remediation: |
+        Verify and maintain your organization's Shodan membership:
+
+        1. Log in to your Shodan account at [shodan.io](https://www.shodan.io/).
+        2. Navigate to your account settings and verify that your membership is active.
+        3. Confirm that the membership tier provides the features your organization requires (e.g., API access, scanning credits, network monitoring).
+        4. If the membership has expired, renew it through the Shodan billing portal.
+        5. If no membership exists, purchase an appropriate plan based on your organization's security monitoring needs.
+    refs:
+      - url: https://www.shodan.io/
+        title: Shodan
+  - uid: mondoo-shodan-no-port
+    title: Ensure no ports are open
+    impact: 80
+    filters: |
+      asset.platform == "shodan-host" &&
+      shodan.host.ip == regex.ipv4
+    mql: shodan.host.ports == empty
+    docs:
+      desc: |
+        This check ensures that all network ports on a specified system or device are securely closed, as identified by Shodan.
+
+        ## Rationale
+
+        Open network ports can expose systems to unauthorized access and potential vulnerabilities. By ensuring that no ports are open, the system enhances its security posture against external threats, reducing the risk of malicious activities such as hacking, data breaches, and unauthorized data transfers.
+      remediation: |
+        Review the open ports identified by Shodan and close any that are not required for the system's operation:
+
+        1. Identify the services running on each open port.
+        2. Disable unnecessary services and close their corresponding ports using firewall rules.
+        3. For required services, ensure they are properly secured with authentication, encryption, and access controls.
+        4. Re-scan the host to verify that the ports have been closed.
+    refs:
+      - url: https://www.shodan.io/
+        title: Shodan
+  - uid: mondoo-shodan-vulnerabilities
+    title: Ensure no vulnerabilities are detected
+    impact: 90
+    filters: |
+      asset.platform == "shodan-host" &&
+      shodan.host.ip == regex.ipv4
+    mql: shodan.host.vulnerabilities == empty
+    docs:
+      desc: |
+        This check ensures that no vulnerabilities are detected on a specified system or device, as identified by Shodan.
+
+        ## Rationale
+
+        Vulnerabilities in systems or devices can be exploited by attackers to gain unauthorized access, disrupt operations, or steal sensitive data. By ensuring that no vulnerabilities are detected, the system enhances its security posture, reducing the risk of exploitation and improving resilience against potential threats.
+      remediation: |
+        Review the vulnerabilities identified by Shodan and remediate them:
+
+        1. Cross-reference the detected CVEs with vendor advisories and the National Vulnerability Database (NVD).
+        2. Apply available patches and updates to affected services.
+        3. If patches are not available, implement compensating controls such as network segmentation or Web Application Firewalls (WAFs).
+        4. Re-scan the host to verify that the vulnerabilities have been addressed.
+    refs:
+      - url: https://www.shodan.io/
+        title: Shodan
+      - url: https://nvd.nist.gov/
+        title: National Vulnerability Database (NVD)

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -87,7 +87,7 @@ queries:
     filters: |
       asset.platform == "shodan-host" &&
       shodan.host.ip == regex.ipv4
-    mql: shodan.host.vulnerabilities == empty
+    mql: shodan.host.vulns == empty
     docs:
       desc: |
         This check ensures that no vulnerabilities are detected on a specified system or device, as identified by Shodan.


### PR DESCRIPTION
## Summary

Adds the **Mondoo Shodan Security** policy (`content/mondoo-shodan.mql.yaml`), which assesses hosts, networks, and IP addresses scanned by [Shodan](https://www.shodan.io/), the search engine for internet-connected devices.

The policy includes:

- **IP address checks** (`shodan-host`): no open ports, no known vulnerabilities.
- **Shodan organization checks** (`shodan-org`): verifies active Shodan membership.

## Test plan

- [ ] `cnspec policy lint content/mondoo-shodan.mql.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)