### PR TITLE
:sparkles: Bring the M365 policy to authoring standards: descriptions, compliance mappings, remediation spec, CLI validation

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -333,6 +333,7 @@ igmp
 iis
 ikev
 imds
+inboxes
 inodes
 insertafter
 installable

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -45,6 +45,10 @@ policies:
   - **Windows / macOS**: `gui`, `cli`, `ansible`, and `script` (PowerShell on Windows, bash on macOS)
   - **Linux**: `cli`, `script` (bash), `ansible`
   - **Kubernetes**: `kubectl`, `manifest` (YAML), and where applicable `helm`
+  - **Microsoft 365** (`mondoo-m365-security`): `console`, `powershell`, and `terraform` where a real resource exists.
+    - `console` — the relevant Microsoft admin center (Microsoft Entra, Microsoft 365, Microsoft Defender, Exchange, SharePoint, or Intune). Always applies.
+    - `powershell` — Microsoft Graph PowerShell for Entra/identity checks, Exchange Online PowerShell for Exchange checks, SharePoint Online Management Shell for SharePoint checks. Always applies, except where the control is a DNS record (SPF), which uses `cli` (`az network dns …`) instead.
+    - `terraform` — **only** where the `azuread` provider (or, for DNS-record checks, a DNS provider such as `azurerm`) exposes a genuine resource for the setting. The Conditional Access checks (`azuread_conditional_access_policy`) and role assignments (`azuread_directory_role_assignment`) qualify. Exchange Online, SharePoint Online, Intune device configuration, the tenant authorization policy, the security-defaults toggle, and per-domain password validity have **no** Terraform resource — use a `# No Terraform remediation:` comment, never a `null_resource` + `local-exec` shell-out or an `azapi` block faking one.
 
   Omit a method only when it genuinely doesn't apply, and leave a YAML comment above the check explaining why (same pattern as the "No Terraform variants" comment above).
 - Verify CLI commands in remediation steps with the validator (see below) before committing.
@@ -251,6 +255,8 @@ python3 content/validation/validate_remediation_commands.py cloudflare
 ```
 
 The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl` CLI command — and `curl` calls against `api.cloudflare.com` — in ```` ```bash ```` code blocks within `id: cli` remediation sections. Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+
+The `azure` target validates **both** `mondoo-azure-security.mql.yaml` and `mondoo-m365-security.mql.yaml`, because the M365 policy's `id: cli` remediations also use the Azure CLI (`az`).
 
 **How the validator sources command data:**
 

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -87,18 +87,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-de-cm-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-10
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies-microsoft365
         tags:
@@ -286,18 +286,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-de-cm-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-10
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies-microsoft365
         tags:
@@ -482,7 +482,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -491,9 +491,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication-microsoft365
         tags:
@@ -665,7 +665,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -674,9 +674,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles-microsoft365
         tags:
@@ -908,7 +908,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -917,9 +917,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles-microsoft365
         tags:
@@ -1085,18 +1085,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-01
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       microsoft.policies.identitySecurityDefaultsEnforcementPolicy.isEnabled == false
     docs:
@@ -1179,7 +1179,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -1187,10 +1187,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(1,4))
     docs:
@@ -1315,7 +1315,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-08
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
@@ -1326,7 +1326,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
-      compliance/vda-isa-5: vda-isa-5-5-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-4
     mql: |
       microsoft.devicemanagement.deviceConfigurations.where( properties['@odata.type'] == "#microsoft.graph.androidGeneralDeviceConfiguration").all(properties.storageRequireDeviceEncryption == true)
     docs:
@@ -1423,13 +1423,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.windows10GeneralConfiguration").all(properties.passwordMinimumLength >= 8)
@@ -1550,13 +1550,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)
@@ -1649,13 +1649,13 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt") != empty)
       microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt").all(properties.text == "v=spf1 include:spf.protection.outlook.com -all"))
@@ -1791,18 +1791,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-3
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps == false
     docs:
       desc: |
@@ -1884,18 +1884,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/hipaa: hipaa-security-ss164-312-e-2-i-transmission-security-integrity-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       ms365.exchangeonline.dkimSigningConfig.all(_['enabled'] == true)
     docs:
@@ -1967,18 +1967,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       ms365.exchangeonline.safeLinksPolicy.length > 0
     docs:
@@ -2063,18 +2063,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       ms365.exchangeonline.safeAttachmentPolicy.length > 0
     docs:
@@ -2157,18 +2157,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       ms365.exchangeonline.antiPhishPolicy.length > 0
     docs:
@@ -2254,7 +2254,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2265,7 +2265,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       ms365.sharepointonline.spoTenant['SharingCapability'] != "ExternalUserAndGuestSharing"
     docs:
@@ -2344,17 +2344,17 @@ queries:
     impact: 70
     tags:
       compliance/bsi-grundschutz-sys15: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
-      compliance/nis-2: nis-2-21-2-e
+      compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/pci-dss-4: pcidss-requirement-4-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       ms365.exchangeonline.transportRule.any(_['state'] == "Enabled" && _['routeMessageOutboundRequireTls'] == true)

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -118,20 +118,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that policies are in place to detect risky sign-ins in real-time and offline. Risky sign-ins refer to attempts that may be performed by unauthorized individuals trying to access user accounts.
+        This check ensures that Microsoft Entra ID Protection is configured to detect and respond to risky sign-in events in real time and offline. By default, no sign-in risk Conditional Access policy is created, leaving the tenant dependent on after-the-fact log review to spot suspicious authentication activity.
 
         **Why this matters**
 
-        Risky sign-ins are a key indicator of potential account compromise. Detecting and responding to these events promptly is critical to safeguarding sensitive data and maintaining the security of user accounts. Policies that monitor and flag risky sign-ins help organizations identify suspicious activities, such as sign-ins from unfamiliar locations, unusual devices, or atypical behavior patterns.
+        - **Real-time threat response:** Sign-in risk policies trigger MFA or block access the moment a suspicious pattern is detected, stopping attackers before they establish a session.
+        - **Coverage of novel attack vectors:** Risk signals include anonymous IP addresses, atypical travel, malware-linked IPs, and unfamiliar sign-in properties, providing protection beyond simple password checks.
+        - **Reduced dwell time:** Automated policy enforcement closes the window between credential compromise and unauthorized access far faster than manual investigation.
+        - **Defense in depth:** Layering risk-based access controls on top of MFA means that even a successfully phished second factor is not enough to complete a high-risk sign-in.
 
-        Without such policies, organizations may fail to detect unauthorized access attempts, leaving accounts vulnerable to compromise. This can lead to data breaches, unauthorized access to sensitive information, and potential compliance violations.
+        **Risk mitigation**
 
-        Implementing policies to detect risky sign-ins supports a proactive security posture and aligns with best practices for identity and access management. It also helps organizations meet compliance requirements for standards such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Ensuring these policies are in place strengthens account security and contributes to an organization's overall defense-in-depth strategy for protecting user identities and access to critical resources.
+        - **Account takeover:** Requiring MFA or blocking access on medium and high sign-in risk stops stolen credentials from granting immediate entry.
+        - **Lateral movement:** Blocking suspicious sign-ins prevents attackers from pivoting across services and escalating privileges once inside the tenant.
+        - **Data exfiltration:** Cutting off a session at the sign-in stage limits the attacker's ability to reach sensitive data, even when credentials are already compromised.
       audit: |
         ### Audit via Console
 
@@ -317,20 +317,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that policies are in place to act on user risk detected by Microsoft Entra ID Protection. User risk reflects the probability that an account itself is compromised, based on signals such as leaked credentials found on the dark web, sign-ins from anonymized IP addresses, and atypical behavior accumulated over time.
+        This check ensures that Microsoft Entra ID Protection is configured with a Conditional Access policy that acts automatically when user risk reaches a high level. By default, no user-risk policy is created, so accounts flagged as likely compromised continue to operate without interruption unless an administrator manually investigates the alert.
 
         **Why this matters**
 
-        A high user risk score is one of the strongest indicators that an account is already in an attacker's hands. A user-risk policy responds automatically by forcing a secure password change or blocking access until the risk is remediated, which closes the window an attacker has to act.
+        - **Automated remediation:** A user-risk policy forces a password change or blocks access the moment Entra ID Protection classifies an account as high risk, reducing attacker dwell time.
+        - **Coverage of credential leak signals:** User risk aggregates intelligence from leaked credential databases, anomalous behavior patterns, and dark-web feeds, detecting compromise that password-based controls alone would miss.
+        - **Privileged account protection:** Compromised accounts with elevated permissions can cause outsized damage; automatic risk-based blocking limits the blast radius before manual review completes.
+        - **Reduced incident response burden:** Automated policy enforcement reduces the volume of manual remediation tasks that security teams must handle after a credential compromise event.
 
-        Without such policies, organizations may fail to respond to compromised accounts, leaving them available for data theft, lateral movement, and privilege escalation. This can lead to data breaches, unauthorized access to sensitive information, and potential compliance violations.
+        **Risk mitigation**
 
-        Implementing policies to act on user risk supports a proactive security posture and aligns with best practices for identity and access management. It also helps organizations meet compliance requirements for standards such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Ensuring these policies are in place strengthens account security and contributes to an organization's overall defense-in-depth strategy for protecting user identities and access to critical resources.
+        - **Credential compromise:** Requiring a password change on high user risk invalidates stolen credentials and forces re-authentication with a fresh secret before the attacker can act.
+        - **Lateral movement:** Blocking high-risk accounts prevents attackers from pivoting to other services and escalating privileges within the tenant.
+        - **Data exfiltration:** Cutting access at the identity layer stops an attacker from reaching sensitive data even when they already hold valid credentials.
       audit: |
         ### Audit via Console
 
@@ -513,22 +513,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that legacy authentication protocols are disabled in Microsoft 365.
+        This check ensures that a Conditional Access policy is in place to block legacy authentication client types, including Exchange ActiveSync clients and other legacy protocols such as POP and IMAP. By default, Microsoft 365 tenants permit these older protocols, which cannot enforce multifactor authentication and are routinely targeted in credential-stuffing and password-spray campaigns.
 
         **Why this matters**
 
-        Legacy authentication protocols, such as POP, IMAP, and SMTP, do not support modern security features like multi-factor authentication (MFA). These protocols are often targeted by attackers as they provide an easier entry point for unauthorized access to user accounts.
+        - **MFA bypass prevention:** Legacy authentication protocols bypass Conditional Access MFA requirements entirely, meaning an attacker with a valid password can authenticate without a second factor.
+        - **Reduced credential-stuffing exposure:** Blocking these protocols eliminates the most common automated attack surface used to test large volumes of stolen credentials against Exchange and other Microsoft services.
+        - **Smaller attack surface:** Disabling client app types that the organization does not need removes an entire class of authentication pathways that cannot be made more secure without replacing the protocol.
+        - **Enforcement consistency:** A Conditional Access block policy applies uniformly across all users, preventing individual exemptions that could leave gaps in coverage.
 
-        Disabling legacy authentication reduces the attack surface by preventing the use of outdated protocols that lack robust security measures. This helps protect sensitive data, prevent unauthorized access, and align with best practices for securing cloud environments.
+        **Risk mitigation**
 
-        Without disabling legacy authentication, organizations risk exposing their accounts to brute force attacks, credential stuffing, and other malicious activities. This can lead to data breaches, compliance violations, and reputational damage.
-
-        Ensuring legacy authentication is disabled strengthens the security posture of an organization and supports compliance with standards such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Disabling legacy authentication is a critical step in implementing a modern, secure authentication framework for Microsoft 365.
+        - **Account compromise:** Attackers lose the ability to authenticate to Exchange ActiveSync and IMAP endpoints using stolen passwords alone, since those endpoints can no longer complete a sign-in.
+        - **Compliance posture:** Blocking legacy authentication satisfies explicit requirements in frameworks that mandate strong authentication, closing the gap created by MFA-incapable protocols.
       audit: |
         ### Audit via Console
 
@@ -696,20 +693,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that multi-factor authentication (MFA) is enabled for all users in administrative roles within the Microsoft 365 tenant.
+        This check ensures that a Conditional Access policy is in place requiring multifactor authentication for all users assigned to privileged directory roles in the Microsoft 365 tenant. By default, no such policy is created, leaving administrative accounts protected only by a password and making them prime targets for credential-based attacks.
 
         **Why this matters**
 
-        Enabling MFA for administrative roles adds an essential layer of security to protect privileged accounts from unauthorized access. Administrative accounts are high-value targets for attackers, as they have elevated permissions that can be exploited to compromise the entire environment.
+        - **Privileged account protection:** Administrative roles carry permissions that can modify tenant configuration, access all user data, and grant additional privileges, so a single compromised admin account can lead to full tenant takeover.
+        - **Phishing resistance:** MFA forces an attacker who has stolen an admin password to also defeat a second factor, significantly raising the cost of a successful attack.
+        - **Blast radius reduction:** Even when credentials are phished, MFA prevents the attacker from completing the sign-in and stops the compromise from escalating beyond the initial credential theft.
+        - **Regulatory alignment:** MFA for privileged users is an explicit requirement in multiple security frameworks, and a Conditional Access policy provides auditable proof of enforcement.
 
-        Without MFA, administrative accounts are more vulnerable to credential theft, phishing attacks, and brute force attempts. This can lead to unauthorized access, data breaches, and potential compliance violations.
+        **Risk mitigation**
 
-        Implementing MFA for administrative roles aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (IA-2: Identification and Authentication)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Ensuring MFA is enabled for administrative roles strengthens the security posture of the organization and reduces the risk of unauthorized access to critical resources.
+        - **Credential compromise:** Requiring a second factor for every administrative sign-in means that stolen passwords alone cannot be used to access the tenant's highest-privilege accounts.
+        - **Insider threat containment:** MFA creates an additional verification step that limits the window during which a disgruntled or inattentive administrator can perform unauthorized actions with a shared or reused credential.
       audit: |
         ### Audit via Console
 
@@ -939,20 +935,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that multi-factor authentication (MFA) is enabled for all users in the Microsoft 365 tenant.
+        This check ensures that a Conditional Access policy is in place requiring multifactor authentication for every user in the Microsoft 365 tenant, not just administrators. By default, no tenant-wide MFA policy exists, so non-privileged user accounts are protected only by a password and are frequently targeted in credential-stuffing and phishing campaigns.
 
         **Why this matters**
 
-        Enabling MFA for all users adds an essential layer of security to protect user accounts from unauthorized access. User accounts are often targeted by attackers, as they can be exploited to gain access to sensitive data and systems.
+        - **Broad attack surface reduction:** Non-administrative accounts far outnumber privileged accounts, and compromising any of them provides an attacker with initial access and data exposure even without elevated privileges.
+        - **Phishing resistance at scale:** Requiring a second factor for all users means that a successful phishing campaign that harvests passwords still cannot result in account access.
+        - **Data protection:** Even accounts with limited permissions can access sensitive files, emails, and collaboration content; MFA closes the gap between credential theft and data exfiltration.
+        - **Uniform policy enforcement:** A single Conditional Access policy covering all users eliminates ad-hoc exceptions and ensures consistent authentication requirements across the tenant.
 
-        Without MFA, user accounts are more vulnerable to credential theft, phishing attacks, and brute force attempts. This can lead to unauthorized access, data breaches, and potential compliance violations.
+        **Risk mitigation**
 
-        Implementing MFA for all users aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (IA-2: Identification and Authentication)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Ensuring MFA is enabled for all users strengthens the security posture of the organization and reduces the risk of unauthorized access to critical resources.
+        - **Credential-stuffing attacks:** Blocking sign-ins that lack a second factor prevents automated tools from using lists of breached passwords to access any account in the tenant.
+        - **Lateral movement:** An attacker who compromises a low-privilege account cannot easily pivot to additional accounts or services because each authentication attempt requires a fresh MFA approval.
       audit: |
         ### Audit via Console
 
@@ -1101,22 +1096,19 @@ queries:
       microsoft.policies.identitySecurityDefaultsEnforcementPolicy.isEnabled == false
     docs:
       desc: |
-        This check ensures that the security defaults (which are enabled by default) are disabled in Azure Active Directory.
+        This check ensures that Microsoft Entra ID Security Defaults are disabled, allowing the organization to enforce access controls through custom Conditional Access policies instead. Security Defaults are enabled by default in new tenants and provide a baseline level of protection, but they prevent organizations from configuring the more granular, risk-based, and role-scoped policies required by mature security programs.
 
         **Why this matters**
 
-        Security defaults are a set of basic identity security mechanisms provided by Microsoft to protect organizations from common identity-related attacks. While they offer a good starting point for securing identities, they may not meet the specific needs of all organizations.
+        - **Policy granularity:** Security Defaults apply a single fixed set of controls across the entire tenant and cannot be scoped by user, group, application, or risk level, making them unsuitable for organizations with differentiated access requirements.
+        - **Legacy authentication blocking:** Security Defaults block some legacy protocols, but a custom Conditional Access policy provides explicit, auditable enforcement with per-client-app-type granularity that satisfies compliance evidence requirements.
+        - **Risk-based access control:** Custom Conditional Access policies can integrate Entra ID Protection sign-in risk and user risk signals, which Security Defaults do not support.
+        - **Break-glass account support:** Custom policies allow explicit exclusions for emergency access accounts, whereas Security Defaults offer no such override mechanism.
 
-        Disabling security defaults allows organizations to implement custom Conditional Access policies tailored to their unique security requirements. This enables more granular control over access to resources, such as enforcing multi-factor authentication (MFA) for specific users or applications, blocking legacy authentication protocols, and applying risk-based access controls.
+        **Risk mitigation**
 
-        Without disabling security defaults, organizations may face limitations in implementing advanced security configurations. This can hinder their ability to align with best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.9.4.2: Secure log-on procedures)
-          - NIST 800-53 (AC-7: Unsuccessful Login Attempts)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
-
-        Disabling security defaults and implementing custom Conditional Access policies strengthens the organization's security posture and provides greater flexibility in managing access to critical resources.
-
-        Note: Using security defaults prohibits custom settings. Many best security practices require custom settings.
+        - **Configuration drift:** Replacing Security Defaults with explicit Conditional Access policies makes the organization's authentication requirements visible, versioned, and auditable rather than relying on an opaque Microsoft-managed baseline.
+        - **Compliance gap:** Several frameworks require evidence of specific, documented authentication controls; a named Conditional Access policy provides that evidence in a way that a vendor-managed default cannot.
       audit: |
         ### Audit via Console
 
@@ -1195,15 +1187,20 @@ queries:
       microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(1,4))
     docs:
       desc: |
-        This check ensures that there are enough Global Admins in a single tenant.
+        This check ensures that the Global Administrator role is assigned to between two and four accounts. By default Microsoft 365 imposes no upper or lower bound on Global Administrator assignments, so tenants frequently end up either with a single point of failure or with an excessively large group of unrestricted privileged accounts.
 
         **Why this matters**
 
-        When it comes to designating global admins, it's important to consider the size and complexity of the organization, as well as the level of responsibility and authority required for the role. As a general rule, it's a good idea to have at least three global admins to ensure that there is redundancy and coverage in case one admin is unavailable or leaves the organization.
+        - **Redundancy:** At least two Global Administrators ensure that critical administrative tasks can continue if one account is unavailable, locked, or compromised.
+        - **Blast-radius control:** Capping assignments at four limits how many accounts can perform tenant-wide destructive actions, reducing the damage a compromised credential can cause.
+        - **Auditability:** A small, bounded set of privileged accounts is easier to monitor, review, and audit than an unbounded list.
+        - **Separation from operational accounts:** Keeping the count low encourages administrators to use role-specific, least-privilege roles for everyday tasks instead of relying on Global Administrator for convenience.
 
-        At the same time, having too many global admins can lead to confusion and inefficiency, as multiple people may be making decisions or taking actions without proper coordination. Therefore, it's recommended to keep the number of global admins to no more than four, unless the organization is particularly large or complex and requires more administrators to properly manage its operations.
+        **Risk mitigation**
 
-        Ensuring the appropriate number of global admins strengthens the organization's ability to manage its operations effectively while maintaining security and operational efficiency.
+        - **Credential compromise:** Fewer Global Administrator accounts reduce the number of high-value targets an attacker can pursue through phishing or credential stuffing.
+        - **Insider threat:** Limiting the role to a small named set of individuals makes unauthorized privilege escalation more visible during periodic access reviews.
+        - **Availability:** Requiring at least two assignments prevents a single account lockout or departure from blocking emergency administrative access to the tenant.
       audit: |
         ### Audit via Console
 
@@ -1331,18 +1328,18 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where( properties['@odata.type'] == "#microsoft.graph.androidGeneralDeviceConfiguration").all(properties.storageRequireDeviceEncryption == true)
     docs:
       desc: |
-        This check ensures that encryption in Android mobile devices has been enabled to prevent any unauthorized access to the data.
+        This check ensures that Android device configuration profiles in Microsoft Intune are configured to require storage encryption. By default Intune does not enforce device encryption in newly created Android profiles, so organizations must explicitly set `storageRequireDeviceEncryption` to require it.
 
         **Why this matters**
 
-        Encryption ensures that sensitive data stored on mobile devices is protected from unauthorized access, even if the device is lost or stolen. Without encryption, attackers can easily access data by bypassing basic security measures.
+        - **Data protection at rest:** Encryption renders the data stored on a device unreadable without the correct decryption key, protecting it if the device is lost or stolen.
+        - **Breach containment:** An encrypted device limits an attacker's ability to extract sensitive corporate data even after gaining physical access.
+        - **Compliance readiness:** Many regulatory frameworks require encryption of data on mobile endpoints, and an explicit Intune policy provides auditable evidence of enforcement.
 
-        Implementing encryption aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.10.1.1: Policy on the use of cryptographic controls)
-          - NIST 800-53 (SC-12: Cryptographic Key Establishment and Management)
-          - CIS Controls (CIS Control 13: Data Protection)
+        **Risk mitigation**
 
-        Enabling encryption on mobile devices strengthens the organization's security posture and reduces the risk of data breaches.
+        - **Lost or stolen devices:** Without encryption a lost Android device exposes all locally cached email, files, and credentials to anyone who finds it.
+        - **Unauthorized physical access:** Encryption prevents data extraction through direct device access methods such as connecting to a computer or removing storage media.
       audit: |
         ### Audit via Console
 
@@ -1439,18 +1436,18 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration").all(properties['passwordMinimumLength'] >= 8)
     docs:
       desc: |
-        This check ensures that there is a minimum password length - at least eight characters - for mobile devices.
+        This check ensures that Microsoft Intune device configuration profiles are configured to require a minimum password or passcode length of at least eight characters across all managed device platforms. By default Intune does not enforce a minimum length in newly created profiles, leaving it up to the device default or the user's choice.
 
         **Why this matters**
 
-        According to NIST (SP 800-63-2), user-chosen memorized secrets should be a minimum of 8 characters long. Enforcing a minimum password length helps protect against brute force attacks and ensures stronger security for mobile devices.
+        - **Brute-force resistance:** Longer passwords expand the search space an attacker must exhaust, making automated guessing attacks substantially more expensive.
+        - **Alignment with security standards:** NIST SP 800-63B recommends a minimum of eight characters for memorized secrets, and enforcing this through MDM policy provides consistent coverage across Windows, macOS, iOS, and Android devices.
+        - **Consistent enforcement:** Centrally managed password-length requirements through Intune remove reliance on users to choose adequately long passwords on their own.
 
-        Without a minimum password length, attackers can exploit weak passwords, increasing the risk of unauthorized access to sensitive data. Implementing this policy aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.9.4.3: Password management system)
-          - NIST 800-53 (IA-5: Authenticator Management)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
+        **Risk mitigation**
 
-        Ensuring a minimum password length strengthens the security posture of the organization and reduces the risk of data breaches.
+        - **Unauthorized device access:** A minimum eight-character password significantly reduces the likelihood of a successful brute-force or opportunistic login on a lost or unattended device.
+        - **Credential reuse:** Requiring a meaningful minimum length discourages the use of trivially guessable PINs or short passwords that users might reuse across personal and corporate accounts.
       audit: |
         ### Audit via Console
 
@@ -1562,18 +1559,19 @@ queries:
       microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)
     docs:
       desc: |
-        This check ensures that Microsoft 365 passwords are set to never expire. Based on new research from several organizations, it has been confirmed that forcing users to change their passwords frequently can lead to weaker password practices and reduced security.
+        This check ensures that all Microsoft 365 domains are configured so that user passwords never expire, reflected by a `passwordValidityPeriodInDays` value of `2147483647`. By default Microsoft 365 sets passwords to expire after 90 days, a practice that modern security research has shown to weaken rather than strengthen credential hygiene.
 
         **Why this matters**
 
-        Forcing users to change their passwords regularly often results in predictable patterns or weaker passwords, as users may resort to minor variations of their previous passwords. This behavior can make it easier for attackers to guess or compromise passwords.
+        - **Eliminates predictable rotation patterns:** Users forced to change passwords on a fixed schedule frequently make minor, predictable modifications to their existing passwords, which attackers exploit using password-spraying techniques that account for common incremental changes.
+        - **Encourages strong initial choices:** When users know a password is permanent, they are more motivated to choose a long, unique, randomly generated credential and store it in a password manager rather than selecting something easily memorable and therefore guessable.
+        - **Aligns with current NIST guidance:** NIST SP 800-63B explicitly recommends against periodic password rotation except after a confirmed compromise, and Microsoft's own security baselines reflect this shift.
+        - **Complements MFA:** Organizations that enforce multi-factor authentication gain a second layer of protection that makes the age of a password largely irrelevant to its security, making forced rotation an unnecessary burden.
 
-        Allowing passwords to never expire, combined with strong password policies and multi-factor authentication (MFA), provides a more secure and user-friendly approach. This aligns with modern security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.9.4.3: Password management system)
-          - NIST 800-63 (IA-5: Authenticator Management)
-          - CIS Controls (CIS Control 16: Account Monitoring and Control)
+        **Risk mitigation**
 
-        Ensuring that passwords do not expire unnecessarily strengthens the organization's security posture while reducing the burden on users.
+        - **Phishing and credential stuffing:** Removing rotation pressure leads users to adopt longer, unique passwords that are far harder to guess or reuse across breached credential databases.
+        - **Help-desk and user friction:** Eliminating expiration-driven password resets reduces support load and the social-engineering opportunities that arise when users are trained to expect reset prompts.
       audit: |
         ### Audit via Console
 
@@ -1661,18 +1659,18 @@ queries:
       microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt").all(properties.text == "v=spf1 include:spf.protection.outlook.com -all"))
     docs:
       desc: |
-        This check ensures that SPF records are created for each domain in Exchange.
+        This check ensures that every Exchange Online domain has a published SPF (Sender Policy Framework) TXT record that explicitly authorizes Microsoft's mail servers. By default no SPF record is created automatically when a domain is added to Microsoft 365; it must be published manually at the DNS provider.
 
         **Why this matters**
 
-        Sender Policy Framework (SPF) records are a critical component of email authentication. They help prevent email spoofing by specifying which mail servers are authorized to send emails on behalf of a domain. Without SPF records, attackers can impersonate your domain to send fraudulent emails, leading to phishing attacks, reputational damage, and potential data breaches.
+        - **Anti-spoofing protection:** SPF lets receiving mail servers confirm that inbound messages claiming to be from your domain actually originate from a server you have authorized, blocking the most common form of sender impersonation.
+        - **Phishing defense:** Without an SPF record, attackers can send email that appears to come from your domain's address with no technical barrier, making your brand a convenient cover for phishing campaigns targeting your customers, partners, or employees.
+        - **Deliverability and reputation:** Receiving servers and spam filters use SPF pass or fail results as a strong signal when deciding whether to deliver, quarantine, or reject email, so a missing record can cause legitimate outbound mail to be flagged as suspicious.
 
-        Implementing SPF records aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.13.2.3: Electronic messaging)
-          - NIST 800-53 (SC-7: Boundary Protection)
-          - CIS Controls (CIS Control 9: Email and Web Browser Protections)
+        **Risk mitigation**
 
-        Ensuring SPF records are published for all Exchange domains strengthens email security, reduces the risk of spoofing, and enhances trust in email communications.
+        - **Domain impersonation:** A valid SPF record with a hard-fail policy (`-all`) causes receiving servers to reject messages sent from unauthorized sources, directly preventing spoofed email from reaching recipients.
+        - **Cascading email-authentication failures:** SPF is a prerequisite for effective DMARC enforcement; without a passing SPF result, DMARC cannot reliably align and reject spoofed messages, undermining the entire email authentication chain.
       audit: |
         Verify that every Exchange domain publishes an SPF record by querying its DNS TXT records:
 
@@ -1806,18 +1804,18 @@ queries:
     mql: microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps == false
     docs:
       desc: |
-        This check ensures that no third-party integrated applications can connect to your services.
+        This check ensures that non-administrator users are blocked from registering third-party applications in Microsoft Entra ID by verifying that the tenant authorization policy sets `allowedToCreateApps` to `false`. By default Microsoft Entra allows any user to register applications, meaning any account in the tenant can grant an external application access to Microsoft 365 data without administrator review or approval.
 
         **Why this matters**
 
-        Allowing third-party integrated applications to connect to your services can introduce security risks, such as unauthorized access, data leakage, or exploitation of vulnerabilities in the third-party applications. Restricting third-party integrations helps maintain control over your organization's data and reduces the attack surface.
+        - **Supply-chain risk reduction:** Restricting app registration to administrators ensures that every OAuth application connected to the tenant has been reviewed and approved, eliminating the risk of users silently connecting malicious or unvetted third-party tools.
+        - **Data exfiltration prevention:** Third-party applications registered by end users can request broad Microsoft Graph permissions, including access to email, files, and calendar data, without visibility to the security team.
+        - **Attack-surface control:** Each registered application is a potential attack vector; limiting who can create them reduces the number of OAuth tokens in circulation and the scope of any single compromised application.
 
-        By preventing third-party applications from connecting, organizations can ensure that only trusted and approved applications are used. This aligns with security best practices and compliance requirements, such as:
-          - ISO/IEC 27001 (A.13.1.1: Network controls)
-          - NIST 800-53 (AC-3: Access Enforcement)
-          - CIS Controls (CIS Control 14: Controlled Access Based on the Need to Know)
+        **Risk mitigation**
 
-        Ensuring that third-party integrated applications are not allowed strengthens the organization's security posture and minimizes the risk of unauthorized access or data breaches.
+        - **OAuth phishing:** Attackers commonly use consent-phishing campaigns that trick users into granting a malicious application persistent access to their mailbox or OneDrive; removing the ability to register apps blocks this technique at its source.
+        - **Unmanaged shadow integrations:** Without enforcement, users can connect personal productivity tools or automation scripts that process corporate data outside the organization's data-governance and DLP policies.
       audit: |
         ### Audit via Console
 
@@ -1900,19 +1898,20 @@ queries:
       ms365.exchangeonline.dkimSigningConfig.all(_['enabled'] == true)
     docs:
       desc: |
-        This check ensures that DKIM (DomainKeys Identified Mail) signing is enabled for all Exchange Online domains. DKIM adds a digital signature to outbound email messages, allowing receiving servers to verify that the message was sent from an authorized mail server and was not modified in transit.
+        This check ensures that Exchange Online is configured to enable DKIM signing for every domain. By default, Microsoft 365 provides a base-level DKIM signature, but custom per-domain signing is not enabled automatically; enabling it adds a cryptographic signature that receiving servers use to verify that a message originated from an authorized source and was not altered in transit.
 
         **Why this matters**
 
-        Without DKIM signing, your organization's email lacks cryptographic authentication:
+        - **Email authentication:** DKIM allows receiving mail servers to verify that outbound messages genuinely originated from your domain and were not tampered with.
+        - **Spoofing deterrence:** Domains with DKIM signatures are significantly harder for attackers to impersonate because forged messages fail cryptographic verification.
+        - **Deliverability protection:** Major mail providers factor DKIM pass/fail into spam scoring, so unsigned domains are more likely to have legitimate mail rejected or quarantined.
+        - **DMARC readiness:** DKIM alignment is a prerequisite for a complete DMARC policy, which provides the strongest email authentication posture available.
+        - **Brand reputation:** Consistent DKIM signing signals to the broader email ecosystem that your domain is well-administered, reducing the likelihood of being blocklisted.
 
-          - **Email spoofing**: Without DKIM, attackers can more easily forge emails that appear to come from your domain.
-          - **Business email compromise**: BEC attacks are more successful when email authentication mechanisms are not in place.
-          - **Deliverability impact**: Many email providers use DKIM verification as part of their spam filtering, and unsigned emails may be flagged.
-          - **Brand protection**: DKIM helps protect your domain's reputation by ensuring only authorized servers send email on its behalf.
-          - **DMARC dependency**: DKIM is a prerequisite for a complete DMARC implementation, which provides the strongest email authentication.
+        **Risk mitigation**
 
-        Enable DKIM signing for all Exchange Online domains to authenticate outbound email and protect against spoofing.
+        - **Prevents domain impersonation:** A valid DKIM signature makes it computationally infeasible for an attacker to craft a message that passes authentication as your domain.
+        - **Reduces business email compromise exposure:** Attackers who rely on spoofed sender addresses lose their primary delivery mechanism when DKIM is enforced across all domains.
       audit: |
         ### Audit via Console
 
@@ -1983,19 +1982,20 @@ queries:
       ms365.exchangeonline.safeLinksPolicy.length > 0
     docs:
       desc: |
-        This check ensures that at least one Safe Links policy is configured in Microsoft Defender for Office 365. Safe Links provides URL scanning and rewriting of inbound email messages, protecting users from malicious links.
+        This check ensures that Microsoft Defender for Office 365 is configured with at least one Safe Links policy. By default, no custom Safe Links policies exist in a new tenant; without them, URLs in email and Office documents are delivered to users without real-time scanning or rewriting.
 
         **Why this matters**
 
-        Without Safe Links policies, users are unprotected against malicious URLs in email:
+        - **Time-of-click scanning:** Safe Links checks URLs at the moment a user clicks, catching links that were benign at delivery but became malicious after the email arrived.
+        - **Zero-day URL protection:** Behavioral analysis at click time identifies newly discovered malicious URLs that have not yet been added to static blocklists.
+        - **Internal email coverage:** Safe Links can be applied to messages sent within the organization, not only to inbound external mail.
+        - **Threat visibility:** Click tracking and reporting surface targeted users and recurring attack patterns that would otherwise go undetected.
+        - **Office application protection:** When configured to cover Office apps, Safe Links extends coverage beyond email to links embedded in Word, Excel, and PowerPoint files.
 
-          - **Phishing protection**: Safe Links scans URLs at time of click, catching links that become malicious after email delivery.
-          - **Time-of-click verification**: Unlike traditional email scanning, Safe Links checks URLs when the user clicks, detecting delayed attacks.
-          - **Zero-day URL protection**: Safe Links can block newly identified malicious URLs without waiting for signature updates.
-          - **Internal email protection**: Safe Links can protect against malicious links in internal email, not just external messages.
-          - **Reporting and visibility**: Safe Links provides click tracking and reporting to help identify targeted users and attack patterns.
+        **Risk mitigation**
 
-        Configure Safe Links policies to protect all users from malicious URLs in email and other Microsoft 365 applications.
+        - **Blocks post-delivery link activation:** Attackers who send benign-looking URLs that redirect to malicious content after delivery are stopped at click time rather than after compromise.
+        - **Reduces successful phishing outcomes:** Removing direct access to malicious URLs interrupts the initial access phase of phishing campaigns that rely on user clicks.
       audit: |
         ### Audit via Console
 
@@ -2079,19 +2079,20 @@ queries:
       ms365.exchangeonline.safeAttachmentPolicy.length > 0
     docs:
       desc: |
-        This check ensures that at least one Safe Attachments policy is configured in Microsoft Defender for Office 365. Safe Attachments opens email attachments in a virtual environment to detect malicious behavior before delivering them to users.
+        This check ensures that Microsoft Defender for Office 365 is configured with at least one Safe Attachments policy. By default, a new tenant has no custom Safe Attachments policies; without them, email attachments are delivered based on traditional antivirus signatures alone, with no sandboxed behavioral analysis.
 
         **Why this matters**
 
-        Without Safe Attachments, users receive email attachments without advanced malware scanning:
+        - **Sandbox detonation:** Safe Attachments opens attachments in an isolated virtual environment and observes their behavior, detecting threats that have no known signature.
+        - **Ransomware prevention:** Blocking malicious attachments before they reach the endpoint interrupts ransomware delivery before any files are encrypted.
+        - **Novel malware coverage:** Behavioral detonation catches newly crafted malware variants that evade signature-based detection engines.
+        - **SharePoint and OneDrive scanning:** When enabled for collaboration workloads, Safe Attachments also scans files uploaded to SharePoint and OneDrive, not only email.
+        - **Dynamic delivery:** Safe Attachments can release the message body immediately while the attachment is scanned, minimizing user impact without sacrificing protection.
 
-          - **Malware delivery**: Email attachments are a primary vector for malware, ransomware, and other threats.
-          - **Zero-day detection**: Safe Attachments uses behavioral analysis in a sandbox environment to detect unknown malware that signature-based scanning may miss.
-          - **Ransomware prevention**: Safe Attachments can block malicious attachments before they execute, preventing ransomware infections.
-          - **Protection beyond signatures**: Traditional antivirus relies on known signatures; Safe Attachments detonates files to detect novel threats.
-          - **SharePoint and OneDrive protection**: Safe Attachments can also scan files uploaded to SharePoint and OneDrive.
+        **Risk mitigation**
 
-        Configure Safe Attachments policies to protect all users from malicious email attachments.
+        - **Stops weaponized documents:** Malicious Office files, PDFs, and archives that carry exploit payloads are quarantined or blocked before reaching user mailboxes.
+        - **Limits dwell time:** Catching malware at the email gateway prevents the initial foothold that attackers need to establish persistence and move laterally.
       audit: |
         ### Audit via Console
 
@@ -2173,19 +2174,20 @@ queries:
       ms365.exchangeonline.antiPhishPolicy.length > 0
     docs:
       desc: |
-        This check ensures that at least one anti-phishing policy is configured in Microsoft Defender for Office 365. Anti-phishing policies protect against impersonation attacks, spoofing, and other phishing techniques.
+        This check ensures that Microsoft Defender for Office 365 is configured with at least one anti-phishing policy. By default, a new tenant has no custom anti-phishing policies; without them, inbound mail receives only basic anti-spoofing checks and lacks impersonation protection for high-value users and trusted domains.
 
         **Why this matters**
 
-        Without anti-phishing policies, users lack protection against sophisticated phishing attacks:
+        - **Impersonation detection:** Anti-phishing policies identify messages that impersonate specific protected users or domains, such as executives and trusted partner organizations.
+        - **Spoof intelligence:** Built-in spoof intelligence analyzes sending infrastructure to flag messages that falsely claim to originate from legitimate domains.
+        - **Mailbox intelligence:** Machine learning models communication patterns for each user and flags messages from senders that deviate from established behavior.
+        - **Business email compromise protection:** Impersonation protection targets the executive and financial-staff accounts most frequently used in BEC fraud campaigns.
+        - **First-contact safety tips:** Users are warned when they receive email from an address they have never interacted with, reducing the chance of acting on a spoofed message.
 
-          - **Impersonation attacks**: Anti-phishing policies detect emails that impersonate specific users or domains your organization trusts.
-          - **Business email compromise (BEC)**: Impersonation protection helps prevent BEC attacks that target executives and financial staff.
-          - **Spoof intelligence**: Anti-phishing policies use spoof intelligence to identify and block spoofed senders.
-          - **Mailbox intelligence**: Machine learning analyzes communication patterns to detect unusual sending behavior.
-          - **First contact safety tips**: Users can be warned when receiving email from a sender for the first time.
+        **Risk mitigation**
 
-        Configure anti-phishing policies with impersonation protection for high-value users and domains.
+        - **Disrupts BEC attack chains:** Quarantining impersonation attempts before they reach inboxes removes the social-engineering messages that initiate wire-transfer fraud and credential theft.
+        - **Reduces spear-phishing success rates:** Targeted phishing campaigns that rely on domain or user impersonation are surfaced and blocked before users can act on them.
       audit: |
         ### Audit via Console
 
@@ -2270,19 +2272,20 @@ queries:
       ms365.sharepointonline.spoTenant['SharingCapability'] != "ExternalUserAndGuestSharing"
     docs:
       desc: |
-        This check ensures that SharePoint Online external sharing is not set to the most permissive level (ExternalUserAndGuestSharing), which allows anyone to share content with external users without requiring authentication.
+        This check ensures that SharePoint Online is configured to restrict external sharing to a level more restrictive than the most permissive default. The most permissive setting, ExternalUserAndGuestSharing, allows any user to generate anonymous "Anyone" links that grant access to files and folders without requiring the recipient to authenticate, which means there is no record of who accessed the content.
 
         **Why this matters**
 
-        Unrestricted external sharing exposes organizational data to unauthorized access:
+        - **Uncontrolled data distribution:** Anonymous sharing links allow recipients to forward access to any third party, removing all organizational control over who views or downloads the content.
+        - **Data exfiltration pathway:** Any internal user who can create an Anyone link can silently exfiltrate documents to external parties without leaving an identity trail.
+        - **Guest account sprawl:** Permissive sharing settings generate large numbers of unmanaged guest accounts that may retain access to content long after a collaboration ends.
+        - **Compliance risk:** Most regulatory frameworks require demonstrable controls over access to sensitive data, and unauthenticated sharing links make access-control attestation impossible.
+        - **Audit gap:** Without authentication requirements, access logs show a link was clicked but cannot attribute the access to a specific identity.
 
-          - **Data exfiltration**: Users can share sensitive documents with anyone, including personal email addresses, without oversight.
-          - **Guest account sprawl**: Permissive sharing creates unmanaged guest accounts with potential access to sensitive content.
-          - **Compliance violations**: Regulatory requirements often mandate controls on data sharing with external parties.
-          - **Loss of data control**: Once shared externally, organizations lose control over how data is used, stored, and further distributed.
-          - **Insider threat**: Malicious insiders can easily exfiltrate data by sharing with external accounts they control.
+        **Risk mitigation**
 
-        Restrict SharePoint external sharing to authenticated guests or existing guests only, and require approval for sharing with new external users.
+        - **Enforces identity-based access:** Restricting sharing to authenticated guests ensures every access event is tied to a verifiable identity that can be reviewed and revoked.
+        - **Limits insider-driven exfiltration:** Requiring guest authentication and scoping sharing to existing or approved guests closes the anonymous link pathway most commonly exploited by malicious insiders.
       audit: |
         ### Audit via Console
 
@@ -2360,19 +2363,20 @@ queries:
       ms365.exchangeonline.transportRule.any(_['state'] == "Enabled" && _['routeMessageOutboundRequireTls'] == true)
     docs:
       desc: |
-        This check ensures that at least one Exchange Online transport rule is configured and enabled to require TLS encryption for outbound email. Transport rules that enforce TLS ensure that email sent to external recipients is encrypted in transit.
+        This check ensures that Exchange Online is configured with at least one enabled transport rule that requires TLS encryption for outbound email. Exchange Online attempts TLS opportunistically by default but does not enforce it; without an explicit transport rule, messages can fall back to unencrypted SMTP delivery when the receiving server does not advertise TLS support.
 
         **Why this matters**
 
-        Without TLS enforcement, email may be transmitted in plaintext:
+        - **Encryption in transit:** A transport rule that mandates TLS prevents Exchange from delivering messages over an unencrypted SMTP connection, regardless of the receiving server's configuration.
+        - **Data confidentiality:** Email content and attachments transmitted without encryption can be captured and read by anyone with access to network traffic along the delivery path.
+        - **Protection against downgrade attacks:** Without enforcement, an attacker who can manipulate DNS or SMTP negotiation can strip TLS and force plaintext delivery; a transport rule blocks the fallback.
+        - **Sensitive-message coverage:** Notifications containing credentials, financial data, or personal information are protected from interception when TLS is required at the mail-flow layer.
+        - **Auditability:** Transport rules provide a documented, enforceable control that can be cited in security assessments and compliance reviews as evidence of encryption-in-transit requirements.
 
-          - **Data exposure**: Email content and attachments can be intercepted when transmitted without encryption.
-          - **Regulatory compliance**: Many compliance frameworks (HIPAA, PCI DSS, GDPR) require encryption of sensitive data in transit.
-          - **Man-in-the-middle attacks**: Without TLS, attackers can intercept and read email communications.
-          - **Credential exposure**: Emails containing password resets, account notifications, or other sensitive information are vulnerable without encryption.
-          - **Business confidentiality**: Unencrypted email exposes business-sensitive communications to interception.
+        **Risk mitigation**
 
-        Configure transport rules to require TLS for outbound email to external recipients, with particular focus on domains that handle sensitive data.
+        - **Prevents opportunistic downgrade:** Enforcing TLS at the transport-rule level removes the possibility of a receiving server negotiating an unencrypted session, closing the most common path to plaintext email interception.
+        - **Reduces man-in-the-middle exposure:** Requiring a verified TLS session before message delivery makes passive eavesdropping and active session hijacking computationally impractical for on-path attackers.
       audit: |
         ### Audit via Console
 

--- a/content/validation/cmd_data/azure_commands.json
+++ b/content/validation/cmd_data/azure_commands.json
@@ -63066,14 +63066,18 @@
     "--zone-name"
   ],
   "network dns record-set txt add-record": [
+    "--acquire-policy-token",
+    "--change-reference",
     "--cmd",
     "--debug",
+    "--defaults",
     "--help",
     "--if-none-match",
     "--only-show-errors",
     "--output",
     "--query",
     "--record-set-name",
+    "--resource-group",
     "--resource-group-name",
     "--subscription",
     "--value",

--- a/content/validation/dump_azure_commands.py
+++ b/content/validation/dump_azure_commands.py
@@ -200,9 +200,19 @@ def main():
     # slow (~0.5s per command), so we only do it for commands that appear in
     # the policy files we validate against. For all other commands, the API
     # flags plus global flags are sufficient for existence checking.
+    #
+    # Both the Azure policy and the M365 policy use `az` in their cli
+    # remediations, so both must be scanned here — otherwise M365-only
+    # commands fall back to dest-name flags (e.g. --resource-group-name).
     policy_dir = SCRIPT_DIR / ".."
+    policy_files = [
+        policy_dir / "mondoo-azure-security.mql.yaml",
+        policy_dir / "mondoo-m365-security.mql.yaml",
+    ]
     policy_commands = set()
-    for policy_file in policy_dir.glob("*azure*.mql.yaml"):
+    for policy_file in policy_files:
+        if not policy_file.exists():
+            continue
         content = policy_file.read_text()
         # Extract az commands from bash blocks in cli remediation sections
         for match in re.finditer(

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -436,7 +436,12 @@ def validate_aws() -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 
 AZURE_POLICY_FILE = SCRIPT_DIR / ".." / "mondoo-azure-security.mql.yaml"
+M365_POLICY_FILE = SCRIPT_DIR / ".." / "mondoo-m365-security.mql.yaml"
 AZURE_COMMANDS_FILE = CMD_DATA_DIR / "azure_commands.json"
+
+# Policy files whose `id: cli` remediations use the Azure CLI (`az`). The M365
+# policy is included here because its CLI remediations also target `az`.
+AZURE_CLI_POLICY_FILES = [AZURE_POLICY_FILE, M365_POLICY_FILE]
 
 
 def parse_az_command(cmd: str, commands_db: dict[str, list[str]]) -> tuple[str, list[str]]:
@@ -503,11 +508,11 @@ def validate_az_command(
 
 
 def validate_azure() -> tuple[int, int]:
-    """Validate Azure CLI commands. Returns (pass_count, fail_count)."""
-    if not AZURE_POLICY_FILE.exists():
-        print(f"Error: Policy file not found: {AZURE_POLICY_FILE}", file=sys.stderr)
-        sys.exit(1)
+    """Validate Azure CLI commands. Returns (pass_count, fail_count).
 
+    Scans both the Azure security policy and the M365 security policy, since
+    M365 `id: cli` remediations also use the Azure CLI (`az`).
+    """
     if not AZURE_COMMANDS_FILE.exists():
         print(
             f"Error: Commands database not found: {AZURE_COMMANDS_FILE}\n"
@@ -517,44 +522,49 @@ def validate_azure() -> tuple[int, int]:
         sys.exit(1)
 
     commands_db = json.loads(AZURE_COMMANDS_FILE.read_text())
-    content = AZURE_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
 
     pass_count = 0
     fail_count = 0
 
-    policy_relpath = str(AZURE_POLICY_FILE.resolve().relative_to(Path.cwd()))
+    for policy_file in AZURE_CLI_POLICY_FILES:
+        if not policy_file.exists():
+            print(f"Error: Policy file not found: {policy_file}", file=sys.stderr)
+            sys.exit(1)
 
-    for block_text, block_line, uid in blocks:
-        commands = split_commands(block_text, "az", block_line)
-        for cmd, line_num in commands:
-            command_path, flags = parse_az_command(cmd, commands_db)
+        content = policy_file.read_text()
+        blocks = extract_bash_blocks(content)
+        policy_relpath = str(policy_file.resolve().relative_to(Path.cwd()))
 
-            if not command_path:
-                continue
+        for block_text, block_line, uid in blocks:
+            commands = split_commands(block_text, "az", block_line)
+            for cmd, line_num in commands:
+                command_path, flags = parse_az_command(cmd, commands_db)
 
-            is_valid, errors = validate_az_command(
-                command_path, flags, commands_db
-            )
+                if not command_path:
+                    continue
 
-            if is_valid:
-                print(f"[PASS] {uid}")
-                print(f"       {truncate_cmd(cmd)}")
-                pass_count += 1
-            else:
-                print(f"[FAIL] {uid}")
-                print(f"       {truncate_cmd(cmd)}")
-                for error in errors:
-                    print(f"       {error}")
-                fail_count += 1
-                FAILURES.append({
-                    "file": policy_relpath,
-                    "line": line_num,
-                    "uid": uid,
-                    "command": truncate_cmd(cmd),
-                    "errors": errors,
-                    "cloud": "azure",
-                })
+                is_valid, errors = validate_az_command(
+                    command_path, flags, commands_db
+                )
+
+                if is_valid:
+                    print(f"[PASS] {uid}")
+                    print(f"       {truncate_cmd(cmd)}")
+                    pass_count += 1
+                else:
+                    print(f"[FAIL] {uid}")
+                    print(f"       {truncate_cmd(cmd)}")
+                    for error in errors:
+                        print(f"       {error}")
+                    fail_count += 1
+                    FAILURES.append({
+                        "file": policy_relpath,
+                        "line": line_num,
+                        "uid": uid,
+                        "command": truncate_cmd(cmd),
+                        "errors": errors,
+                        "cloud": "azure",
+                    })
 
     return pass_count, fail_count
 


### PR DESCRIPTION
## Summary

Brings the Mondoo Microsoft 365 Security policy fully in line with `content/CLAUDE.md` authoring standards, and adds the missing tooling/standards to support it. Policy version stays at `2.3.0`. Four coordinated workstreams:

### A. M365 remediation standard in `content/CLAUDE.md`

`content/CLAUDE.md` had no remediation-coverage entry for Microsoft 365. Added one: `console` (Microsoft admin centers), `powershell` (Graph / Exchange Online / SharePoint Online), and `terraform` **only** where the `azuread` provider exposes a genuine resource — with an explicit rule never to fake Terraform remediation with `null_resource` + `local-exec` or `azapi`.

### B. CLI remediation validator now covers the M365 policy

`validate_remediation_commands.py` was per-cloud and never scanned the M365 policy, so its `az` remediations went unchecked. `validate_azure()` now scans `mondoo-m365-security.mql.yaml` alongside the Azure policy, and `dump_azure_commands.py` collects `--help` flags from both policies so M365-only commands (e.g. `az network dns record-set txt add-record`) resolve to real CLI flags. `azure_commands.json` regenerated. The M365 SPF check's CLI remediation now validates (`293 passed, 0 failed`).

### C. All 18 `desc:` bodies rewritten to the docs template

None of the 18 check descriptions followed the `content/CLAUDE.md` `docs:` shape. Each is now: a lead assertion paragraph, a bulleted **Why this matters** section, and a bulleted **Risk mitigation** section. Hardcoded compliance/standards lists embedded in prose were removed (compliance mapping belongs in tags).

### D. Compliance framework mappings audited and corrected

Every `compliance/*` tag on all 18 checks was verified against the authoritative control text in `cnspec-enterprise-policies/frameworks/`. **87 mappings corrected** across 10 frameworks; `nist-csf-2` and DORA verified correct as-is. Recurring fixes:

- Email threat-protection checks (Safe Links / Safe Attachments / anti-phishing / DKIM) were mapped to logging or configuration controls — repointed to malware-protection and cryptography controls.
- MFA checks under CSA CCM moved from the password-policy control to the strong-authentication control (IAM-14).
- Identity Protection risk-policy checks set to `false` for NIST 800-171 / NIS-2 / PCI DSS 4, which have no fitting control — a missing mapping is better than a wrong one.

Every recommended control UID was validated to exist in its framework file before being written.

## Testing

- `cnspec policy lint content/mondoo-m365-security.mql.yaml` → `valid policy bundle(s)` (only the 3 pre-existing, out-of-scope `query-deprecated-symbol` warnings).
- `python3 content/validation/validate_remediation_commands.py azure` → `293 passed, 0 failed`.
- All 18 checks confirmed to carry `desc:`, `audit:`, and `remediation:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
