### PR TITLE
:sparkles: Add VMware vSphere security policies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -30,8 +30,8 @@ apachectl
 apigatewayv
 apikey
 apim
-appconfig
 apparmor
+appconfig
 appdata
 appdb
 appengine
@@ -52,6 +52,7 @@ authsettings
 autobackup
 autoclean
 autoconfiguration
+autologon
 autoremove
 autorepair
 autoscalers
@@ -112,6 +113,8 @@ chargen
 chatgpt
 cheatsheet
 checkend
+chkconfig
+CIMSLP
 cimv
 claude
 click
@@ -172,10 +175,12 @@ datafactory
 datalakes
 datasize
 datasource
+datastorename
 datastream
 DBfor
 DBRS
 dccp
+dcui
 ddos
 deactivateduser
 deanonymize
@@ -193,6 +198,7 @@ diffie
 directoryservice
 dlp
 dlq
+dnd
 DNSKEY
 docdb
 dpd
@@ -203,6 +209,8 @@ dsse
 dstaddr
 dumpable
 dumpdev
+DVersion
+dvfilter
 Eacces
 EBSKMS
 ecdhe
@@ -293,19 +301,23 @@ groupname
 grouppolicy
 grundschutz
 GTK
+guestlib
 gunicorn
+Hba
 hbdev
 hcloud
 HDFS
 healthreporting
 Helpdesk
 hetzner
+hgfs
 Hostbased
 hostpath
 hotlink
 hpa
 hsts
 hstspreload
+HVCI
 hvm
 hwaddr
 Iaa
@@ -362,6 +374,7 @@ KVM
 langen
 lastday
 lastlog
+launchmenu
 ldisc
 letsencrypt
 linuxkit
@@ -492,6 +505,7 @@ pagerduty
 paloaltonetworks
 panos
 partlabel
+Passthru
 pbs
 pcidss
 PCo
@@ -508,6 +522,7 @@ pmd
 pmf
 PMTU
 poap
+portgroup
 posix
 postgre
 pricings
@@ -515,6 +530,7 @@ privateca
 privkey
 privs
 PROJECTID
+protocolhandler
 proxmox
 psc
 psql
@@ -608,6 +624,7 @@ siem
 Signin
 sigv
 skype
+slp
 sntrup
 socketfilterfw
 softwareupdate
@@ -641,6 +658,7 @@ supermaven
 switchports
 syncookies
 SYSADMIN
+systemlogs
 tabnine
 tacacs
 tailnets
@@ -662,6 +680,7 @@ tmsh
 TNS
 totp
 trae
+trayicon
 TSecurity
 tsuki
 tvm
@@ -671,6 +690,7 @@ uem
 umac
 Unauth
 unauthorizedapicalls
+unbootable
 UNDROP
 unicodedata
 unifi
@@ -678,6 +698,7 @@ uniformbucketlevelaccess
 unlinkat
 uploaders
 upnp
+usb
 userdel
 userlist
 userns
@@ -697,7 +718,9 @@ Virtualisation
 vlans
 vllm
 vmbr
+vmdk
 vmid
+vmx
 vnc
 vnet
 vnic
@@ -719,9 +742,9 @@ WIFI
 winget
 winhttp
 winnuke
-wlans
 WITHECDSA
 WITHRSA
+wlans
 workdir
 workspacesweb
 wpa

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -1,0 +1,885 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline
+    name: Mondoo VMware vSphere ESXi Security
+    version: 2.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: vmware,vmware-esxi
+    require:
+      - provider: vsphere
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    docs:
+      desc: |-
+        The Mondoo VMware vSphere ESXi Security policy provides security guidelines for VMware ESXi hosts. It covers installation, communication, logging, access control, console, storage, and network configurations to ensure ESXi hosts are hardened against unauthorized access and misconfiguration.
+
+        ## Join the community!
+
+        Our goal is to build policies that are simple to deploy, accurate, and actionable.
+
+        If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+    groups:
+      - title: Install
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-default-value-of-individual-salt-per-vm-is-configured
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-image-profile-vib-acceptance-level-is-configured-properly
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-uefi-secure-boot-is-enabled-on-the-esxi-host
+      - title: Communication
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dns-is-statically-configured-on-the-esxi-host
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-slp-service-is-disabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled
+      - title: Logging
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-persistent-logging-is-configured-for-all-esxi-hosts
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-remote-logging-is-configured-for-esxi-hosts
+      - title: Access
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-account-lockout-is-set-to-15-minutes
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-maximum-failed-login-attempts-is-set-to-5
+      - title: Console
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ssh-is-disabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-shell-services-timeout-is-set-to-1-hour-or-less
+      - title: Storage
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
+      - title: vNetwork
+        filters: |
+          asset.platform == "vmware-esxi"
+        checks:
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject
+          - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-account-lockout-is-set-to-15-minutes
+    title: Ensure account lockout is set to 15 minutes
+    impact: 80
+    mql: |
+      vsphere.host.advancedSettings['Security.AccountUnlockTime'] == 900
+    docs:
+      desc: An account is automatically locked after the maximum number of failed consecutive login attempts is reached. The account should be automatically unlocked after 15 minutes, otherwise administrators will need to manually unlock accounts on request by authorized users.
+      remediation: |-
+        To set the account lockout to 15 minutes, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `System`.
+        3. Select `Advanced System Settings` then select `Edit`.
+        4. Enter `Security.AccountUnlockTime` in the filter.
+        5. Set the value for this parameter to `900`.
+
+        Alternately, use the following PowerCLI command:
+
+        ```powershell
+        Get-VMHost | Get-AdvancedSetting -Name Security.AccountUnlockTime | Set-AdvancedSetting -Value 900
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
+    title: Ensure all loaded ESXi kernel modules are signed
+    impact: 80
+    mql: |
+      vsphere.host.kernelModules.where( loaded == true ).all( signedStatus != "Unsigned" )
+    docs:
+      desc: |-
+        The VMkernel loads kernel modules (device drivers and other low-level components) to operate the ESXi host. A signed module carries a cryptographic signature that establishes its origin and integrity. An unsigned module has not been verified and may indicate tampering or the presence of untrusted third-party software.
+
+        Loading only signed kernel modules ensures the integrity of the hypervisor and is a prerequisite for a meaningful UEFI Secure Boot configuration.
+      remediation: |-
+        Identify unsigned modules on the host, then replace or remove them:
+
+        1. Connect to the ESXi host via SSH.
+        2. List loaded modules and their signed status:
+
+           ```bash
+           esxcli system module list
+           esxcli system module get --module=<module-name>
+           ```
+
+        3. For any module reporting `Signed Status: Unsigned`, remove the associated VIB or replace it with a signed version from the vendor.
+        4. Reboot the host so the updated module set is loaded.
+
+        Configure the host image profile acceptance level so that unsigned VIBs cannot be installed in the first place. See "Ensure the Image Profile VIB acceptance level is configured properly".
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
+    title: Ensure bidirectional CHAP authentication for iSCSI traffic is enabled
+    impact: 80
+    mql: |
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthEnabled'] == true )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthenticationType'] == 'chapPreferred' )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapName'] != empty )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapSecret'] != empty )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['mutualChapAuthenticationType'] == 'chapPreferred' )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['mutualChapName'] != empty )
+      vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['mutualChapSecret'] != empty )
+    docs:
+      desc: vSphere allows for the use of bidirectional authentication of both the iSCSI target and host. Bidirectional Challenge-Handshake Authentication Protocol (CHAP), also known as Mutual CHAP, should be enabled to provide bidirectional authentication.
+      remediation: |-
+        To enable bidirectional CHAP authentication for iSCSI traffic, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `Storage`.
+        3. Select `Storage Adapters` then select the iSCSI Adapter.
+        4. Under `Properties` select `Edit` next to `Authentication`.
+        5. Next to `Authentication Method` select `Use bidirectional CHAP` from the dropdown.
+        6. Specify the outgoing CHAP name.
+
+        - Make sure that the name you specify matches the name configured on the storage side.
+            - To set the CHAP name to the iSCSI adapter name, select "Use initiator name".
+            - To set the CHAP name to anything other than the iSCSI initiator name, deselect "Use initiator name" and type a name in the Name text box.
+
+        1. Enter an outgoing CHAP secret to be used as part of authentication. Use the same secret as your storage side secret.
+        2. Specify incoming CHAP credentials. Make sure your outgoing and incoming secrets do not match.
+        3. Select `OK`.
+        4. Select the second to last symbol labeled `Rescan Adapter`.
+
+        Alternately, run the following PowerCLI command to set the Chap settings for the iSCSI Adapter:
+
+        ```powershell
+        Get-VMHost | Get-VMHostHba | Where {$_.Type -eq "Iscsi"} | Set-VMHostHba # Use desired parameters here
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dns-is-statically-configured-on-the-esxi-host
+    title: Ensure DNS is statically configured on the ESXi host
+    impact: 60
+    mql: |
+      vsphere.host.dnsConfig.dhcp == false
+      vsphere.host.dnsConfig.servers != empty
+    docs:
+      desc: |-
+        ESXi hosts rely on DNS to resolve the names of vCenter Server, NTP servers, syslog targets, and other infrastructure services. When DNS settings are obtained from DHCP, an attacker who can influence DHCP responses can redirect name resolution and intercept or disrupt management traffic.
+
+        Management interfaces should use statically configured, trusted DNS servers rather than DHCP-supplied values.
+      remediation: |-
+        To configure static DNS, perform the following from the vSphere Web Client:
+
+        1. Select the host.
+        2. Select `Configure`, then expand `Networking` and select `TCP/IP configuration`.
+        3. Select the `Default` TCP/IP stack, then select `Edit`.
+        4. Select `DNS configuration` and choose `Enter settings manually`.
+        5. Provide the trusted DNS server addresses and search domains.
+        6. Select `OK`.
+
+        Alternately, use the following ESXi shell commands:
+
+        ```bash
+        esxcli network ip dns server add --server=<dns-ip>
+        esxcli network ip interface ipv4 set --interface-name=vmk0 --type=static
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
+    title: Ensure dvfilter API is not configured if not used
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['Net.DVFilterBindIpAddress'] == empty
+    docs:
+      desc: The dvfilter network API is used by some products (e.g., VMSafe). If it is not in use, it should not be configured to send network information to a VM.
+      remediation: |-
+        To remove the configuration for the dvfilter network API, perform the following from the vSphere web client:
+
+        1. From the vSphere web client, select the host and select `Configure` then expand `System`
+        2. Select `Advanced System Settings` then `Edit`.
+        3. Search for `Net.DVFilterBindIpAddress` in the filter.
+        4. Set `Net.DVFilterBindIpAddress` has an empty value.
+        5. If an appliance is being used, make sure the value of this parameter is set to the proper IP address.
+        6. Enter the proper IP address.
+        7. Select `OK`.
+
+        Alternatively, run the following PowerCLI command to set Net.DVFilterBindIpAddress to null on all hosts:
+
+        ```powershell
+        Get-VMHost HOST1 | Foreach { Set-AdvancedSetting -VMHost $_ -Name Net.DVFilterBindIpAddress -IPValue "" }
+        ```
+
+        **Impact:**
+
+        This will prevent a dvfilter-based network security appliance such as a firewall from functioning if not configured correctly.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
+    title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] <= 300
+      vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] != 0
+    docs:
+      desc: |-
+        The `ESXiShellInteractiveTimeOut`
+        allows you to automatically terminate idle ESXi shell and SSH sessions. The permitted idle time should be 300 seconds or less.
+      remediation: |-
+        To set the timeout to the desired value, perform the following from the vSphere web client:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `System`.
+        3. Select `Advanced System Settings` then select `Edit`.
+        4. Enter `ESXiShellInteractiveTimeOut` in the filter.
+        5. Set the value for this parameter is set to the appropriate value ( `300` seconds or less).
+        6. Select `OK`.
+
+        **Note:**
+        A value of 0 disables the ESXi ShellInteractiveTimeOut.
+
+        Alternately, use the following PowerCLI command to set Remove UserVars.ESXiShellInteractiveTimeOut to 300 on all hosts
+
+        ```powershell
+        Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellInteractiveTimeOut' | Set-AdvancedSetting -Value "300"
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
+    title: Ensure Managed Object Browser (MOB) is disabled
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['Config.HostAgent.plugins.solo.enableMob'] == false
+    docs:
+      desc: The Managed Object Browser (MOB) is a web-based server application that lets you examine objects that exist on the server side, explore the object model used by the VM kernel to manage the host, and change configurations. It is installed and started automatically when vCenter is installed.
+      remediation: |-
+        To disable MOB, perform the following from the vSphere Web Client:
+
+        1. Select a host
+        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+        3. Select `Edit` then search for `Config.HostAgent.plugins.solo.enableMob`
+        4. Set the value to `false`.
+        5. Select `OK`.
+
+        **Note:**
+        You cannot disable the MOB while a host is in lockdown mode.
+
+        **Note 2:**
+        You must disable MOB from the vSphere interface, not via the `vim-cmd` command.
+
+        **Impact:**
+
+        Some third-party tools may utilize the Managed Object Browser (MOB). Disabling MOB may cause those tools to malfunction.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
+    title: Ensure Normal Lockdown mode is enabled
+    impact: 80
+    mql: |
+      vsphere.host.properties['config']['lockdownMode'] == "lockdownNormal"
+    docs:
+      desc: |-
+        Enabling lockdown mode disables direct local access to an ESXi host, requiring the host to be managed remotely from vCenter Server.
+
+        There are some operations, such as backup and troubleshooting, that require direct access to the host. In these cases, lockdown mode can be disabled on a temporary basis for specific hosts as needed and then re-enabled when the task is completed.
+
+        Note: Lockdown mode does not apply to users who log in using authorized keys. Also, users in the DCUI. Access lists for each host can override lockdown mode and log in to the DCUI. By default, the "root" user is the only user listed in the DCUI. Access list.
+      remediation: |-
+        To enable lockdown mode, perform the following from the vSphere web client:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `System` and select `Security Profile`.
+        3. Across from `Lockdown Mode` select `Edit`.
+        4. Select the radio button for `Normal`.
+        5. Select `OK`.
+
+        Alternately, run the following PowerCLI command to enable lockdown mode for each host:
+
+        ```powershell
+        Get-VMHost | Foreach { $_.EnterLockdownMode() }
+        ```
+
+        **Impact:**
+
+        With lockdown mode enabled the host will only be accessible through vCenter preventing 'local' access.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
+    title: Ensure NTP time synchronization is configured properly
+    impact: 60
+    mql: |
+      vsphere.host.services.where( key == "ntpd").all( running == true )
+      vsphere.host.services.where( key == "ntpd").all( policy == "on" )
+    docs:
+      desc: Network Time Protocol (NTP) synchronization should be configured correctly and enabled on each VMware ESXi host to ensure accurate time for system event logs. The time sources used by the ESXi hosts should be in sync with an agreed-upon time standard such as Coordinated Universal Time (UTC). There should be at minimum two NTP sources in place, and they should sync whenever possible.
+      remediation: |-
+        To enable and properly configure NTP synchronization, perform the following from the vSphere web client:
+
+        1. Select a host
+        2. Select `Configure` then expand `System` then select `Time Configuration`.
+        3. Select `Edit` next to Network Time Protocol
+        4. Select the `Enable` box, then fill in the appropriate NTP Servers.
+        5. in the `NTP Service Startup Policy` drop down select `Start and stop with host`.
+        6. Select `OK`.
+
+        To implement the recommended configuration state, run the following PowerCLI command:
+
+        ```
+        Set the NTP Settings for all hosts
+        If an internal NTP server is used, replace pool.ntp.org with
+        the IP address or the Fully Qualified Domain Name (FQDN) of the internal NTP server
+        $NTPServers = "pool.ntp.org", "pool2.ntp.org"
+        Get-VMHost | Add-VmHostNtpServer $NTPServers
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-persistent-logging-is-configured-for-all-esxi-hosts
+    title: Ensure persistent logging is configured for all ESXi hosts
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['Syslog.global.logDir'] != ""
+      vsphere.host.advancedSettings['Syslog.global.logDir'] != /scratch/
+    docs:
+      desc: |-
+        ESXi can be configured to store log files on an in-memory file system. This occurs when the host's `Syslog.global.LogDir`
+        property is set to a non-persistent location, such as `/scratch.`
+        When this is done, only a single day's worth of logs are stored at any time. Additionally, log files will be reinitialized upon each reboot.
+      remediation: |-
+        To configure persistent logging properly, perform the following from the vSphere web client:
+
+        1. Select the host
+        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+        3. Select `Edit` then enter `Syslog.global.LogDir` in the filter.
+        4. Set `Syslog.global.logDir` to a persistent location specified as [datastorename] path\_to\_file where the path is relative to the datastore. For example, [datastore1] /systemlogs.
+        5. Select `OK`.
+
+        Alternatively, run the following PowerCLI command:
+
+        ```
+        Set Syslog.global.logDir for each host
+        Get-VMHost | Foreach { Set-AdvancedConfiguration -VMHost $_ -Name Syslog.global.logDir -Value "<NewLocation>" }
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan
+    title: Ensure port groups are not configured to the value of the native VLAN
+    impact: 60
+    mql: |
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] >= 2 )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] <= 4094 )
+    docs:
+      desc: ESXi does not use the concept of native VLAN, so do not configure port groups to use the native VLAN ID. If the default value of 1 for the native VLAN is being used, the ESXi Server virtual switch port groups should be configured with any value between 2 and 4094. Otherwise, ensure that the port group is not configured to use whatever value is set for the native VLAN.
+      remediation: |-
+        To stop using the native VLAN ID for port groups, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `Networking`.
+        3. Select `Virtual switches`.
+        4. Expand the Standard vSwitch.
+        5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
+        6. For each port group on the vSwitch, verify and record the VLAN IDs used.
+        7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
+        8. Select the `Edit settings` option.
+        9. In the Properties section, enter an appropriate name in the `Network label` field.
+        10. In the `VLAN ID` dropdown select or type a new VLAN.
+        11. Select `OK`.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-
+    title: Ensure port groups are not configured to VLAN 4095 and 0 except for Virtual Guest Tagging (VGT)
+    impact: 60
+    mql: |
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 0 )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 4095 )
+    docs:
+      desc: Port groups should not be configured to VLAN 4095 or 0 except for Virtual Guest Tagging (VGT). When a port group is set to VLAN 4095, this activates VGT mode. In this mode, the vSwitch passes all network frames to the guest virtual machine without modifying the VLAN tags, leaving it up to the guest to deal with them. VLAN 4095 should be used only if the guest has been specifically configured to manage VLAN tags itself.
+      remediation: |-
+        To set port groups to values other than 4095 and 0 unless VGT is required, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `Networking`.
+        3. Select `Virtual switches`.
+        4. Expand the Standard vSwitch.
+        5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
+        6. For each port group on the vSwitch, verify and record the VLAN IDs used.
+        7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
+        8. Select the `Edit settings` option.
+        9. In the Properties section, enter an appropriate name in the `Network label` field.
+        10. In the `VLAN ID` dropdown select or type a new VLAN.
+        11. Select `OK`.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-remote-logging-is-configured-for-esxi-hosts
+    title: Ensure remote logging is configured for ESXi hosts
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['Syslog.global.logHost'] != ""
+    docs:
+      desc: By default, ESXI logs are stored on a local scratch volume or ramdisk. To preserve logs, also configure remote logging to a central log host for the ESXI hosts.
+      remediation: |-
+        To configure remote logging properly, perform the following from the vSphere web client:
+
+        1. Select the host
+        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+        3. Select `Edit` then enter `Syslog.global.logHost` in the filter.
+        4. Set the `Syslog.global.logHost` to the hostname or IP address of the central log server.
+        5. Select `OK`.
+
+        Alternately, run the following PowerCLI command:
+
+        ```
+        Set Syslog.global.logHost for each host
+        Get-VMHost | Foreach { Set-AdvancedSetting -VMHost $_ -Name Syslog.global.logHost -Value "<NewLocation>" }
+        ```
+
+        **Note:**
+        When setting a remote log host, it is also recommended to set the "Syslog.global.logDirUnique" to true. You must configure the syslog settings for each host.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ssh-is-disabled
+    title: Ensure SSH is disabled
+    impact: 75
+    mql: |
+      vsphere.host.services.where( key == "TSM-SSH").all( running == false )
+      vsphere.host.services.where( key == "TSM-SSH").all( policy == "off" )
+    docs:
+      desc: The ESXi shell, when enabled, can be accessed directly from the host console through the DCUI or remotely using SSH. Disable Secure Shell (SSH) for each ESXi host to prevent remote access to the ESXi shell, and only enable SSH when needed for troubleshooting or diagnostics.
+      remediation: |-
+        To disable SSH, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure` then expand `System` and select `Services`.
+        3. Select `SSH` then select `Edit Startup Policy`.
+        4. Set the Startup Policy is set to `Start and Stop Manually`.
+        5. Select `OK`.
+        6. While `ESXi Shell`is still selected select `Stop`.
+
+        Alternately, use the following PowerCLI command:
+
+        ```
+        Set SSH to start manually rather than automatically for all hosts
+        Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM-SSH" } | Set-VMHostService -Policy Off
+        ```
+
+        **Impact:**
+
+        In troubleshooting and assessment scenarios having SSH disabled, which is the default, may prevent connections to the host by tools or via other methods.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
+    title: Ensure Strict Lockdown mode is enabled
+    impact: 80
+    mql: |
+      vsphere.host.properties['config']['lockdownMode'] == "lockdownStrict"
+    docs:
+      desc: |-
+        Enabling lockdown mode disables direct local access to an ESXi host, requiring the host to be managed remotely from the vCenter Server.
+
+        There are some operations, such as backup and troubleshooting, that require direct access to the host. In these cases, lockdown mode can be disabled on a temporary basis for specific hosts as needed and then re-enabled when the task is completed.
+
+        Note: Lockdown mode does not apply to users who log in using authorized keys. Also, users in the DCUI. Access lists for each host can override lockdown mode and log in to the DCUI. By default, the "root" user is the only user listed in the DCUI. Access list.
+      remediation: |-
+        To enable lockdown mode, perform the following from the vSphere web client:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `System` and select `Security Profile`.
+        3. Across from `Lockdown Mode` select `Edit`.
+        4. Select the radio button for `Strict`.
+        5. Select `OK`.
+
+        Alternately, run the following PowerCLI command:
+
+        ```
+        Enable lockdown mode for each host
+        Get-VMHost | Foreach { $_.EnterLockdownMode() }
+        ```
+
+        **Impact:**
+
+        With lockdown mode enabled, the host will only be accessible through vCenter preventing 'local' access. Disabling the DCUI can create a potential "lockout" situation, should the host become isolated from vCenter Server. Recovering from a "lockout" scenario requires reinstalling ESXi. Consider leaving DCUI enabled, and instead enable lockdown mode and limit the users allowed to access the DCUI using the DCUI. Access list.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
+    title: Ensure the DCUI timeout is set to 600 seconds or less
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] <= 600
+      vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] != 0
+    docs:
+      desc: The Direct Console User Interface (DCUI) is used for directly logging into an ESXi host and carrying out host management tasks. This setting terminates an idle DCUI session after the specified number of seconds has elapsed.
+      remediation: |-
+        To correct the DCUI timeout setting, perform the following steps:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then under `System` select `Advanced System Settings`.
+        3. Select `Edit` then enter `UserVars.DcuiTimeOut` in the filter.
+        4. Change the current value to 600 seconds or less.
+
+        Alternately, use the following PowerCLI command:
+
+        ```
+        Get-VMHost | Get-AdvancedSetting -Name UserVars.DcuiTimeOut | Set-AdvancedSetting -Value 600
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-default-value-of-individual-salt-per-vm-is-configured
+    title: Ensure the default value of individual salt per vm is configured
+    impact: 60
+    mql: vsphere.host.advancedSettings['Mem.ShareForceSalting'] == 2
+    docs:
+      desc: |-
+        The concept of salting has been introduced to help address concerns system administrators may have over the security implications of Transparent Page Sharing, otherwise known as TPS. As per the original TPS implementation, multiple virtual machines could share pages when the contents of the pages were the same. With the new salting settings, the virtual machines can share pages only if the salt value and contents of the pages are identical. A new host config option Mem.ShareForceSalting is introduced to enable or disable salting.
+
+        By default, salting is enabled (Mem.ShareForceSalting=2), and each virtual machine has a different salt. This means page sharing does not occur across the virtual machines (inter-VM TPS) and only happens inside a virtual machine (intra VM).
+      remediation: |-
+        From the vSphere Web Client:
+
+        1. Select a host
+        2. Select `Configure`, then expand `System` and select `Advanced System settings`.
+        3. Select `Edit`, then Filter for `Mem.ShareForceSalting`.
+        4. Set the value to `2`.
+        5. Select `OK`.
+
+        Additionally, the following PowerCLI command can be used:
+
+        ```
+        Get-VMHost | Get-AdvancedSetting -Name Mem.ShareForceSalting | Set-AdvancedSetting -Value 2
+        ```
+
+        **Impact:**
+
+        There is potential for a performance impact with this setting depending on environment and infrastructure details.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
+    title: Ensure the ESXi host firewall is configured to restrict access to services running on the host
+    impact: 60
+    mql: |
+      vsphere.host.services.where( running == true ).all( ruleset != [] )
+      vsphere.host.properties['config']['firewall']['ruleset'].all( _['allowedHosts']['allIp'] == false )
+      vsphere.host.properties['config']['firewall']['ruleset'].all( _['allowedHosts']['ipNetwork'] != null )
+    docs:
+      desc: The ESXi firewall is enabled by default and allows ping (ICMP) and communication with DHCP/DNS clients. Access to services should only be allowed by authorized IP addresses/networks.
+      remediation: |-
+        To properly restrict access to services running on an ESXi host, perform the following from the vSphere web client:
+
+        1. Select a host
+        2. Select `Configure`, then expand `System` and select `Firewall`.
+        3. Select `Edit` to view services which are enabled (indicated by a check).
+        4. For each enabled service, (e.g., ssh, vSphere Web Access, http client) provide a list of allowed IP addresses.
+        5. Select `OK`.
+
+        **Impact:**
+
+        Connections from IP addresses and ranges that are not explicitly set will be denied. Take care to ensure appropriate IPs/IP address ranges are allowed.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
+    title: Ensure the ESXi host SSL certificate is not expired or expiring soon
+    impact: 80
+    mql: |
+      vsphere.host.certificate.notAfter - time.now > 90 * time.day
+    docs:
+      desc: |-
+        Each ESXi host presents an SSL/TLS certificate to secure management connections from vCenter Server and API clients. When this certificate expires, the trust relationship with vCenter breaks: host management can be interrupted, and operators may be tempted into insecure workarounds such as disabling certificate validation.
+
+        This check verifies that the host machine certificate remains valid for at least 90 more days, providing a window to renew it before an outage occurs.
+      remediation: |-
+        To renew or replace an expiring ESXi host certificate, perform the following from the vSphere Web Client:
+
+        1. Select the host.
+        2. Select `Configure`, then expand `System` and select `Certificate`.
+        3. Review the validity period, then select `Renew` to issue a new certificate from the VMware Certificate Authority, or `Import` to install a certificate signed by an enterprise or public CA.
+        4. Confirm the host reconnects to vCenter Server successfully.
+
+        For environments using custom CA-signed certificates, ensure a renewal process is in place well ahead of the expiration date.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+        title: Securing ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
+    title: Ensure the ESXi shell is disabled
+    impact: 75
+    mql: |
+      vsphere.host.services.where( key == "TSM").all( running == false )
+      vsphere.host.services.where( key == "TSM").all( policy == "off" )
+    docs:
+      desc: The ESXi shell is an interactive command line environment available from the Direct Console User Interface (DCUI) or remotely via SSH. The ESXi shell should only be enabled on a host when running diagnostics or troubleshooting.
+      remediation: |-
+        To disable the ESXi shell, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`m then expand `System` and select `Services`.
+        3. Select `ESXi Shell`, then select `Edit Startup Policy`.
+        4. Set the Startup Policy is set to `Start and Stop Manually`.
+        5. Select `OK`.
+
+        Alternately, use the following PowerCLI command:
+
+        ```
+        Set the ESXi shell to start manually rather than automatically for all hosts
+        Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM" } | Set-VMHostService -Policy Off
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-image-profile-vib-acceptance-level-is-configured-properly
+    title: Ensure the Image Profile VIB acceptance level is configured properly
+    impact: 60
+    mql: vsphere.host.acceptanceLevel == /VMwareCertified|VMwareAccepted|PartnerSupported/
+    docs:
+      desc: |-
+        A VIB (vSphere Installation Bundle) is a collection of files that are packaged into an archive. The VIB contains a signature file that is used to verify the level of trust. The ESXi Image Profile supports four VIB acceptance levels:
+
+        1. VMware Certified - VIBs created, tested, and signed by VMware
+        2. VMware Accepted - VIBs created by a VMware partner but tested and signed by VMware
+        3. Partner Supported - VIBs created, tested, and signed by a certified VMware partner
+        4. Community Supported - VIBs that have not been tested by VMware or a VMware partner
+      remediation: |-
+        To verify the host image profile acceptance level, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then under `System` and select `Security Profile`.
+        3. Under `Host Image Profile Acceptance Level` select `Edit`
+        4. In the dropdown select one of the following - `VMware Certified`, `VMware Accepted`, or `Partner Supported`.
+
+        To implement the recommended configuration state, run the following PowerCLI command (in the example code, the level is Partner Supported):
+
+        ```
+        Set the Software AcceptanceLevel for each host<span>
+        Foreach ($VMHost in Get-VMHost ) {
+        $ESXCli = Get-EsxCli -VMHost $VMHost
+        $ESXCli.software.acceptance.Set("PartnerSupported")
+        }
+        ```
+
+        **Impact:**
+
+        Unsigned (Community Supported) VIBs will not be able to be utilized on a host.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-maximum-failed-login-attempts-is-set-to-5
+    title: Ensure the maximum failed login attempts is set to 5
+    impact: 80
+    mql: |
+      vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5
+    docs:
+      desc: Authentication should be configured so there is a maximum number of consecutive failed login attempts for each account, at which point the account at risk will be locked out.
+      remediation: |-
+        To set the maximum failed login attempts correctly, perform the following steps:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `System`.
+        3. Select `Advanced System Settings` then select `Edit`.
+        4. Enter `Security.AccountLockFailures` in the filter.
+        5. Set the value for this parameter to `5`.
+
+        Alternately, use the following PowerCLI command:
+
+        ```powershell
+        Get-VMHost | Get-AdvancedSetting -Name Security.AccountLockFailures | Set-AdvancedSetting -Value 5
+        ```
+
+        **Impact:**
+
+        A users account will be locked after 5 unsuccessful login attempts.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-shell-services-timeout-is-set-to-1-hour-or-less
+    title: Ensure the shell services timeout is set to 1 hour or less
+    impact: 60
+    mql: |
+      vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] <= 3600
+      vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] != 0
+    docs:
+      desc: |-
+        When the ESXi shell or SSH services are enabled on a host, they will run indefinitely. To avoid this, set the `ESXiShellTimeOut`, which defines a window of time after which the ESXi shell and SSH services will automatically be terminated.
+
+        It is recommended to set the `ESXiShellInteractiveTimeOut` together with `ESXiShellTimeOut`.
+      remediation: |-
+        To set the timeout to the desired value, perform the following from the vSphere web client:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `System`.
+        3. Select `Advanced System Settings`, then select `Edit`.
+        4. Enter `ESXiShellTimeOut` in the filter.
+        5. Set the value for this parameter is set to `3600` (1 hour) or less
+        6. Select `OK`.
+
+        **Note:**
+        A value of 0 disables the ESXiShellTimeOut.
+
+        Alternately, run the following PowerCLI command to set UserVars.ESXiShellTimeOut to 3600 on all hosts
+
+        ```powershell
+        Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellTimeOut' | Set-AdvancedSetting -Value "3600"
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-slp-service-is-disabled
+    title: Ensure the SLP service is disabled
+    impact: 80
+    mql: |
+      vsphere.host.services.where( key == "slpd" ).all( running == false )
+      vsphere.host.services.where( key == "slpd" ).all( policy == "off" )
+    docs:
+      desc: |-
+        The Service Location Protocol (SLP) daemon (`slpd`) allows ESXi to advertise and discover services such as CIM-based hardware monitoring. SLP has been the target of multiple critical ESXi vulnerabilities — most notably CVE-2021-21974, which was exploited at scale by ransomware campaigns targeting unpatched ESXi hosts.
+
+        VMware recommends disabling the SLP service on hosts that do not require CIM-based hardware monitoring over SLP.
+      remediation: |-
+        To disable the SLP service, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `System` and select `Services`.
+        3. Select `slpd`, then select `Stop`.
+        4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
+        5. Select `OK`.
+
+        Alternately, use the following ESXi shell commands:
+
+        ```bash
+        esxcli system slp stats get
+        /etc/init.d/slpd stop
+        esxcli network firewall ruleset set --ruleset-id CIMSLP --enabled false
+        chkconfig slpd off
+        ```
+    refs:
+      - url: https://knowledge.broadcom.com/external/article/318251
+        title: VMware ESXi SLP Service Security Advisory
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled
+    title: Ensure the SNMP service is disabled
+    impact: 70
+    mql: |
+      vsphere.host.services.where( key == "snmpd" ).all( running == false )
+      vsphere.host.services.where( key == "snmpd" ).all( policy == "off" )
+    docs:
+      desc: |-
+        The SNMP daemon (`snmpd`) exposes host monitoring data over the network. SNMP v1 and v2c rely on community strings transmitted in clear text, which can be sniffed and replayed to disclose host information or, depending on configuration, modify settings.
+
+        Disable the SNMP service on ESXi hosts unless it is explicitly required for monitoring. When SNMP is required, configure SNMPv3 with authentication and privacy rather than community-based v1/v2c.
+      remediation: |-
+        To disable the SNMP service, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `System` and select `Services`.
+        3. Select `snmpd`, then select `Stop`.
+        4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
+        5. Select `OK`.
+
+        Alternately, use the following ESXi shell command:
+
+        ```bash
+        esxcli system snmp set --enable false
+        ```
+
+        If SNMP monitoring is required, enable SNMPv3 instead:
+
+        ```bash
+        esxcli system snmp set --v3targets <target> --authentication SHA1 --privacy AES128
+        ```
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject
+    title: Ensure the vSwitch Forged Transmits policy is set to reject
+    impact: 60
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowForgedTransmits == false )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['computedPolicy']['security']['forgedTransmits'] == false )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['policy']['security']['forgedTransmits'] == false )
+    docs:
+      desc: Set the vSwitch Forged Transmits policy to reject for each vSwitch. Reject Forged Transmit can be set at the vSwitch and/or the Portgroup level. You can override switch-level settings at the Portgroup level.
+      remediation: |-
+        To set the policy to reject forged transmissions, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure,  then expand `Networking`.
+        3. Select `Virtual switches`, then select `Edit`.
+        4. Select `Security`.
+        5. Set `Forged transmits` to `Reject` in the dropdown.
+        6. Select `OK`.
+
+        Alternately, the following ESXi shell command may be used:
+
+        ```bash
+        esxcli network vswitch standard policy security set -v vSwitch2 -f false
+        ```
+
+        **Impact:**
+
+        This will prevent VMs from changing their effective MAC address. This will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject
+    title: Ensure the vSwitch MAC Address Change policy is set to reject
+    impact: 60
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowMacChanges == false )
+    docs:
+      desc: Ensure the MAC Address Change policy within the vSwitch is set to reject. Reject MAC Changes can be set at the vSwitch and/or the Portgroup level. You can override switch-level settings at the Portgroup level.
+      remediation: |-
+        To set the policy to reject, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `Networking`.
+        3. Select `Virtual switches`, then select `Edit`.
+        4. Select `Security`.
+        5. Set `MAC address changes` to `Reject` in the dropdown.
+        6. Select `OK`.
+
+        Alternately, perform the following using the ESXi shell:
+
+        ```bash
+        esxcli network vswitch standard policy security set -v vSwitch2 -m false
+        ```
+
+        **Impact:**
+
+        This will prevent VMs from changing their effective MAC address. It will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject
+    title: Ensure the vSwitch Promiscuous Mode policy is set to reject
+    impact: 80
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowPromiscuous == false )
+    docs:
+      desc: Ensure the Promiscuous Mode Policy within the vSwitch is set to reject. Promiscuous mode can be set at the vSwitch and/or the Portgroup level. You can override switch-level settings at the Portgroup level.
+      remediation: |-
+        To set the policy to reject, perform the following:
+
+        1. From the vSphere Web Client, select the host.
+        2. Select `Configure`, then expand `Networking`.
+        3. Select `Virtual switches`, then select `Edit`.
+        4. Select `Security`.
+        5. Set `Promiscuous mode` to `Reject` in the dropdown.
+        6. Select `OK`.
+
+        Alternately, perform the following via the ESXi shell:
+
+        ```bash
+        esxcli network vswitch standard policy security set -v vSwitch2 -p false
+        ```
+
+        **Impact:**
+
+        There might be a legitimate reason to enable promiscuous mode for debugging, monitoring, or troubleshooting reasons. Security devices might require the ability to see all packets on a vSwitch. An exception should be made for the dvPortgroups that these applications are connected to in order to allow for full-time visibility to the traffic on that dvPortgroup.
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-uefi-secure-boot-is-enabled-on-the-esxi-host
+    title: Ensure UEFI Secure Boot is enabled on the ESXi host
+    impact: 80
+    mql: |
+      vsphere.host.secureBootEnabled == true
+    docs:
+      desc: |-
+        UEFI Secure Boot establishes a chain of trust from the platform firmware through the ESXi bootloader, the VMkernel, and all installed VIBs. At each stage, the cryptographic signature of the next component is validated before it is allowed to run.
+
+        With Secure Boot enabled, tampered or unsigned code cannot be executed during boot, protecting the host against boot-time tampering and unauthorized modifications to the hypervisor.
+      remediation: |-
+        Enabling UEFI Secure Boot requires the host to boot in UEFI mode and all installed VIBs to be properly signed.
+
+        1. Confirm the host is configured to boot in UEFI mode (not legacy BIOS) in the server firmware.
+        2. Validate that the current ESXi installation is Secure Boot compatible:
+
+           ```bash
+           /usr/lib/vmware/secureboot/bin/secureBoot.py -c
+           ```
+
+        3. Reboot the host, enter the firmware setup, and enable `Secure Boot`.
+        4. Boot ESXi and confirm Secure Boot is active:
+
+           ```bash
+           /usr/lib/vmware/secureboot/bin/secureBoot.py -s
+           ```
+
+        **Impact:**
+
+        If any installed VIB is unsigned or improperly signed, the host will fail to boot with Secure Boot enabled. Resolve unsigned modules first (see "Ensure all loaded ESXi kernel modules are signed").
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-5D5EE0D1-2596-43D7-95C8-0B29733191D9.html
+        title: UEFI Secure Boot for ESXi Hosts

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -502,7 +502,7 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
     title: Ensure hardware-based 3D acceleration is disabled
     impact: 60
-    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
+    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == false ) )
     docs:
       desc: |-
         This check ensures that hardware-based 3D acceleration is disabled for virtual machines running on VMware ESXi hosts unless explicitly required. Disabling 3D acceleration minimizes attack surface and reduces the risk of GPU-based vulnerabilities that could compromise host integrity or impact performance isolation.
@@ -1591,7 +1591,7 @@ queries:
     impact: 60
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['connected'] == false || _['connectable']['connected'] == null ) ) )
-      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['startConnected'] == false || _['connectable']['connected'] == null ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['startConnected'] == false || _['connectable']['startConnected'] == null ) ) )
     docs:
       desc: |-
         This check ensures that USB devices are not connected to virtual machines unless explicitly required. To fully disconnect a USB device, the usb.present parameter should either be absent or set to FALSE. Removing unnecessary USB device access reduces the risk of data exfiltration, malware introduction, and unauthorized communication within VMware ESXi environments.
@@ -1981,7 +1981,7 @@ queries:
           - Prevents excessive use of shared datastore resources by managing cumulative log size.
           - Supports compliance with audit, incident response, and forensic analysis requirements.
 
-        To implement this control effectively, set log.rotateSize = "1048576" (1 MB) and log.keepOld = "10" in the VM’s configuration. This ensures that logging is both space-efficient and useful for troubleshooting, without compromising datastore health or operational stability in VMware ESXi environments.
+        To implement this control effectively, set log.rotateSize = "1024000" and log.keepOld = "10" in the VM’s configuration. This ensures that logging is both space-efficient and useful for troubleshooting, without compromising datastore health or operational stability in VMware ESXi environments.
       remediation: |-
         To set this configuration utilize the vSphere interface as follows:
 

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -132,7 +132,7 @@ queries:
     title: Ensure Autologon is disabled
     impact: 100
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that automatic login (Autologon) is disabled on VMware ESXi hosts unless explicitly required for a controlled use case. Disabling Autologon helps maintain access control integrity by ensuring that only authenticated users can access the ESXi Shell or DCUI (Direct Console User Interface).
@@ -178,7 +178,7 @@ queries:
     title: Ensure BIOS BBS is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that BIOS Boot Specification (BBS) is disabled on VMware ESXi hosts unless explicitly required for legacy boot configurations. Disabling BBS helps prevent unauthorized boot sources from being prioritized and reduces the risk of system compromise via external or removable media.
@@ -221,7 +221,7 @@ queries:
     title: Ensure Drag and Drop Version Get is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Drag and Drop Version Get feature is disabled on VMware ESXi hosts to prevent unauthorized or unintended data exchange between guest VMs and the host system. Disabling this feature reduces the risk of information leakage and maintains strict isolation between virtual machines and the hypervisor.
@@ -268,7 +268,7 @@ queries:
     title: Ensure Drag and Drop Version Set is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Drag and Drop Version Set feature is disabled on VMware ESXi hosts to prevent guest virtual machines from interacting with host-side drag-and-drop capabilities. Disabling this feature helps preserve strong isolation between the guest and host, minimizing the risk of data leakage or lateral movement.
@@ -315,7 +315,7 @@ queries:
     title: Ensure GetCreds is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the GetCreds functionality in VMware Tools is disabled on VMware ESXi hosts. GetCreds can expose sensitive credential-related operations between guest virtual machines and the host, and disabling it helps maintain strict isolation and reduces the risk of credential leakage or misuse.
@@ -362,7 +362,7 @@ queries:
     title: Ensure Guest Host Interaction Launch Menu is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Launch Menu feature is disabled on VMware ESXi hosts. Disabling this setting prevents guest virtual machines from invoking host-side functionality through interactive VMware Tools features, reducing the risk of unauthorized actions and preserving strict isolation between guests and the hypervisor.
@@ -409,7 +409,7 @@ queries:
     title: Ensure Guest Host Interaction Protocol Handler is set to disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Protocol Handler feature is disabled on VMware ESXi hosts. Disabling this setting prevents guest virtual machines from invoking or registering protocol handlers on the host system, maintaining strict isolation and minimizing the risk of abuse or lateral movement.
@@ -456,7 +456,7 @@ queries:
     title: Ensure Guest Host Interaction Tray Icon is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Tray Icon feature is disabled on VMware ESXi hosts. Disabling this setting helps reduce unnecessary visibility into VMware Tools features from within guest virtual machines and limits potential user interaction with host-integrated functionality.
@@ -547,7 +547,7 @@ queries:
     title: Ensure Host Guest File System Server is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Host Guest File System (HGFS) Server is disabled on VMware ESXi hosts to prevent direct file sharing between guest virtual machines and the host. Disabling HGFS helps enforce strong isolation boundaries and protects against data leakage, unauthorized access, or misuse of host resources.
@@ -594,7 +594,7 @@ queries:
     title: Ensure host information is not sent to guests
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == false ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == "false" ) )
     docs:
       desc: |-
         This check ensures that VMware Tools is configured to prevent the transmission of host system information to guest virtual machines unless explicitly required for legitimate performance monitoring. Disabling unnecessary host-to-guest data sharing helps preserve workload isolation and minimizes the risk of system reconnaissance or data leakage from the hypervisor.
@@ -678,7 +678,7 @@ queries:
     title: Ensure memSchedFakeSampleStats is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the memSchedFakeSampleStats setting is disabled on VMware ESXi hosts. Disabling this advanced memory scheduler feature prevents the generation of synthetic memory statistics, ensuring that only accurate, real-time memory usage data is collected and reported for virtual machines.
@@ -865,7 +865,7 @@ queries:
     title: Ensure Request Disk Topology is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Request Disk Topology feature is disabled on VMware ESXi hosts to prevent guest virtual machines from retrieving detailed information about the underlying physical disk layout. Disabling this capability helps preserve host confidentiality and reduces the risk of targeted attacks or system reconnaissance.
@@ -912,7 +912,7 @@ queries:
     title: Ensure Shell Action is disabled
     impact: 100
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Shell Action feature is disabled on VMware ESXi hosts. Disabling Shell Action helps prevent guest virtual machines from executing commands or triggering actions in the ESXi Shell, thereby preserving hypervisor integrity and reducing the risk of privilege escalation or host compromise.
@@ -1005,7 +1005,7 @@ queries:
     title: Ensure Trash Folder State is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Trash Folder State feature is disabled on VMware ESXi hosts to prevent the creation and retention of deleted file references within virtual machine environments. Disabling this feature helps reduce unnecessary datastore usage and prevents unintended data persistence in secure or regulated environments.
@@ -1080,7 +1080,7 @@ queries:
     title: Ensure unauthorized connection of devices is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that unauthorized device connections—such as USB, CD/DVD, and other removable or passthrough devices—are disabled for virtual machines in VMware ESXi environments. Disabling or restricting dynamic device connections helps prevent data leakage, malware introduction, and unauthorized access to sensitive resources.
@@ -1115,7 +1115,7 @@ queries:
     title: Ensure unauthorized modification and disconnection of devices is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that unauthorized users are prevented from modifying or disconnecting virtual hardware devices—such as network adapters, hard disks, and virtual NICs—attached to virtual machines in VMware ESXi environments. Restricting these actions helps maintain system integrity, prevents misconfiguration, and protects against intentional or accidental disruption of VM operations.
@@ -1150,7 +1150,7 @@ queries:
     title: Ensure Unity Active is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity Active feature is disabled on VMware ESXi hosts to prevent guest virtual machines from displaying applications seamlessly on the host desktop using VMware Unity mode. Disabling Unity mode reduces the risk of unauthorized interactions between the guest and host environments and preserves clear isolation boundaries.
@@ -1197,7 +1197,7 @@ queries:
     title: Ensure Unity Interlock is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity Interlock feature is disabled on VMware ESXi hosts to prevent guest virtual machines from interacting with host-side user interface components through Unity mode. Disabling Unity Interlock strengthens the isolation between guest and host environments, reducing the risk of unauthorized access or data leakage.
@@ -1244,7 +1244,7 @@ queries:
     title: Ensure Unity is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity feature is fully disabled on VMware ESXi hosts. Disabling Unity mode prevents guest virtual machines from integrating with the host desktop interface, thereby enforcing strong isolation between guest and host environments and reducing the risk of unauthorized interaction or data leakage.
@@ -1291,7 +1291,7 @@ queries:
     title: Ensure Unity Push Update is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity Push Update feature is disabled on VMware ESXi hosts unless explicitly required. Disabling this feature prevents guest virtual machines from receiving Unity mode configuration updates from the host, thereby preserving system integrity and minimizing unnecessary guest-host communication.
@@ -1338,7 +1338,7 @@ queries:
     title: Ensure Unity Taskbar is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity Taskbar feature is disabled on VMware ESXi hosts unless explicitly required. Disabling the Unity Taskbar prevents guest applications from being displayed in the host's taskbar during Unity mode operations, preserving system boundaries and reducing the risk of unauthorized information exposure or interaction.
@@ -1385,7 +1385,7 @@ queries:
     title: Ensure Unity Window Contents is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that the Unity Window Contents feature is disabled on VMware ESXi hosts. Disabling this feature prevents the host from rendering or displaying the visual content of guest VM application windows in Unity mode, thereby maintaining strong isolation and reducing the risk of unauthorized data exposure.
@@ -1629,7 +1629,7 @@ queries:
     title: Ensure virtual disk shrinking is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that virtual disk shrinking is disabled on VMware ESXi hosts unless there is a specific operational need. Repeated shrinking operations can degrade virtual disk integrity and availability, potentially leading to denial-of-service (DoS) conditions for affected virtual machines.
@@ -1676,7 +1676,7 @@ queries:
     title: Ensure virtual disk wiping is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that virtual disk wiping is disabled on VMware ESXi hosts unless specifically needed for secure data sanitization. Repeated or unnecessary disk wiping operations can negatively impact performance, reduce availability, and potentially lead to denial-of-service (DoS) conditions. In most datacenter environments, this feature is not needed and should be restricted.
@@ -1786,7 +1786,7 @@ queries:
     title: Ensure VM Console Copy operations are disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that copy operations from the VM console are disabled in VMware ESXi environments. Disabling console-based copy functionality helps prevent unauthorized data exfiltration and enforces strict isolation between guest virtual machines and users accessing them through the vSphere client or other management interfaces.
@@ -1829,7 +1829,7 @@ queries:
     title: Ensure VM Console Drag and Drop operations is disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that drag and drop operations via the VM console are disabled in VMware ESXi environments. Disabling this feature helps prevent unauthorized file transfers between the guest virtual machine and the administrative host system, reducing the risk of data exfiltration, malware introduction, and compliance violations.
@@ -1872,7 +1872,7 @@ queries:
     title: Ensure VM Console GUI Options is disabled
     impact: 75
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == false ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == "false" ) )
     docs:
       desc: |-
         This check ensures that VM Console GUI options are disabled in VMware ESXi environments to prevent unauthorized access to advanced console features and reduce the risk of system misconfiguration or data leakage through the graphical user interface.
@@ -1915,7 +1915,7 @@ queries:
     title: Ensure VM Console Paste operations are disabled
     impact: 60
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == true ) )
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == "true" ) )
     docs:
       desc: |-
         This check ensures that paste operations into virtual machines via the VM console are disabled in VMware ESXi environments. Disabling paste functionality prevents unauthorized data injection into guest systems and enforces strict boundaries between administrative systems and virtual machines.

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -502,7 +502,7 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
     title: Ensure hardware-based 3D acceleration is disabled
     impact: 60
-    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == false ) )
+    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
     docs:
       desc: |-
         This check ensures that hardware-based 3D acceleration is disabled for virtual machines running on VMware ESXi hosts unless explicitly required. Disabling 3D acceleration minimizes attack surface and reduces the risk of GPU-based vulnerabilities that could compromise host integrity or impact performance isolation.

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -1,0 +1,2002 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-vmware-vsphere-security-baseline
+    name: Mondoo VMware vSphere Security Baseline
+    version: 2.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: vmware,vmware-vsphere
+    require:
+      - provider: vsphere
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    docs:
+      desc: |-
+        The Mondoo VMware vSphere Security Baseline policy provides security guidelines for virtual machines running on VMware vSphere. It covers communication, device, monitor, and logging configurations to ensure VMs are hardened against unauthorized access and information leakage.
+
+        ## Join the community!
+
+        Our goal is to build policies that are simple to deploy, accurate, and actionable.
+
+        If you have any suggestions for how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+    groups:
+      - title: Communication
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time
+      - title: Devices
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-pci-and-pcie-device-passthrough-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-cddvd-devices-are-disconnected
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-floppy-devices-are-disconnected
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-parallel-ports-are-disconnected
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-serial-ports-are-disconnected
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-usb-devices-are-disconnected
+      - title: Monitor
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled
+      - title: Encryption and Boot Security
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled
+      - title: Resources
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
+      - title: Storage
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-nonpersistent-disks-are-limited
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled
+      - title: Tools
+        filters: |
+          asset.platform == "vmware-vsphere"
+        checks:
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present
+    title: Ensure a virtual Trusted Platform Module is present
+    impact: 70
+    mql: |
+      vsphere.datacenters.all( vms.all( vtpmPresent == true ) )
+    docs:
+      desc: |-
+        A virtual Trusted Platform Module (vTPM) is a software-based TPM 2.0 device that vSphere presents to a virtual machine. It provides the guest operating system with a hardware-rooted store for cryptographic keys and platform measurements.
+
+        A vTPM enables guest security features that depend on a TPM, including Windows BitLocker, Measured Boot, Credential Guard, and Device Guard. The vTPM's secrets are protected by VM encryption and backed by the configured key provider.
+
+        **A vTPM provides:**
+        - A protected store for guest disk-encryption keys
+        - Measured Boot and remote attestation for the guest OS
+        - Backing for Windows Credential Guard and Device Guard
+
+        **Best Practice:**
+        - Attach a vTPM to virtual machines that run modern Windows or Linux guests requiring trusted-platform features.
+      remediation: |-
+        Adding a vTPM requires that a key provider is configured in vCenter Server and that the virtual machine uses EFI firmware.
+
+        **To add a vTPM via the vSphere Client:**
+
+        1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
+        2. Power off the virtual machine.
+        3. Right-click the VM and select `Edit Settings`.
+        4. Select `ADD NEW DEVICE`, then choose `Trusted Platform Module`.
+        5. Select `OK`, then power the VM back on.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-A45F1862-A2E1-4FFE-A2DF-29B3FE3A5D80.html
+        title: Securing Virtual Machines with Virtual Trusted Platform Module
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled
+    title: Ensure Autologon is disabled
+    impact: 100
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that automatic login (Autologon) is disabled on VMware ESXi hosts unless explicitly required for a controlled use case. Disabling Autologon helps maintain access control integrity by ensuring that only authenticated users can access the ESXi Shell or DCUI (Direct Console User Interface).
+
+        **Rationale:**
+
+        Autologon allows a system to automatically log in a specified user at startup without requiring manual authentication. In the context of ESXi:
+          - Autologon may be enabled through configuration settings in /etc/rc.local.d/local.sh or other initialization scripts.
+          - Systems configured with Autologon bypass the need for credential-based access to the ESXi Shell or DCUI.
+          - If a user account is pre-configured for Autologon, it may also have elevated privileges or unrestricted shell access.
+
+        Enabling Autologon on ESXi hosts can result in:
+          - Unauthorized access if physical or network-level security is compromised.
+          - Privilege escalation if the Autologon user has administrative rights.
+          - Compliance violations under standards like CIS VMware ESXi Benchmark, NIST 800-53, PCI DSS, and ISO 27001.
+          - Audit trail disruption, as access is not tied to unique, authenticated user sessions.
+
+        **Risk mitigation:**
+          - Prevents unauthorized or unmonitored access to critical system interfaces.
+          - Enforces strong authentication practices for interactive shell or console access.
+          - Ensures accountability by requiring individual logins, enabling accurate logging and auditing.
+          - Aligns with industry best practices for securing hypervisor access.
+
+        Disabling Autologon strengthens ESXi host security by reducing the attack surface and ensuring that only authorized, authenticated users can access sensitive host interfaces.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.autologon.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        Alternatively you may run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.autologon.disable" -value $true
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled
+    title: Ensure BIOS BBS is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that BIOS Boot Specification (BBS) is disabled on VMware ESXi hosts unless explicitly required for legacy boot configurations. Disabling BBS helps prevent unauthorized boot sources from being prioritized and reduces the risk of system compromise via external or removable media.
+
+        **Rationale:**
+
+        The BIOS Boot Specification allows systems to enumerate and prioritize bootable devices, including network adapters, USB drives, and optical media. On ESXi hosts:
+          - BBS can enable boot from removable devices that may bypass normal bootloader integrity checks.
+          - Attackers with physical or low-level access could exploit BBS settings to boot unauthorized operating systems or recovery tools.
+          - Legacy boot methods via BBS may not support modern security features like Secure Boot, increasing exposure to rootkits or bootkits.
+
+        Enabling BIOS BBS without a specific need can lead to:
+          - Unauthorized access to host resources via rogue boot media.
+          - Bypassing of hypervisor security controls by booting alternative OS environments.
+          - Loss of integrity in the hypervisor boot chain, undermining trust in the platform.
+          - Non-compliance with hardening guidance from standards like the CIS VMware ESXi Benchmark and NIST SP 800-147.
+
+        **Risk mitigation:**
+          - Reduces the risk of malicious or accidental boot from external or legacy devices.
+          - Enforces a secure, predictable boot process aligned with UEFI and Secure Boot best practices.
+          - Strengthens the chain of trust by limiting boot sources to verified, intended media.
+          - Supports compliance with hypervisor hardening requirements in regulated environments.
+
+        Disabling BIOS BBS when not required limits the system's exposure to boot-level threats and helps maintain the integrity of the ESXi host's startup process.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.bios.bbs.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable BIOS BBS, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.bios.bbs.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled
+    title: Ensure Drag and Drop Version Get is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Drag and Drop Version Get feature is disabled on VMware ESXi hosts to prevent unauthorized or unintended data exchange between guest VMs and the host system. Disabling this feature reduces the risk of information leakage and maintains strict isolation between virtual machines and the hypervisor.
+
+        **Rationale:**
+
+        The Drag and Drop Version Get feature is part of VMware Tools and supports enhanced interaction between guest VMs and the host, including clipboard and drag-and-drop operations. While convenient for some desktop virtualization use cases, in server or sensitive environments it introduces unnecessary risk:
+          - This feature enables a guest to detect host drag-and-drop capability versions, which may be exploited for compatibility probing or feature enumeration.
+          - It can facilitate unintended host-to-guest or guest-to-host communication channels.
+          - Combined with other VMware Tools features, it could be used as a stepping stone for more advanced guest-to-host interaction or lateral movement in a compromised environment.
+
+        Leaving Drag and Drop Version Get enabled can result in:
+          - Data exfiltration from guest VMs or the host through side channels.
+          - Loss of VM isolation, violating secure multi-tenancy principles.
+          - Expanded attack surface, particularly in environments with untrusted or external workloads.
+          - Non-compliance with virtualization hardening benchmarks such as CIS VMware ESXi and DISA STIGs.
+
+        **Risk mitigation:**
+          - Eliminates unnecessary guest-host integration features that could be exploited.
+          - Enforces stronger workload isolation, especially in multi-tenant or regulated environments.
+          - Aligns with VMware hardening guidance for server-class deployments.
+          - Reduces visibility of host-side capabilities from within the guest operating system.
+
+        Disabling Drag and Drop Version Get helps ensure that VMware Tools do not introduce communication channels that compromise the security posture of ESXi hosts and virtual machines.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.vmxDnDVersionGet.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Drag and Drop Version Get feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.vmxDnDVersionGet.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled
+    title: Ensure Drag and Drop Version Set is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Drag and Drop Version Set feature is disabled on VMware ESXi hosts to prevent guest virtual machines from interacting with host-side drag-and-drop capabilities. Disabling this feature helps preserve strong isolation between the guest and host, minimizing the risk of data leakage or lateral movement.
+
+        **Rationale:**
+
+        The Drag and Drop Version Set feature, exposed via VMware Tools, allows guest VMs to interact with and set the drag-and-drop protocol version. While primarily designed for improved usability in desktop virtualization, this capability can introduce security concerns in server or sensitive environments:
+          - It allows a guest VM to initiate communication with the host environment by setting drag-and-drop version parameters.
+          - Combined with other guest-host integration features, it may enable or escalate unintended data exchange channels.
+          - Attackers with access to a compromised VM may abuse this feature to enumerate, influence, or exploit host-side functionality.
+
+        Leaving Drag and Drop Version Set enabled can result in:
+          - Increased attack surface, enabling guest-to-host communication paths not typically needed in secure environments.
+          - Potential data leakage through misused or hijacked drag-and-drop operations.
+          - Weakened workload isolation, undermining virtualization boundaries.
+          - Non-compliance with hardening frameworks such as the CIS VMware ESXi Benchmark, DISA STIGs, or NIST guidelines.
+
+        **Risk mitigation:**
+          - Prevents guest VMs from attempting to set or alter host drag-and-drop communication protocols.
+          - Enforces stricter boundaries between guest and host systems to protect against lateral threats.
+          - Aligns with best practices for securing hypervisors in production or regulated environments.
+          - Reduces the potential for VMware Tools misuse in compromised guest environments.
+
+        Disabling Drag and Drop Version Set is a key step in securing ESXi deployments by ensuring guest VMs cannot influence or initiate host-side drag-and-drop behaviors, thereby upholding strong host-to-guest isolation.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.guestDnDVersionSet.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Drag and Drop Version Set feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.guestDnDVersionSet.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled
+    title: Ensure GetCreds is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the GetCreds functionality in VMware Tools is disabled on VMware ESXi hosts. GetCreds can expose sensitive credential-related operations between guest virtual machines and the host, and disabling it helps maintain strict isolation and reduces the risk of credential leakage or misuse.
+
+        **Rationale:**
+
+        The GetCreds feature is part of VMware's guest-host communication mechanisms. It allows guest virtual machines to request or interact with credential services exposed by the host through VMware Tools. While useful in certain enterprise integrations, in most environments—especially sensitive or multi-tenant deployments—this capability presents a security risk:
+          - It enables a guest VM to retrieve authentication or credential information intended for host or service use.
+          - If misconfigured or abused, it could allow unauthorized access to sensitive data or services through improperly scoped credential requests.
+          - An attacker with access to a compromised VM may attempt to harvest host-related credentials or escalate privileges.
+
+        Leaving GetCreds enabled can result in:
+          - Credential exposure, particularly in environments where host-agent communication is not tightly controlled.
+          - Unauthorized access to services or APIs leveraging shared or injected credentials.
+          - Breakdown of guest-host trust boundaries, weakening isolation guarantees.
+          - Non-compliance with virtualization security guidelines such as CIS VMware ESXi Benchmark, DISA STIGs, and NIST SP 800-53 controls for credential management.
+
+        **Risk mitigation:**
+          - Eliminates a guest-accessible path to sensitive credential operations or data.
+          - Enforces a clear separation of duties and access between guest VMs and host-level services.
+          - Protects against misuse of VMware Tools capabilities in compromised or untrusted environments.
+          - Supports compliance with least privilege and secure credential handling best practices.
+
+        Disabling GetCreds ensures that guest VMs cannot interact with or retrieve credentials from host systems or integrated services, maintaining a secure and isolated virtualization environment.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.getCreds.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the GetCreds feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.getCreds.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled
+    title: Ensure Guest Host Interaction Launch Menu is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Guest Host Interaction Launch Menu feature is disabled on VMware ESXi hosts. Disabling this setting prevents guest virtual machines from invoking host-side functionality through interactive VMware Tools features, reducing the risk of unauthorized actions and preserving strict isolation between guests and the hypervisor.
+
+        **Rationale:**
+
+        The Guest Host Interaction Launch Menu is a VMware Tools feature that allows guest operating systems to trigger host-side actions or display launchable menu items. While intended to enhance usability in desktop or test environments, this capability poses a risk in production or multi-tenant server environments:
+          - It enables a guest VM to request and potentially initiate host-side operations, which may expose administrative interfaces or execute host-level processes.
+          - Attackers could use this feature as an entry point to pivot toward the hypervisor or to interact with host-managed tools or services.
+          - This level of guest-host interaction contradicts the principle of strong isolation and minimal trust between virtual machines and their underlying hosts.
+
+        Leaving this feature enabled can result in:
+          - Inadvertent exposure of host functionality to untrusted or compromised guest systems.
+          - Privilege escalation opportunities if guest-triggered actions affect host behavior or services.
+          - Non-compliance with hypervisor hardening guidance from frameworks such as CIS VMware ESXi Benchmark, DISA STIGs, and NIST security controls.
+          - Security boundary erosion, especially in regulated or multi-user virtual environments.
+
+        **Risk mitigation:**
+          - Blocks the ability for guest VMs to invoke host-side launch menus or UI-driven actions.
+          - Strengthens the virtualization boundary by ensuring guest systems operate in isolation from the host.
+          - Reduces potential attack vectors that rely on VMware Tools integration features.
+          - Supports secure deployment best practices in both enterprise and cloud-hosted environments.
+
+        Disabling the Guest Host Interaction Launch Menu helps enforce clean separation between virtual machines and host infrastructure, reducing the risk of misuse and enhancing the overall security posture of VMware ESXi environments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.launchmenu.change` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Guest Host Interaction Launch Menu feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.launchmenu.change" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled
+    title: Ensure Guest Host Interaction Protocol Handler is set to disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Guest Host Interaction Protocol Handler feature is disabled on VMware ESXi hosts. Disabling this setting prevents guest virtual machines from invoking or registering protocol handlers on the host system, maintaining strict isolation and minimizing the risk of abuse or lateral movement.
+
+        **Rationale:**
+
+        The Guest Host Interaction Protocol Handler is a VMware Tools feature that allows guest virtual machines to interact with specific URI-based protocol handlers on the host, enabling certain types of guest-triggered operations. While useful in development or desktop environments, it introduces security concerns in production ESXi deployments:
+          - It allows guest systems to initiate host-side actions via registered protocol handlers (e.g., vmware:// URIs).
+          - This communication channel can be misused by attackers to execute host-side behaviors, potentially bypassing intended access controls.
+          - In environments with untrusted workloads or multi-tenancy, this feature creates unnecessary risk and undermines isolation guarantees.
+
+        If this feature remains enabled, it can lead to:
+          - Unauthorized access to host features or services exposed via protocol handlers.
+          - Abuse of host-level integrations that could allow code execution, information disclosure, or privilege escalation.
+          - Non-compliance with virtualization hardening frameworks like CIS VMware ESXi Benchmark, DISA STIGs, and NIST 800-53.
+          - Expanded attack surface, especially when combined with other guest-host interaction mechanisms.
+
+        **Risk mitigation:**
+          - Prevents guest VMs from triggering or registering host-level protocol handlers.
+          - Maintains strict separation between guest OS behavior and host system functions.
+          - Limits potential vectors for privilege escalation or lateral movement via VMware Tools.
+          - Aligns with industry best practices for securing virtualized infrastructure and minimizing trust between guest and host.
+
+        Disabling the Guest Host Interaction Protocol Handler is a critical step in securing VMware ESXi environments, ensuring that guest virtual machines cannot leverage protocol-based communication channels to affect or manipulate host behavior.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.protocolhandler.info.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable Guest Host Interaction Protocol Handle, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.protocolhandler.info.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled
+    title: Ensure Guest Host Interaction Tray Icon is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Guest Host Interaction Tray Icon feature is disabled on VMware ESXi hosts. Disabling this setting helps reduce unnecessary visibility into VMware Tools features from within guest virtual machines and limits potential user interaction with host-integrated functionality.
+
+        **Rationale:**
+
+        The Guest Host Interaction Tray Icon is part of the VMware Tools suite and displays a system tray icon inside guest operating systems. This icon can expose host-guest integration features or shortcuts for initiating host-side actions. While useful in desktop environments, it presents risks in production, multi-tenant, or server-class deployments:
+          - It may enable or encourage end users within guest VMs to initiate actions that interface with the ESXi host.
+          - The icon exposes functionality that could lead to unintended interactions with the host, especially when other guest-host features are enabled.
+          - In sensitive environments, this visibility increases the risk of misconfiguration, misuse, or attack surface exposure.
+
+        Leaving the tray icon enabled can result in:
+          - User-initiated host interactions from within guest VMs, increasing risk of configuration drift or unauthorized actions.
+          - Information exposure, revealing underlying virtualization tooling or host capabilities.
+          - Degradation of workload isolation, especially when users are not meant to know they are operating in a virtualized environment.
+          - Non-compliance with hardening recommendations such as those from CIS VMware ESXi Benchmark and DISA STIGs.
+
+        **Risk mitigation:**
+          - Removes unnecessary guest-facing indicators of host integration, limiting end-user interaction vectors.
+          - Prevents misuse of VMware Tools capabilities through the tray interface.
+          - Enforces a clean separation between host management and guest user experience.
+          - Reduces the attack surface, especially in shared or regulated environments.
+
+        Disabling the Guest Host Interaction Tray Icon helps enforce stronger security boundaries by limiting visibility into virtualization tooling and preventing user-driven interactions with host-level features from within guest systems.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.trayicon.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Guest Host Interaction Tray Icon feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.trayicon.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
+    title: Ensure hardware-based 3D acceleration is disabled
+    impact: 60
+    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
+    docs:
+      desc: |-
+        This check ensures that hardware-based 3D acceleration is disabled for virtual machines running on VMware ESXi hosts unless explicitly required. Disabling 3D acceleration minimizes attack surface and reduces the risk of GPU-based vulnerabilities that could compromise host integrity or impact performance isolation.
+
+        **Rationale:**
+
+        VMware ESXi supports hardware-based 3D graphics acceleration by allowing virtual machines to leverage physical GPU resources via DirectPath I/O or vGPU technology. While beneficial for workloads requiring rich graphical interfaces—such as VDI or CAD applications—enabling 3D acceleration in environments where it's not needed introduces avoidable risk:
+          - It increases the complexity of the virtual hardware environment, expanding the potential for misconfiguration or exploitation.
+          - GPU passthrough or sharing features have historically been vulnerable to escape conditions or denial-of-service (DoS) scenarios.
+          - Multi-tenant workloads sharing GPU resources may experience performance interference or information leakage across isolation boundaries.
+
+        If left enabled without a specific business need, hardware-based 3D acceleration can lead to:
+          - Guest-to-host escape vulnerabilities, especially through graphics drivers or hypervisor interfaces.
+          - Performance unpredictability due to resource contention or overprovisioned GPU access.
+          - Non-compliance with security baselines like the CIS VMware ESXi Benchmark, DISA STIGs, or NIST 800-53, which recommend minimizing non-essential virtual hardware.
+
+        **Risk mitigation:**
+          - Prevents exposure to GPU driver or passthrough-related vulnerabilities.
+          - Ensures consistent performance and stronger isolation for workloads that do not require 3D graphics.
+          - Reduces complexity in virtual machine configuration and maintenance.
+          - Aligns with hypervisor hardening standards and secure virtualization practices.
+
+        Disabling hardware-based 3D acceleration helps secure ESXi environments by minimizing unnecessary virtual hardware exposure and preventing graphics-related vulnerabilities that could affect host stability or tenant isolation.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `mks.enable3d` with a value of `FALSE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable hardware-based 3D acceleration, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "mks.enable3d" -value $false
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled
+    title: Ensure Host Guest File System Server is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Host Guest File System (HGFS) Server is disabled on VMware ESXi hosts to prevent direct file sharing between guest virtual machines and the host. Disabling HGFS helps enforce strong isolation boundaries and protects against data leakage, unauthorized access, or misuse of host resources.
+
+        **Rationale:**
+
+        The Host Guest File System Server is a VMware Tools feature that enables shared folders between a guest VM and the ESXi host. This functionality allows files to be transferred seamlessly without using network file sharing protocols. While convenient in development or testing environments, it introduces significant security concerns in production deployments:
+          - HGFS provides a direct communication path between the guest OS and host file system, bypassing traditional access controls.
+          - If a VM is compromised, an attacker could use HGFS to access or manipulate host files or shared data.
+          - File sharing via HGFS may violate data segmentation policies in regulated or multi-tenant environments.
+
+        If HGFS is enabled, it may result in:
+          - Unauthorized file access or modification, especially in cases of misconfiguration or insufficient file permission enforcement.
+          - Increased risk of lateral movement, as the guest can access host-side directories or services not otherwise exposed.
+          - Compliance violations with hardening standards such as the CIS VMware ESXi Benchmark, NIST 800-53, and PCI DSS.
+          - Reduced auditability, since file access via HGFS may not be logged or monitored effectively.
+
+        **Risk mitigation:**
+          - Prevents guest VMs from accessing or sharing files with the ESXi host or other VMs.
+          - Reinforces secure workload isolation and reduces the risk of data exposure.
+          - Aligns with best practices for securing virtualization platforms by disabling unnecessary integration features.
+          - Supports compliance with security frameworks that require strict separation of roles and data access.
+
+        Disabling the Host Guest File System Server helps protect VMware ESXi environments by eliminating insecure file-sharing mechanisms and enforcing clear boundaries between guest virtual machines and the host operating system.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.hgfsServerSet.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Host Guest File System Server, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.hgfsServerSet.disable" -value $true
+        ```
+
+        **Impact:**
+
+        This will cause the VMX process to not respond to commands from the tools process. Setting isolation.tools.hgfsServerSet.disable to TRUE disables the registration of the guest's HGFS server with the host. APIs that use HGFS to transfer files to and from the guest operating system, such as some VIX commands or the VMware Tools auto-upgrade utility, will not function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests
+    title: Ensure host information is not sent to guests
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == false ) )
+    docs:
+      desc: |-
+        This check ensures that VMware Tools is configured to prevent the transmission of host system information to guest virtual machines unless explicitly required for legitimate performance monitoring. Disabling unnecessary host-to-guest data sharing helps preserve workload isolation and minimizes the risk of system reconnaissance or data leakage from the hypervisor.
+
+        **Rationale:**
+
+        VMware Tools provides enhanced integration between the guest operating system and the hypervisor, including the ability for the guest to receive details about the underlying host—such as hostname, CPU model, memory capacity, or other system metadata. While useful for monitoring or diagnostics in some scenarios, exposing host information to all guest VMs introduces risk:
+          - It enables system reconnaissance from within the guest, allowing attackers to learn about the host infrastructure.
+          - Host metadata could be used to fingerprint environments, identify targets for attack, or coordinate lateral movement.
+          - In shared or multi-tenant environments, this violates the principle of least knowledge and undermines workload separation.
+
+        Leaving this setting enabled without a specific business need may result in:
+          - Information disclosure about the host system that can aid in targeted attacks.
+          - Weakened isolation between guests and the hypervisor.
+          - Non-compliance with hardening baselines such as the CIS VMware ESXi Benchmark, DISA STIGs, or ISO 27001.
+          - Reduced control over what telemetry is shared with potentially untrusted VMs.
+
+        **Risk mitigation:**
+          - Restricts guest access to sensitive host metadata unless explicitly required for performance tooling.
+          - Reduces visibility into the hypervisor and physical infrastructure from within guest operating systems.
+          - Enforces strict separation between the host and guest environments in line with zero-trust principles.
+          - Aligns with secure virtualization practices and regulatory requirements that emphasize data minimization.
+
+        Configuring VMware Tools to block host information sharing by default helps limit exposure of internal infrastructure details and ensures that only authorized VMs can access such data for legitimate performance monitoring purposes.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `tools.guestlib.enableHostInfo` with a value of `FALSE`.
+        5. Select `OK`, then `OK` again.
+
+        To prevent host information from being sent to guests, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "tools.guestlib.enableHostInfo" -value $false
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited
+    title: Ensure informational messages from the VM to the VMX file are limited
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['tools.setInfo.sizeLimit'] == 1048576 ) )
+    docs:
+      desc: |-
+        This check ensures that informational messages written from the guest VM to the VMX configuration file are limited, helping to prevent unnecessary datastore consumption and maintaining the stability of the VMware ESXi host environment.
+
+        **Rationale:**
+
+        The VMX file is the configuration file for a virtual machine and contains critical name-value pairs that define its virtual hardware and runtime behavior. In some environments, guest operating systems or applications may log custom data or diagnostic messages to the VMX file. Although the default file size is limited to 1 MB, excessive or unregulated message logging can lead to:
+          - VMX files growing beyond their intended size, especially if the size limit is increased to accommodate custom metadata.
+          - Datastore exhaustion, which can cause service degradation, failure to power on VMs, or broader instability across the host.
+          - Loss of important configuration or state data if the VMX file becomes corrupted due to overuse.
+
+        Uncontrolled VMX logging may result in:
+          - Storage resource exhaustion across shared datastores, impacting multiple VMs.
+          - Performance degradation during VM operations or host maintenance tasks.
+          - Compliance or operational risks if configuration files contain excessive, sensitive, or unmanaged custom data.
+          - Backup and snapshot bloat, increasing time and storage cost for routine VM lifecycle operations.
+
+        **Risk mitigation:**
+          - Enforces size and verbosity limits on guest-generated data written to the VMX configuration file.
+          - Helps maintain VM configuration integrity and supports consistent VM lifecycle operations.
+          - Prevents accidental denial-of-service conditions caused by oversized or overused configuration files.
+          - Aligns with operational hardening best practices recommended in VMware documentation and security benchmarks.
+
+        Limiting informational messages written to the VMX file ensures that guest activity does not unintentionally consume critical storage or affect the stability of the ESXi environment, particularly in multi-VM or shared-datastore scenarios.
+      remediation: |-
+        To set this configuration run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "tools.setInfo.sizeLimit" -value 1048576
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled
+    title: Ensure memSchedFakeSampleStats is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the memSchedFakeSampleStats setting is disabled on VMware ESXi hosts. Disabling this advanced memory scheduler feature prevents the generation of synthetic memory statistics, ensuring that only accurate, real-time memory usage data is collected and reported for virtual machines.
+
+        **Rationale:**
+
+        The memSchedFakeSampleStats parameter is an internal debugging setting used by VMware to simulate memory scheduling statistics. When enabled, it can populate memory statistics fields with fabricated data, which may be useful for development or testing but is inappropriate for production environments:
+          - It skews monitoring and performance data, potentially leading to misinterpretation of memory behavior or resource bottlenecks.
+          - Misleading statistics can negatively impact capacity planning, troubleshooting, or automated policy enforcement tools that rely on accurate telemetry.
+          - Environments using memory-based alerting or chargeback models may report incorrect usage, leading to financial, operational, or compliance discrepancies.
+
+        If memSchedFakeSampleStats is enabled in production, it can lead to:
+          - Inaccurate performance monitoring, making it difficult to identify real memory contention or overcommitment.
+          - Misguided tuning decisions, based on false indicators.
+          - Non-compliance with service-level objectives (SLOs) or regulatory reporting that depends on accurate usage data.
+          - Reduced confidence in the virtualization platform's observability and automation systems.
+
+        **Risk mitigation:**
+          - Ensures memory scheduler statistics accurately reflect real VM usage and contention.
+          - Supports trustworthy monitoring, alerting, and reporting systems.
+          - Prevents internal debugging features from affecting production observability or resource management.
+          - Aligns with VMware ESXi hardening guidance by disabling non-essential and potentially misleading advanced features.
+
+        Disabling memSchedFakeSampleStats is a critical step in maintaining the integrity of memory usage telemetry within VMware ESXi environments, ensuring reliable operations, accurate diagnostics, and effective resource planning.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.memSchedFakeSampleStats.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the memSchedFakeSampleStats feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.memSchedFakeSampleStats.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-nonpersistent-disks-are-limited
+    title: Ensure nonpersistent disks are limited
+    impact: 60
+    mql: |
+      vsphere.datacenters.all(
+        vms.all(
+          properties['config']['hardware']['device'].where(
+            _['backing']['fileName'].contains('vmdk') ).all(
+              _['backing']['diskMode'] != 'independent_nonpersistent'
+            )
+          )
+        )
+    docs:
+      desc: |-
+        This check ensures that virtual machine disks are not configured in independent nonpersistent mode unless explicitly required for disposable workloads. Nonpersistent mode should be avoided in production environments where data integrity and persistence are critical, as all disk changes are lost upon VM reboot.
+
+        **Rationale:**
+
+        By default, virtual disks in VMware are created in dependent mode, meaning they are affected by snapshots. When configured in independent mode, a disk operates outside the scope of VM snapshots and can be further configured as:
+          - Persistent: All changes are immediately and permanently written to disk.
+          - Nonpersistent: All changes are discarded when the VM is powered off or rebooted, restoring the disk to its original state.
+
+        While nonpersistent mode is useful for temporary workloads—such as kiosks, training environments, or stateless testing—its use in production or critical systems presents serious risks:
+          - Data loss: Any changes to the disk are lost on shutdown, potentially resulting in lost configurations, logs, or user data.
+          - Inconsistent recovery: Backup and recovery processes may fail to capture critical data if the disk state resets after each reboot.
+          - Compliance violations: Many data protection and retention standards require that systems maintain audit logs and persistent configurations.
+
+        If used improperly, nonpersistent disks can result in:
+          - Unrecoverable operational data, increasing incident response time.
+          - Loss of audit trails in regulated environments.
+          - Misalignment with disaster recovery strategies that depend on consistent disk states.
+          - Unexpected system behavior when changes made during runtime are not preserved.
+
+        **Risk mitigation:**
+          - Enforces the use of persistent or snapshot-compatible disk modes in systems where data retention is necessary.
+          - Ensures that data written during system operation is preserved across restarts.
+          - Helps meet regulatory requirements for data integrity, auditability, and recoverability.
+          - Prevents accidental use of stateless disk configurations in production workloads.
+
+        Use of independent nonpersistent mode should be limited to VMs explicitly designed to operate without persistent disk data. For all other workloads, persistent or dependent disk modes provide greater reliability, auditability, and data protection within VMware ESXi environments.
+      remediation: |-
+        To limit the use of nonpersistent mode, run the following PowerCLI command:
+
+        ```
+        #Add the parameters for the following cmdlet to set the VM Disk Type:
+        Get-VM | Get-HardDisk | Set-HardDisk
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time
+    title: Ensure only one remote console connection is permitted to a VM at any time
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['RemoteDisplay.maxConnections'] == 1 ) )
+    docs:
+      desc: |-
+        This check ensures that only a single remote console connection is permitted to a virtual machine (VM) at any given time. Limiting remote console access helps maintain control over administrative sessions, reduces the risk of conflicting actions, and prevents unauthorized observation or interference with VM operations.
+
+        **Rationale:**
+
+        The VMware remote console allows administrators to interact with a VM's display, keyboard, and mouse—similar to physical console access on a physical machine. By default, multiple remote console sessions may be allowed simultaneously, which introduces potential security and operational concerns:
+          - Multiple users could interfere with each other's actions, leading to configuration errors or system instability.
+          - Unmonitored sessions may allow unauthorized users to observe or control the VM, increasing the risk of insider threats or privilege abuse.
+          - Session concurrency complicates audit trails, making it harder to attribute changes to specific users.
+
+        Allowing more than one remote console session can result in:
+          - Unauthorized access to sensitive VM consoles, particularly in shared administrative environments.
+          - Operational conflicts when simultaneous users attempt to modify system settings or troubleshoot issues.
+          - Compliance violations if session control and accountability are required by frameworks such as PCI DSS, HIPAA, or NIST 800-53.
+          - Reduced visibility and control over critical administrative interfaces.
+
+        **Risk mitigation:**
+          - Enforces exclusive console access, ensuring only one administrator can interact with the VM console at a time.
+          - Prevents unauthorized monitoring or manipulation of VM consoles by additional users.
+          - Simplifies session auditing by ensuring clear attribution of actions.
+          - Aligns with security best practices that prioritize session control and administrative accountability.
+
+        Restricting remote console access to a single active connection per VM improves security posture, minimizes operational risk, and supports compliance with access control and monitoring requirements in VMware ESXi environments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `RemoteDisplay.maxConnections` with a value of `1`.
+        5. Select `OK`, then `OK` again.
+
+        Alternatively, run the following PowerCLI command for VMs that do not specify the setting:
+
+        ```
+        Add the setting to all VMs
+        Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1
+        ```
+
+        Run the following PowerCLI command for VMs that specify the setting but have the wrong value for it:
+
+        ```
+        Add the setting to all VMs
+        Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1 -Force
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-pci-and-pcie-device-passthrough-is-disabled
+    title: Ensure PCI and PCIe device pass-through is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings.where ( key.contains('pciPassthru')).length == 0 ) )
+    docs:
+      desc: |-
+        This check ensures that PCI and PCIe device pass-through (VMDirectPath I/O) is disabled on VMware ESXi hosts unless explicitly required. Disabling this feature helps maintain workload isolation, reduces the risk of hardware-level attacks, and supports secure, manageable virtual infrastructure.
+
+        **Rationale:**
+
+        VMDirectPath I/O enables a virtual machine to access physical PCI or PCIe devices directly by bypassing the ESXi hypervisor. While this offers performance benefits for specific use cases—such as high-performance networking or GPU workloads—it also introduces significant security and operational risks:
+          - Pass-through devices bypass hypervisor-level controls, including resource scheduling, isolation, and introspection.
+          - Malicious or compromised VMs may be able to interact directly with hardware, increasing the risk of host compromise or denial-of-service.
+          - Direct hardware assignment complicates live migration, high availability, and backup, reducing operational flexibility and resilience.
+
+        When PCI/PCIe pass-through is enabled unnecessarily, it can result in:
+          - Breakdown of isolation between VMs and the hypervisor, exposing the host to hardware-level attacks.
+          - Loss of visibility into VM behavior through hypervisor-level security and monitoring tools.
+          - Reduced VM portability, making it difficult to migrate workloads or perform routine maintenance.
+          - Compliance challenges when device-level control and auditability are required (e.g., under PCI DSS, NIST 800-53, or ISO 27001).
+
+        **Risk mitigation:**
+          - Prevents unauthorized or unnecessary direct access to hardware from guest virtual machines.
+          - Maintains hypervisor-level visibility and control over I/O operations.
+          - Supports robust workload isolation and protects the integrity of the host environment.
+          - Ensures compatibility with advanced virtualization features like vMotion, snapshots, and HA.
+
+        PCI and PCIe device pass-through should only be enabled for trusted workloads with clear, documented requirements. In all other cases, disabling VMDirectPath I/O strengthens security boundaries and simplifies the management of VMware ESXi environments.
+      remediation: |-
+        The following PowerCLI command can be used:
+
+        ```
+        Add the setting to all VMs
+        Get-VM | New-AdvancedSetting -Name "pciPassthru*.present" -value ""
+        ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+        title: VMware vSphere Security Guide
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled
+    title: Ensure Request Disk Topology is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Request Disk Topology feature is disabled on VMware ESXi hosts to prevent guest virtual machines from retrieving detailed information about the underlying physical disk layout. Disabling this capability helps preserve host confidentiality and reduces the risk of targeted attacks or system reconnaissance.
+
+        **Rationale:**
+
+        The Request Disk Topology feature allows guest operating systems to query and receive information about the structure of the storage backing their virtual disks—such as physical sector size, alignment, and other topology details. While useful in certain performance tuning scenarios, this feature introduces potential risks:
+          - It exposes host storage configuration to the guest, increasing the visibility of the virtualization and hardware layer.
+          - Malicious actors in the guest OS could use this data for system fingerprinting, identifying underlying infrastructure to inform targeted exploits.
+          - In multi-tenant or regulated environments, exposing topology data can violate isolation principles or compliance requirements.
+
+        If left enabled without a legitimate need, Request Disk Topology may lead to:
+          - Information disclosure of storage architecture, potentially aiding in hypervisor or host-targeted attacks.
+          - Reduced abstraction, undermining the virtualization layer's role in concealing hardware details from guests.
+          - Compliance violations in environments that require strict separation between tenant workloads and host metadata (e.g., PCI DSS, FedRAMP, ISO 27001).
+          - Greater risk during compromise, as attackers gain deeper insight into how storage is structured and accessed.
+
+        **Risk mitigation:**
+          - Prevents guest VMs from accessing detailed physical storage characteristics.
+          - Maintains abstraction boundaries between guest and host, reinforcing virtualization security.
+          - Reduces attack surface and limits reconnaissance opportunities from within guest operating systems.
+          - Aligns with VMware ESXi hardening best practices and regulatory requirements for workload isolation.
+
+        Disabling the Request Disk Topology feature ensures that virtual machines operate independently of underlying storage layout details, preserving security boundaries and reducing the risk of host infrastructure exposure.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dispTopoRequest.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Request Disk Topology feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.dispTopoRequest.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled
+    title: Ensure Shell Action is disabled
+    impact: 100
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Shell Action feature is disabled on VMware ESXi hosts. Disabling Shell Action helps prevent guest virtual machines from executing commands or triggering actions in the ESXi Shell, thereby preserving hypervisor integrity and reducing the risk of privilege escalation or host compromise.
+
+        **Rationale:**
+
+        The Shell Action capability allows guest virtual machines—via VMware Tools and certain APIs—to initiate shell commands or scripts on the ESXi host. While intended for automation and advanced integration, this feature creates a direct control path from the guest to the host, which poses serious security risks in most environments:
+          - It violates the principle of least privilege, allowing VMs to potentially influence host behavior.
+          - If a VM is compromised, attackers could leverage Shell Action to execute arbitrary commands on the host, leading to full system compromise.
+          - This type of guest-to-host interaction undermines workload isolation and hypervisor hardening, increasing the attack surface.
+
+        If Shell Action is enabled in environments where it is not explicitly required, it may result in:
+          - Unauthorized command execution on the ESXi host from within guest systems.
+          - Privilege escalation, allowing lateral movement from guest to host.
+          - Audit and compliance issues, particularly under frameworks like NIST 800-53, CIS VMware ESXi Benchmark, and ISO 27001, which require strict access control and system boundary enforcement.
+          - Loss of control over critical administrative interfaces.
+
+        **Risk mitigation:**
+          - Prevents guest VMs from initiating shell commands on the ESXi host.
+          - Reinforces strict boundaries between virtual machines and the hypervisor control plane.
+          - Reduces the risk of host compromise via VMware Tools or remote management interfaces.
+          - Supports secure configuration baselines that disable unneeded guest-host integration features.
+
+        Disabling Shell Action is essential for maintaining a secure VMware ESXi environment, ensuring that guest virtual machines cannot execute host-level commands and preserving the integrity and security of the hypervisor.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.ghi.host.shellAction.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Shell Action feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.ghi.host.shellAction.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly
+    title: Ensure the number of VM log files is configured properly
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['log.keepOld'] == 10 ) )
+    docs:
+      desc: |-
+        This check ensures that the maximum number of log files retained for each virtual machine (VM) is configured appropriately to balance diagnostic value with storage efficiency and prevent datastore clutter. Proper log file retention helps maintain system performance, supports auditing, and reduces the risk of storage overutilization.
+
+        **Rationale:**
+
+        Each VMware virtual machine generates log files (vmware.log) to capture operational events, errors, and activity during runtime. By default, multiple rotated logs are retained to support historical troubleshooting and auditing. However, if the number of retained log files is too high—or left at default in high-activity environments—it can lead to:
+          - Excessive datastore usage, especially across many VMs with high churn or verbose logging.
+          - Performance degradation, as backup, snapshot, or replication operations process unnecessary log data.
+          - Loss of visibility if too few logs are retained and older diagnostic information is overwritten too quickly.
+
+        Improper log file retention configuration may result in:
+          - Storage exhaustion on shared datastores or local disk, affecting VM availability and host operations.
+          - Inadequate forensic data, impairing root cause analysis and incident response.
+          - Non-compliance with audit requirements under standards such as PCI DSS, HIPAA, or NIST 800-92, which may mandate a minimum retention period or log availability for security events.
+
+        **Risk mitigation:**
+          - Controls the number of log file rotations (log.rotateSize, log.keepOld) to retain essential diagnostic history without bloating storage.
+          - Ensures that VMs do not accumulate excessive logs over time, especially in long-running workloads.
+          - Supports reliable auditing and troubleshooting by preserving the right amount of historical data.
+          - Aligns with VMware operational best practices and reduces administrative overhead.
+
+        Configuring the number of VM log files properly helps organizations maintain a secure and efficient VMware ESXi environment by balancing the need for historical visibility with the realities of limited storage resources and operational performance.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `log.keepOld` with a value of `10`.
+        5. Select `OK`, then `OK` again.
+
+        To set the number of log files to be used to `10`, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "log.keepOld" -value "10"
+        ```
+
+        **Impact:**
+
+        A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled
+    title: Ensure Trash Folder State is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Trash Folder State feature is disabled on VMware ESXi hosts to prevent the creation and retention of deleted file references within virtual machine environments. Disabling this feature helps reduce unnecessary datastore usage and prevents unintended data persistence in secure or regulated environments.
+
+        **Rationale:**
+
+        The Trash Folder State feature allows virtual machines to retain deleted files temporarily in a trash or recycle-like state rather than removing them immediately. While this may offer convenience for desktop or end-user environments, it introduces several security and operational concerns in server-class, multi-tenant, or regulated deployments:
+          - Deleted files may continue to consume storage, contributing to datastore sprawl or unexpected capacity issues.
+          - Sensitive data may remain recoverable beyond its intended lifecycle, violating data retention or disposal policies.
+          - In environments with strict audit or compliance requirements, retaining deleted files could lead to regulatory violations or forensic concerns.
+
+        If Trash Folder State is left enabled, it may result in:
+          - Data persistence risks, where deleted files remain accessible or recoverable.
+          - Storage inefficiency, particularly in high-churn environments where file deletion is frequent.
+          - Failure to meet data sanitization policies, especially under compliance frameworks such as GDPR, HIPAA, or NIST SP 800-88.
+          - Reduced clarity around what data is actively in use versus what is marked for deletion.
+
+        **Risk mitigation:**
+          - Ensures that file deletions from guest VMs are final and immediate, minimizing residual data.
+          - Reduces unnecessary use of datastore space, improving overall storage management.
+          - Aligns with secure data handling and disposal practices required by regulatory standards.
+          - Limits the risk of unintentional data exposure or recovery in sensitive environments.
+
+        Disabling the Trash Folder State strengthens data hygiene practices in VMware ESXi environments by ensuring that deleted files are truly removed, supporting both operational efficiency and compliance with secure data lifecycle management standards.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.trashFolderState.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Trash Folder State feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.trashFolderState.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines
+    title: Ensure UEFI Secure Boot is enabled for virtual machines
+    impact: 80
+    mql: |
+      vsphere.datacenters.all( vms.all( bootFirmware == "efi" ) )
+      vsphere.datacenters.all( vms.all( secureBootEnabled == true ) )
+    docs:
+      desc: |-
+        UEFI Secure Boot validates the cryptographic signature of the guest bootloader, kernel, and drivers each time a virtual machine starts. Code that is unsigned or signed by an untrusted authority is prevented from running.
+
+        Secure Boot protects a guest operating system against bootkits and rootkits that attempt to load before the OS. It requires the virtual machine to use EFI firmware rather than legacy BIOS.
+
+        **Best Practice:**
+        - Configure virtual machines with EFI firmware and enable Secure Boot for guest operating systems that support it.
+      remediation: |-
+        **To enable Secure Boot via the vSphere Client:**
+
+        1. Power off the virtual machine.
+        2. Right-click the VM and select `Edit Settings`.
+        3. Select the `VM Options` tab and expand `Boot Options`.
+        4. Confirm `Firmware` is set to `EFI`.
+        5. Select the `Secure Boot` checkbox.
+        6. Select `OK`, then power the VM back on.
+
+        **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before converting existing virtual machines.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-898217D4-689D-4EB5-866C-888353FE241C.html
+        title: Enable or Disable UEFI Secure Boot for a Virtual Machine
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled
+    title: Ensure unauthorized connection of devices is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that unauthorized device connections—such as USB, CD/DVD, and other removable or passthrough devices—are disabled for virtual machines in VMware ESXi environments. Disabling or restricting dynamic device connections helps prevent data leakage, malware introduction, and unauthorized access to sensitive resources.
+
+        **Rationale:**
+
+        VMware allows administrators—and potentially end users with sufficient permissions—to connect devices such as USB drives, CD/DVD images, and other hardware interfaces to running virtual machines. While useful for certain workflows, this functionality poses significant risks in production, multi-tenant, or regulated environments:
+          - Removable media can be used to introduce malicious payloads or exfiltrate sensitive data.
+          - Device passthrough enables direct communication between the guest and host or external devices, bypassing security controls.
+          - Uncontrolled device access violates the principle of least privilege and can undermine host integrity or VM isolation.
+
+        Allowing unauthorized or unmanaged device connections can result in:
+          - Data loss or theft, especially when external storage is mounted to sensitive VMs.
+          - Malware injection, including ransomware or rootkits introduced via removable media.
+          - Non-compliance with data protection and access control standards such as PCI DSS, NIST 800-171, HIPAA, and ISO 27001.
+          - Audit trail gaps, where devices are added without proper authorization or monitoring.
+
+        **Risk mitigation:**
+          - Restricts the ability to connect devices dynamically unless explicitly authorized for the workload.
+          - Prevents VMs from interfacing with removable media or passthrough hardware that could expose data or the hypervisor.
+          - Enforces secure configuration baselines by limiting access to only essential virtual hardware components.
+          - Supports compliance with security frameworks requiring control over external device access.
+
+        Disabling unauthorized connection of devices is a critical control for maintaining the security, integrity, and compliance of VMware ESXi environments, particularly where data sensitivity, workload isolation, or regulatory enforcement is a concern.
+      remediation: |-
+        To prevent unauthorized device connections, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.device.connectable.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled
+    title: Ensure unauthorized modification and disconnection of devices is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that unauthorized users are prevented from modifying or disconnecting virtual hardware devices—such as network adapters, hard disks, and virtual NICs—attached to virtual machines in VMware ESXi environments. Restricting these actions helps maintain system integrity, prevents misconfiguration, and protects against intentional or accidental disruption of VM operations.
+
+        **Rationale:**
+
+        VMware ESXi allows users with appropriate permissions to modify or disconnect virtual devices while a VM is powered on. While this capability can be useful for administrative tasks, it introduces substantial risks if left unrestricted:
+          - Users could disconnect critical virtual hardware, such as network adapters or system disks, causing VM outages or service disruption.
+          - Malicious insiders or compromised accounts may alter device configurations to reroute traffic, disable logging, or bypass security controls.
+          - Improper modifications can result in configuration drift, making VMs inconsistent with security baselines or automation templates.
+
+        Allowing unregulated modification or disconnection of virtual devices can lead to:
+          - System outages, affecting availability and business continuity.
+          - Security control bypasses, such as disabling firewalls, security monitoring, or network segmentation.
+          - Non-compliance with operational and regulatory requirements, including PCI DSS, HIPAA, and CIS VMware ESXi Benchmark.
+          - Lack of accountability, as actions may not be properly logged or attributed if privilege boundaries are not enforced.
+
+        **Risk mitigation:**
+          - Ensures only authorized users can modify or disconnect virtual hardware on running or powered-off VMs.
+          - Maintains system availability and reduces the risk of accidental or malicious misconfiguration.
+          - Preserves integrity of VM configurations across lifecycle events and security audits.
+          - Aligns with best practices for access control, change management, and secure virtualization.
+
+        Disabling unauthorized modification and disconnection of virtual devices helps secure VMware ESXi environments by enforcing strict control over hardware configurations, supporting both operational reliability and compliance with security standards.
+      remediation: |-
+        To prevent unauthorized device modifications and disconnections, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.device.edit.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled
+    title: Ensure Unity Active is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity Active feature is disabled on VMware ESXi hosts to prevent guest virtual machines from displaying applications seamlessly on the host desktop using VMware Unity mode. Disabling Unity mode reduces the risk of unauthorized interactions between the guest and host environments and preserves clear isolation boundaries.
+
+        **Rationale:**
+
+        Unity Mode is a VMware feature designed primarily for desktop virtualization products (like VMware Workstation and Fusion), allowing applications running inside a VM to appear as if they are native to the host operating system. While this may enhance usability in certain desktop scenarios, it introduces significant security concerns in server, multi-tenant, or regulated environments:
+          - It blurs the boundary between guest and host, making it more difficult to enforce separation of duties and control over system interactions.
+          - A compromised guest VM may attempt to interact with or manipulate host UI components through Unity integration.
+          - In environments where security, data segmentation, or auditability is critical, Unity mode violates isolation principles.
+
+        Leaving Unity Active enabled can lead to:
+          - Data leakage between guest and host systems through shared windows or input handling.
+          - Unauthorized access or monitoring of host desktop activity from within the guest.
+          - Non-compliance with virtualization hardening benchmarks such as the CIS VMware ESXi Benchmark, DISA STIGs, or industry-specific regulatory frameworks.
+          - Increased attack surface, especially when the guest OS is untrusted or exposed to external users.
+
+        **Risk mitigation:**
+          - Enforces strong host-guest separation, reducing the risk of UI-based or interaction-driven exploits.
+          - Prevents guest applications from presenting themselves on the host desktop, maintaining a secure VM boundary.
+          - Supports compliance with security frameworks that mandate virtualization isolation and access control.
+          - Aligns with VMware best practices for server-class deployments by disabling non-essential desktop features.
+
+        Disabling Unity Active is essential in securing VMware ESXi environments, particularly where guest VMs should remain strictly isolated from the host and where host desktop interaction is unnecessary or explicitly prohibited.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityActive.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity Active feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unityActive.disable" -value $True
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled
+    title: Ensure Unity Interlock is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity Interlock feature is disabled on VMware ESXi hosts to prevent guest virtual machines from interacting with host-side user interface components through Unity mode. Disabling Unity Interlock strengthens the isolation between guest and host environments, reducing the risk of unauthorized access or data leakage.
+
+        **Rationale:**
+
+        Unity Interlock is a supporting mechanism for VMware Unity mode, primarily used in desktop virtualization products like VMware Workstation and Fusion. It facilitates integration between guest applications and the host desktop environment, allowing windows from a guest VM to operate as if they are native host applications. While useful in user-centric desktop environments, it is inappropriate for production ESXi deployments:
+          - Unity Interlock enables deep guest-host UI integration, which can weaken security boundaries between isolated systems.
+          - In environments where the host is shared, regulated, or exposed to sensitive workloads, this feature can expose host resources to untrusted guests.
+          - Guest applications may interfere with host UI elements or capture user input unintentionally, violating principles of secure virtualization.
+
+        If Unity Interlock is enabled, it can lead to:
+          - Unintended access to host system interfaces or user input streams.
+          - Data leakage or manipulation via shared clipboard or window management behavior.
+          - Non-compliance with virtualization hardening standards such as the CIS VMware ESXi Benchmark, DISA STIGs, or NIST security controls.
+          - Breakdown of isolation in multi-tenant, regulated, or security-sensitive deployments.
+
+        **Risk mitigation:**
+          - Prevents guest virtual machines from initiating UI-level integration with the host desktop.
+          - Maintains strict isolation between guest workloads and host operating system resources.
+          - Reduces the attack surface by disabling unnecessary guest-host interaction features.
+          - Aligns with best practices for secure server virtualization by disabling non-essential desktop-oriented functionality.
+
+        Disabling Unity Interlock ensures a clear separation between guest and host systems in VMware ESXi environments, helping to uphold strong isolation policies, prevent UI-level data exposure, and meet compliance requirements in secure deployments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityInterlockOperation.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity Interlock feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unityInterlockOperation.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled
+    title: Ensure Unity is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity feature is fully disabled on VMware ESXi hosts. Disabling Unity mode prevents guest virtual machines from integrating with the host desktop interface, thereby enforcing strong isolation between guest and host environments and reducing the risk of unauthorized interaction or data leakage.
+
+        **Rationale:**
+
+        Unity Mode is a VMware feature primarily used in desktop virtualization products like VMware Workstation and Fusion. It allows applications running inside a virtual machine to appear as native windows on the host desktop, blending the guest and host user experiences. While convenient in personal or development environments, Unity mode introduces serious security concerns in ESXi-based server environments:
+          - It creates a shared interface layer between guest VMs and the host system, violating strict workload isolation principles.
+          - Unity mode may expose host UI components or user input to guest systems, especially when combined with features like shared clipboard or drag-and-drop.
+          - In multi-tenant or compliance-sensitive environments, this integration increases the risk of data leakage, privilege abuse, or unauthorized access.
+
+        If Unity is enabled in ESXi environments, it may result in:
+          - Unauthorized guest-host interaction, including application window sharing or input capturing.
+          - Information disclosure, as guest VMs gain visibility into host-side elements.
+          - Non-compliance with security baselines such as the CIS VMware ESXi Benchmark, DISA STIGs, or NIST 800-53, which emphasize strict isolation and access control.
+          - Increased attack surface, particularly where untrusted or external workloads are hosted.
+
+        **Risk mitigation:**
+          - Fully disables Unity mode, ensuring guest VMs cannot present windows or applications on the host desktop.
+          - Preserves virtualization boundaries by enforcing a clear separation between host and guest environments.
+          - Reduces risk of input redirection, UI spoofing, or data leakage from integrated desktop behavior.
+          - Aligns with hardening best practices for secure ESXi deployments where host system exposure must be minimized.
+
+        Disabling Unity is critical for securing VMware ESXi environments. It prevents unnecessary and potentially risky guest-host UI integration, helping maintain strong security, privacy, and compliance standards across virtualized infrastructure.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled
+    title: Ensure Unity Push Update is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity Push Update feature is disabled on VMware ESXi hosts unless explicitly required. Disabling this feature prevents guest virtual machines from receiving Unity mode configuration updates from the host, thereby preserving system integrity and minimizing unnecessary guest-host communication.
+
+        **Rationale:**
+
+        Unity Push Update is part of the broader Unity integration functionality, designed for desktop virtualization platforms like VMware Workstation and Fusion. It allows the host to push Unity-related settings or updates—such as window position or integration behavior—to the guest. While helpful for seamless user experience in desktop environments, this capability introduces potential security and operational concerns in production ESXi environments:
+          - It creates an additional communication channel from host to guest that may be exploited or misused if the guest is compromised or untrusted.
+          - In regulated or multi-tenant environments, pushing updates from host to guest without tight controls violates isolation and trust boundaries.
+          - These updates may affect guest behavior or UI unexpectedly, leading to unpredictable user experiences or misconfigurations.
+
+        If Unity Push Update is enabled without a valid use case, it can result in:
+          - Unintended guest configuration changes, potentially affecting performance or stability.
+          - Expanded attack surface, as guest VMs interpret instructions from the host.
+          - Non-compliance with hardening guides like the CIS VMware ESXi Benchmark, DISA STIGs, and NIST 800-53, which emphasize limiting unnecessary guest-host interactions.
+          - Reduced auditability, as configuration changes occur outside of standard management workflows.
+
+        **Risk mitigation:**
+          - Prevents the host from transmitting Unity integration settings to guest VMs.
+          - Maintains strict separation between host and guest systems, especially in security-sensitive environments.
+          - Ensures predictable VM behavior by blocking unsolicited or unnecessary updates from the host.
+          - Aligns with secure virtualization best practices by disabling unused or unnecessary guest-host integration features.
+
+        Disabling Unity Push Update strengthens the security posture of VMware ESXi environments by ensuring that guest VMs remain isolated and are not subject to remote configuration updates from the host unless explicitly authorized and required.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.push.update.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity Push Update feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.push.update.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled
+    title: Ensure Unity Taskbar is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity Taskbar feature is disabled on VMware ESXi hosts unless explicitly required. Disabling the Unity Taskbar prevents guest applications from being displayed in the host's taskbar during Unity mode operations, preserving system boundaries and reducing the risk of unauthorized information exposure or interaction.
+
+        **Rationale:**
+
+        The Unity Taskbar feature is part of VMware's Unity mode, primarily intended for desktop virtualization environments such as VMware Workstation or Fusion. When enabled, it allows applications running inside a guest VM to appear in the host operating system's taskbar, as if they were native applications. While this improves user experience in desktop scenarios, it presents serious security and operational risks in ESXi environments:
+          - It blurs the separation between guest and host by making guest processes visible and accessible from the host interface.
+          - Unauthorized or untrusted VMs may leak information through taskbar metadata such as application names, icons, or activity.
+          - It may allow user input or control of guest applications via the host taskbar, which can violate isolation policies.
+
+        If the Unity Taskbar feature is enabled unnecessarily, it can result in:
+          - Data leakage, exposing sensitive guest application details to the host.
+          - Security boundary violations, allowing guest processes to appear or be manipulated from the host interface.
+          - Non-compliance with virtualization hardening standards such as the CIS VMware ESXi Benchmark, DISA STIGs, and ISO 27001.
+          - Reduced accountability and auditability, particularly in environments requiring strict separation of duties or systems.
+
+        **Risk mitigation:**
+          - Prevents guest applications from being surfaced in the host system's taskbar.
+          - Maintains clear and enforceable boundaries between guest virtual machines and the host environment.
+          - Eliminates unnecessary guest-host integration features that may introduce risk.
+          - Aligns with secure virtualization best practices for ESXi, especially in production, regulated, or multi-tenant environments.
+
+        Disabling the Unity Taskbar feature is essential for upholding strong isolation in VMware ESXi environments, ensuring that guest application visibility and interaction are limited to their intended scope and do not cross into the host system's user interface.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.taskbar.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity Taskbar feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.taskbar.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled
+    title: Ensure Unity Window Contents is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that the Unity Window Contents feature is disabled on VMware ESXi hosts. Disabling this feature prevents the host from rendering or displaying the visual content of guest VM application windows in Unity mode, thereby maintaining strong isolation and reducing the risk of unauthorized data exposure.
+
+        **Rationale:**
+
+        The Unity Window Contents feature is part of VMware's Unity mode, used primarily in desktop virtualization products like VMware Workstation and Fusion. When enabled, it allows the host system to display the full graphical content of guest application windows, making them appear and behave like native host applications. While beneficial for user experience in desktop environments, this behavior introduces risks in production ESXi settings:
+          - It creates a visual bridge between guest VMs and the host, allowing sensitive application content to be rendered on the host.
+          - In regulated or multi-tenant environments, this can result in data leakage or unauthorized access to guest activity.
+          - Attackers with host access may be able to view or capture guest application data, violating confidentiality and trust boundaries.
+
+        If Unity Window Contents is enabled without a justified need, it may result in:
+          - Exposure of guest data through host-rendered application windows.
+          - Security boundary violations, undermining the separation between host and guest systems.
+          - Non-compliance with hardening guides like the CIS VMware ESXi Benchmark, DISA STIGs, or NIST 800-53, which stress the importance of system isolation.
+          - Expanded attack surface, especially if combined with other Unity mode features such as clipboard sharing or drag-and-drop.
+
+        **Risk mitigation:**
+          - Prevents guest application visuals from being drawn on the host system, preserving data confidentiality.
+          - Enforces strict host-guest separation by eliminating shared UI rendering paths.
+          - Reduces the risk of information leakage in sensitive or multi-tenant environments.
+          - Aligns with security best practices for server-class deployments where Unity mode is not required.
+
+        Disabling Unity Window Contents is a key control for ensuring VMware ESXi environments remain secure and isolated, helping to prevent the host system from accessing or rendering sensitive guest window data.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.windowContents.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable the Unity Window Contents feature, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.windowContents.disable" -value $True
+        ```
+
+        **Impact:**
+
+        Some automated tools and processes may cease to function.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-cddvd-devices-are-disconnected
+    title: Ensure unnecessary CD/DVD devices are disconnected
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['connected'] == false ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['startConnected'] == false ) ) )
+    docs:
+      desc: |-
+        This check ensures that virtual CD/DVD drives are disconnected from virtual machines unless explicitly required. Disconnecting unused virtual media devices helps reduce the risk of unauthorized data access, malware introduction, and inadvertent configuration changes within VMware ESXi environments.
+
+        **Rationale:**
+
+        Virtual CD/DVD drives in VMware can be connected to ISO images, physical devices, or remote client drives. While necessary during OS installation or software provisioning, these devices often remain attached long after they are needed. If left connected:
+          - They may provide a persistent attack vector, especially if connected to remote or user-controlled media.
+          - Malicious ISO files or auto-mounted content can be used to compromise the guest operating system.
+          - Connected media may interfere with boot order, allowing for unintended or unauthorized boot scenarios.
+
+        Unnecessary CD/DVD device connections can result in:
+          - Security vulnerabilities, where outdated or tampered media is accessible to the VM.
+          - Data leakage if removable media is mounted with sensitive content.
+          - Operational issues, such as failed backups or unexpected reboots due to bootable ISO presence.
+          - Non-compliance with hardening standards like CIS VMware ESXi Benchmark, DISA STIGs, and NIST 800-53, which recommend minimizing virtual hardware.
+
+        **Risk mitigation:**
+          - Prevents exposure to untrusted or unnecessary media sources.
+          - Reduces the virtual attack surface by eliminating unused device paths.
+          - Ensures VMs boot from expected, validated disks by avoiding attached bootable media.
+          - Aligns with virtualization hardening best practices and compliance requirements.
+
+        Disconnecting unnecessary CD/DVD devices ensures a cleaner, more secure configuration for each virtual machine, minimizing the risk of media-based threats and supporting operational consistency in VMware ESXi environments.
+      remediation: |-
+        To disconnect all CD/DVD drives from VMs, run the following PowerCLI command:
+
+        ```
+        Remove all CD/DVD Drives attached to VMs
+        Get-VM | Get-CDDrive | Remove-CDDrive
+        ```
+
+        The VM will need to be powered off for this change to take effect.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-floppy-devices-are-disconnected
+    title: Ensure unnecessary floppy devices are disconnected
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['connected'] == false ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['startConnected'] == false ) ) )
+    docs:
+      desc: |-
+        This check ensures that virtual floppy drives are disconnected from virtual machines unless explicitly required. Removing unused floppy devices reduces the attack surface, prevents legacy-based threats, and supports a secure, streamlined VMware ESXi environment.
+
+        **Rationale:**
+
+        Virtual floppy drives are a legacy hardware feature that remains available in VMware for compatibility purposes. In modern environments, floppy devices are rarely needed, and their continued presence can introduce unnecessary risk:
+          - Floppy drives can be connected to remote or user-supplied images, which may contain outdated or malicious software.
+          - Even when unused, virtual floppy devices create additional virtual hardware that can complicate auditing and increase the system's complexity.
+          - In some cases, connected floppy devices may affect VM boot behavior, especially if boot order is misconfigured.
+
+        Leaving virtual floppy drives connected without purpose can lead to:
+          - Malware exposure, particularly if outdated images or user-controlled content is mounted.
+          - Configuration drift that complicates VM management and auditing.
+          - Non-compliance with virtualization hardening standards like the CIS VMware ESXi Benchmark or DISA STIGs, which recommend removing unnecessary virtual hardware.
+          - Operational inconsistencies, such as failed boots or errors during snapshot or backup operations.
+
+        **Risk mitigation:**
+          - Eliminates obsolete hardware interfaces that are no longer required in modern systems.
+          - Reduces potential threat vectors introduced by legacy media devices.
+          - Supports consistent, minimal VM configurations aligned with secure deployment practices.
+          - Helps meet compliance requirements by minimizing unnecessary virtual machine components.
+
+        Disconnecting unnecessary floppy devices improves the security and manageability of VMware ESXi environments by reducing reliance on legacy components and ensuring that virtual machines are provisioned with only the hardware they need.
+      remediation: |-
+        To disconnect all floppy drives from VMs, run the following PowerCLI command:
+
+        ```
+        Remove all Floppy drives attached to VMs
+        Get-VM | Get-FloppyDrive | Remove-FloppyDrive
+        ```
+
+        The VM will need to be powered off for this change to take effect.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-parallel-ports-are-disconnected
+    title: Ensure unnecessary parallel ports are disconnected
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['connected'] == false ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['startConnected'] == false ) ) )
+    docs:
+      desc: |-
+        This check ensures that parallel ports are not connected to virtual machines unless explicitly needed. If a parallel port is not required, the parallelX.present parameter should either be absent or set to FALSE. Removing unused parallel ports reduces the virtual hardware attack surface and improves overall VM security posture.
+
+        **Rationale:**
+
+        Parallel ports are a legacy hardware interface once commonly used for printers and external devices. In virtualized environments, these ports are rarely necessary. Retaining unused parallel ports can:
+          - Expose unnecessary device interfaces that may be exploited by malicious software or users.
+          - Complicate configuration auditing and management, as legacy hardware devices appear in VM definitions.
+          - In some cases, create compatibility or boot issues, particularly if the hardware is misconfigured or improperly mapped.
+
+        Leaving parallel ports connected without a valid business reason may result in:
+          - Security risks from unmonitored or unprotected interfaces exposed to guest VMs.
+          - Violation of minimal-configuration principles, increasing the potential for misconfiguration or policy drift.
+          - Non-compliance with virtualization hardening benchmarks such as CIS VMware ESXi Benchmark, DISA STIGs, or ISO 27001.
+          - Reduced VM portability and performance, due to inclusion of unnecessary hardware in snapshots or backups.
+
+        **Risk mitigation:**
+          - Ensures that virtual machines only include hardware required for their intended workload.
+          - Reduces the attack surface by eliminating unused and legacy device interfaces.
+          - Simplifies VM configuration, audit, and compliance processes.
+          - Supports secure provisioning practices and enforces least-privilege hardware access.
+
+        To maintain a secure and efficient VMware ESXi environment, parallel ports should be disabled unless absolutely required. This is achieved by ensuring that the parallelX.present parameter is either not defined or explicitly set to FALSE in the VM configuration.
+      remediation: |-
+        To disconnect all parallel ports from VMs, run the following PowerCLI command:
+
+        ```
+        In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
+        Remove all Parallel Ports attached to VMs
+        Get-VM | Get-ParallelPort | Remove-ParallelPort
+        ```
+
+        The VM will need to be powered off for this change to take effect.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-serial-ports-are-disconnected
+    title: Ensure unnecessary serial ports are disconnected
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['connected'] == false ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['startConnected'] == false ) ) )
+    docs:
+      desc: |-
+        This check ensures that serial ports are not connected to virtual machines unless explicitly required. If a serial port is unnecessary, the serialX.present parameter should either be absent or explicitly set to FALSE. Removing unused serial ports helps minimize potential attack vectors and supports hardened virtual machine configurations in VMware ESXi environments.
+
+        **Rationale:**
+
+        Serial ports are legacy interfaces historically used for console access, modem connections, and specialized hardware. In most modern virtualized environments, they are no longer needed for standard workloads. Retaining active serial ports introduces avoidable risks:
+          - Connected serial ports can expose internal or external interfaces, especially if mapped to files, sockets, or physical devices.
+          - They can be abused by malicious actors inside a guest VM to exfiltrate data or communicate covertly.
+          - Serial ports increase configuration complexity and may be overlooked during audits, leading to drift from secure baselines.
+
+        If left enabled without justification, serial ports can result in:
+          - Information leakage through unintended data transmission paths.
+          - Unauthorized communication channels between guest VMs and external systems.
+          - Non-compliance with security standards such as CIS VMware ESXi Benchmark, DISA STIGs, NIST 800-53, or ISO 27001, which recommend minimizing virtual hardware.
+          - Potential misconfiguration of backup, snapshot, or migration processes involving virtual hardware mappings.
+
+        **Risk mitigation:**
+          - Enforces minimal hardware exposure by disabling unused serial interfaces.
+          - Prevents VMs from establishing unauthorized connections through mapped serial devices.
+          - Simplifies auditing and ensures alignment with secure configuration baselines.
+          - Supports strong isolation and compliance with industry best practices for virtualization security.
+
+        To reduce exposure and maintain VM integrity, serial ports should only be enabled when explicitly required for a supported use case. Otherwise, ensure the serialX.present parameter is removed or set to FALSE in the VM's configuration file.
+      remediation: |-
+        To disconnect all serial ports from VMs, run the following PowerCLI command:
+
+        ```
+        In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
+        Remove all Serial Ports attached to VMs
+        Get-VM | Get-SerialPort | Remove-SerialPort
+        ```
+
+        The VM will need to be powered off for this change to take effect.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-usb-devices-are-disconnected
+    title: Ensure unnecessary USB devices are disconnected
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['connected'] == false || _['connectable']['connected'] == null ) ) )
+      vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['startConnected'] == false || _['connectable']['connected'] == null ) ) )
+    docs:
+      desc: |-
+        This check ensures that USB devices are not connected to virtual machines unless explicitly required. To fully disconnect a USB device, the usb.present parameter should either be absent or set to FALSE. Removing unnecessary USB device access reduces the risk of data exfiltration, malware introduction, and unauthorized communication within VMware ESXi environments.
+
+        **Rationale:**
+
+        USB device passthrough allows virtual machines to connect directly to physical USB devices attached to the host or client system. While useful for specific workloads involving peripheral devices, in most server or production environments USB access is unnecessary and introduces security and operational risks:
+          - USB devices can serve as vectors for malware, including ransomware, rootkits, or keyloggers.
+          - A guest VM with USB access may be used to exfiltrate sensitive data or interact with unauthorized external systems.
+          - USB passthrough complicates auditability and access control, especially in shared or multi-tenant environments.
+
+        Leaving USB devices connected without a valid requirement can result in:
+          - Unauthorized data transfer between guest VMs and removable media.
+          - Increased attack surface, particularly when USB ports are exposed to end users or external systems.
+          - Non-compliance with security frameworks such as CIS VMware ESXi Benchmark, DISA STIGs, PCI DSS, and NIST 800-53, which discourage unnecessary device passthrough.
+          - Operational unpredictability, especially during VM migration or snapshot operations involving non-standard virtual hardware.
+
+        **Risk mitigation:**
+          - Prevents access to removable media and peripherals that may introduce vulnerabilities.
+          - Enforces minimal and controlled virtual hardware configurations for guest VMs.
+          - Supports data loss prevention strategies and endpoint protection in virtualized environments.
+          - Aligns with best practices for secure ESXi deployment and regulatory compliance.
+
+        To uphold strong isolation and limit exposure, USB devices should only be enabled when explicitly required. All other VMs should ensure the usb.present parameter is either removed or set to FALSE in their configuration files.
+      remediation: |-
+        To disconnect all USB devices from VMs, run the following PowerCLI command:
+
+        ```
+        Remove all USB Devices attached to VMs
+        Get-VM | Get-USBDevice | Remove-USBDevice
+        ```
+
+        The VM will need to be powered off for this change to take effect.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled
+    title: Ensure virtual disk shrinking is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that virtual disk shrinking is disabled on VMware ESXi hosts unless there is a specific operational need. Repeated shrinking operations can degrade virtual disk integrity and availability, potentially leading to denial-of-service (DoS) conditions for affected virtual machines.
+
+        **Rationale:**
+
+        Virtual disk shrinking is a VMware Tools feature that allows users to reduce the size of a virtual disk by removing unused space. While intended to optimize storage utilization, disk shrinking is generally not required in most enterprise environments and can be highly disruptive when misused:
+          - Repeated shrinking can result in fragmentation, performance degradation, and eventually disk corruption.
+          - In worst-case scenarios, it can render the virtual disk unavailable, effectively taking the VM offline and leading to a denial-of-service.
+          - Allowing guest users or automated scripts to invoke disk shrinking can bypass storage management policies and introduce unpredictable behavior.
+
+        If virtual disk shrinking remains enabled without proper controls, it may result in:
+          - Loss of availability due to failed or corrupted disk operations.
+          - Security risks, as malicious actors could deliberately trigger shrink operations to disrupt services.
+          - Non-compliance with data protection and availability requirements under frameworks like NIST 800-53, ISO 27001, or PCI DSS.
+          - Storage management inconsistencies, especially in environments with thin-provisioned disks and shared datastores.
+
+        **Risk mitigation:**
+          - Disables guest-initiated disk shrinking to preserve disk integrity and system availability.
+          - Prevents misuse or overuse of a feature that can introduce operational risk.
+          - Reinforces centralized control of storage management through hypervisor-level tools and policies.
+          - Aligns with VMware hardening guidance and best practices for secure infrastructure management.
+
+        To ensure virtual machine stability and protect against denial-of-service risks, virtual disk shrinking should be disabled unless explicitly required. This can be enforced by configuring VMware Tools settings to block shrink operations from within the guest operating system.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskShrink.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To implement the recommended configuration state, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.diskShrink.disable" -value $true
+        ```
+
+        **Impact:**
+
+        Inability to shrink virtual machine disks in the event that a datastore runs out of space.
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled
+    title: Ensure virtual disk wiping is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that virtual disk wiping is disabled on VMware ESXi hosts unless specifically needed for secure data sanitization. Repeated or unnecessary disk wiping operations can negatively impact performance, reduce availability, and potentially lead to denial-of-service (DoS) conditions. In most datacenter environments, this feature is not needed and should be restricted.
+
+        **Rationale:**
+
+        Virtual disk wiping is a VMware Tools feature that allows users or processes within a guest VM to zero out unused disk space to reclaim host storage in thin-provisioned disks. While intended for space optimization, it presents risks when invoked frequently or without oversight:
+          - Wiping operations are I/O-intensive and may cause the virtual disk to become temporarily unavailable during execution.
+          - Normal users or automated processes—even without administrative privileges—can initiate disk wipes if the feature is enabled.
+          - In shared or production environments, uncontrolled wiping can degrade host performance or disrupt availability of critical workloads.
+
+        Leaving virtual disk wiping enabled by default can result in:
+          - Denial-of-service scenarios, where VMs become unresponsive or inaccessible during prolonged wipe operations.
+          - Unregulated storage operations, bypassing centralized storage management and impacting capacity planning.
+          - Security policy violations, as sensitive operations like disk sanitization are performed without proper authorization or audit controls.
+          - Non-compliance with operational hardening standards such as CIS VMware ESXi Benchmark or NIST SP 800-53, which recommend restricting low-level disk functions.
+
+        **Risk mitigation:**
+          - Prevents guest users or low-privilege processes from initiating disk wipe operations.
+          - Reduces performance and availability risks associated with unnecessary I/O-intensive background tasks.
+          - Ensures that secure data erasure and storage reclamation are centrally managed by authorized administrators.
+          - Aligns with best practices for protecting virtual infrastructure from misuse or disruption.
+
+        Disabling virtual disk wiping helps safeguard VMware ESXi environments from unintended service disruption, enforces controlled storage operations, and ensures that disk-level sanitization is reserved for valid, authorized use cases only.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskWiper.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To disable virtual disk wiping, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.diskWiper.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
+    title: Ensure virtual machine encryption is enabled
+    impact: 80
+    mql: |
+      vsphere.datacenters.all( vms.all( encrypted == true ) )
+    docs:
+      desc: |-
+        VM encryption protects virtual machine data at rest. When a virtual machine is encrypted, vSphere encrypts the VM configuration files, the virtual disk files, and the swap and suspend files using keys supplied by a configured key provider.
+
+        Encryption prevents the disclosure of guest data if the underlying datastore, backup media, or VM files are copied or stolen. It also protects against offline tampering with the VM's contents.
+
+        **VM encryption provides:**
+        - Confidentiality of virtual disks and configuration at rest
+        - Protection of data on shared, replicated, or backed-up storage
+        - A foundation for vTPM, which depends on VM encryption to protect its secrets
+
+        **Best Practice:**
+        - Encrypt virtual machines that store sensitive or regulated data.
+        - Use a Native Key Provider or an external KMS, and protect access to the key provider.
+      remediation: |-
+        Encrypting a virtual machine requires a key provider configured in vCenter Server.
+
+        **To encrypt a virtual machine via the vSphere Client:**
+
+        1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
+        2. Power off the virtual machine.
+        3. Right-click the VM and select `VM Policies` → `Edit VM Storage Policies`.
+        4. From the `VM storage policy` drop-down, select `VM Encryption Policy`.
+        5. Select `OK`, then power the VM back on.
+
+        **Impact:**
+
+        Encrypted virtual machines cannot be migrated to hosts that lack access to the key provider, and some operations (such as content-based deduplication) are not available for encrypted VMs.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E6C5CE29-CD1D-4555-859C-A0492E7CB45D.html
+        title: Virtual Machine Encryption
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled
+    title: Ensure Virtualization-Based Security is enabled
+    impact: 70
+    mql: |
+      vsphere.datacenters.all( vms.all( vbsEnabled == true ) )
+    docs:
+      desc: |-
+        Virtualization-Based Security (VBS) is a Microsoft Windows feature that uses hardware virtualization to create an isolated, hypervisor-protected region of memory. Windows uses this isolated region to run sensitive security functions, such as Credential Guard and Hypervisor-Protected Code Integrity (HVCI).
+
+        When VBS is enabled for a virtual machine, vSphere exposes the virtualization extensions the guest needs to run these protections, hardening the guest against credential theft and kernel-level malware.
+
+        **VBS provides:**
+        - Isolation for Windows Credential Guard, protecting domain credentials
+        - Hypervisor-Protected Code Integrity (HVCI) for the guest kernel
+        - A reduced attack surface for pass-the-hash and kernel-mode attacks
+
+        **Best Practice:**
+        - Enable VBS for Windows virtual machines that support it, alongside EFI firmware, Secure Boot, and a vTPM.
+      remediation: |-
+        Enabling VBS requires the virtual machine to use EFI firmware with Secure Boot, hardware virtualization exposed to the guest, and a supported Windows guest OS.
+
+        **To enable VBS via the vSphere Client:**
+
+        1. Power off the virtual machine.
+        2. Right-click the VM and select `Edit Settings`.
+        3. On the `VM Options` tab, select the `Enable` checkbox next to `Virtualization Based Security`.
+        4. Select `OK`, then power the VM back on.
+        5. In the Windows guest, enable VBS and Credential Guard via Group Policy or the Windows security settings.
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CC0C6FE0-2902-4DBC-BFFE-1710A971B57F.html
+        title: Virtualization-based Security
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled
+    title: Ensure VM Console Copy operations are disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that copy operations from the VM console are disabled in VMware ESXi environments. Disabling console-based copy functionality helps prevent unauthorized data exfiltration and enforces strict isolation between guest virtual machines and users accessing them through the vSphere client or other management interfaces.
+
+        **Rationale:**
+
+        The VM console provides direct access to a virtual machine’s display and input, similar to physical console access. By default, VMware Tools enables copy (and optionally paste) operations between the administrator’s client system and the VM through the console. While convenient for troubleshooting, this feature introduces significant security risks:
+          - It allows data to be copied out of the VM, creating a potential data leakage vector.
+          - In environments with sensitive or regulated data, allowing copy operations may violate data handling policies.
+          - This feature can be exploited by malicious insiders or compromised accounts to exfiltrate information during remote access sessions.
+
+        If VM console copy operations remain enabled, it may result in:
+          - Unauthorized data transfer from guest VMs to external systems without proper logging or oversight.
+          - Insider threats, where privileged users leverage console access to extract confidential data.
+          - Non-compliance with data protection and regulatory requirements such as HIPAA, PCI DSS, ISO 27001, and NIST 800-53.
+          - Weakened isolation between management interfaces and virtualized workloads.
+
+        **Risk mitigation:**
+          - Blocks copy operations from VM consoles, preventing data exfiltration via clipboard interaction.
+          - Enforces strict boundaries between guest systems and administrative clients.
+          - Enhances auditability by requiring approved methods (e.g., secure file transfer) for data movement.
+          - Supports regulatory compliance and aligns with VMware ESXi hardening best practices.
+
+        Disabling VM console copy operations is a critical control for securing virtual environments, especially in multi-tenant, regulated, or high-sensitivity deployments where data leakage through management interfaces must be strictly prevented.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.copy.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To explicitly disable VM console copy operations, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.copy.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled
+    title: Ensure VM Console Drag and Drop operations is disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that drag and drop operations via the VM console are disabled in VMware ESXi environments. Disabling this feature helps prevent unauthorized file transfers between the guest virtual machine and the administrative host system, reducing the risk of data exfiltration, malware introduction, and compliance violations.
+
+        **Rationale:**
+
+        When VMware Tools is installed, administrators accessing a VM through the vSphere client or Workstation interface may be able to drag files to and from the virtual machine console. While this simplifies file transfers for troubleshooting, it poses a serious security concern in production or regulated environments:
+          - Drag and drop enables unaudited file transfers, potentially bypassing established security controls.
+          - It creates a bidirectional data path between the VM and the host, which can be exploited for malware injection or data leakage.
+          - This functionality is not logged or monitored by default, making it difficult to detect or investigate misuse.
+
+        If drag and drop is enabled in the VM console, it can lead to:
+          - Unauthorized data movement, including sensitive information leaving the VM environment.
+          - Infection of VMs with unverified or malicious files transferred by users or attackers.
+          - Non-compliance with data handling and access control standards under frameworks such as HIPAA, PCI DSS, NIST 800-53, and CIS VMware ESXi Benchmark.
+          - Erosion of virtualization boundaries, increasing the risk of lateral movement and insider threats.
+
+        **Risk mitigation:**
+          - Prevents direct, unmanaged file transfers between host systems and guest VMs.
+          - Supports strict data access and movement policies by requiring approved, auditable file transfer mechanisms.
+          - Reduces the attack surface by eliminating a potentially invisible ingress/egress path.
+          - Aligns with secure virtualization best practices and regulatory compliance requirements.
+
+        Disabling VM console drag and drop operations strengthens isolation between administrative systems and guest workloads, helping to maintain the integrity and confidentiality of virtual machines in VMware ESXi environments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dnd.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To explicitly disable VM console drag and drop operations, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.dnd.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled
+    title: Ensure VM Console GUI Options is disabled
+    impact: 75
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == false ) )
+    docs:
+      desc: |-
+        This check ensures that VM Console GUI options are disabled in VMware ESXi environments to prevent unauthorized access to advanced console features and reduce the risk of system misconfiguration or data leakage through the graphical user interface.
+
+        **Rationale:**
+
+        The VM Console GUI options in the vSphere client and other VMware interfaces provide access to various convenience features for interacting with a virtual machine’s graphical display. These may include menu items for mounting media, toggling devices, adjusting display settings, or accessing host-integrated features. While useful for interactive use cases, these GUI options introduce potential risks in secure, production, or regulated environments:
+          - They can enable users to bypass security controls by attaching devices or media without authorization.
+          - Some GUI options may expose host-guest integration points, undermining VM isolation.
+          - Access to these features is often not tightly audited or restricted, increasing the potential for misconfiguration or abuse.
+
+        If VM Console GUI options remain enabled, it may result in:
+          - Uncontrolled configuration changes, such as device mounting or display behavior alterations.
+          - Security control bypasses, especially when VMs are accessible by multiple administrators or external personnel.
+          - Non-compliance with virtualization hardening benchmarks like CIS VMware ESXi Benchmark, DISA STIGs, or regulatory frameworks such as PCI DSS and HIPAA.
+          - Data leakage or exposure, particularly if GUI actions enable file or clipboard sharing without proper controls.
+
+        **Risk mitigation:**
+          - Removes access to unnecessary console-based GUI options, enforcing stricter control over virtual machine interactions.
+          - Minimizes the risk of accidental or unauthorized VM configuration changes through the graphical interface.
+          - Enhances auditability and policy compliance by requiring approved tools or workflows for VM administration.
+          - Supports secure VM isolation and aligns with ESXi hardening best practices.
+
+        Disabling VM Console GUI options is an important control for maintaining the security, stability, and compliance of VMware ESXi environments—ensuring that access to sensitive VM operations is both intentional and well-governed.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.setGUIOptions.enable` with a value of `FALSE`.
+        5. Select `OK`, then `OK` again.
+
+        To explicitly disable VM console and paste GUI options, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.setGUIOptions.enable" -value $false
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled
+    title: Ensure VM Console Paste operations are disabled
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == true ) )
+    docs:
+      desc: |-
+        This check ensures that paste operations into virtual machines via the VM console are disabled in VMware ESXi environments. Disabling paste functionality prevents unauthorized data injection into guest systems and enforces strict boundaries between administrative systems and virtual machines.
+
+        **Rationale:**
+
+        When VMware Tools is installed, users accessing a VM through the console can often paste clipboard contents from their local machine directly into the guest operating system. While useful for tasks like command-line entry or configuration updates, this feature poses a security risk in sensitive or controlled environments:
+          - It creates a data injection path from the administrator’s host system into the VM without audit or access controls.
+          - Malicious or unintended clipboard contents may be pasted into a privileged session, leading to configuration errors, command execution, or data corruption.
+          - Sensitive data copied on the administrator’s system could be inadvertently transferred to the VM, violating data handling or segmentation policies.
+
+        If VM Console Paste operations are left enabled, it can result in:
+          - Unintentional or unauthorized data transfer from host to guest systems.
+          - Security policy violations, particularly in regulated environments where data ingress must be controlled and logged.
+          - Increased risk of insider threats, where privileged users use the console to inject unmonitored content.
+          - Non-compliance with hardening guidance from CIS VMware ESXi Benchmark, DISA STIGs, NIST 800-53, and similar frameworks.
+
+        **Risk mitigation:**
+          - Blocks administrative users from pasting clipboard contents into VMs via the console interface.
+          - Enforces secure and controlled methods for configuration and data entry.
+          - Reduces the risk of accidental or malicious data transfer to guest systems.
+          - Aligns with virtualization security best practices by minimizing unmanaged host-to-guest communication channels.
+
+        Disabling VM Console Paste operations helps ensure that all data interactions with virtual machines are deliberate, controlled, and compliant with security policies—strengthening isolation and reducing the risk of misconfiguration or data leakage in VMware ESXi environments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.paste.disable` with a value of `TRUE`.
+        5. Select `OK`, then `OK` again.
+
+        To explicitly disable VM console paste operations, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "isolation.tools.paste.disable" -value $true
+        ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited
+    title: Ensure VM log file size is limited
+    impact: 60
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['log.rotateSize'] == 1024000 ) )
+    docs:
+      desc: |-
+        This check ensures that VM log file size and rotation policies are configured to limit growth and retain recent log data without consuming excessive storage. Configuring log rotation parameters—such as maximum file size and number of retained logs—prevents datastore clutter and ensures that logs remain manageable, auditable, and performance-safe in VMware ESXi environments.
+
+        **Rationale:**
+
+        By default, a new VM log file (vmware.log) is typically created only when a host is rebooted, which can result in large, unwieldy log files on long-running virtual machines. Without rotation or size limits, these logs can consume significant datastore space, degrade performance, and complicate log analysis or retention efforts. To maintain efficient and secure operations, VMware recommends:
+          - Limiting each log file to 1 MB using the log.rotateSize parameter.
+          - Retaining a maximum of 10 log files per VM via the log.keepOld setting.
+
+        If logging behavior is not properly configured, it can lead to:
+          - Datastore exhaustion from unbounded log growth.
+          - Delayed or failed VM operations, especially during backups, migrations, or snapshots.
+          - Loss of relevant log data, as older logs may be overwritten too quickly or missing entirely.
+          - Non-compliance with operational and security standards such as CIS VMware ESXi Benchmark and NIST 800-92, which recommend proper logging and retention policies.
+
+        **Risk mitigation:**
+          - Limits the size of each log file to prevent performance degradation or uncontrolled growth.
+          - Ensures recent operational logs are preserved through intelligent log rotation.
+          - Prevents excessive use of shared datastore resources by managing cumulative log size.
+          - Supports compliance with audit, incident response, and forensic analysis requirements.
+
+        To implement this control effectively, set log.rotateSize = "1048576" (1 MB) and log.keepOld = "10" in the VM’s configuration. This ensures that logging is both space-efficient and useful for troubleshooting, without compromising datastore health or operational stability in VMware ESXi environments.
+      remediation: |-
+        To set this configuration utilize the vSphere interface as follows:
+
+        1. Select the VM then select `Actions` followed by `Edit Settings`.
+        2. Select `VM Options` tab then expand `Advanced`.
+        3. Select `EDIT CONFIGURATION`.
+        4. Select `ADD CONFIGURATION PARAMS` then input `log.rotateSize` with a value of `1024000`.
+        5. Select `OK`, then `OK` again.
+
+        To properly limit the maximum log file size, run the following PowerCLI command for each VM:
+
+        ```powershell
+        Get-VM | New-AdvancedSetting -Name "log.rotateSize" -value "1024000"
+        ```
+
+        **Impact:**
+
+        A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.


### PR DESCRIPTION
## Summary

Adds two VMware vSphere security policies to the default content:

- **Mondoo VMware vSphere ESXi Security** (`mondoo-vmware-vsphere-esxi-security-baseline`) — security guidelines for VMware ESXi hosts, covering installation, communication, logging, access control, console, storage, and network configuration. Includes host SSL certificate expiry, signed kernel modules, UEFI Secure Boot, SNMP/SLP service hardening, and static DNS configuration.
- **Mondoo VMware vSphere** (`mondoo-vmware-vsphere`) — security checks for vSphere virtual machines, including an Encryption and Boot Security group covering VM encryption, UEFI Secure Boot, virtual TPM presence, and Virtualization-Based Security.

Both policies use the BUSL-1.1 license and copyright header consistent with the rest of the default content.

## Test plan

- [x] `cnspec policy lint content/mondoo-vmware-vsphere-esxi.mql.yaml content/mondoo-vmware-vsphere.mql.yaml` — valid policy bundle(s), no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)