### PR TITLE
:sparkles: Add linter rule warning on check titles over 75 characters

### DIFF
--- a/internal/bundle/lint_rules_queries.go
+++ b/internal/bundle/lint_rules_queries.go
@@ -5,18 +5,23 @@ package bundle
 
 import (
 	"fmt"
+	"unicode/utf8"
 )
 
 // Query Rule ID Constants
 const (
 	QueryUidRuleID                         = "query-uid"
 	QueryTitleRuleID                       = "query-name" // Original ID was query-name
+	QueryTitleTooLongRuleID                = "query-title-too-long"
 	QueryUidUniqueRuleID                   = "query-uid-unique"
 	QueryUnassignedRuleID                  = "query-unassigned"
 	QueryUsedAsDifferentTypesRuleID        = "query-used-as-different-types"
 	QueryMissingMQLRuleID                  = "query-missing-mql"
 	QueryVariantUsesNonDefaultFieldsRuleID = "query-variant-uses-non-default-fields"
 )
+
+// MaxQueryTitleLength is the maximum allowed length, in characters, for a check title.
+const MaxQueryTitleLength = 75
 
 // GetQueryLintRules is the input type for lint checks on queries.
 func GetQueryLintRules() []LintRule {
@@ -33,6 +38,12 @@ func GetQueryLintRules() []LintRule {
 			Description: "Ensures non-variant queries have a `title` field.",
 			Severity:    LevelError,
 			Run:         runRuleQueryTitle,
+		}, {
+			ID:          QueryTitleTooLongRuleID,
+			Name:        "Query Title Length",
+			Description: fmt.Sprintf("Warns when check titles are longer than %d characters.", MaxQueryTitleLength),
+			Severity:    LevelWarning,
+			Run:         runRuleQueryTitleLength,
 		}, {
 			ID:          QueryVariantUsesNonDefaultFieldsRuleID,
 			Name:        "Query Variant Field Restrictions",
@@ -158,6 +169,36 @@ func runRuleQueryTitle(ctx *LintContext, item any) []*Entry {
 		}
 	}
 	return nil
+}
+
+func runRuleQueryTitleLength(ctx *LintContext, item any) []*Entry {
+	input, ok := item.(QueryLintInput)
+	if !ok {
+		return nil
+	}
+	q := input.Query
+
+	// Only checks have a length constraint on their titles.
+	if _, usedAsCheck := ctx.QueryUsageAsCheck[q.Uid]; !usedAsCheck {
+		return nil
+	}
+
+	length := utf8.RuneCountInString(q.Title)
+	if length <= MaxQueryTitleLength {
+		return nil
+	}
+
+	return []*Entry{{
+		RuleID: QueryTitleTooLongRuleID,
+		Message: fmt.Sprintf("%s title is %d characters long, exceeding the maximum of %d",
+			queryIdentifier(q, input.IsGlobal), length, MaxQueryTitleLength),
+		Level: LevelWarning,
+		Location: []Location{{
+			File:   ctx.FilePath,
+			Line:   q.FileContext.Line,
+			Column: q.FileContext.Column,
+		}},
+	}}
 }
 
 func runRuleQueryVariantFields(ctx *LintContext, item any) []*Entry {

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -181,6 +181,16 @@ func TestLinter_Fail(t *testing.T) {
 		assert.Equal(t, "error", results.Entries[0].Level)
 	})
 
+	t.Run("fail-query-title-too-long", func(t *testing.T) {
+		file := "./testdata/fail-query-title-too-long.mql.yaml"
+		results, err := Lint(schema, testLintOptions, file)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(results.Entries))
+		assert.Equal(t, "Global query 'ubuntu-hard-2-2' title is 83 characters long, exceeding the maximum of 75", results.Entries[0].Message)
+		assert.Equal(t, "query-title-too-long", results.Entries[0].RuleID)
+		assert.Equal(t, "warning", results.Entries[0].Level)
+	})
+
 	t.Run("fail-query-variant-uses-non-default-fields", func(t *testing.T) {
 		file := "./testdata/fail-query-variant-uses-non-default-fields.mql.yaml"
 		results, err := Lint(schema, testLintOptions, file)

--- a/internal/bundle/testdata/fail-query-title-too-long.mql.yaml
+++ b/internal/bundle/testdata/fail-query-title-too-long.mql.yaml
@@ -1,0 +1,41 @@
+policies:
+  - uid: ubuntu-bench-2
+    name: Ubuntu Benchmark 2
+    version: 1.0.0
+    tags:
+      mondoo.com/category: compliance
+      mondoo.com/platform: ubuntu:24.04,linux
+    require:
+      - provider: os
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    docs:
+      desc: test description
+    groups:
+      - uid: ubuntu-hard-2
+        title: Configure Ubuntu 2
+        filters: |
+          asset.platform == "ubuntu"
+          asset.version == "24.04"
+          asset.kind != "container-image"
+        checks:
+          - uid: ubuntu-hard-2-2
+    scoring_system: highest impact
+queries:
+  - uid: ubuntu-hard-2-2
+    title: Ensure that the system password file exists and is readable by everyone on the host
+    impact: 30
+    tags:
+      test/tag: hard-2-2
+    mql: |
+      file("/etc/passwd").exists
+    docs:
+      desc: test_description
+      audit: test_description
+      remediation:
+        - id: terraform
+          desc: |
+            test-description
+        - id: ansible
+          desc: test-description


### PR DESCRIPTION
## Summary

Adds a new `query-title-too-long` lint rule that warns when a check's `title` exceeds 75 characters.

- `content/CLAUDE.md` already documents the rule ("Check `title` fields must be 75 characters or fewer"); this makes `cnspec policy lint` surface violations automatically.
- The rule is **warning-level**, so it does not fail linting on existing policies.
- It applies only to queries used as checks, counting Unicode characters (`utf8.RuneCountInString`) rather than bytes.

Running the linter against `./content` currently flags 4 existing checks that exceed the limit (2 in `mondoo-kubernetes-security`, 2 in `mondoo-vmware-vsphere-esxi`). These are surfaced as warnings and can be addressed separately.

## Test plan

- Added `internal/bundle/testdata/fail-query-title-too-long.mql.yaml` and a `fail-query-title-too-long` subtest in `lint_test.go`.
- `go test ./internal/bundle/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)