### PR TITLE
:sparkles: Add Terraform variants to the VMware vSphere policies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -319,7 +319,6 @@ hotlink
 hpa
 hsts
 hstspreload
-HVCI
 hvm
 hwaddr
 Iaa
@@ -734,6 +733,7 @@ vtpm
 vtproto
 vty
 vulns
+vvtd
 vzdump
 wafv
 wazuh

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -185,7 +185,7 @@ The `# No Terraform variants:` comment goes on the line before `- uid:`:
 - uid: mondoo-<cloud>-security-...
 ```
 
-The `# No Terraform remediation:` comment goes **inside the `remediation:` list**, as its last line — where an `- id: terraform` entry would otherwise sit:
+The `# No Terraform remediation:` comment goes **inside the `remediation:` list**, as its last line, indented at the same level as the `- id:` entries — where an `- id: terraform` entry would otherwise sit:
 
 ```yaml
 remediation:

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -178,19 +178,23 @@ If the runtime check has no Terraform analog, **leave a YAML comment above the p
 - The runtime check depends on cross-resource correlation (e.g., "every cluster has a backup plan that points at it") that the runtime check itself does not yet implement correctly — in which case fix the runtime first.
 - The runtime check inspects a field whose Terraform analog is a different feature (don't paper over the mismatch with a vacuous variant).
 
-Comment formats (inserted on the line before `- uid:`):
+The `# No Terraform variants:` comment goes on the line before `- uid:`:
 
 ```yaml
 # No Terraform variants: <one-sentence reason>. <Optional: when this could be revisited>.
 - uid: mondoo-<cloud>-security-...
 ```
 
+The `# No Terraform remediation:` comment goes **inside the `remediation:` list**, as its last line — where an `- id: terraform` entry would otherwise sit:
+
 ```yaml
-# No Terraform remediation: <one-sentence reason>. <Optional: when this could be revisited>.
-- uid: mondoo-<cloud>-security-...
+remediation:
+  - id: console
+    desc: ...
+  # No Terraform remediation: <one-sentence reason>. <Optional: when this could be revisited>.
 ```
 
-When neither variants nor remediation are possible (the usual case — if you can't write a variant, you usually can't write Terraform remediation either), include both comments. The comment must explain the technical limitation, not just say "skip".
+When neither variants nor remediation are possible (the usual case — if you can't write a variant, you usually can't write Terraform remediation either), include both comments. Each comment must explain the technical limitation, not just say "skip".
 
 ### MQL parser quirk for Terraform variants
 

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -82,6 +82,8 @@ policies:
           - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject
     scoring_system: highest impact
 queries:
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Security.AccountUnlockTime.
+  # No Terraform remediation: the account-lockout window is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-account-lockout-is-set-to-15-minutes
     title: Ensure account lockout is set to 15 minutes
     impact: 80
@@ -132,23 +134,28 @@ queries:
            ```
 
         The host passes when `Security.AccountUnlockTime` is `900`. Any other value, including `0`, is a failing result.
-      remediation: |-
-        To set the account lockout to 15 minutes, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the account lockout to 15 minutes using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `System`.
-        3. Select `Advanced System Settings` then select `Edit`.
-        4. Enter `Security.AccountUnlockTime` in the filter.
-        5. Set the value for this parameter to `900`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `System`.
+            3. Select `Advanced System Settings` then select `Edit`.
+            4. Enter `Security.AccountUnlockTime` in the filter.
+            5. Set the value for this parameter to `900`.
+        - id: powershell
+          desc: |
+            To set the account lockout to 15 minutes using PowerCLI:
 
-        Alternately, use the following PowerCLI command:
-
-        ```powershell
-        Get-VMHost | Get-AdvancedSetting -Name Security.AccountUnlockTime | Set-AdvancedSetting -Value 900
-        ```
+            ```powershell
+            Get-VMHost | Get-AdvancedSetting -Name Security.AccountUnlockTime | Set-AdvancedSetting -Value 900
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage installed VIBs or the kernel modules loaded by the VMkernel at runtime.
+  # No Terraform remediation: kernel module signing is verified against live host state, not declarable Terraform configuration.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
     title: Ensure all loaded ESXi kernel modules are signed
     impact: 80
@@ -209,24 +216,28 @@ queries:
            ```
 
         The host passes when every loaded module reports a `Signed Status` other than `Unsigned`. A module reporting `Signed Status: Unsigned` is a failing result.
-      remediation: |-
-        Identify unsigned modules on the host, then replace or remove them:
+      remediation:
+        - id: cli
+          desc: |
+            To identify unsigned modules and replace or remove them using the ESXi shell:
 
-        1. Connect to the ESXi host via SSH.
-        2. List loaded modules and their signed status:
+            1. Connect to the ESXi host via SSH.
+            2. List loaded modules and their signed status:
 
-           ```bash
-           esxcli system module list
-           esxcli system module get --module=<module-name>
-           ```
+               ```bash
+               esxcli system module list
+               esxcli system module get --module=<module-name>
+               ```
 
-        3. For any module reporting `Signed Status: Unsigned`, remove the associated VIB or replace it with a signed version from the vendor.
-        4. Reboot the host so the updated module set is loaded.
+            3. For any module reporting `Signed Status: Unsigned`, remove the associated VIB or replace it with a signed version from the vendor.
+            4. Reboot the host so the updated module set is loaded.
 
-        Configure the host image profile acceptance level so that unsigned VIBs cannot be installed in the first place. See "Ensure the Image Profile VIB acceptance level is configured properly".
+            Configure the host image profile acceptance level so that unsigned VIBs cannot be installed in the first place. See "Ensure the Image Profile VIB acceptance level is configured properly".
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi iSCSI host bus adapter CHAP authentication properties.
+  # No Terraform remediation: iSCSI CHAP credentials are configured on the live storage adapter and have no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
     title: Ensure bidirectional CHAP authentication for iSCSI traffic is enabled
     impact: 80
@@ -285,30 +296,35 @@ queries:
            ```
 
         The host passes when every iSCSI adapter has CHAP enabled with `chapPreferred` for both the outgoing and mutual authentication types, and both the CHAP name and secret and the mutual CHAP name and secret are set. An adapter with CHAP disabled, with a non-`chapPreferred` type, or with an empty name or secret is a failing result.
-      remediation: |-
-        To enable bidirectional CHAP authentication for iSCSI traffic, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable bidirectional CHAP authentication for iSCSI traffic using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `Storage`.
-        3. Select `Storage Adapters` then select the iSCSI Adapter.
-        4. Under `Properties` select `Edit` next to `Authentication`.
-        5. Next to `Authentication Method` select `Use bidirectional CHAP` from the dropdown.
-        6. Specify the outgoing CHAP name.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `Storage`.
+            3. Select `Storage Adapters` then select the iSCSI Adapter.
+            4. Under `Properties` select `Edit` next to `Authentication`.
+            5. Next to `Authentication Method` select `Use bidirectional CHAP` from the dropdown.
+            6. Specify the outgoing CHAP name.
 
-        - Make sure that the name you specify matches the name configured on the storage side.
-            - To set the CHAP name to the iSCSI adapter name, select "Use initiator name".
-            - To set the CHAP name to anything other than the iSCSI initiator name, deselect "Use initiator name" and type a name in the Name text box.
+            - Make sure that the name you specify matches the name configured on the storage side.
+                - To set the CHAP name to the iSCSI adapter name, select "Use initiator name".
+                - To set the CHAP name to anything other than the iSCSI initiator name, deselect "Use initiator name" and type a name in the Name text box.
 
-        1. Enter an outgoing CHAP secret to be used as part of authentication. Use the same secret as your storage side secret.
-        2. Specify incoming CHAP credentials. Make sure your outgoing and incoming secrets do not match.
-        3. Select `OK`.
-        4. Select the second to last symbol labeled `Rescan Adapter`.
+            1. Enter an outgoing CHAP secret to be used as part of authentication. Use the same secret as your storage side secret.
+            2. Specify incoming CHAP credentials. Make sure your outgoing and incoming secrets do not match.
+            3. Select `OK`.
+            4. Select the second to last symbol labeled `Rescan Adapter`.
+        - id: powershell
+          desc: |
+            To set the CHAP settings for the iSCSI adapter using PowerCLI:
 
-        Alternately, run the following PowerCLI command to set the Chap settings for the iSCSI Adapter:
-
-        ```powershell
-        Get-VMHost | Get-VMHostHba | Where {$_.Type -eq "Iscsi"} | Set-VMHostHba # Use desired parameters here
-        ```
+            ```powershell
+            Get-VMHost | Get-VMHostHba | Where {$_.Type -eq "Iscsi"} | Set-VMHostHba # Use desired parameters here
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host DNS network configuration.
+  # No Terraform remediation: the host DNS configuration is runtime network state with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dns-is-statically-configured-on-the-esxi-host
     title: Ensure DNS is statically configured on the ESXi host
     impact: 60
@@ -361,25 +377,30 @@ queries:
            ```
 
         The host passes when DHCP is disabled for DNS and one or more static DNS servers are configured. A host obtaining DNS settings from DHCP, or with no DNS servers configured, is a failing result.
-      remediation: |-
-        To configure static DNS, perform the following from the vSphere Web Client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To configure static DNS using the vSphere Client:
 
-        1. Select the host.
-        2. Select `Configure`, then expand `Networking` and select `TCP/IP configuration`.
-        3. Select the `Default` TCP/IP stack, then select `Edit`.
-        4. Select `DNS configuration` and choose `Enter settings manually`.
-        5. Provide the trusted DNS server addresses and search domains.
-        6. Select `OK`.
+            1. Select the host.
+            2. Select `Configure`, then expand `Networking` and select `TCP/IP configuration`.
+            3. Select the `Default` TCP/IP stack, then select `Edit`.
+            4. Select `DNS configuration` and choose `Enter settings manually`.
+            5. Provide the trusted DNS server addresses and search domains.
+            6. Select `OK`.
+        - id: cli
+          desc: |
+            To configure static DNS using the ESXi shell:
 
-        Alternately, use the following ESXi shell commands:
-
-        ```bash
-        esxcli network ip dns server add --server=<dns-ip>
-        esxcli network ip interface ipv4 set --interface-name=vmk0 --type=static
-        ```
+            ```bash
+            esxcli network ip dns server add --server=<dns-ip>
+            esxcli network ip interface ipv4 set --interface-name=vmk0 --type=static
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Net.DVFilterBindIpAddress.
+  # No Terraform remediation: the dvfilter bind address is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
     title: Ensure dvfilter API is not configured if not used
     impact: 60
@@ -430,29 +451,34 @@ queries:
            ```
 
         The host passes when `Net.DVFilterBindIpAddress` is empty. A non-empty value on a host that does not run a dvfilter-based security appliance is a failing result.
-      remediation: |-
-        To remove the configuration for the dvfilter network API, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To remove the configuration for the dvfilter network API using the vSphere Client:
 
-        1. From the vSphere web client, select the host and select `Configure` then expand `System`
-        2. Select `Advanced System Settings` then `Edit`.
-        3. Search for `Net.DVFilterBindIpAddress` in the filter.
-        4. Set `Net.DVFilterBindIpAddress` has an empty value.
-        5. If an appliance is being used, make sure the value of this parameter is set to the proper IP address.
-        6. Enter the proper IP address.
-        7. Select `OK`.
+            1. From the vSphere web client, select the host and select `Configure` then expand `System`
+            2. Select `Advanced System Settings` then `Edit`.
+            3. Search for `Net.DVFilterBindIpAddress` in the filter.
+            4. Set `Net.DVFilterBindIpAddress` has an empty value.
+            5. If an appliance is being used, make sure the value of this parameter is set to the proper IP address.
+            6. Enter the proper IP address.
+            7. Select `OK`.
 
-        Alternatively, run the following PowerCLI command to set Net.DVFilterBindIpAddress to null on all hosts:
+            **Impact:**
 
-        ```powershell
-        Get-VMHost HOST1 | Foreach { Set-AdvancedSetting -VMHost $_ -Name Net.DVFilterBindIpAddress -IPValue "" }
-        ```
+            This will prevent a dvfilter-based network security appliance such as a firewall from functioning if not configured correctly.
+        - id: powershell
+          desc: |
+            To set Net.DVFilterBindIpAddress to null on all hosts using PowerCLI:
 
-        **Impact:**
-
-        This will prevent a dvfilter-based network security appliance such as a firewall from functioning if not configured correctly.
+            ```powershell
+            Get-VMHost HOST1 | Foreach { Set-AdvancedSetting -VMHost $_ -Name Net.DVFilterBindIpAddress -IPValue "" }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.ESXiShellInteractiveTimeOut.
+  # No Terraform remediation: the interactive shell idle timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
     title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
     impact: 60
@@ -504,27 +530,32 @@ queries:
            ```
 
         The host passes when `UserVars.ESXiShellInteractiveTimeOut` is between `1` and `300` seconds. A value greater than `300`, or `0` (which disables the timeout entirely), is a failing result.
-      remediation: |-
-        To set the timeout to the desired value, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the timeout to the desired value using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `System`.
-        3. Select `Advanced System Settings` then select `Edit`.
-        4. Enter `ESXiShellInteractiveTimeOut` in the filter.
-        5. Set the value for this parameter is set to the appropriate value ( `300` seconds or less).
-        6. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `System`.
+            3. Select `Advanced System Settings` then select `Edit`.
+            4. Enter `ESXiShellInteractiveTimeOut` in the filter.
+            5. Set the value for this parameter is set to the appropriate value ( `300` seconds or less).
+            6. Select `OK`.
 
-        **Note:**
-        A value of 0 disables the ESXi ShellInteractiveTimeOut.
+            **Note:**
+            A value of 0 disables the ESXi ShellInteractiveTimeOut.
+        - id: powershell
+          desc: |
+            To set UserVars.ESXiShellInteractiveTimeOut to 300 on all hosts using PowerCLI:
 
-        Alternately, use the following PowerCLI command to set Remove UserVars.ESXiShellInteractiveTimeOut to 300 on all hosts
-
-        ```powershell
-        Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellInteractiveTimeOut' | Set-AdvancedSetting -Value "300"
-        ```
+            ```powershell
+            Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellInteractiveTimeOut' | Set-AdvancedSetting -Value "300"
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Config.HostAgent.plugins.solo.enableMob.
+  # No Terraform remediation: the Managed Object Browser toggle is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
     title: Ensure Managed Object Browser (MOB) is disabled
     impact: 60
@@ -575,24 +606,28 @@ queries:
            ```
 
         The host passes when `Config.HostAgent.plugins.solo.enableMob` is `false`. A value of `true` is a failing result.
-      remediation: |-
-        To disable MOB, perform the following from the vSphere Web Client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable MOB using the vSphere Client:
 
-        1. Select a host
-        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
-        3. Select `Edit` then search for `Config.HostAgent.plugins.solo.enableMob`
-        4. Set the value to `false`.
-        5. Select `OK`.
+            1. Select a host
+            2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+            3. Select `Edit` then search for `Config.HostAgent.plugins.solo.enableMob`
+            4. Set the value to `false`.
+            5. Select `OK`.
 
-        **Note:**
-        You cannot disable the MOB while a host is in lockdown mode.
+            **Note:**
+            You cannot disable the MOB while a host is in lockdown mode.
 
-        **Note 2:**
-        You must disable MOB from the vSphere interface, not via the `vim-cmd` command.
+            **Note 2:**
+            You must disable MOB from the vSphere interface, not via the `vim-cmd` command.
 
-        **Impact:**
+            **Impact:**
 
-        Some third-party tools may utilize the Managed Object Browser (MOB). Disabling MOB may cause those tools to malfunction.
+            Some third-party tools may utilize the Managed Object Browser (MOB). Disabling MOB may cause those tools to malfunction.
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
+  # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
     title: Ensure Normal Lockdown mode is enabled
     impact: 80
@@ -642,24 +677,29 @@ queries:
            ```
 
         The host passes when the lockdown mode is `lockdownNormal`. A value of `lockdownDisabled` or `lockdownStrict` is a failing result for this check.
-      remediation: |-
-        To enable lockdown mode, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable lockdown mode using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `System` and select `Security Profile`.
-        3. Across from `Lockdown Mode` select `Edit`.
-        4. Select the radio button for `Normal`.
-        5. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `System` and select `Security Profile`.
+            3. Across from `Lockdown Mode` select `Edit`.
+            4. Select the radio button for `Normal`.
+            5. Select `OK`.
 
-        Alternately, run the following PowerCLI command to enable lockdown mode for each host:
+            **Impact:**
 
-        ```powershell
-        Get-VMHost | Foreach { $_.EnterLockdownMode() }
-        ```
+            With lockdown mode enabled the host will only be accessible through vCenter preventing 'local' access.
+        - id: powershell
+          desc: |
+            To enable lockdown mode for each host using PowerCLI:
 
-        **Impact:**
-
-        With lockdown mode enabled the host will only be accessible through vCenter preventing 'local' access.
+            ```powershell
+            Get-VMHost | Foreach { $_.EnterLockdownMode() }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the ntpd time-synchronization daemon.
+  # No Terraform remediation: NTP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
     title: Ensure NTP time synchronization is configured properly
     impact: 60
@@ -712,25 +752,30 @@ queries:
            ```
 
         The host passes when the `ntpd` service is `Running` and its `Policy` is `on`. A stopped service or a policy other than `on` is a failing result.
-      remediation: |-
-        To enable and properly configure NTP synchronization, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable and properly configure NTP synchronization using the vSphere Client:
 
-        1. Select a host
-        2. Select `Configure` then expand `System` then select `Time Configuration`.
-        3. Select `Edit` next to Network Time Protocol
-        4. Select the `Enable` box, then fill in the appropriate NTP Servers.
-        5. in the `NTP Service Startup Policy` drop down select `Start and stop with host`.
-        6. Select `OK`.
+            1. Select a host
+            2. Select `Configure` then expand `System` then select `Time Configuration`.
+            3. Select `Edit` next to Network Time Protocol
+            4. Select the `Enable` box, then fill in the appropriate NTP Servers.
+            5. in the `NTP Service Startup Policy` drop down select `Start and stop with host`.
+            6. Select `OK`.
+        - id: powershell
+          desc: |
+            To implement the recommended NTP configuration state using PowerCLI:
 
-        To implement the recommended configuration state, run the following PowerCLI command:
-
-        ```
-        Set the NTP Settings for all hosts
-        If an internal NTP server is used, replace pool.ntp.org with
-        the IP address or the Fully Qualified Domain Name (FQDN) of the internal NTP server
-        $NTPServers = "pool.ntp.org", "pool2.ntp.org"
-        Get-VMHost | Add-VmHostNtpServer $NTPServers
-        ```
+            ```
+            Set the NTP Settings for all hosts
+            If an internal NTP server is used, replace pool.ntp.org with
+            the IP address or the Fully Qualified Domain Name (FQDN) of the internal NTP server
+            $NTPServers = "pool.ntp.org", "pool2.ntp.org"
+            Get-VMHost | Add-VmHostNtpServer $NTPServers
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Syslog.global.logDir.
+  # No Terraform remediation: the persistent log directory is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-persistent-logging-is-configured-for-all-esxi-hosts
     title: Ensure persistent logging is configured for all ESXi hosts
     impact: 60
@@ -782,21 +827,24 @@ queries:
            ```
 
         The host passes when `Syslog.global.logDir` points to a persistent datastore location. An empty value or a non-persistent location under `/scratch` is a failing result.
-      remediation: |-
-        To configure persistent logging properly, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To configure persistent logging properly using the vSphere Client:
 
-        1. Select the host
-        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
-        3. Select `Edit` then enter `Syslog.global.LogDir` in the filter.
-        4. Set `Syslog.global.logDir` to a persistent location specified as [datastorename] path\_to\_file where the path is relative to the datastore. For example, [datastore1] /systemlogs.
-        5. Select `OK`.
+            1. Select the host
+            2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+            3. Select `Edit` then enter `Syslog.global.LogDir` in the filter.
+            4. Set `Syslog.global.logDir` to a persistent location specified as [datastorename] path\_to\_file where the path is relative to the datastore. For example, [datastore1] /systemlogs.
+            5. Select `OK`.
+        - id: powershell
+          desc: |
+            To configure persistent logging using PowerCLI:
 
-        Alternatively, run the following PowerCLI command:
-
-        ```
-        Set Syslog.global.logDir for each host
-        Get-VMHost | Foreach { Set-AdvancedConfiguration -VMHost $_ -Name Syslog.global.logDir -Value "<NewLocation>" }
-        ```
+            ```
+            Set Syslog.global.logDir for each host
+            Get-VMHost | Foreach { Set-AdvancedConfiguration -VMHost $_ -Name Syslog.global.logDir -Value "<NewLocation>" }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
@@ -817,9 +865,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] >= 2 )
-      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] <= 4094 )
+    variants:
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-vsphere
+        tags:
+          mondoo.com/filter-title: VMware ESXi
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that virtual switch port groups use a VLAN ID between 2 and 4094 and avoid the native VLAN. ESXi has no concept of a native VLAN, so placing a port group on the upstream native VLAN ID, commonly 1, mixes virtual machine traffic with untagged switch traffic.
@@ -851,20 +913,35 @@ queries:
            ```
 
         The host passes when every port group uses a VLAN ID between `2` and `4094`. A port group set to VLAN `0`, `1`, or any value above `4094` is a failing result.
-      remediation: |-
-        To stop using the native VLAN ID for port groups, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To stop using the native VLAN ID for port groups using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `Networking`.
-        3. Select `Virtual switches`.
-        4. Expand the Standard vSwitch.
-        5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
-        6. For each port group on the vSwitch, verify and record the VLAN IDs used.
-        7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
-        8. Select the `Edit settings` option.
-        9. In the Properties section, enter an appropriate name in the `Network label` field.
-        10. In the `VLAN ID` dropdown select or type a new VLAN.
-        11. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `Networking`.
+            3. Select `Virtual switches`.
+            4. Expand the Standard vSwitch.
+            5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
+            6. For each port group on the vSwitch, verify and record the VLAN IDs used.
+            7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
+            8. Select the `Edit settings` option.
+            9. In the Properties section, enter an appropriate name in the `Network label` field.
+            10. In the `VLAN ID` dropdown select or type a new VLAN.
+            11. Select `OK`.
+        - id: terraform
+          desc: |
+            To move a port group off the native VLAN using Terraform, set `vlan_id` to a value between `2` and `4094` on the `vsphere_host_port_group` resource:
+
+            ```hcl
+            resource "vsphere_host_port_group" "pg" {
+              name                = "VM Network"
+              host_system_id      = data.vsphere_host.host.id
+              virtual_switch_name = vsphere_host_virtual_switch.switch.name
+
+              vlan_id = 100
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
@@ -885,9 +962,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 0 )
-      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 4095 )
+    variants:
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-vsphere
+        tags:
+          mondoo.com/filter-title: VMware ESXi
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that virtual switch port groups avoid VLAN IDs 0 and 4095. VLAN 4095 activates Virtual Guest Tagging, which passes every frame to the guest with its VLAN tags intact, and should be used only when a guest is explicitly built to manage VLAN tags itself.
@@ -919,20 +1010,37 @@ queries:
            ```
 
         The host passes when no port group uses VLAN ID `0` or `4095`. A port group set to VLAN `0`, or set to VLAN `4095` without a guest explicitly configured for Virtual Guest Tagging, is a failing result.
-      remediation: |-
-        To set port groups to values other than 4095 and 0 unless VGT is required, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set port groups to values other than 4095 and 0 unless VGT is required using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `Networking`.
-        3. Select `Virtual switches`.
-        4. Expand the Standard vSwitch.
-        5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
-        6. For each port group on the vSwitch, verify and record the VLAN IDs used.
-        7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
-        8. Select the `Edit settings` option.
-        9. In the Properties section, enter an appropriate name in the `Network label` field.
-        10. In the `VLAN ID` dropdown select or type a new VLAN.
-        11. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `Networking`.
+            3. Select `Virtual switches`.
+            4. Expand the Standard vSwitch.
+            5. View the topology diagram of the switch, which shows the various port groups associated with that switch.
+            6. For each port group on the vSwitch, verify and record the VLAN IDs used.
+            7. If a VLAN ID change is needed, select the name of the port group in the topology diagram of the virtual switch.
+            8. Select the `Edit settings` option.
+            9. In the Properties section, enter an appropriate name in the `Network label` field.
+            10. In the `VLAN ID` dropdown select or type a new VLAN.
+            11. Select `OK`.
+        - id: terraform
+          desc: |
+            To keep a port group off VLAN 0 and VLAN 4095 using Terraform, set `vlan_id` to a value between `1` and `4094` on the `vsphere_host_port_group` resource. Use VLAN 4095 only for a guest explicitly configured for Virtual Guest Tagging:
+
+            ```hcl
+            resource "vsphere_host_port_group" "pg" {
+              name                = "VM Network"
+              host_system_id      = data.vsphere_host.host.id
+              virtual_switch_name = vsphere_host_virtual_switch.switch.name
+
+              vlan_id = 100
+            }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Syslog.global.logHost.
+  # No Terraform remediation: the remote syslog host is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-remote-logging-is-configured-for-esxi-hosts
     title: Ensure remote logging is configured for ESXi hosts
     impact: 60
@@ -983,24 +1091,29 @@ queries:
            ```
 
         The host passes when `Syslog.global.logHost` is set to the hostname or IP address of a central log server. An empty value is a failing result.
-      remediation: |-
-        To configure remote logging properly, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To configure remote logging properly using the vSphere Client:
 
-        1. Select the host
-        2. Select `Configure` then expand `System` then select `Advanced System Settings`.
-        3. Select `Edit` then enter `Syslog.global.logHost` in the filter.
-        4. Set the `Syslog.global.logHost` to the hostname or IP address of the central log server.
-        5. Select `OK`.
+            1. Select the host
+            2. Select `Configure` then expand `System` then select `Advanced System Settings`.
+            3. Select `Edit` then enter `Syslog.global.logHost` in the filter.
+            4. Set the `Syslog.global.logHost` to the hostname or IP address of the central log server.
+            5. Select `OK`.
 
-        Alternately, run the following PowerCLI command:
+            **Note:**
+            When setting a remote log host, it is also recommended to set the "Syslog.global.logDirUnique" to true. You must configure the syslog settings for each host.
+        - id: powershell
+          desc: |
+            To configure remote logging using PowerCLI:
 
-        ```
-        Set Syslog.global.logHost for each host
-        Get-VMHost | Foreach { Set-AdvancedSetting -VMHost $_ -Name Syslog.global.logHost -Value "<NewLocation>" }
-        ```
-
-        **Note:**
-        When setting a remote log host, it is also recommended to set the "Syslog.global.logDirUnique" to true. You must configure the syslog settings for each host.
+            ```
+            Set Syslog.global.logHost for each host
+            Get-VMHost | Foreach { Set-AdvancedSetting -VMHost $_ -Name Syslog.global.logHost -Value "<NewLocation>" }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the TSM-SSH daemon.
+  # No Terraform remediation: SSH service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ssh-is-disabled
     title: Ensure SSH is disabled
     impact: 75
@@ -1053,26 +1166,31 @@ queries:
            ```
 
         The host passes when the `TSM-SSH` service is not running and its `Policy` is `off`. A running service or a policy of `on` is a failing result.
-      remediation: |-
-        To disable SSH, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable SSH using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure` then expand `System` and select `Services`.
-        3. Select `SSH` then select `Edit Startup Policy`.
-        4. Set the Startup Policy is set to `Start and Stop Manually`.
-        5. Select `OK`.
-        6. While `ESXi Shell`is still selected select `Stop`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure` then expand `System` and select `Services`.
+            3. Select `SSH` then select `Edit Startup Policy`.
+            4. Set the Startup Policy is set to `Start and Stop Manually`.
+            5. Select `OK`.
+            6. While `ESXi Shell`is still selected select `Stop`.
 
-        Alternately, use the following PowerCLI command:
+            **Impact:**
 
-        ```
-        Set SSH to start manually rather than automatically for all hosts
-        Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM-SSH" } | Set-VMHostService -Policy Off
-        ```
+            In troubleshooting and assessment scenarios having SSH disabled, which is the default, may prevent connections to the host by tools or via other methods.
+        - id: powershell
+          desc: |
+            To set SSH to start manually rather than automatically for all hosts using PowerCLI:
 
-        **Impact:**
-
-        In troubleshooting and assessment scenarios having SSH disabled, which is the default, may prevent connections to the host by tools or via other methods.
+            ```
+            Set SSH to start manually rather than automatically for all hosts
+            Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM-SSH" } | Set-VMHostService -Policy Off
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
+  # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
     title: Ensure Strict Lockdown mode is enabled
     impact: 80
@@ -1122,25 +1240,30 @@ queries:
            ```
 
         The host passes when the lockdown mode is `lockdownStrict`. A value of `lockdownDisabled` or `lockdownNormal` is a failing result for this check.
-      remediation: |-
-        To enable lockdown mode, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable lockdown mode using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `System` and select `Security Profile`.
-        3. Across from `Lockdown Mode` select `Edit`.
-        4. Select the radio button for `Strict`.
-        5. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `System` and select `Security Profile`.
+            3. Across from `Lockdown Mode` select `Edit`.
+            4. Select the radio button for `Strict`.
+            5. Select `OK`.
 
-        Alternately, run the following PowerCLI command:
+            **Impact:**
 
-        ```
-        Enable lockdown mode for each host
-        Get-VMHost | Foreach { $_.EnterLockdownMode() }
-        ```
+            With lockdown mode enabled, the host will only be accessible through vCenter preventing 'local' access. Disabling the DCUI can create a potential "lockout" situation, should the host become isolated from vCenter Server. Recovering from a "lockout" scenario requires reinstalling ESXi. Consider leaving DCUI enabled, and instead enable lockdown mode and limit the users allowed to access the DCUI using the DCUI. Access list.
+        - id: powershell
+          desc: |
+            To enable lockdown mode for each host using PowerCLI:
 
-        **Impact:**
-
-        With lockdown mode enabled, the host will only be accessible through vCenter preventing 'local' access. Disabling the DCUI can create a potential "lockout" situation, should the host become isolated from vCenter Server. Recovering from a "lockout" scenario requires reinstalling ESXi. Consider leaving DCUI enabled, and instead enable lockdown mode and limit the users allowed to access the DCUI using the DCUI. Access list.
+            ```
+            Enable lockdown mode for each host
+            Get-VMHost | Foreach { $_.EnterLockdownMode() }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.DcuiTimeOut.
+  # No Terraform remediation: the DCUI timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
     title: Ensure the DCUI timeout is set to 600 seconds or less
     impact: 60
@@ -1192,19 +1315,24 @@ queries:
            ```
 
         The host passes when `UserVars.DcuiTimeOut` is between `1` and `600` seconds. A value greater than `600`, or `0` (which disables the timeout entirely), is a failing result.
-      remediation: |-
-        To correct the DCUI timeout setting, perform the following steps:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To correct the DCUI timeout setting using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then under `System` select `Advanced System Settings`.
-        3. Select `Edit` then enter `UserVars.DcuiTimeOut` in the filter.
-        4. Change the current value to 600 seconds or less.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then under `System` select `Advanced System Settings`.
+            3. Select `Edit` then enter `UserVars.DcuiTimeOut` in the filter.
+            4. Change the current value to 600 seconds or less.
+        - id: powershell
+          desc: |
+            To correct the DCUI timeout setting using PowerCLI:
 
-        Alternately, use the following PowerCLI command:
-
-        ```
-        Get-VMHost | Get-AdvancedSetting -Name UserVars.DcuiTimeOut | Set-AdvancedSetting -Value 600
-        ```
+            ```
+            Get-VMHost | Get-AdvancedSetting -Name UserVars.DcuiTimeOut | Set-AdvancedSetting -Value 600
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Mem.ShareForceSalting.
+  # No Terraform remediation: the Transparent Page Sharing salt setting is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-default-value-of-individual-salt-per-vm-is-configured
     title: Ensure the default value of individual salt per vm is configured
     impact: 60
@@ -1254,27 +1382,32 @@ queries:
            ```
 
         The host passes when `Mem.ShareForceSalting` is `2`. Any other value is a failing result.
-      remediation: |-
-        From the vSphere Web Client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To configure per-VM salting using the vSphere Client:
 
-        1. Select a host
-        2. Select `Configure`, then expand `System` and select `Advanced System settings`.
-        3. Select `Edit`, then Filter for `Mem.ShareForceSalting`.
-        4. Set the value to `2`.
-        5. Select `OK`.
+            1. Select a host
+            2. Select `Configure`, then expand `System` and select `Advanced System settings`.
+            3. Select `Edit`, then Filter for `Mem.ShareForceSalting`.
+            4. Set the value to `2`.
+            5. Select `OK`.
 
-        Additionally, the following PowerCLI command can be used:
+            **Impact:**
 
-        ```
-        Get-VMHost | Get-AdvancedSetting -Name Mem.ShareForceSalting | Set-AdvancedSetting -Value 2
-        ```
+            There is potential for a performance impact with this setting depending on environment and infrastructure details.
+        - id: powershell
+          desc: |
+            To configure per-VM salting using PowerCLI:
 
-        **Impact:**
-
-        There is potential for a performance impact with this setting depending on environment and infrastructure details.
+            ```
+            Get-VMHost | Get-AdvancedSetting -Name Mem.ShareForceSalting | Set-AdvancedSetting -Value 2
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host firewall rulesets or their allowed-IP networks.
+  # No Terraform remediation: the host firewall ruleset configuration is runtime host state with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
     title: Ensure the ESXi host firewall restricts access to running services
     impact: 60
@@ -1328,18 +1461,22 @@ queries:
            ```
 
         The host passes when every running service is associated with a firewall ruleset, no ruleset allows all IP addresses, and each ruleset defines a specific allowed network. A ruleset with `Allow All IP` enabled or with no allowed network is a failing result.
-      remediation: |-
-        To properly restrict access to services running on an ESXi host, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To properly restrict access to services running on an ESXi host using the vSphere Client:
 
-        1. Select a host
-        2. Select `Configure`, then expand `System` and select `Firewall`.
-        3. Select `Edit` to view services which are enabled (indicated by a check).
-        4. For each enabled service, (e.g., ssh, vSphere Web Access, http client) provide a list of allowed IP addresses.
-        5. Select `OK`.
+            1. Select a host
+            2. Select `Configure`, then expand `System` and select `Firewall`.
+            3. Select `Edit` to view services which are enabled (indicated by a check).
+            4. For each enabled service, (e.g., ssh, vSphere Web Access, http client) provide a list of allowed IP addresses.
+            5. Select `OK`.
 
-        **Impact:**
+            **Impact:**
 
-        Connections from IP addresses and ranges that are not explicitly set will be denied. Take care to ensure appropriate IPs/IP address ranges are allowed.
+            Connections from IP addresses and ranges that are not explicitly set will be denied. Take care to ensure appropriate IPs/IP address ranges are allowed.
+  # No Terraform variants: the vsphere Terraform provider does not manage the ESXi host SSL machine certificate or its validity period.
+  # No Terraform remediation: certificate expiry is observed runtime host state, not declarable Terraform configuration.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
     title: Ensure the ESXi host SSL certificate is not expired or expiring soon
     impact: 80
@@ -1391,18 +1528,22 @@ queries:
            ```
 
         The host passes when the certificate's expiration date is more than 90 days in the future. A certificate that is expired or expires within 90 days is a failing result.
-      remediation: |-
-        To renew or replace an expiring ESXi host certificate, perform the following from the vSphere Web Client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To renew or replace an expiring ESXi host certificate using the vSphere Client:
 
-        1. Select the host.
-        2. Select `Configure`, then expand `System` and select `Certificate`.
-        3. Review the validity period, then select `Renew` to issue a new certificate from the VMware Certificate Authority, or `Import` to install a certificate signed by an enterprise or public CA.
-        4. Confirm the host reconnects to vCenter Server successfully.
+            1. Select the host.
+            2. Select `Configure`, then expand `System` and select `Certificate`.
+            3. Review the validity period, then select `Renew` to issue a new certificate from the VMware Certificate Authority, or `Import` to install a certificate signed by an enterprise or public CA.
+            4. Confirm the host reconnects to vCenter Server successfully.
 
-        For environments using custom CA-signed certificates, ensure a renewal process is in place well ahead of the expiration date.
+            For environments using custom CA-signed certificates, ensure a renewal process is in place well ahead of the expiration date.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the TSM (ESXi Shell) daemon.
+  # No Terraform remediation: ESXi Shell service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
     title: Ensure the ESXi shell is disabled
     impact: 75
@@ -1455,21 +1596,26 @@ queries:
            ```
 
         The host passes when the `TSM` service is not running and its `Policy` is `off`. A running service or a policy of `on` is a failing result.
-      remediation: |-
-        To disable the ESXi shell, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the ESXi shell using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`m then expand `System` and select `Services`.
-        3. Select `ESXi Shell`, then select `Edit Startup Policy`.
-        4. Set the Startup Policy is set to `Start and Stop Manually`.
-        5. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`m then expand `System` and select `Services`.
+            3. Select `ESXi Shell`, then select `Edit Startup Policy`.
+            4. Set the Startup Policy is set to `Start and Stop Manually`.
+            5. Select `OK`.
+        - id: powershell
+          desc: |
+            To set the ESXi shell to start manually rather than automatically for all hosts using PowerCLI:
 
-        Alternately, use the following PowerCLI command:
-
-        ```
-        Set the ESXi shell to start manually rather than automatically for all hosts
-        Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM" } | Set-VMHostService -Policy Off
-        ```
+            ```
+            Set the ESXi shell to start manually rather than automatically for all hosts
+            Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM" } | Set-VMHostService -Policy Off
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage the ESXi host image profile VIB acceptance level.
+  # No Terraform remediation: the image profile acceptance level is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-image-profile-vib-acceptance-level-is-configured-properly
     title: Ensure the Image Profile VIB acceptance level is configured properly
     impact: 60
@@ -1518,27 +1664,32 @@ queries:
            ```
 
         The host passes when the acceptance level is `VMwareCertified`, `VMwareAccepted`, or `PartnerSupported`. An acceptance level of `CommunitySupported` is a failing result.
-      remediation: |-
-        To verify the host image profile acceptance level, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the host image profile acceptance level using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then under `System` and select `Security Profile`.
-        3. Under `Host Image Profile Acceptance Level` select `Edit`
-        4. In the dropdown select one of the following - `VMware Certified`, `VMware Accepted`, or `Partner Supported`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then under `System` and select `Security Profile`.
+            3. Under `Host Image Profile Acceptance Level` select `Edit`
+            4. In the dropdown select one of the following - `VMware Certified`, `VMware Accepted`, or `Partner Supported`.
 
-        To implement the recommended configuration state, run the following PowerCLI command (in the example code, the level is Partner Supported):
+            **Impact:**
 
-        ```
-        Set the Software AcceptanceLevel for each host<span>
-        Foreach ($VMHost in Get-VMHost ) {
-        $ESXCli = Get-EsxCli -VMHost $VMHost
-        $ESXCli.software.acceptance.Set("PartnerSupported")
-        }
-        ```
+            Unsigned (Community Supported) VIBs will not be able to be utilized on a host.
+        - id: powershell
+          desc: |
+            To set the host image profile acceptance level using PowerCLI (in the example code, the level is Partner Supported):
 
-        **Impact:**
-
-        Unsigned (Community Supported) VIBs will not be able to be utilized on a host.
+            ```
+            Set the Software AcceptanceLevel for each host<span>
+            Foreach ($VMHost in Get-VMHost ) {
+            $ESXCli = Get-EsxCli -VMHost $VMHost
+            $ESXCli.software.acceptance.Set("PartnerSupported")
+            }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Security.AccountLockFailures.
+  # No Terraform remediation: the maximum failed-login count is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-maximum-failed-login-attempts-is-set-to-5
     title: Ensure the maximum failed login attempts is set to 5
     impact: 80
@@ -1589,24 +1740,29 @@ queries:
            ```
 
         The host passes when `Security.AccountLockFailures` is `5`. Any other value is a failing result.
-      remediation: |-
-        To set the maximum failed login attempts correctly, perform the following steps:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the maximum failed login attempts correctly using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `System`.
-        3. Select `Advanced System Settings` then select `Edit`.
-        4. Enter `Security.AccountLockFailures` in the filter.
-        5. Set the value for this parameter to `5`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `System`.
+            3. Select `Advanced System Settings` then select `Edit`.
+            4. Enter `Security.AccountLockFailures` in the filter.
+            5. Set the value for this parameter to `5`.
 
-        Alternately, use the following PowerCLI command:
+            **Impact:**
 
-        ```powershell
-        Get-VMHost | Get-AdvancedSetting -Name Security.AccountLockFailures | Set-AdvancedSetting -Value 5
-        ```
+            A users account will be locked after 5 unsuccessful login attempts.
+        - id: powershell
+          desc: |
+            To set the maximum failed login attempts correctly using PowerCLI:
 
-        **Impact:**
-
-        A users account will be locked after 5 unsuccessful login attempts.
+            ```powershell
+            Get-VMHost | Get-AdvancedSetting -Name Security.AccountLockFailures | Set-AdvancedSetting -Value 5
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.ESXiShellTimeOut.
+  # No Terraform remediation: the shell services timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-shell-services-timeout-is-set-to-1-hour-or-less
     title: Ensure the shell services timeout is set to 1 hour or less
     impact: 60
@@ -1658,24 +1814,29 @@ queries:
            ```
 
         The host passes when `UserVars.ESXiShellTimeOut` is between `1` and `3600` seconds. A value greater than `3600`, or `0` (which disables the timeout entirely), is a failing result.
-      remediation: |-
-        To set the timeout to the desired value, perform the following from the vSphere web client:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the timeout to the desired value using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `System`.
-        3. Select `Advanced System Settings`, then select `Edit`.
-        4. Enter `ESXiShellTimeOut` in the filter.
-        5. Set the value for this parameter is set to `3600` (1 hour) or less
-        6. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `System`.
+            3. Select `Advanced System Settings`, then select `Edit`.
+            4. Enter `ESXiShellTimeOut` in the filter.
+            5. Set the value for this parameter is set to `3600` (1 hour) or less
+            6. Select `OK`.
 
-        **Note:**
-        A value of 0 disables the ESXiShellTimeOut.
+            **Note:**
+            A value of 0 disables the ESXiShellTimeOut.
+        - id: powershell
+          desc: |
+            To set UserVars.ESXiShellTimeOut to 3600 on all hosts using PowerCLI:
 
-        Alternately, run the following PowerCLI command to set UserVars.ESXiShellTimeOut to 3600 on all hosts
-
-        ```powershell
-        Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellTimeOut' | Set-AdvancedSetting -Value "3600"
-        ```
+            ```powershell
+            Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellTimeOut' | Set-AdvancedSetting -Value "3600"
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the slpd (CIM SLP) daemon.
+  # No Terraform remediation: SLP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-slp-service-is-disabled
     title: Ensure the SLP service is disabled
     impact: 80
@@ -1728,26 +1889,31 @@ queries:
            ```
 
         The host passes when the `slpd` service is not running and its `Policy` is `off`. A running service or a policy of `on` is a failing result.
-      remediation: |-
-        To disable the SLP service, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the SLP service using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `System` and select `Services`.
-        3. Select `slpd`, then select `Stop`.
-        4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
-        5. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `System` and select `Services`.
+            3. Select `slpd`, then select `Stop`.
+            4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
+            5. Select `OK`.
+        - id: cli
+          desc: |
+            To disable the SLP service using the ESXi shell:
 
-        Alternately, use the following ESXi shell commands:
-
-        ```bash
-        esxcli system slp stats get
-        /etc/init.d/slpd stop
-        esxcli network firewall ruleset set --ruleset-id CIMSLP --enabled false
-        chkconfig slpd off
-        ```
+            ```bash
+            esxcli system slp stats get
+            /etc/init.d/slpd stop
+            esxcli network firewall ruleset set --ruleset-id CIMSLP --enabled false
+            chkconfig slpd off
+            ```
     refs:
       - url: https://knowledge.broadcom.com/external/article/318251
         title: VMware ESXi SLP Service Security Advisory
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the snmpd daemon.
+  # No Terraform remediation: SNMP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled
     title: Ensure the SNMP service is disabled
     impact: 70
@@ -1800,26 +1966,29 @@ queries:
            ```
 
         The host passes when the `snmpd` service is not running and its `Policy` is `off`. A running service or a policy of `on` is a failing result.
-      remediation: |-
-        To disable the SNMP service, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the SNMP service using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `System` and select `Services`.
-        3. Select `snmpd`, then select `Stop`.
-        4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
-        5. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `System` and select `Services`.
+            3. Select `snmpd`, then select `Stop`.
+            4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
+            5. Select `OK`.
+        - id: cli
+          desc: |
+            To disable the SNMP service using the ESXi shell:
 
-        Alternately, use the following ESXi shell command:
+            ```bash
+            esxcli system snmp set --enable false
+            ```
 
-        ```bash
-        esxcli system snmp set --enable false
-        ```
+            If SNMP monitoring is required, enable SNMPv3 instead:
 
-        If SNMP monitoring is required, enable SNMPv3 instead:
-
-        ```bash
-        esxcli system snmp set --v3targets <target> --authentication SHA1 --privacy AES128
-        ```
+            ```bash
+            esxcli system snmp set --v3targets <target> --authentication SHA1 --privacy AES128
+            ```
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject
     title: Ensure the vSwitch Forged Transmits policy is set to reject
     impact: 60
@@ -1837,10 +2006,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.host.standardSwitch.all( securityPolicySettings.allowForgedTransmits == false )
-      vsphere.host.properties['config']['network']['portgroup'].all( _['computedPolicy']['security']['forgedTransmits'] == false )
-      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['policy']['security']['forgedTransmits'] == false )
+    variants:
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-vsphere
+        tags:
+          mondoo.com/filter-title: VMware ESXi
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Forged Transmits security policy is set to reject on every standard vSwitch and port group. Forged Transmits controls whether a virtual machine may send traffic using a source MAC address other than the one assigned to its virtual adapter.
@@ -1872,25 +2054,44 @@ queries:
            ```
 
         The host passes when `Allow Forged Transmits` is `false` on every standard vSwitch and on every port group. A value of `true` at either level is a failing result.
-      remediation: |-
-        To set the policy to reject forged transmissions, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the policy to reject forged transmissions using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure,  then expand `Networking`.
-        3. Select `Virtual switches`, then select `Edit`.
-        4. Select `Security`.
-        5. Set `Forged transmits` to `Reject` in the dropdown.
-        6. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure,  then expand `Networking`.
+            3. Select `Virtual switches`, then select `Edit`.
+            4. Select `Security`.
+            5. Set `Forged transmits` to `Reject` in the dropdown.
+            6. Select `OK`.
 
-        Alternately, the following ESXi shell command may be used:
+            **Impact:**
 
-        ```bash
-        esxcli network vswitch standard policy security set -v vSwitch2 -f false
-        ```
+            This will prevent VMs from changing their effective MAC address. This will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+        - id: cli
+          desc: |
+            To set the policy to reject forged transmissions using the ESXi shell:
 
-        **Impact:**
+            ```bash
+            esxcli network vswitch standard policy security set -v vSwitch2 -f false
+            ```
+        - id: terraform
+          desc: |
+            To reject forged transmits on a standard vSwitch using Terraform, set `allow_forged_transmits` to `false` on the `vsphere_host_virtual_switch` resource:
 
-        This will prevent VMs from changing their effective MAC address. This will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+            ```hcl
+            resource "vsphere_host_virtual_switch" "switch" {
+              name           = "vSwitch2"
+              host_system_id = data.vsphere_host.host.id
+
+              network_adapters = ["vmnic0", "vmnic1"]
+
+              allow_promiscuous      = false
+              allow_mac_changes      = false
+              allow_forged_transmits = false
+            }
+            ```
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject
     title: Ensure the vSwitch MAC Address Change policy is set to reject
     impact: 60
@@ -1908,8 +2109,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.host.standardSwitch.all( securityPolicySettings.allowMacChanges == false )
+    variants:
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-vsphere
+        tags:
+          mondoo.com/filter-title: VMware ESXi
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the MAC Address Change security policy is set to reject on every standard vSwitch. This policy controls whether a guest may change the effective MAC address of its virtual adapter to a value different from the one configured by ESXi.
@@ -1941,25 +2157,44 @@ queries:
            ```
 
         The host passes when `Allow MAC Address Change` is `false` on every standard vSwitch. A value of `true` is a failing result.
-      remediation: |-
-        To set the policy to reject, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the MAC Address Change policy to reject using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `Networking`.
-        3. Select `Virtual switches`, then select `Edit`.
-        4. Select `Security`.
-        5. Set `MAC address changes` to `Reject` in the dropdown.
-        6. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `Networking`.
+            3. Select `Virtual switches`, then select `Edit`.
+            4. Select `Security`.
+            5. Set `MAC address changes` to `Reject` in the dropdown.
+            6. Select `OK`.
 
-        Alternately, perform the following using the ESXi shell:
+            **Impact:**
 
-        ```bash
-        esxcli network vswitch standard policy security set -v vSwitch2 -m false
-        ```
+            This will prevent VMs from changing their effective MAC address. It will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+        - id: cli
+          desc: |
+            To set the MAC Address Change policy to reject using the ESXi shell:
 
-        **Impact:**
+            ```bash
+            esxcli network vswitch standard policy security set -v vSwitch2 -m false
+            ```
+        - id: terraform
+          desc: |
+            To reject MAC address changes on a standard vSwitch using Terraform, set `allow_mac_changes` to `false` on the `vsphere_host_virtual_switch` resource:
 
-        This will prevent VMs from changing their effective MAC address. It will affect applications that require this functionality, such as Microsoft Clustering, which requires systems to effectively share a MAC address. This will affect how a layer 2 bridge will operate. This will also affect applications that require a specific MAC address for licensing. An exception should be made for the port groups that these applications are connected to.
+            ```hcl
+            resource "vsphere_host_virtual_switch" "switch" {
+              name           = "vSwitch2"
+              host_system_id = data.vsphere_host.host.id
+
+              network_adapters = ["vmnic0", "vmnic1"]
+
+              allow_promiscuous      = false
+              allow_mac_changes      = false
+              allow_forged_transmits = false
+            }
+            ```
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject
     title: Ensure the vSwitch Promiscuous Mode policy is set to reject
     impact: 80
@@ -1977,8 +2212,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.host.standardSwitch.all( securityPolicySettings.allowPromiscuous == false )
+    variants:
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-vsphere
+        tags:
+          mondoo.com/filter-title: VMware ESXi
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Promiscuous Mode security policy is set to reject on every standard vSwitch. Promiscuous mode lets a virtual machine adapter receive all frames passing through the vSwitch, not only those addressed to it.
@@ -2010,25 +2260,46 @@ queries:
            ```
 
         The host passes when `Allow Promiscuous` is `false` on every standard vSwitch. A value of `true` is a failing result.
-      remediation: |-
-        To set the policy to reject, perform the following:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the Promiscuous Mode policy to reject using the vSphere Client:
 
-        1. From the vSphere Web Client, select the host.
-        2. Select `Configure`, then expand `Networking`.
-        3. Select `Virtual switches`, then select `Edit`.
-        4. Select `Security`.
-        5. Set `Promiscuous mode` to `Reject` in the dropdown.
-        6. Select `OK`.
+            1. From the vSphere Web Client, select the host.
+            2. Select `Configure`, then expand `Networking`.
+            3. Select `Virtual switches`, then select `Edit`.
+            4. Select `Security`.
+            5. Set `Promiscuous mode` to `Reject` in the dropdown.
+            6. Select `OK`.
 
-        Alternately, perform the following via the ESXi shell:
+            **Impact:**
 
-        ```bash
-        esxcli network vswitch standard policy security set -v vSwitch2 -p false
-        ```
+            There might be a legitimate reason to enable promiscuous mode for debugging, monitoring, or troubleshooting reasons. Security devices might require the ability to see all packets on a vSwitch. An exception should be made for the dvPortgroups that these applications are connected to in order to allow for full-time visibility to the traffic on that dvPortgroup.
+        - id: cli
+          desc: |
+            To set the Promiscuous Mode policy to reject using the ESXi shell:
 
-        **Impact:**
+            ```bash
+            esxcli network vswitch standard policy security set -v vSwitch2 -p false
+            ```
+        - id: terraform
+          desc: |
+            To reject promiscuous mode on a standard vSwitch using Terraform, set `allow_promiscuous` to `false` on the `vsphere_host_virtual_switch` resource:
 
-        There might be a legitimate reason to enable promiscuous mode for debugging, monitoring, or troubleshooting reasons. Security devices might require the ability to see all packets on a vSwitch. An exception should be made for the dvPortgroups that these applications are connected to in order to allow for full-time visibility to the traffic on that dvPortgroup.
+            ```hcl
+            resource "vsphere_host_virtual_switch" "switch" {
+              name           = "vSwitch2"
+              host_system_id = data.vsphere_host.host.id
+
+              network_adapters = ["vmnic0", "vmnic1"]
+
+              allow_promiscuous      = false
+              allow_mac_changes      = false
+              allow_forged_transmits = false
+            }
+            ```
+  # No Terraform variants: the vsphere Terraform provider does not manage ESXi host UEFI Secure Boot firmware state.
+  # No Terraform remediation: UEFI Secure Boot is platform firmware configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-uefi-secure-boot-is-enabled-on-the-esxi-host
     title: Ensure UEFI Secure Boot is enabled on the ESXi host
     impact: 80
@@ -2082,26 +2353,157 @@ queries:
            ```
 
         The host passes when UEFI Secure Boot reports as enabled. A host booting in legacy BIOS mode, or with Secure Boot disabled, is a failing result.
-      remediation: |-
-        Enabling UEFI Secure Boot requires the host to boot in UEFI mode and all installed VIBs to be properly signed.
+      remediation:
+        - id: cli
+          desc: |
+            To enable UEFI Secure Boot using the ESXi shell and server firmware (the host must boot in UEFI mode and all installed VIBs must be properly signed):
 
-        1. Confirm the host is configured to boot in UEFI mode (not legacy BIOS) in the server firmware.
-        2. Validate that the current ESXi installation is Secure Boot compatible:
+            1. Confirm the host is configured to boot in UEFI mode (not legacy BIOS) in the server firmware.
+            2. Validate that the current ESXi installation is Secure Boot compatible:
 
-           ```bash
-           /usr/lib/vmware/secureboot/bin/secureBoot.py -c
-           ```
+               ```bash
+               /usr/lib/vmware/secureboot/bin/secureBoot.py -c
+               ```
 
-        3. Reboot the host, enter the firmware setup, and enable `Secure Boot`.
-        4. Boot ESXi and confirm Secure Boot is active:
+            3. Reboot the host, enter the firmware setup, and enable `Secure Boot`.
+            4. Boot ESXi and confirm Secure Boot is active:
 
-           ```bash
-           /usr/lib/vmware/secureboot/bin/secureBoot.py -s
-           ```
+               ```bash
+               /usr/lib/vmware/secureboot/bin/secureBoot.py -s
+               ```
 
-        **Impact:**
+            **Impact:**
 
-        If any installed VIB is unsigned or improperly signed, the host will fail to boot with Secure Boot enabled. Resolve unsigned modules first (see "Ensure all loaded ESXi kernel modules are signed").
+            If any installed VIB is unsigned or improperly signed, the host will fail to boot with Secure Boot enabled. Resolve unsigned modules first (see "Ensure all loaded ESXi kernel modules are signed").
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-5D5EE0D1-2596-43D7-95C8-0B29733191D9.html
         title: UEFI Secure Boot for ESXi Hosts
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-vsphere
+    filters: asset.platform == 'vmware-esxi'
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowForgedTransmits == false )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['computedPolicy']['security']['forgedTransmits'] == false )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['policy']['security']['forgedTransmits'] == false )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.resources('vsphere_host_virtual_switch').all(
+        arguments['allow_forged_transmits'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_host_virtual_switch').all(
+        change.after['allow_forged_transmits'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_host_virtual_switch').all(
+        values['allow_forged_transmits'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-vsphere
+    filters: asset.platform == 'vmware-esxi'
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowMacChanges == false )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.resources('vsphere_host_virtual_switch').all(
+        arguments['allow_mac_changes'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_host_virtual_switch').all(
+        change.after['allow_mac_changes'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_host_virtual_switch').all(
+        values['allow_mac_changes'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-vsphere
+    filters: asset.platform == 'vmware-esxi'
+    mql: |
+      vsphere.host.standardSwitch.all( securityPolicySettings.allowPromiscuous == false )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.resources('vsphere_host_virtual_switch').all(
+        arguments['allow_promiscuous'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_host_virtual_switch').all(
+        change.after['allow_promiscuous'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_host_virtual_switch')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_host_virtual_switch').all(
+        values['allow_promiscuous'] == false
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-vsphere
+    filters: asset.platform == 'vmware-esxi'
+    mql: |
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] >= 2 )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] <= 4094 )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_port_group')
+    mql: |
+      terraform.resources('vsphere_host_port_group').all(
+        arguments['vlan_id'] >= 2 && arguments['vlan_id'] <= 4094
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_host_port_group')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_host_port_group').all(
+        change.after['vlan_id'] >= 2 && change.after['vlan_id'] <= 4094
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_host_port_group')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_host_port_group').all(
+        values['vlan_id'] >= 2 && values['vlan_id'] <= 4094
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-vsphere
+    filters: asset.platform == 'vmware-esxi'
+    mql: |
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 0 )
+      vsphere.host.properties['config']['network']['portgroup'].all( _['spec']['vlanId'] != 4095 )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_port_group')
+    mql: |
+      terraform.resources('vsphere_host_port_group').all(
+        arguments['vlan_id'] != 0 && arguments['vlan_id'] != 4095
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_host_port_group')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_host_port_group').all(
+        change.after['vlan_id'] != 0 && change.after['vlan_id'] != 4095
+      )
+  - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_host_port_group')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_host_port_group').all(
+        values['vlan_id'] != 0 && values['vlan_id'] != 4095
+      )

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -83,7 +83,6 @@ policies:
     scoring_system: highest impact
 queries:
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Security.AccountUnlockTime.
-  # No Terraform remediation: the account-lockout window is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-account-lockout-is-set-to-15-minutes
     title: Ensure account lockout is set to 15 minutes
     impact: 80
@@ -151,11 +150,11 @@ queries:
             ```powershell
             Get-VMHost | Get-AdvancedSetting -Name Security.AccountUnlockTime | Set-AdvancedSetting -Value 900
             ```
+        # No Terraform remediation: the account-lockout window is a runtime host advanced setting with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage installed VIBs or the kernel modules loaded by the VMkernel at runtime.
-  # No Terraform remediation: kernel module signing is verified against live host state, not declarable Terraform configuration.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
     title: Ensure all loaded ESXi kernel modules are signed
     impact: 80
@@ -233,11 +232,11 @@ queries:
             4. Reboot the host so the updated module set is loaded.
 
             Configure the host image profile acceptance level so that unsigned VIBs cannot be installed in the first place. See "Ensure the Image Profile VIB acceptance level is configured properly".
+        # No Terraform remediation: kernel module signing is verified against live host state, not declarable Terraform configuration.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi iSCSI host bus adapter CHAP authentication properties.
-  # No Terraform remediation: iSCSI CHAP credentials are configured on the live storage adapter and have no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
     title: Ensure bidirectional CHAP authentication for iSCSI traffic is enabled
     impact: 80
@@ -323,8 +322,8 @@ queries:
             ```powershell
             Get-VMHost | Get-VMHostHba | Where {$_.Type -eq "Iscsi"} | Set-VMHostHba # Use desired parameters here
             ```
+        # No Terraform remediation: iSCSI CHAP credentials are configured on the live storage adapter and have no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host DNS network configuration.
-  # No Terraform remediation: the host DNS configuration is runtime network state with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dns-is-statically-configured-on-the-esxi-host
     title: Ensure DNS is statically configured on the ESXi host
     impact: 60
@@ -396,11 +395,11 @@ queries:
             esxcli network ip dns server add --server=<dns-ip>
             esxcli network ip interface ipv4 set --interface-name=vmk0 --type=static
             ```
+        # No Terraform remediation: the host DNS configuration is runtime network state with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Net.DVFilterBindIpAddress.
-  # No Terraform remediation: the dvfilter bind address is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
     title: Ensure dvfilter API is not configured if not used
     impact: 60
@@ -474,11 +473,11 @@ queries:
             ```powershell
             Get-VMHost HOST1 | Foreach { Set-AdvancedSetting -VMHost $_ -Name Net.DVFilterBindIpAddress -IPValue "" }
             ```
+        # No Terraform remediation: the dvfilter bind address is a runtime host advanced setting with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.ESXiShellInteractiveTimeOut.
-  # No Terraform remediation: the interactive shell idle timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
     title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
     impact: 60
@@ -551,11 +550,11 @@ queries:
             ```powershell
             Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellInteractiveTimeOut' | Set-AdvancedSetting -Value "300"
             ```
+        # No Terraform remediation: the interactive shell idle timeout is a runtime host advanced setting with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Config.HostAgent.plugins.solo.enableMob.
-  # No Terraform remediation: the Managed Object Browser toggle is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
     title: Ensure Managed Object Browser (MOB) is disabled
     impact: 60
@@ -626,8 +625,8 @@ queries:
             **Impact:**
 
             Some third-party tools may utilize the Managed Object Browser (MOB). Disabling MOB may cause those tools to malfunction.
+        # No Terraform remediation: the Managed Object Browser toggle is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
-  # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
     title: Ensure Normal Lockdown mode is enabled
     impact: 80
@@ -698,8 +697,8 @@ queries:
             ```powershell
             Get-VMHost | Foreach { $_.EnterLockdownMode() }
             ```
+        # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the ntpd time-synchronization daemon.
-  # No Terraform remediation: NTP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
     title: Ensure NTP time synchronization is configured properly
     impact: 60
@@ -774,8 +773,8 @@ queries:
             $NTPServers = "pool.ntp.org", "pool2.ntp.org"
             Get-VMHost | Add-VmHostNtpServer $NTPServers
             ```
+        # No Terraform remediation: NTP service state and startup policy are runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Syslog.global.logDir.
-  # No Terraform remediation: the persistent log directory is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-persistent-logging-is-configured-for-all-esxi-hosts
     title: Ensure persistent logging is configured for all ESXi hosts
     impact: 60
@@ -845,6 +844,7 @@ queries:
             Set Syslog.global.logDir for each host
             Get-VMHost | Foreach { Set-AdvancedConfiguration -VMHost $_ -Name Syslog.global.logDir -Value "<NewLocation>" }
             ```
+        # No Terraform remediation: the persistent log directory is a runtime host advanced setting with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
@@ -1040,7 +1040,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Syslog.global.logHost.
-  # No Terraform remediation: the remote syslog host is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-remote-logging-is-configured-for-esxi-hosts
     title: Ensure remote logging is configured for ESXi hosts
     impact: 60
@@ -1112,8 +1111,8 @@ queries:
             Set Syslog.global.logHost for each host
             Get-VMHost | Foreach { Set-AdvancedSetting -VMHost $_ -Name Syslog.global.logHost -Value "<NewLocation>" }
             ```
+        # No Terraform remediation: the remote syslog host is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the TSM-SSH daemon.
-  # No Terraform remediation: SSH service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ssh-is-disabled
     title: Ensure SSH is disabled
     impact: 75
@@ -1189,8 +1188,8 @@ queries:
             Set SSH to start manually rather than automatically for all hosts
             Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM-SSH" } | Set-VMHostService -Policy Off
             ```
+        # No Terraform remediation: SSH service state and startup policy are runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
-  # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
     title: Ensure Strict Lockdown mode is enabled
     impact: 80
@@ -1262,8 +1261,8 @@ queries:
             Enable lockdown mode for each host
             Get-VMHost | Foreach { $_.EnterLockdownMode() }
             ```
+        # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.DcuiTimeOut.
-  # No Terraform remediation: the DCUI timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
     title: Ensure the DCUI timeout is set to 600 seconds or less
     impact: 60
@@ -1331,8 +1330,8 @@ queries:
             ```
             Get-VMHost | Get-AdvancedSetting -Name UserVars.DcuiTimeOut | Set-AdvancedSetting -Value 600
             ```
+        # No Terraform remediation: the DCUI timeout is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Mem.ShareForceSalting.
-  # No Terraform remediation: the Transparent Page Sharing salt setting is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-default-value-of-individual-salt-per-vm-is-configured
     title: Ensure the default value of individual salt per vm is configured
     impact: 60
@@ -1403,11 +1402,11 @@ queries:
             ```
             Get-VMHost | Get-AdvancedSetting -Name Mem.ShareForceSalting | Set-AdvancedSetting -Value 2
             ```
+        # No Terraform remediation: the Transparent Page Sharing salt setting is a runtime host advanced setting with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host firewall rulesets or their allowed-IP networks.
-  # No Terraform remediation: the host firewall ruleset configuration is runtime host state with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
     title: Ensure the ESXi host firewall restricts access to running services
     impact: 60
@@ -1475,8 +1474,8 @@ queries:
             **Impact:**
 
             Connections from IP addresses and ranges that are not explicitly set will be denied. Take care to ensure appropriate IPs/IP address ranges are allowed.
+        # No Terraform remediation: the host firewall ruleset configuration is runtime host state with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage the ESXi host SSL machine certificate or its validity period.
-  # No Terraform remediation: certificate expiry is observed runtime host state, not declarable Terraform configuration.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
     title: Ensure the ESXi host SSL certificate is not expired or expiring soon
     impact: 80
@@ -1539,11 +1538,11 @@ queries:
             4. Confirm the host reconnects to vCenter Server successfully.
 
             For environments using custom CA-signed certificates, ensure a renewal process is in place well ahead of the expiration date.
+        # No Terraform remediation: certificate expiry is observed runtime host state, not declarable Terraform configuration.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the TSM (ESXi Shell) daemon.
-  # No Terraform remediation: ESXi Shell service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
     title: Ensure the ESXi shell is disabled
     impact: 75
@@ -1614,8 +1613,8 @@ queries:
             Set the ESXi shell to start manually rather than automatically for all hosts
             Get-VMHost | Get-VMHostService | Where { $_.key -eq "TSM" } | Set-VMHostService -Policy Off
             ```
+        # No Terraform remediation: ESXi Shell service state and startup policy are runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage the ESXi host image profile VIB acceptance level.
-  # No Terraform remediation: the image profile acceptance level is runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-image-profile-vib-acceptance-level-is-configured-properly
     title: Ensure the Image Profile VIB acceptance level is configured properly
     impact: 60
@@ -1688,8 +1687,8 @@ queries:
             $ESXCli.software.acceptance.Set("PartnerSupported")
             }
             ```
+        # No Terraform remediation: the image profile acceptance level is runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Security.AccountLockFailures.
-  # No Terraform remediation: the maximum failed-login count is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-maximum-failed-login-attempts-is-set-to-5
     title: Ensure the maximum failed login attempts is set to 5
     impact: 80
@@ -1761,8 +1760,8 @@ queries:
             ```powershell
             Get-VMHost | Get-AdvancedSetting -Name Security.AccountLockFailures | Set-AdvancedSetting -Value 5
             ```
+        # No Terraform remediation: the maximum failed-login count is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.ESXiShellTimeOut.
-  # No Terraform remediation: the shell services timeout is a runtime host advanced setting with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-shell-services-timeout-is-set-to-1-hour-or-less
     title: Ensure the shell services timeout is set to 1 hour or less
     impact: 60
@@ -1835,8 +1834,8 @@ queries:
             ```powershell
             Get-VMHost | Get-AdvancedSetting -Name 'UserVars.ESXiShellTimeOut' | Set-AdvancedSetting -Value "3600"
             ```
+        # No Terraform remediation: the shell services timeout is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the slpd (CIM SLP) daemon.
-  # No Terraform remediation: SLP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-slp-service-is-disabled
     title: Ensure the SLP service is disabled
     impact: 80
@@ -1909,11 +1908,11 @@ queries:
             esxcli network firewall ruleset set --ruleset-id CIMSLP --enabled false
             chkconfig slpd off
             ```
+        # No Terraform remediation: SLP service state and startup policy are runtime host configuration with no Terraform resource.
     refs:
       - url: https://knowledge.broadcom.com/external/article/318251
         title: VMware ESXi SLP Service Security Advisory
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the snmpd daemon.
-  # No Terraform remediation: SNMP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled
     title: Ensure the SNMP service is disabled
     impact: 70
@@ -1989,6 +1988,7 @@ queries:
             ```bash
             esxcli system snmp set --v3targets <target> --authentication SHA1 --privacy AES128
             ```
+        # No Terraform remediation: SNMP service state and startup policy are runtime host configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject
     title: Ensure the vSwitch Forged Transmits policy is set to reject
     impact: 60
@@ -2299,7 +2299,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host UEFI Secure Boot firmware state.
-  # No Terraform remediation: UEFI Secure Boot is platform firmware configuration with no Terraform resource.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-uefi-secure-boot-is-enabled-on-the-esxi-host
     title: Ensure UEFI Secure Boot is enabled on the ESXi host
     impact: 80
@@ -2375,6 +2374,7 @@ queries:
             **Impact:**
 
             If any installed VIB is unsigned or improperly signed, the host will fail to boot with Secure Boot enabled. Resolve unsigned modules first (see "Ensure all loaded ESXi kernel modules are signed").
+        # No Terraform remediation: UEFI Secure Boot is platform firmware configuration with no Terraform resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-5D5EE0D1-2596-43D7-95C8-0B29733191D9.html
         title: UEFI Secure Boot for ESXi Hosts

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -1460,7 +1460,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
-  # No Terraform remediation: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-nonpersistent-disks-are-limited
     title: Ensure nonpersistent disks are limited
     impact: 60
@@ -1527,6 +1526,7 @@ queries:
             #Add the parameters for the following cmdlet to set the VM Disk Type:
             Get-VM | Get-HardDisk | Set-HardDisk
             ```
+        # No Terraform remediation: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -1634,7 +1634,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
-  # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-pci-and-pcie-device-passthrough-is-disabled
     title: Ensure PCI and PCIe device pass-through is disabled
     impact: 60
@@ -1694,6 +1693,7 @@ queries:
             Add the setting to all VMs
             Get-VM | New-AdvancedSetting -Name "pciPassthru*.present" -value ""
             ```
+        # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -2952,7 +2952,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere_virtual_machine cdrom block exposes no per-device connected or start-connected state attribute.
-  # No Terraform remediation: the vsphere_virtual_machine cdrom block exposes no per-device connected or start-connected state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-cddvd-devices-are-disconnected
     title: Ensure unnecessary CD/DVD devices are disconnected
     impact: 60
@@ -3015,8 +3014,8 @@ queries:
             ```
 
             The VM will need to be powered off for this change to take effect.
+        # No Terraform remediation: the vsphere_virtual_machine cdrom block exposes no per-device connected or start-connected state attribute.
   # No Terraform variants: the vsphere_virtual_machine resource has no floppy device block or connection-state attribute.
-  # No Terraform remediation: the vsphere_virtual_machine resource has no floppy device block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-floppy-devices-are-disconnected
     title: Ensure unnecessary floppy devices are disconnected
     impact: 60
@@ -3079,8 +3078,8 @@ queries:
             ```
 
             The VM will need to be powered off for this change to take effect.
+        # No Terraform remediation: the vsphere_virtual_machine resource has no floppy device block or connection-state attribute.
   # No Terraform variants: the vsphere_virtual_machine resource has no parallel port block or connection-state attribute.
-  # No Terraform remediation: the vsphere_virtual_machine resource has no parallel port block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-parallel-ports-are-disconnected
     title: Ensure unnecessary parallel ports are disconnected
     impact: 60
@@ -3144,8 +3143,8 @@ queries:
             ```
 
             The VM will need to be powered off for this change to take effect.
+        # No Terraform remediation: the vsphere_virtual_machine resource has no parallel port block or connection-state attribute.
   # No Terraform variants: the vsphere_virtual_machine resource has no serial port block or connection-state attribute.
-  # No Terraform remediation: the vsphere_virtual_machine resource has no serial port block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-serial-ports-are-disconnected
     title: Ensure unnecessary serial ports are disconnected
     impact: 60
@@ -3209,8 +3208,8 @@ queries:
             ```
 
             The VM will need to be powered off for this change to take effect.
+        # No Terraform remediation: the vsphere_virtual_machine resource has no serial port block or connection-state attribute.
   # No Terraform variants: the vsphere_virtual_machine resource has no USB device block or connection-state attribute.
-  # No Terraform remediation: the vsphere_virtual_machine resource has no USB device block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-usb-devices-are-disconnected
     title: Ensure unnecessary USB devices are disconnected
     impact: 60
@@ -3273,6 +3272,7 @@ queries:
             ```
 
             The VM will need to be powered off for this change to take effect.
+        # No Terraform remediation: the vsphere_virtual_machine resource has no USB device block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled
     title: Ensure virtual disk shrinking is disabled
     impact: 60
@@ -3468,7 +3468,6 @@ queries:
             }
             ```
   # No Terraform variants: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
-  # No Terraform remediation: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
     title: Ensure virtual machine encryption is enabled
     impact: 80
@@ -3535,6 +3534,7 @@ queries:
             **Impact:**
 
             Encrypted virtual machines cannot be migrated to hosts that lack access to the key provider, and some operations (such as content-based deduplication) are not available for encrypted VMs.
+        # No Terraform remediation: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E6C5CE29-CD1D-4555-859C-A0492E7CB45D.html
         title: Virtual Machine Encryption

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -114,8 +114,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( vtpmPresent == true ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that each virtual machine has a virtual Trusted Platform Module (vTPM) attached. A vTPM is a software-based TPM 2.0 device that gives the guest operating system a hardware-rooted store for cryptographic keys and platform measurements, which modern guest security features depend on.
@@ -147,16 +162,30 @@ queries:
         ```
 
         The check passes when every virtual machine has a vTPM device present. It fails for any VM that returns no Trusted Platform Module device.
-      remediation: |-
-        Adding a vTPM requires that a key provider is configured in vCenter Server and that the virtual machine uses EFI firmware.
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To add a vTPM using the vSphere Client:
 
-        **To add a vTPM via the vSphere Client:**
+            Adding a vTPM requires that a key provider is configured in vCenter Server and that the virtual machine uses EFI firmware.
 
-        1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
-        2. Power off the virtual machine.
-        3. Right-click the VM and select `Edit Settings`.
-        4. Select `ADD NEW DEVICE`, then choose `Trusted Platform Module`.
-        5. Select `OK`, then power the VM back on.
+            1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
+            2. Power off the virtual machine.
+            3. Right-click the VM and select `Edit Settings`.
+            4. Select `ADD NEW DEVICE`, then choose `Trusted Platform Module`.
+            5. Select `OK`, then power the VM back on.
+        - id: terraform
+          desc: |
+            To attach a vTPM with Terraform, add a `vtpm` block to the `vsphere_virtual_machine` resource. The VM must use EFI firmware and a key provider must be configured in vCenter Server.
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              firmware = "efi"
+
+              vtpm {}
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-A45F1862-A2E1-4FFE-A2DF-29B3FE3A5D80.html
         title: Securing Virtual Machines with Virtual Trusted Platform Module
@@ -177,8 +206,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that automatic login is disabled for each virtual machine through the `isolation.tools.ghi.autologon.disable` parameter. Autologon lets a guest operating system sign in a user at startup without authentication, and disabling it ensures only authenticated users can reach an interactive session.
@@ -211,20 +255,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable Autologon using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.autologon.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.autologon.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable Autologon using PowerCLI, run the following command for each VM:
 
-        Alternatively you may run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.autologon.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.autologon.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.ghi.autologon.disable" = "true"
+              }
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -245,8 +304,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the BIOS Boot Specification (BBS) is disabled for each virtual machine through the `isolation.bios.bbs.disable` parameter. BBS lets the virtual firmware enumerate and prioritize bootable devices, and disabling it prevents the guest from being booted from unauthorized or removable media.
@@ -279,20 +353,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable BIOS BBS using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.bios.bbs.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.bios.bbs.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable BIOS BBS using PowerCLI, run the following command for each VM:
 
-        To disable BIOS BBS, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.bios.bbs.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.bios.bbs.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.bios.bbs.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled
     title: Ensure Drag and Drop Version Get is disabled
     impact: 60
@@ -310,8 +399,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Drag and Drop Version Get feature is disabled for each virtual machine through the `isolation.tools.vmxDnDVersionGet.disable` parameter. The feature lets the guest query the host's drag-and-drop capability version, and disabling it removes an unnecessary guest-to-host communication path.
@@ -344,24 +448,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Drag and Drop Version Get feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.vmxDnDVersionGet.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.vmxDnDVersionGet.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Drag and Drop Version Get feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.vmxDnDVersionGet.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Drag and Drop Version Get feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.vmxDnDVersionGet.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.vmxDnDVersionGet.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled
     title: Ensure Drag and Drop Version Set is disabled
     impact: 60
@@ -379,8 +498,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Drag and Drop Version Set feature is disabled for each virtual machine through the `isolation.tools.guestDnDVersionSet.disable` parameter. The feature lets the guest set the drag-and-drop protocol version, and disabling it prevents the guest from initiating host-side drag-and-drop interaction.
@@ -413,24 +547,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Drag and Drop Version Set feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.guestDnDVersionSet.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.guestDnDVersionSet.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Drag and Drop Version Set feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.guestDnDVersionSet.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Drag and Drop Version Set feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.guestDnDVersionSet.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.guestDnDVersionSet.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled
     title: Ensure GetCreds is disabled
     impact: 60
@@ -448,8 +597,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the GetCreds feature is disabled for each virtual machine through the `isolation.tools.getCreds.disable` parameter. GetCreds lets a guest request credential-related operations from the host through VMware Tools, and disabling it removes a guest-accessible path to sensitive credential data.
@@ -482,24 +646,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the GetCreds feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.getCreds.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.getCreds.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the GetCreds feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.getCreds.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the GetCreds feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.getCreds.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.getCreds.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled
     title: Ensure Guest Host Interaction Launch Menu is disabled
     impact: 60
@@ -517,8 +696,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Launch Menu feature is disabled for each virtual machine through the `isolation.tools.ghi.launchmenu.change` parameter. The feature lets a guest trigger host-side actions or launchable menu items, and disabling it keeps the guest from invoking host functionality.
@@ -551,24 +745,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Guest Host Interaction Launch Menu feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.launchmenu.change` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.launchmenu.change` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Guest Host Interaction Launch Menu feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.launchmenu.change" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Guest Host Interaction Launch Menu feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.launchmenu.change" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.ghi.launchmenu.change" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled
     title: Ensure Guest Host Interaction Protocol Handler is set to disabled
     impact: 60
@@ -586,8 +795,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Protocol Handler feature is disabled for each virtual machine through the `isolation.tools.ghi.protocolhandler.info.disable` parameter. The feature lets a guest interact with URI-based protocol handlers on the host, and disabling it keeps the guest from triggering or registering them.
@@ -620,24 +844,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Guest Host Interaction Protocol Handler feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.protocolhandler.info.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.protocolhandler.info.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable Guest Host Interaction Protocol Handle, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.protocolhandler.info.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Guest Host Interaction Protocol Handler feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.protocolhandler.info.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.ghi.protocolhandler.info.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled
     title: Ensure Guest Host Interaction Tray Icon is disabled
     impact: 60
@@ -655,8 +894,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Guest Host Interaction Tray Icon feature is disabled for each virtual machine through the `isolation.tools.ghi.trayicon.disable` parameter. The tray icon surfaces host-integration shortcuts inside the guest, and disabling it limits guest-side visibility into host functionality.
@@ -689,24 +943,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Guest Host Interaction Tray Icon feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.trayicon.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.ghi.trayicon.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Guest Host Interaction Tray Icon feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.trayicon.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Guest Host Interaction Tray Icon feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.trayicon.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.ghi.trayicon.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled
     title: Ensure hardware-based 3D acceleration is disabled
     impact: 60
@@ -724,7 +993,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that hardware-based 3D acceleration is disabled for each virtual machine through the `mks.enable3d` parameter. The feature lets a VM use physical GPU resources, and disabling it where 3D graphics are not required removes avoidable virtual-hardware exposure.
@@ -757,20 +1042,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `FALSE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable hardware-based 3D acceleration using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `mks.enable3d` with a value of `FALSE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `mks.enable3d` with a value of `FALSE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable hardware-based 3D acceleration using PowerCLI, run the following command for each VM:
 
-        To disable hardware-based 3D acceleration, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "mks.enable3d" -value $false
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "mks.enable3d" -value $false
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "mks.enable3d" = "false"
+              }
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -791,8 +1091,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Host Guest File System (HGFS) Server is disabled for each virtual machine through the `isolation.tools.hgfsServerSet.disable` parameter. HGFS provides shared folders between the guest and the host, and disabling it removes a direct file-sharing path that bypasses normal access controls.
@@ -825,24 +1140,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Host Guest File System Server using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.hgfsServerSet.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.hgfsServerSet.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Host Guest File System Server, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.hgfsServerSet.disable" -value $true
-        ```
+            This will cause the VMX process to not respond to commands from the tools process. Setting isolation.tools.hgfsServerSet.disable to TRUE disables the registration of the guest's HGFS server with the host. APIs that use HGFS to transfer files to and from the guest operating system, such as some VIX commands or the VMware Tools auto-upgrade utility, will not function.
+        - id: powershell
+          desc: |
+            To disable the Host Guest File System Server using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.hgfsServerSet.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        This will cause the VMX process to not respond to commands from the tools process. Setting isolation.tools.hgfsServerSet.disable to TRUE disables the registration of the guest's HGFS server with the host. APIs that use HGFS to transfer files to and from the guest operating system, such as some VIX commands or the VMware Tools auto-upgrade utility, will not function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.hgfsServerSet.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests
     title: Ensure host information is not sent to guests
     impact: 60
@@ -860,8 +1190,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == "false" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that host system information is not sent to each virtual machine through the `tools.guestlib.enableHostInfo` parameter. VMware Tools can expose host details such as hostname, CPU model, and memory capacity to the guest, and disabling that sharing keeps host metadata out of the guest unless it is genuinely needed.
@@ -894,20 +1239,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `FALSE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To prevent host information from being sent to guests using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `tools.guestlib.enableHostInfo` with a value of `FALSE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `tools.guestlib.enableHostInfo` with a value of `FALSE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To prevent host information from being sent to guests using PowerCLI, run the following command for each VM:
 
-        To prevent host information from being sent to guests, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "tools.guestlib.enableHostInfo" -value $false
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "tools.guestlib.enableHostInfo" -value $false
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "tools.guestlib.enableHostInfo" = "false"
+              }
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -928,8 +1288,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['tools.setInfo.sizeLimit'] == 1048576 ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that informational messages written from each virtual machine to its VMX configuration file are capped at 1 MB through the `tools.setInfo.sizeLimit` parameter. The VMX file holds the VM's hardware and runtime configuration, and bounding guest-generated data keeps it from growing without limit.
@@ -962,12 +1337,26 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `1048576` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration run the following PowerCLI command for each VM:
+      remediation:
+        - id: powershell
+          desc: |
+            To limit informational messages from the VM to the VMX file using PowerCLI, run the following command for each VM:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "tools.setInfo.sizeLimit" -value 1048576
-        ```
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "tools.setInfo.sizeLimit" -value 1048576
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "tools.setInfo.sizeLimit" = 1048576
+              }
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -988,8 +1377,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the memSchedFakeSampleStats feature is disabled for each virtual machine through the `isolation.tools.memSchedFakeSampleStats.disable` parameter. The setting is an internal debugging aid that fabricates memory scheduler statistics, and disabling it ensures the guest sees only real memory telemetry.
@@ -1022,24 +1426,41 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the memSchedFakeSampleStats feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.memSchedFakeSampleStats.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.memSchedFakeSampleStats.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the memSchedFakeSampleStats feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.memSchedFakeSampleStats.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the memSchedFakeSampleStats feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.memSchedFakeSampleStats.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.memSchedFakeSampleStats.disable" = "true"
+              }
+            }
+            ```
+  # No Terraform variants: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
+  # No Terraform remediation: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-nonpersistent-disks-are-limited
     title: Ensure nonpersistent disks are limited
     impact: 60
@@ -1097,13 +1518,15 @@ queries:
         ```
 
         The check passes when no virtual disk uses independent nonpersistent mode. It fails for any VM that has a disk reported as `IndependentNonPersistent`.
-      remediation: |-
-        To limit the use of nonpersistent mode, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To limit the use of nonpersistent disk mode using PowerCLI, run the following command:
 
-        ```
-        #Add the parameters for the following cmdlet to set the VM Disk Type:
-        Get-VM | Get-HardDisk | Set-HardDisk
-        ```
+            ```
+            #Add the parameters for the following cmdlet to set the VM Disk Type:
+            Get-VM | Get-HardDisk | Set-HardDisk
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -1124,8 +1547,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['RemoteDisplay.maxConnections'] == 1 ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that each virtual machine permits only one remote console connection at a time through the `RemoteDisplay.maxConnections` parameter. The remote console grants display, keyboard, and mouse access to a VM, and limiting it to a single session keeps administrative access controlled.
@@ -1158,28 +1596,45 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `1` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To limit a VM to one remote console connection using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `RemoteDisplay.maxConnections` with a value of `1`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `RemoteDisplay.maxConnections` with a value of `1`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To limit a VM to one remote console connection using PowerCLI, run the following command for VMs that do not specify the setting:
 
-        Alternatively, run the following PowerCLI command for VMs that do not specify the setting:
+            ```
+            Add the setting to all VMs
+            Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1
+            ```
 
-        ```
-        Add the setting to all VMs
-        Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1
-        ```
+            Run the following PowerCLI command for VMs that specify the setting but have the wrong value for it:
 
-        Run the following PowerCLI command for VMs that specify the setting but have the wrong value for it:
+            ```
+            Add the setting to all VMs
+            Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1 -Force
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```
-        Add the setting to all VMs
-        Get-VM | New-AdvancedSetting -Name "RemoteDisplay.maxConnections" -value 1 -Force
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "RemoteDisplay.maxConnections" = 1
+              }
+            }
+            ```
+  # No Terraform variants: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
+  # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-pci-and-pcie-device-passthrough-is-disabled
     title: Ensure PCI and PCIe device pass-through is disabled
     impact: 60
@@ -1230,13 +1685,15 @@ queries:
         ```
 
         The check passes when no virtual machine has any `pciPassthru` advanced parameter defined. It fails for any VM where the command returns one or more matching parameters.
-      remediation: |-
-        The following PowerCLI command can be used:
+      remediation:
+        - id: powershell
+          desc: |
+            To disable PCI and PCIe device pass-through using PowerCLI, run the following command:
 
-        ```
-        Add the setting to all VMs
-        Get-VM | New-AdvancedSetting -Name "pciPassthru*.present" -value ""
-        ```
+            ```
+            Add the setting to all VMs
+            Get-VM | New-AdvancedSetting -Name "pciPassthru*.present" -value ""
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
         title: VMware vSphere Security Guide
@@ -1257,8 +1714,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Request Disk Topology feature is disabled for each virtual machine through the `isolation.tools.dispTopoRequest.disable` parameter. The feature lets a guest query the physical layout of its backing storage, and disabling it keeps host storage details hidden from the guest.
@@ -1291,24 +1763,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Request Disk Topology feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dispTopoRequest.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dispTopoRequest.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Request Disk Topology feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.dispTopoRequest.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Request Disk Topology feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.dispTopoRequest.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.dispTopoRequest.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled
     title: Ensure Shell Action is disabled
     impact: 100
@@ -1326,8 +1813,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Shell Action feature is disabled for each virtual machine through the `isolation.ghi.host.shellAction.disable` parameter. The feature lets a guest initiate shell commands or scripts on the host, and disabling it removes a direct control path from the guest to the hypervisor.
@@ -1360,24 +1862,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Shell Action feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.ghi.host.shellAction.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.ghi.host.shellAction.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Shell Action feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.ghi.host.shellAction.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Shell Action feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.ghi.host.shellAction.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.ghi.host.shellAction.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly
     title: Ensure the number of VM log files is configured properly
     impact: 60
@@ -1395,8 +1912,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-5-2-4
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['log.keepOld'] == 10 ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that each virtual machine retains 10 log files through the `log.keepOld` parameter. Setting a defined retention count balances diagnostic history against storage use, so logs stay useful without filling the datastore.
@@ -1429,24 +1961,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `10` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To set the number of VM log files to `10` using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `log.keepOld` with a value of `10`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `log.keepOld` with a value of `10`.
+            5. Select `OK`, then `OK` again.
 
-        To set the number of log files to be used to `10`, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "log.keepOld" -value "10"
-        ```
+            A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+        - id: powershell
+          desc: |
+            To set the number of VM log files to `10` using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "log.keepOld" -value "10"
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "log.keepOld" = 10
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled
     title: Ensure Trash Folder State is disabled
     impact: 60
@@ -1464,8 +2011,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Trash Folder State feature is disabled for each virtual machine through the `isolation.tools.trashFolderState.disable` parameter. The feature keeps deleted files in a recycle-like state, and disabling it ensures deletions are final and immediate.
@@ -1498,24 +2060,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Trash Folder State feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.trashFolderState.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.trashFolderState.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Trash Folder State feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.trashFolderState.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Trash Folder State feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.trashFolderState.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.trashFolderState.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines
     title: Ensure UEFI Secure Boot is enabled for virtual machines
     impact: 80
@@ -1533,9 +2110,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( bootFirmware == "efi" ) )
-      vsphere.datacenters.all( vms.all( secureBootEnabled == true ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that each virtual machine uses EFI firmware with UEFI Secure Boot enabled. Secure Boot validates the cryptographic signature of the guest bootloader, kernel, and drivers at every start, so code that is unsigned or signed by an untrusted authority is blocked from running.
@@ -1567,17 +2158,30 @@ queries:
         ```
 
         The check passes when every virtual machine reports `efi` firmware and Secure Boot enabled. It fails for any VM that uses BIOS firmware or has Secure Boot disabled.
-      remediation: |-
-        **To enable Secure Boot via the vSphere Client:**
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable UEFI Secure Boot using the vSphere Client:
 
-        1. Power off the virtual machine.
-        2. Right-click the VM and select `Edit Settings`.
-        3. Select the `VM Options` tab and expand `Boot Options`.
-        4. Confirm `Firmware` is set to `EFI`.
-        5. Select the `Secure Boot` checkbox.
-        6. Select `OK`, then power the VM back on.
+            1. Power off the virtual machine.
+            2. Right-click the VM and select `Edit Settings`.
+            3. Select the `VM Options` tab and expand `Boot Options`.
+            4. Confirm `Firmware` is set to `EFI`.
+            5. Select the `Secure Boot` checkbox.
+            6. Select `OK`, then power the VM back on.
 
-        **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before converting existing virtual machines.
+            **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before converting existing virtual machines.
+        - id: terraform
+          desc: |
+            To enable UEFI Secure Boot with Terraform, set EFI firmware and the `efi_secure_boot_enabled` argument on the `vsphere_virtual_machine` resource:
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              firmware                = "efi"
+              efi_secure_boot_enabled = true
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-898217D4-689D-4EB5-866C-888353FE241C.html
         title: Enable or Disable UEFI Secure Boot for a Virtual Machine
@@ -1598,8 +2202,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that unauthorized device connections are blocked for each virtual machine through the `isolation.device.connectable.disable` parameter. The setting prevents a guest from dynamically connecting devices such as USB drives or CD/DVD images, removing a path for data leakage or malware introduction.
@@ -1632,12 +2251,26 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To prevent unauthorized device connections, run the following PowerCLI command for each VM:
+      remediation:
+        - id: powershell
+          desc: |
+            To prevent unauthorized device connections using PowerCLI, run the following command for each VM:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.device.connectable.disable" -value $true
-        ```
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.device.connectable.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.device.connectable.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled
     title: Ensure unauthorized modification and disconnection of devices is disabled
     impact: 60
@@ -1655,8 +2288,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that unauthorized modification and disconnection of virtual devices is blocked for each virtual machine through the `isolation.device.edit.disable` parameter. The setting prevents a guest from editing or disconnecting attached hardware such as network adapters and disks, protecting the VM from disruption or tampering.
@@ -1689,12 +2337,26 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To prevent unauthorized device modifications and disconnections, run the following PowerCLI command for each VM:
+      remediation:
+        - id: powershell
+          desc: |
+            To prevent unauthorized device modifications and disconnections using PowerCLI, run the following command for each VM:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.device.edit.disable" -value $true
-        ```
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.device.edit.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.device.edit.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled
     title: Ensure Unity Active is disabled
     impact: 60
@@ -1712,8 +2374,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity Active feature is disabled for each virtual machine through the `isolation.tools.unityActive.disable` parameter. Unity mode lets guest applications appear on the host desktop, and disabling it preserves a clear boundary between guest and host.
@@ -1746,24 +2423,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity Active feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityActive.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityActive.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity Active feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unityActive.disable" -value $True
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity Active feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityActive.disable" -value $True
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unityActive.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled
     title: Ensure Unity Interlock is disabled
     impact: 60
@@ -1781,8 +2473,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity Interlock feature is disabled for each virtual machine through the `isolation.tools.unityInterlockOperation.disable` parameter. Unity Interlock supports deep UI integration between guest applications and the host desktop, and disabling it strengthens guest-host isolation.
@@ -1815,24 +2522,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity Interlock feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityInterlockOperation.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unityInterlockOperation.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity Interlock feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unityInterlockOperation.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity Interlock feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityInterlockOperation.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unityInterlockOperation.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled
     title: Ensure Unity is disabled
     impact: 60
@@ -1850,8 +2572,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity feature is fully disabled for each virtual machine through the `isolation.tools.unity.disable` parameter. Unity mode lets guest applications appear as native windows on the host desktop, and disabling it enforces a clean separation between guest and host.
@@ -1884,24 +2621,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unity.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled
     title: Ensure Unity Push Update is disabled
     impact: 60
@@ -1919,8 +2671,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity Push Update feature is disabled for each virtual machine through the `isolation.tools.unity.push.update.disable` parameter. The feature lets the host push Unity-related settings to the guest, and disabling it removes an unnecessary host-to-guest channel.
@@ -1953,24 +2720,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity Push Update feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.push.update.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.push.update.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity Push Update feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.push.update.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity Push Update feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.push.update.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unity.push.update.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled
     title: Ensure Unity Taskbar is disabled
     impact: 60
@@ -1988,8 +2770,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity Taskbar feature is disabled for each virtual machine through the `isolation.tools.unity.taskbar.disable` parameter. The feature surfaces guest applications in the host taskbar, and disabling it keeps guest processes out of the host interface.
@@ -2022,24 +2819,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity Taskbar feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.taskbar.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.taskbar.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity Taskbar feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.taskbar.disable" -value $true
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity Taskbar feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.taskbar.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unity.taskbar.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled
     title: Ensure Unity Window Contents is disabled
     impact: 60
@@ -2057,8 +2869,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that the Unity Window Contents feature is disabled for each virtual machine through the `isolation.tools.unity.windowContents.disable` parameter. The feature lets the host render the visual content of guest application windows, and disabling it keeps guest window data off the host.
@@ -2091,24 +2918,41 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable the Unity Window Contents feature using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.windowContents.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.unity.windowContents.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To disable the Unity Window Contents feature, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.windowContents.disable" -value $True
-        ```
+            Some automated tools and processes may cease to function.
+        - id: powershell
+          desc: |
+            To disable the Unity Window Contents feature using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.windowContents.disable" -value $True
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Some automated tools and processes may cease to function.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.unity.windowContents.disable" = "true"
+              }
+            }
+            ```
+  # No Terraform variants: the vsphere_virtual_machine cdrom block exposes no per-device connected or start-connected state attribute.
+  # No Terraform remediation: the vsphere_virtual_machine cdrom block exposes no per-device connected or start-connected state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-cddvd-devices-are-disconnected
     title: Ensure unnecessary CD/DVD devices are disconnected
     impact: 60
@@ -2160,15 +3004,19 @@ queries:
         ```
 
         The check passes when every CD/DVD drive is disconnected and not set to connect at power on. It fails for any VM with a CD/DVD drive that is connected or configured to connect at power on.
-      remediation: |-
-        To disconnect all CD/DVD drives from VMs, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To disconnect all CD/DVD drives from VMs using PowerCLI, run the following command:
 
-        ```
-        Remove all CD/DVD Drives attached to VMs
-        Get-VM | Get-CDDrive | Remove-CDDrive
-        ```
+            ```
+            Remove all CD/DVD Drives attached to VMs
+            Get-VM | Get-CDDrive | Remove-CDDrive
+            ```
 
-        The VM will need to be powered off for this change to take effect.
+            The VM will need to be powered off for this change to take effect.
+  # No Terraform variants: the vsphere_virtual_machine resource has no floppy device block or connection-state attribute.
+  # No Terraform remediation: the vsphere_virtual_machine resource has no floppy device block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-floppy-devices-are-disconnected
     title: Ensure unnecessary floppy devices are disconnected
     impact: 60
@@ -2220,15 +3068,19 @@ queries:
         ```
 
         The check passes when every floppy drive is disconnected and not set to connect at power on. It fails for any VM with a floppy drive that is connected or configured to connect at power on.
-      remediation: |-
-        To disconnect all floppy drives from VMs, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To disconnect all floppy drives from VMs using PowerCLI, run the following command:
 
-        ```
-        Remove all Floppy drives attached to VMs
-        Get-VM | Get-FloppyDrive | Remove-FloppyDrive
-        ```
+            ```
+            Remove all Floppy drives attached to VMs
+            Get-VM | Get-FloppyDrive | Remove-FloppyDrive
+            ```
 
-        The VM will need to be powered off for this change to take effect.
+            The VM will need to be powered off for this change to take effect.
+  # No Terraform variants: the vsphere_virtual_machine resource has no parallel port block or connection-state attribute.
+  # No Terraform remediation: the vsphere_virtual_machine resource has no parallel port block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-parallel-ports-are-disconnected
     title: Ensure unnecessary parallel ports are disconnected
     impact: 60
@@ -2280,16 +3132,20 @@ queries:
         ```
 
         The check passes when every parallel port is disconnected and not set to connect at power on, or when no parallel ports are defined. It fails for any VM with a parallel port that is connected or configured to connect at power on.
-      remediation: |-
-        To disconnect all parallel ports from VMs, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To disconnect all parallel ports from VMs using PowerCLI, run the following command:
 
-        ```
-        In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
-        Remove all Parallel Ports attached to VMs
-        Get-VM | Get-ParallelPort | Remove-ParallelPort
-        ```
+            ```
+            In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
+            Remove all Parallel Ports attached to VMs
+            Get-VM | Get-ParallelPort | Remove-ParallelPort
+            ```
 
-        The VM will need to be powered off for this change to take effect.
+            The VM will need to be powered off for this change to take effect.
+  # No Terraform variants: the vsphere_virtual_machine resource has no serial port block or connection-state attribute.
+  # No Terraform remediation: the vsphere_virtual_machine resource has no serial port block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-serial-ports-are-disconnected
     title: Ensure unnecessary serial ports are disconnected
     impact: 60
@@ -2341,16 +3197,20 @@ queries:
         ```
 
         The check passes when every serial port is disconnected and not set to connect at power on, or when no serial ports are defined. It fails for any VM with a serial port that is connected or configured to connect at power on.
-      remediation: |-
-        To disconnect all serial ports from VMs, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To disconnect all serial ports from VMs using PowerCLI, run the following command:
 
-        ```
-        In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
-        Remove all Serial Ports attached to VMs
-        Get-VM | Get-SerialPort | Remove-SerialPort
-        ```
+            ```
+            In this Example you will need to add the functions from this post: http://blogs.vmware.com/vipowershell/2012/05/working-with-vm-devices-in-powercli.html
+            Remove all Serial Ports attached to VMs
+            Get-VM | Get-SerialPort | Remove-SerialPort
+            ```
 
-        The VM will need to be powered off for this change to take effect.
+            The VM will need to be powered off for this change to take effect.
+  # No Terraform variants: the vsphere_virtual_machine resource has no USB device block or connection-state attribute.
+  # No Terraform remediation: the vsphere_virtual_machine resource has no USB device block or connection-state attribute.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unnecessary-usb-devices-are-disconnected
     title: Ensure unnecessary USB devices are disconnected
     impact: 60
@@ -2402,15 +3262,17 @@ queries:
         ```
 
         The check passes when no USB device is connected or set to connect at power on, or when no USB devices are defined. It fails for any VM with a USB device that is connected or configured to connect at power on.
-      remediation: |-
-        To disconnect all USB devices from VMs, run the following PowerCLI command:
+      remediation:
+        - id: powershell
+          desc: |
+            To disconnect all USB devices from VMs using PowerCLI, run the following command:
 
-        ```
-        Remove all USB Devices attached to VMs
-        Get-VM | Get-USBDevice | Remove-USBDevice
-        ```
+            ```
+            Remove all USB Devices attached to VMs
+            Get-VM | Get-USBDevice | Remove-USBDevice
+            ```
 
-        The VM will need to be powered off for this change to take effect.
+            The VM will need to be powered off for this change to take effect.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled
     title: Ensure virtual disk shrinking is disabled
     impact: 60
@@ -2428,8 +3290,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that virtual disk shrinking is disabled for each virtual machine through the `isolation.tools.diskShrink.disable` parameter. Disk shrinking lets a guest reduce the size of a virtual disk, and disabling it protects disk integrity and availability.
@@ -2462,24 +3339,39 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable virtual disk shrinking using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskShrink.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskShrink.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
 
-        To implement the recommended configuration state, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.diskShrink.disable" -value $true
-        ```
+            Inability to shrink virtual machine disks in the event that a datastore runs out of space.
+        - id: powershell
+          desc: |
+            To disable virtual disk shrinking using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskShrink.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        Inability to shrink virtual machine disks in the event that a datastore runs out of space.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.diskShrink.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled
     title: Ensure virtual disk wiping is disabled
     impact: 60
@@ -2497,8 +3389,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that virtual disk wiping is disabled for each virtual machine through the `isolation.tools.diskWiper.disable` parameter. Disk wiping lets a guest zero out unused disk space, and disabling it prevents I/O-intensive operations that can disrupt availability.
@@ -2531,20 +3438,37 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable virtual disk wiping using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskWiper.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.diskWiper.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable virtual disk wiping using PowerCLI, run the following command for each VM:
 
-        To disable virtual disk wiping, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskWiper.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.diskWiper.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.diskWiper.disable" = "true"
+              }
+            }
+            ```
+  # No Terraform variants: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
+  # No Terraform remediation: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
     title: Ensure virtual machine encryption is enabled
     impact: 80
@@ -2595,20 +3519,22 @@ queries:
         ```
 
         The check passes when every virtual machine reports as encrypted. It fails for any VM that has no encryption key assigned.
-      remediation: |-
-        Encrypting a virtual machine requires a key provider configured in vCenter Server.
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To encrypt a virtual machine using the vSphere Client:
 
-        **To encrypt a virtual machine via the vSphere Client:**
+            Encrypting a virtual machine requires a key provider configured in vCenter Server.
 
-        1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
-        2. Power off the virtual machine.
-        3. Right-click the VM and select `VM Policies` → `Edit VM Storage Policies`.
-        4. From the `VM storage policy` drop-down, select `VM Encryption Policy`.
-        5. Select `OK`, then power the VM back on.
+            1. Ensure a key provider (Native Key Provider or a registered KMS) is configured under `vCenter` → `Configure` → `Key Providers`.
+            2. Power off the virtual machine.
+            3. Right-click the VM and select `VM Policies` → `Edit VM Storage Policies`.
+            4. From the `VM storage policy` drop-down, select `VM Encryption Policy`.
+            5. Select `OK`, then power the VM back on.
 
-        **Impact:**
+            **Impact:**
 
-        Encrypted virtual machines cannot be migrated to hosts that lack access to the key provider, and some operations (such as content-based deduplication) are not available for encrypted VMs.
+            Encrypted virtual machines cannot be migrated to hosts that lack access to the key provider, and some operations (such as content-based deduplication) are not available for encrypted VMs.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E6C5CE29-CD1D-4555-859C-A0492E7CB45D.html
         title: Virtual Machine Encryption
@@ -2629,8 +3555,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( vbsEnabled == true ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that Virtualization-Based Security (VBS) is enabled for each virtual machine. VBS is a Windows feature that uses hardware virtualization to create an isolated, hypervisor-protected region of memory for sensitive security functions, and vSphere must expose the required virtualization extensions for the guest to use it.
@@ -2662,16 +3603,32 @@ queries:
         ```
 
         The check passes when every virtual machine reports VBS as enabled. It fails for any VM where Virtualization-Based Security is disabled.
-      remediation: |-
-        Enabling VBS requires the virtual machine to use EFI firmware with Secure Boot, hardware virtualization exposed to the guest, and a supported Windows guest OS.
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable Virtualization-Based Security using the vSphere Client:
 
-        **To enable VBS via the vSphere Client:**
+            Enabling VBS requires the virtual machine to use EFI firmware with Secure Boot, hardware virtualization exposed to the guest, and a supported Windows guest OS.
 
-        1. Power off the virtual machine.
-        2. Right-click the VM and select `Edit Settings`.
-        3. On the `VM Options` tab, select the `Enable` checkbox next to `Virtualization Based Security`.
-        4. Select `OK`, then power the VM back on.
-        5. In the Windows guest, enable VBS and Credential Guard via Group Policy or the Windows security settings.
+            1. Power off the virtual machine.
+            2. Right-click the VM and select `Edit Settings`.
+            3. On the `VM Options` tab, select the `Enable` checkbox next to `Virtualization Based Security`.
+            4. Select `OK`, then power the VM back on.
+            5. In the Windows guest, enable VBS and Credential Guard via Group Policy or the Windows security settings.
+        - id: terraform
+          desc: |
+            To enable Virtualization-Based Security with Terraform, set the `vbs_enabled` argument on the `vsphere_virtual_machine` resource. VBS also requires EFI firmware, Secure Boot, and nested hardware virtualization.
+
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              firmware                       = "efi"
+              efi_secure_boot_enabled         = true
+              nested_hv_enabled               = true
+              vvtd_enabled                    = true
+              vbs_enabled                     = true
+            }
+            ```
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CC0C6FE0-2902-4DBC-BFFE-1710A971B57F.html
         title: Virtualization-based Security
@@ -2692,8 +3649,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that copy operations from the VM console are disabled for each virtual machine through the `isolation.tools.copy.disable` parameter. Console copy lets data move from the guest to the administrator's client clipboard, and disabling it removes a data-exfiltration path.
@@ -2726,20 +3698,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable VM Console Copy operations using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.copy.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.copy.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable VM Console Copy operations using PowerCLI, run the following command for each VM:
 
-        To explicitly disable VM console copy operations, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.copy.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.copy.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.copy.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled
     title: Ensure VM Console Drag and Drop operations is disabled
     impact: 60
@@ -2757,8 +3744,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that drag and drop operations through the VM console are disabled for each virtual machine through the `isolation.tools.dnd.disable` parameter. Console drag and drop lets files move between the administrator's client and the guest, and disabling it removes an unmanaged file-transfer path.
@@ -2791,20 +3793,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable VM Console Drag and Drop operations using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dnd.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.dnd.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable VM Console Drag and Drop operations using PowerCLI, run the following command for each VM:
 
-        To explicitly disable VM console drag and drop operations, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.dnd.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.dnd.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.dnd.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled
     title: Ensure VM Console GUI Options is disabled
     impact: 75
@@ -2822,8 +3839,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == "false" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that VM Console GUI options are disabled for each virtual machine through the `isolation.tools.setGUIOptions.enable` parameter. These options expose console menu actions such as mounting media or toggling devices, and disabling them keeps console interaction tightly controlled.
@@ -2856,20 +3888,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `FALSE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable VM Console GUI Options using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.setGUIOptions.enable` with a value of `FALSE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.setGUIOptions.enable` with a value of `FALSE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable VM Console GUI Options using PowerCLI, run the following command for each VM:
 
-        To explicitly disable VM console and paste GUI options, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.setGUIOptions.enable" -value $false
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.setGUIOptions.enable" -value $false
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.setGUIOptions.enable" = "false"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled
     title: Ensure VM Console Paste operations are disabled
     impact: 60
@@ -2887,8 +3934,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == "true" ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that paste operations into the VM console are disabled for each virtual machine through the `isolation.tools.paste.disable` parameter. Console paste lets clipboard contents move from the administrator's client into the guest, and disabling it removes an unmanaged data-injection path.
@@ -2921,20 +3983,35 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `TRUE` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To disable VM Console Paste operations using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.paste.disable` with a value of `TRUE`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `isolation.tools.paste.disable` with a value of `TRUE`.
+            5. Select `OK`, then `OK` again.
+        - id: powershell
+          desc: |
+            To disable VM Console Paste operations using PowerCLI, run the following command for each VM:
 
-        To explicitly disable VM console paste operations, run the following PowerCLI command for each VM:
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.paste.disable" -value $true
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "isolation.tools.paste.disable" -value $true
-        ```
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "isolation.tools.paste.disable" = "true"
+              }
+            }
+            ```
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited
     title: Ensure VM log file size is limited
     impact: 60
@@ -2952,8 +4029,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-5-2-4
-    mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings['log.rotateSize'] == 1024000 ) )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that each virtual machine caps its log file size through the `log.rotateSize` parameter set to 1024000 bytes. Without a size limit, a log file on a long-running VM grows without bound, so capping it triggers rotation at a manageable size.
@@ -2986,21 +4078,937 @@ queries:
         ```
 
         The check passes only when the parameter is present and set to `1024000` for every virtual machine. It fails if the parameter is absent or set to any other value.
-      remediation: |-
-        To set this configuration utilize the vSphere interface as follows:
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To limit the VM log file size using the vSphere Client:
 
-        1. Select the VM then select `Actions` followed by `Edit Settings`.
-        2. Select `VM Options` tab then expand `Advanced`.
-        3. Select `EDIT CONFIGURATION`.
-        4. Select `ADD CONFIGURATION PARAMS` then input `log.rotateSize` with a value of `1024000`.
-        5. Select `OK`, then `OK` again.
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. Select `VM Options` tab then expand `Advanced`.
+            3. Select `EDIT CONFIGURATION`.
+            4. Select `ADD CONFIGURATION PARAMS` then input `log.rotateSize` with a value of `1024000`.
+            5. Select `OK`, then `OK` again.
 
-        To properly limit the maximum log file size, run the following PowerCLI command for each VM:
+            **Impact:**
 
-        ```powershell
-        Get-VM | New-AdvancedSetting -Name "log.rotateSize" -value "1024000"
-        ```
+            A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+        - id: powershell
+          desc: |
+            To limit the VM log file size using PowerCLI, run the following command for each VM:
 
-        **Impact:**
+            ```powershell
+            Get-VM | New-AdvancedSetting -Name "log.rotateSize" -value "1024000"
+            ```
+        - id: terraform
+          desc: |
+            To enforce this setting with Terraform, set the advanced configuration key on the `vsphere_virtual_machine` resource:
 
-        A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+            ```hcl
+            resource "vsphere_virtual_machine" "vm" {
+              # ...
+              extra_config = {
+                "log.rotateSize" = 1024000
+              }
+            }
+            ```
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( vtpmPresent == true ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['vtpm'] != empty
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['vtpm'] != empty
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['vtpm'] != empty
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.autologon.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.ghi.autologon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.ghi.autologon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.ghi.autologon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.bios.bbs.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.bios.bbs.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.bios.bbs.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.bios.bbs.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.vmxDnDVersionGet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.guestDnDVersionSet.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.guestDnDVersionSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.guestDnDVersionSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.guestDnDVersionSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.getCreds.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.getCreds.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.getCreds.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.getCreds.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.launchmenu.change'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.ghi.launchmenu.change'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.ghi.launchmenu.change'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.ghi.launchmenu.change'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.ghi.protocolhandler.info.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.ghi.trayicon.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.ghi.trayicon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.ghi.trayicon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.ghi.trayicon.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['mks.enable3d'].downcase == "false" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['mks.enable3d'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['mks.enable3d'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['mks.enable3d'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.hgfsServerSet.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.hgfsServerSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.hgfsServerSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.hgfsServerSet.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['tools.guestlib.enableHostInfo'].downcase == "false" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['tools.guestlib.enableHostInfo'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['tools.guestlib.enableHostInfo'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['tools.guestlib.enableHostInfo'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['tools.setInfo.sizeLimit'] == 1048576 ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['tools.setInfo.sizeLimit'] == "1048576"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['tools.setInfo.sizeLimit'] == "1048576"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['tools.setInfo.sizeLimit'] == "1048576"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.memSchedFakeSampleStats.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['RemoteDisplay.maxConnections'] == 1 ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['RemoteDisplay.maxConnections'] == "1"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['RemoteDisplay.maxConnections'] == "1"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['RemoteDisplay.maxConnections'] == "1"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dispTopoRequest.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.dispTopoRequest.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.dispTopoRequest.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.dispTopoRequest.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.ghi.host.shellAction.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.ghi.host.shellAction.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.ghi.host.shellAction.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.ghi.host.shellAction.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['log.keepOld'] == 10 ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['log.keepOld'] == "10"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['log.keepOld'] == "10"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['log.keepOld'] == "10"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.trashFolderState.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.trashFolderState.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.trashFolderState.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.trashFolderState.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( bootFirmware == "efi" ) )
+      vsphere.datacenters.all( vms.all( secureBootEnabled == true ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['firmware'] == 'efi' && arguments['efi_secure_boot_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['firmware'] == 'efi' && change.after['efi_secure_boot_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['firmware'] == 'efi' && values['efi_secure_boot_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.connectable.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.device.connectable.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.device.connectable.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.device.connectable.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.device.edit.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.device.edit.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.device.edit.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.device.edit.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityActive.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unityActive.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unityActive.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unityActive.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unityInterlockOperation.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unityInterlockOperation.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unityInterlockOperation.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unityInterlockOperation.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unity.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unity.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unity.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.push.update.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unity.push.update.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unity.push.update.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unity.push.update.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.taskbar.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unity.taskbar.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unity.taskbar.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unity.taskbar.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.unity.windowContents.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.unity.windowContents.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.unity.windowContents.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.unity.windowContents.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskShrink.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.diskShrink.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.diskShrink.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.diskShrink.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.diskWiper.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.diskWiper.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.diskWiper.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.diskWiper.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( vbsEnabled == true ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['vbs_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['vbs_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['vbs_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.copy.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.copy.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.copy.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.copy.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.dnd.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.dnd.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.dnd.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.dnd.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.setGUIOptions.enable'].downcase == "false" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.setGUIOptions.enable'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.setGUIOptions.enable'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.setGUIOptions.enable'].downcase == "false"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['isolation.tools.paste.disable'].downcase == "true" ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['isolation.tools.paste.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['isolation.tools.paste.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['isolation.tools.paste.disable'].downcase == "true"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all( vms.all( advancedSettings['log.rotateSize'] == 1024000 ) )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_virtual_machine')
+    mql: |
+      terraform.resources('vsphere_virtual_machine').all(
+        arguments['extra_config']['log.rotateSize'] == "1024000"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_virtual_machine').all(
+        change.after['extra_config']['log.rotateSize'] == "1024000"
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_virtual_machine')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
+        values['extra_config']['log.rotateSize'] == "1024000"
+      )


### PR DESCRIPTION
## Summary

Adds Terraform asset support to the two VMware vSphere security policies, so their checks run against `terraform-hcl`, `terraform-plan`, and `terraform-state` assets in addition to the live vSphere runtime.

- **Structured remediation** — the freeform `remediation:` blocks in both policies were converted to the structured `- id:` format: `vsphere-client`, `powershell`, and `cli` (esxcli) entries.
- **vSphere VM policy** — 36 of 44 checks converted to `variants:` blocks (`-vsphere` runtime + `-terraform-hcl/-plan/-state`). Per-VM advanced settings map to the `vsphere_virtual_machine` `extra_config` map; vTPM, UEFI Secure Boot, and VBS map to dedicated resource arguments. Each gets an `- id: terraform` remediation entry. The other 8 checks (VM encryption, PCI passthrough, CD/DVD, floppy, serial, parallel, USB, nonpersistent disks) carry `# No Terraform variants` / `# No Terraform remediation` comments — no faithful `vsphere_virtual_machine` attribute exists.
- **ESXi host policy** — the 5 host-network checks (vSwitch forged-transmits / MAC / promiscuous, port-group VLAN) converted to variants against `vsphere_host_virtual_switch` and `vsphere_host_port_group`. The other 24 host-state checks carry `# No Terraform variants` comments — the `hashicorp/vsphere` provider does not manage host services, advanced settings, SSL certificates, kernel modules, or lockdown mode.

`extra_config` is a string map in Terraform, so the numeric advanced-setting checks compare against quoted string values.

## Test plan

- `cnspec policy lint` passes on both policy files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)