### PR TITLE
:sparkles: Add compliance framework mappings to Shodan and VMware vSphere policies

### DIFF
--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -37,6 +37,20 @@ queries:
   - uid: mondoo-shodan-membership
     title: Verify Shodan membership
     impact: 50
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     filters: asset.platform == "shodan-org"
     mql: shodan.profile.member == true
     docs:
@@ -82,6 +96,20 @@ queries:
   - uid: mondoo-shodan-no-port
     title: Ensure no ports are open
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: false
     filters: |
       asset.platform == "shodan-host" &&
       shodan.host.ip == regex.ipv4
@@ -127,6 +155,20 @@ queries:
   - uid: mondoo-shodan-vulnerabilities
     title: Ensure no vulnerabilities are detected
     impact: 90
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-id-ra-1
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     filters: |
       asset.platform == "shodan-host" &&
       shodan.host.ip == regex.ipv4

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -85,6 +85,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-account-lockout-is-set-to-15-minutes
     title: Ensure account lockout is set to 15 minutes
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['Security.AccountUnlockTime'] == 900
     docs:
@@ -138,6 +152,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
     title: Ensure all loaded ESXi kernel modules are signed
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.kernelModules.where( loaded == true ).all( signedStatus != "Unsigned" )
     docs:
@@ -202,6 +230,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
     title: Ensure bidirectional CHAP authentication for iSCSI traffic is enabled
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthEnabled'] == true )
       vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthenticationType'] == 'chapPreferred' )
@@ -270,6 +312,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dns-is-statically-configured-on-the-esxi-host
     title: Ensure DNS is statically configured on the ESXi host
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.dnsConfig.dhcp == false
       vsphere.host.dnsConfig.servers != empty
@@ -327,6 +383,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
     title: Ensure dvfilter API is not configured if not used
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['Net.DVFilterBindIpAddress'] == empty
     docs:
@@ -386,6 +456,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
     title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
+      compliance/pci-dss-4: pcidss-requirement-8-2-8
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] <= 300
       vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] != 0
@@ -444,6 +528,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
     title: Ensure Managed Object Browser (MOB) is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['Config.HostAgent.plugins.solo.enableMob'] == false
     docs:
@@ -498,6 +596,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
     title: Ensure Normal Lockdown mode is enabled
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a5
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.properties['config']['lockdownMode'] == "lockdownNormal"
     docs:
@@ -551,6 +663,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
     title: Ensure NTP time synchronization is configured properly
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a7
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( key == "ntpd").all( running == true )
       vsphere.host.services.where( key == "ntpd").all( policy == "on" )
@@ -608,6 +734,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-persistent-logging-is-configured-for-all-esxi-hosts
     title: Ensure persistent logging is configured for all ESXi hosts
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.advancedSettings['Syslog.global.logDir'] != ""
       vsphere.host.advancedSettings['Syslog.global.logDir'] != /scratch/
@@ -663,6 +803,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan
     title: Ensure port groups are not configured to the value of the native VLAN
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] >= 2 )
       vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] <= 4094 )
@@ -717,6 +871,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-
     title: Ensure port groups avoid VLAN 4095 and 0 except for VGT
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 0 )
       vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 4095 )
@@ -768,6 +936,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-remote-logging-is-configured-for-esxi-hosts
     title: Ensure remote logging is configured for ESXi hosts
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.advancedSettings['Syslog.global.logHost'] != ""
     docs:
@@ -822,6 +1004,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ssh-is-disabled
     title: Ensure SSH is disabled
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( key == "TSM-SSH").all( running == false )
       vsphere.host.services.where( key == "TSM-SSH").all( policy == "off" )
@@ -880,6 +1076,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
     title: Ensure Strict Lockdown mode is enabled
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a5
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.properties['config']['lockdownMode'] == "lockdownStrict"
     docs:
@@ -934,6 +1144,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
     title: Ensure the DCUI timeout is set to 600 seconds or less
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
+      compliance/pci-dss-4: pcidss-requirement-8-2-8
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] <= 600
       vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] != 0
@@ -984,6 +1208,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-default-value-of-individual-salt-per-vm-is-configured
     title: Ensure the default value of individual salt per vm is configured
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: vsphere.host.advancedSettings['Mem.ShareForceSalting'] == 2
     docs:
       desc: |-
@@ -1040,6 +1278,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
     title: Ensure the ESXi host firewall restricts access to running services
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( running == true ).all( ruleset != [] )
       vsphere.host.properties['config']['firewall']['ruleset'].all( _['allowedHosts']['allIp'] == false )
@@ -1091,6 +1343,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
     title: Ensure the ESXi host SSL certificate is not expired or expiring soon
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       vsphere.host.certificate.notAfter - time.now > 90 * time.day
     docs:
@@ -1140,6 +1406,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
     title: Ensure the ESXi shell is disabled
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( key == "TSM").all( running == false )
       vsphere.host.services.where( key == "TSM").all( policy == "off" )
@@ -1193,6 +1473,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-image-profile-vib-acceptance-level-is-configured-properly
     title: Ensure the Image Profile VIB acceptance level is configured properly
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: vsphere.host.acceptanceLevel == /VMwareCertified|VMwareAccepted|PartnerSupported/
     docs:
       desc: |-
@@ -1248,6 +1542,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-maximum-failed-login-attempts-is-set-to-5
     title: Ensure the maximum failed login attempts is set to 5
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5
     docs:
@@ -1302,6 +1610,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-shell-services-timeout-is-set-to-1-hour-or-less
     title: Ensure the shell services timeout is set to 1 hour or less
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
+      compliance/pci-dss-4: pcidss-requirement-8-2-8
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] <= 3600
       vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] != 0
@@ -1357,6 +1679,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-slp-service-is-disabled
     title: Ensure the SLP service is disabled
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( key == "slpd" ).all( running == false )
       vsphere.host.services.where( key == "slpd" ).all( policy == "off" )
@@ -1415,6 +1751,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled
     title: Ensure the SNMP service is disabled
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.services.where( key == "snmpd" ).all( running == false )
       vsphere.host.services.where( key == "snmpd" ).all( policy == "off" )
@@ -1473,6 +1823,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject
     title: Ensure the vSwitch Forged Transmits policy is set to reject
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.standardSwitch.all( securityPolicySettings.allowForgedTransmits == false )
       vsphere.host.properties['config']['network']['portgroup'].all( _['computedPolicy']['security']['forgedTransmits'] == false )
@@ -1530,6 +1894,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject
     title: Ensure the vSwitch MAC Address Change policy is set to reject
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.standardSwitch.all( securityPolicySettings.allowMacChanges == false )
     docs:
@@ -1585,6 +1963,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject
     title: Ensure the vSwitch Promiscuous Mode policy is set to reject
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.standardSwitch.all( securityPolicySettings.allowPromiscuous == false )
     docs:
@@ -1640,6 +2032,20 @@ queries:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-uefi-secure-boot-is-enabled-on-the-esxi-host
     title: Ensure UEFI Secure Boot is enabled on the ESXi host
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.host.secureBootEnabled == true
     docs:

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -100,6 +100,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present
     title: Ensure a virtual Trusted Platform Module is present
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( vtpmPresent == true ) )
     docs:
@@ -149,6 +163,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled
     title: Ensure Autologon is disabled
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == "true" ) )
     docs:
@@ -203,6 +231,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled
     title: Ensure BIOS BBS is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == "true" ) )
     docs:
@@ -254,6 +296,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled
     title: Ensure Drag and Drop Version Get is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true" ) )
     docs:
@@ -309,6 +365,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled
     title: Ensure Drag and Drop Version Set is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == "true" ) )
     docs:
@@ -364,6 +434,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled
     title: Ensure GetCreds is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == "true" ) )
     docs:
@@ -419,6 +503,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled
     title: Ensure Guest Host Interaction Launch Menu is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == "true" ) )
     docs:
@@ -474,6 +572,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled
     title: Ensure Guest Host Interaction Protocol Handler is set to disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true" ) )
     docs:
@@ -529,6 +641,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled
     title: Ensure Guest Host Interaction Tray Icon is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == "true" ) )
     docs:
@@ -584,6 +710,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
     title: Ensure hardware-based 3D acceleration is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
     docs:
       desc: |-
@@ -637,6 +777,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled
     title: Ensure Host Guest File System Server is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == "true" ) )
     docs:
@@ -692,6 +846,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests
     title: Ensure host information is not sent to guests
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == "false" ) )
     docs:
@@ -746,6 +914,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited
     title: Ensure informational messages from the VM to the VMX file are limited
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['tools.setInfo.sizeLimit'] == 1048576 ) )
     docs:
@@ -792,6 +974,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled
     title: Ensure memSchedFakeSampleStats is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true" ) )
     docs:
@@ -847,6 +1043,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-nonpersistent-disks-are-limited
     title: Ensure nonpersistent disks are limited
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all(
         vms.all(
@@ -900,6 +1110,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time
     title: Ensure only one remote console connection is permitted to a VM at any time
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['RemoteDisplay.maxConnections'] == 1 ) )
     docs:
@@ -959,6 +1183,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-pci-and-pcie-device-passthrough-is-disabled
     title: Ensure PCI and PCIe device pass-through is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings.where ( key.contains('pciPassthru')).length == 0 ) )
     docs:
@@ -1005,6 +1243,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled
     title: Ensure Request Disk Topology is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == "true" ) )
     docs:
@@ -1060,6 +1312,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled
     title: Ensure Shell Action is disabled
     impact: 100
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == "true" ) )
     docs:
@@ -1115,6 +1381,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly
     title: Ensure the number of VM log files is configured properly
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['log.keepOld'] == 10 ) )
     docs:
@@ -1170,6 +1450,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled
     title: Ensure Trash Folder State is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == "true" ) )
     docs:
@@ -1225,6 +1519,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines
     title: Ensure UEFI Secure Boot is enabled for virtual machines
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( bootFirmware == "efi" ) )
       vsphere.datacenters.all( vms.all( secureBootEnabled == true ) )
@@ -1276,6 +1584,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled
     title: Ensure unauthorized connection of devices is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == "true" ) )
     docs:
@@ -1319,6 +1641,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled
     title: Ensure unauthorized modification and disconnection of devices is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == "true" ) )
     docs:
@@ -1362,6 +1698,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled
     title: Ensure Unity Active is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == "true" ) )
     docs:
@@ -1417,6 +1767,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled
     title: Ensure Unity Interlock is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == "true" ) )
     docs:
@@ -1472,6 +1836,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled
     title: Ensure Unity is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == "true" ) )
     docs:
@@ -1527,6 +1905,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled
     title: Ensure Unity Push Update is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == "true" ) )
     docs:
@@ -1582,6 +1974,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled
     title: Ensure Unity Taskbar is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == "true" ) )
     docs:
@@ -1637,6 +2043,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled
     title: Ensure Unity Window Contents is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == "true" ) )
     docs:
@@ -1692,6 +2112,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-cddvd-devices-are-disconnected
     title: Ensure unnecessary CD/DVD devices are disconnected
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -1738,6 +2172,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-floppy-devices-are-disconnected
     title: Ensure unnecessary floppy devices are disconnected
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -1784,6 +2232,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-parallel-ports-are-disconnected
     title: Ensure unnecessary parallel ports are disconnected
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -1831,6 +2293,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-serial-ports-are-disconnected
     title: Ensure unnecessary serial ports are disconnected
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -1878,6 +2354,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-usb-devices-are-disconnected
     title: Ensure unnecessary USB devices are disconnected
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['connected'] == false || _['connectable']['connected'] == null ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['startConnected'] == false || _['connectable']['startConnected'] == null ) ) )
@@ -1924,6 +2414,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled
     title: Ensure virtual disk shrinking is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == "true" ) )
     docs:
@@ -1979,6 +2483,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled
     title: Ensure virtual disk wiping is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == "true" ) )
     docs:
@@ -2030,6 +2548,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
     title: Ensure virtual machine encryption is enabled
     impact: 80
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a28
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       vsphere.datacenters.all( vms.all( encrypted == true ) )
     docs:
@@ -2083,6 +2615,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled
     title: Ensure Virtualization-Based Security is enabled
     impact: 70
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( vbsEnabled == true ) )
     docs:
@@ -2132,6 +2678,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled
     title: Ensure VM Console Copy operations are disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == "true" ) )
     docs:
@@ -2183,6 +2743,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled
     title: Ensure VM Console Drag and Drop operations is disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == "true" ) )
     docs:
@@ -2234,6 +2808,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled
     title: Ensure VM Console GUI Options is disabled
     impact: 75
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == "false" ) )
     docs:
@@ -2285,6 +2873,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled
     title: Ensure VM Console Paste operations are disabled
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == "true" ) )
     docs:
@@ -2336,6 +2938,20 @@ queries:
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited
     title: Ensure VM log file size is limited
     impact: 60
+    tags:
+      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings['log.rotateSize'] == 1024000 ) )
     docs:


### PR DESCRIPTION
## Summary

Adds compliance framework mappings to every check in the Shodan and VMware vSphere security policies, matching the standard 13-framework set already used by `mondoo-aws-security`, `mondoo-azure-security`, and `mondoo-kubernetes-security`.

- **Shodan** (3 checks), **VMware vSphere ESXi** (29 checks), **VMware vSphere** (44 checks) — each check now carries a `tags:` block mapping it to ISO 27001:2022, NIST SP 800-53 Rev5, NIST SP 800-171, NIST CSF 1 & 2, SOC 2, PCI DSS 4, CSA CCM 4, DORA, NIS-2, HIPAA, BSI IT-Grundschutz SYS.1.5, and VDA ISA 5.
- Every control uid was verified against the framework definitions in `cnspec-enterprise-policies`. Where no control is a strict fit, the mapping is the unquoted boolean `false`, per the compliance-tag process in `content/CLAUDE.md` — a missing mapping is preferable to a wrong one.
- Only `tags:` blocks were added; no `title`, `impact`, `mql`, `docs`, or `uid` fields were changed.

## Test plan

- `cnspec policy lint` passes on all three policy files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)