### PR TITLE
:sparkles: Add Tier 1 high-impact security checks to the M365 policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -481,6 +481,7 @@ omsagent
 oncall
 ondigitalocean
 onestop
+onmicrosoft
 ONTAP
 opasswd
 openai

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -130,6 +130,8 @@ Order the list consistently: `console`/`portal` → `cli` → `terraform` → `c
 
 **Never copy compliance tags from a neighboring check.** The nearby check was mapped for a different control objective; reusing its tags propagates a wrong mapping and misleads auditors. Two checks that both "relate to identity" can map to different controls.
 
+**A new check is not done until it carries compliance tags.** Any check added to a policy whose existing checks have `compliance/*` tags must ship with its own verified tags (completing the process below) — or with the user's explicit approval to skip them. Do **not** open a PR that adds untagged checks next to tagged siblings and merely note the omission in the PR body; that ships an inconsistent, half-finished policy. An empty `find` for the `cnspec-enterprise-policies` repo means **ask the user where the clone lives** — it does not authorize proceeding without tags.
+
 When adding or changing compliance tags, follow this process for **each** framework the policy already tags:
 
 1. **Read the authoritative control text.** Open the framework definition in `cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where their clone lives if you don't already know; if the files aren't available, stop and tell the user — do not guess.

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -11,6 +11,7 @@ policies:
     require:
       - provider: ms365
       - provider: terraform
+      - provider: network
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
@@ -49,6 +50,7 @@ policies:
           - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles
           - uid: mondoo-m365-security-ensure-security-defaults-is-disabled-on-azure-active-directory
           - uid: mondoo-m365-security-ensure-that-between-two-and-four-global-admins-are-designated
+          - uid: mondoo-m365-security-require-pim-for-privileged-roles
       - title: Password Policies
         filters: |
           asset.platform == "microsoft365"
@@ -66,6 +68,8 @@ policies:
         checks:
           - uid: mondoo-m365-security-ensure-that-spf-records-are-published-for-all-exchange-domains
           - uid: mondoo-m365-security-ensure-dkim-signing-enabled-for-all-exchange-domains
+          - uid: mondoo-m365-security-ensure-dmarc-records-published
+          - uid: mondoo-m365-security-block-external-email-auto-forwarding
           - uid: mondoo-m365-security-ensure-safe-links-policies-configured
           - uid: mondoo-m365-security-ensure-safe-attachments-policies-configured
           - uid: mondoo-m365-security-ensure-anti-phishing-policies-enabled
@@ -75,11 +79,17 @@ policies:
           asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-third-party-integrated-applications-are-not-allowed
+          - uid: mondoo-m365-security-restrict-user-consent-to-applications
       - title: SharePoint Security
         filters: |
           asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-sharepoint-external-sharing-restricted
+      - title: Audit & Logging
+        filters: |
+          asset.platform == "microsoft365"
+        checks:
+          - uid: mondoo-m365-security-ensure-unified-audit-log-enabled
     scoring_system: highest impact
 queries:
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies
@@ -2427,3 +2437,501 @@ queries:
         title: Mail flow rules in Exchange Online
       - url: https://learn.microsoft.com/en-us/purview/exchange-online-uses-tls-to-secure-email-connections
         title: How Exchange Online uses TLS
+  # No Terraform variants: Exchange Online configuration has no Terraform provider.
+  - uid: mondoo-m365-security-ensure-unified-audit-log-enabled
+    title: Ensure the Microsoft 365 unified audit log is enabled
+    impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      ms365.exchangeonline.adminAuditLogConfig['unifiedAuditLogIngestionEnabled'] == true
+    docs:
+      desc: |
+        This check ensures that unified audit logging is enabled for the Microsoft 365 tenant. The unified audit log records user and administrator activity across Exchange Online, SharePoint Online, OneDrive, Microsoft Entra ID, Teams, and other workloads in a single searchable log.
+
+        **Why this matters**
+
+        Without the unified audit log, the tenant produces no centralized record of who did what:
+
+          - **No incident detection:** Suspicious activity such as mass downloads, mailbox rule creation, or privilege changes goes unrecorded and unnoticed.
+          - **No forensic trail:** After a breach, responders cannot reconstruct attacker actions, identify compromised accounts, or scope data access.
+          - **No insider-threat visibility:** Data exfiltration and policy violations by internal users leave no evidence.
+          - **Compliance exposure:** Most regulatory frameworks require audit trails for access to sensitive data, so a disabled log is a direct finding.
+
+        **Risk mitigation**
+
+        - **Detection:** Enabling the log lets security tooling and analysts surface anomalous behavior in near real time.
+        - **Accountability:** A complete activity record deters misuse and supports investigations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Microsoft Purview portal at `https://purview.microsoft.com`.
+        2. Go to **Audit**.
+        3. Confirm auditing is on. If auditing is disabled, a banner offers to start recording user and admin activity.
+
+        A passing tenant shows auditing as enabled. A failing tenant shows the option to turn on auditing.
+
+        ### Audit via PowerShell
+
+        1. Connect to Exchange Online and read the audit log configuration:
+
+        ```powershell
+        Connect-ExchangeOnline
+        (Get-AdminAuditLogConfig).UnifiedAuditLogIngestionEnabled
+        ```
+
+        A passing tenant returns `True`. A failing tenant returns `False`.
+      remediation:
+        - id: console
+          desc: |
+            **To enable the unified audit log using the Microsoft Purview portal:**
+
+            1. Sign in to the [Microsoft Purview portal](https://purview.microsoft.com).
+            2. Go to **Audit**.
+            3. Select **Start recording user and admin activity** on the banner.
+            4. Confirm the action.
+        - id: powershell
+          desc: |
+            **Using Exchange Online PowerShell**
+
+            ```powershell
+            Connect-ExchangeOnline
+
+            # Enable unified audit log ingestion for the tenant
+            Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true
+            ```
+
+            It can take up to 60 minutes for the change to take effect across all workloads.
+        # No Terraform remediation: Exchange Online configuration has no Terraform provider.
+    refs:
+      - url: https://learn.microsoft.com/en-us/purview/audit-log-enable-disable
+        title: Turn auditing on or off
+      - url: https://learn.microsoft.com/en-us/purview/audit-solutions-overview
+        title: Microsoft Purview auditing solutions
+  # No Terraform variants: Exchange Online configuration has no Terraform provider.
+  - uid: mondoo-m365-security-block-external-email-auto-forwarding
+    title: Ensure automatic external email forwarding is blocked
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-7-1
+      compliance/vda-isa-5: false
+    mql: |
+      ms365.exchangeonline.hostedOutboundSpamFilterPolicy.all(_['autoForwardingMode'] == "Off")
+      ms365.exchangeonline.remoteDomain.all(_['autoForwardEnabled'] == false)
+    docs:
+      desc: |
+        This check ensures that automatic forwarding of email to external recipients is blocked, both through the outbound spam filter policy and the default remote domain configuration. By default Microsoft 365 permits automatic forwarding, which lets mailbox rules silently relay mail outside the organization.
+
+        **Why this matters**
+
+        Attacker-created forwarding rules are one of the most common business email compromise techniques:
+
+          - **Silent data exfiltration:** A compromised mailbox can forward every incoming message to an attacker-controlled address with no further interaction.
+          - **Persistence after remediation:** A forwarding rule survives password resets and keeps leaking mail until the rule itself is found and removed.
+          - **Invoice and payroll fraud:** Forwarded threads give attackers the context to insert fraudulent payment instructions.
+          - **Exposure of secrets:** Password resets, MFA codes, and account notifications are forwarded along with everything else.
+
+        **Risk mitigation**
+
+        - **Containment:** Blocking forwarding at the tenant level neutralizes attacker forwarding rules even before the compromised account is identified.
+        - **Controlled exceptions:** Legitimate forwarding can still be allowed through scoped policies for specific users or domains.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Microsoft Defender portal at `https://security.microsoft.com`.
+        2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies** > **Anti-spam**.
+        3. Open each outbound spam policy and review the automatic forwarding setting.
+
+        A passing tenant has every outbound spam policy set to **Off - Forwarding is disabled**. A failing tenant has policies set to **Automatic** or **On**.
+
+        ### Audit via PowerShell
+
+        1. Connect to Exchange Online and review the outbound spam and remote domain settings:
+
+        ```powershell
+        Connect-ExchangeOnline
+        Get-HostedOutboundSpamFilterPolicy | Select-Object Name, AutoForwardingMode
+        Get-RemoteDomain Default | Select-Object DomainName, AutoForwardEnabled
+        ```
+
+        A passing tenant returns `AutoForwardingMode : Off` for every outbound spam policy and `AutoForwardEnabled : False` for the default remote domain. A failing tenant returns `Automatic`, `On`, or `True`.
+      remediation:
+        - id: console
+          desc: |
+            **To block automatic forwarding using the Microsoft Defender portal:**
+
+            1. Sign in to the [Microsoft Defender portal](https://security.microsoft.com).
+            2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies** > **Anti-spam**.
+            3. Open each outbound spam policy and select **Edit automatic forwarding**.
+            4. Set the forwarding rule to **Off - Forwarding is disabled**.
+            5. Save the policy.
+        - id: powershell
+          desc: |
+            **Using Exchange Online PowerShell**
+
+            ```powershell
+            Connect-ExchangeOnline
+
+            # Block automatic forwarding on every outbound spam filter policy
+            Get-HostedOutboundSpamFilterPolicy | ForEach-Object {
+              Set-HostedOutboundSpamFilterPolicy -Identity $_.Name -AutoForwardingMode Off
+            }
+
+            # Disable automatic forwarding on the default remote domain
+            Set-RemoteDomain -Identity Default -AutoForwardEnabled $false
+            ```
+        # No Terraform remediation: Exchange Online configuration has no Terraform provider.
+    refs:
+      - url: https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding
+        title: Control automatic external email forwarding in Microsoft 365
+      - url: https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/remote-domains/remote-domains
+        title: Remote domains in Exchange Online
+  # No Terraform variants: the tenant authorization policy has no resource in the azuread Terraform provider.
+  - uid: mondoo-m365-security-restrict-user-consent-to-applications
+    title: Ensure users cannot consent to applications accessing company data
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-9
+      compliance/pci-dss-4: pcidss-requirement-7-2-3
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-1-3-3
+    mql: |
+      microsoft.policies.authorizationPolicy.defaultUserRolePermissions.permissionGrantPoliciesAssigned == empty
+    docs:
+      desc: |
+        This check ensures that non-administrative users cannot grant consent for applications to access organizational data on their behalf. When user consent is restricted, the default user role has no permission grant policy assigned, and application access must be approved by an administrator.
+
+        **Why this matters**
+
+        Illicit consent grants, also called consent phishing, let an attacker bypass passwords and MFA entirely:
+
+          - **Token-based account takeover:** A user who consents to a malicious app hands the attacker a long-lived OAuth token for their mailbox, files, and Teams data.
+          - **MFA bypass:** OAuth tokens are honored without re-prompting for MFA, so the attacker keeps access even after a password reset.
+          - **Tenant-wide reach:** A single consenting user can expose data far beyond their own account if the app requests broad Graph scopes.
+          - **Low visibility:** Consent grants do not trigger the alerts a new sign-in would, so malicious apps can persist undetected.
+
+        **Risk mitigation**
+
+        - **Administrative gate:** Requiring admin approval ensures every third-party app is reviewed before it can read organizational data.
+        - **Reduced attack surface:** Removing self-service consent eliminates the most common path for OAuth-based phishing.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Microsoft Entra admin center at `https://entra.microsoft.com`.
+        2. Go to **Identity** > **Applications** > **Enterprise applications** > **Consent and permissions** > **User consent settings**.
+        3. Review the **User consent for applications** setting.
+
+        A passing tenant has user consent set to **Do not allow user consent**. A failing tenant allows users to consent for some or all applications.
+
+        ### Audit via PowerShell
+
+        1. Connect to Microsoft Graph and read the tenant authorization policy:
+
+        ```powershell
+        Connect-MgGraph -Scopes "Policy.Read.All"
+        (Get-MgPolicyAuthorizationPolicy).DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
+        ```
+
+        A passing tenant returns no permission grant policies. A failing tenant returns one or more `ManagePermissionGrantsForSelf.*` policies.
+      remediation:
+        - id: console
+          desc: |
+            **To restrict user consent using the Microsoft Entra admin center:**
+
+            1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+            2. Go to **Identity** > **Applications** > **Enterprise applications** > **Consent and permissions** > **User consent settings**.
+            3. Under **User consent for applications**, select **Do not allow user consent**.
+            4. Save the change.
+            5. Optionally, configure the admin consent workflow so users can request approval for the apps they need.
+        - id: powershell
+          desc: |
+            **Using Microsoft Graph PowerShell**
+
+            ```powershell
+            Connect-MgGraph -Scopes "Policy.ReadWrite.Authorization"
+
+            # Remove all permission grant policies from the default user role
+            $params = @{
+                defaultUserRolePermissions = @{
+                    permissionGrantPoliciesAssigned = @()
+                }
+            }
+            Update-MgPolicyAuthorizationPolicy -BodyParameter $params
+            ```
+        # No Terraform remediation: the tenant authorization policy has no resource in the azuread Terraform provider.
+    refs:
+      - url: https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent
+        title: Configure how users consent to applications
+      - url: https://learn.microsoft.com/en-us/defender-cloud-apps/investigate-risky-oauth
+        title: Investigate risky OAuth apps
+  # No Terraform variants: Microsoft Entra PIM role eligibility has no resource in the azuread Terraform provider.
+  - uid: mondoo-m365-security-require-pim-for-privileged-roles
+    title: Ensure privileged roles are managed with Privileged Identity Management
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      microsoft.identityAndAccess.roleEligibilityScheduleInstances != empty
+    docs:
+      desc: |
+        This check ensures that Microsoft Entra Privileged Identity Management (PIM) is used to govern privileged roles, indicated by the presence of eligible role assignments. PIM grants administrative access just-in-time: a user is eligible for a role and must activate it for a limited window rather than holding it permanently.
+
+        **Why this matters**
+
+        Permanent, always-active admin assignments leave high-value access standing around the clock:
+
+          - **Always-on attack surface:** A compromised account with a permanent Global Administrator assignment gives an attacker full tenant control at any moment, with no activation step to detect.
+          - **No activation trail:** Standing assignments produce no just-in-time activation events, removing a key signal for spotting misuse.
+          - **Privilege sprawl:** Without periodic activation and review, stale admin rights accumulate on accounts that no longer need them.
+          - **Broader blast radius:** Every permanently privileged account is an independent path to tenant takeover.
+
+        **Risk mitigation**
+
+        - **Just-in-time access:** Eligible assignments mean privileges exist only during an approved, time-bound activation window.
+        - **Approval and review:** PIM can require justification, approval, and MFA on activation, and supports recurring access reviews.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Microsoft Entra admin center at `https://entra.microsoft.com`.
+        2. Go to **Identity governance** > **Privileged Identity Management** > **Microsoft Entra roles** > **Assignments**.
+        3. Review the **Eligible assignments** tab for privileged roles such as Global Administrator.
+
+        A passing tenant manages privileged roles through eligible assignments. A failing tenant has no eligible assignments and relies on permanent (active) assignments.
+
+        ### Audit via PowerShell
+
+        1. Connect to Microsoft Graph and list role eligibility schedule instances:
+
+        ```powershell
+        Connect-MgGraph -Scopes "RoleManagement.Read.Directory"
+        Get-MgRoleManagementDirectoryRoleEligibilityScheduleInstance
+        ```
+
+        A passing tenant returns one or more eligible role assignments. A failing tenant returns nothing.
+      remediation:
+        - id: console
+          desc: |
+            **To manage privileged roles with PIM using the Microsoft Entra admin center:**
+
+            1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+            2. Go to **Identity governance** > **Privileged Identity Management** > **Microsoft Entra roles** > **Roles**.
+            3. Select a privileged role, such as **Global Administrator**.
+            4. Select **Add assignments**, choose the user, and set the assignment type to **Eligible**.
+            5. For each role, open **Settings** and require MFA, justification, and approval on activation.
+            6. Remove the corresponding permanent (active) assignment once the eligible assignment is in place.
+        - id: powershell
+          desc: |
+            **Using Microsoft Graph PowerShell**
+
+            ```powershell
+            Connect-MgGraph -Scopes "RoleManagement.ReadWrite.Directory"
+
+            # Create an eligible assignment for a privileged role
+            $params = @{
+                action           = "adminAssign"
+                principalId      = "<user-object-id>"
+                roleDefinitionId = "<role-definition-id>"
+                directoryScopeId = "/"
+                scheduleInfo     = @{
+                    startDateTime = (Get-Date)
+                    expiration    = @{ type = "noExpiration" }
+                }
+            }
+            New-MgRoleManagementDirectoryRoleEligibilityScheduleRequest -BodyParameter $params
+            ```
+        # No Terraform remediation: Microsoft Entra PIM role eligibility has no resource in the azuread Terraform provider.
+    refs:
+      - url: https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure
+        title: What is Microsoft Entra Privileged Identity Management
+      - url: https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-add-role-to-user
+        title: Assign Microsoft Entra roles in PIM
+  # No Terraform variants: DMARC records are published at an external DNS provider, not in Microsoft 365.
+  - uid: mondoo-m365-security-ensure-dmarc-records-published
+    title: Ensure DMARC records are published for all Exchange domains
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/v=DMARC1/))
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/p=quarantine|p=reject/))
+    docs:
+      desc: |
+        This check ensures that every verified custom domain publishes a DMARC record with an enforcing policy of `quarantine` or `reject`. DMARC (Domain-based Message Authentication, Reporting, and Conformance) tells receiving mail servers what to do with messages that fail SPF and DKIM alignment.
+
+        **Why this matters**
+
+        SPF and DKIM alone do not stop spoofed mail. DMARC is the enforcement layer:
+
+          - **Domain spoofing:** Without an enforcing DMARC policy, attackers can send mail that appears to come from your domain, since receivers have no instruction to reject failures.
+          - **Business email compromise:** Spoofed executive or finance messages drive fraudulent wire transfers and credential theft.
+          - **Brand and deliverability damage:** Spoofing campaigns harm domain reputation and can cause legitimate mail to be filtered.
+          - **No visibility:** A `p=none` policy or a missing record leaves the organization blind to who is sending mail as its domain.
+
+        **Risk mitigation**
+
+        - **Enforced rejection:** A `quarantine` or `reject` policy instructs receivers to drop or isolate unauthenticated mail claiming to be from your domain.
+        - **Reporting:** DMARC aggregate reports reveal spoofing attempts and misconfigured legitimate senders.
+      audit: |
+        Verify that every verified custom domain publishes an enforcing DMARC record by querying the `_dmarc` TXT record:
+
+        ```bash
+        dig +short TXT _dmarc.example.com
+        ```
+
+        A passing domain returns a TXT record beginning with `v=DMARC1` and containing `p=quarantine` or `p=reject`. A failing domain returns no record, or a record with `p=none`.
+      remediation:
+        - id: console
+          desc: |
+            **To publish a DMARC record:**
+
+            1. Confirm SPF and DKIM are already configured for the domain.
+            2. At your DNS provider, add a TXT record for the host `_dmarc` (for example, `_dmarc.example.com`).
+            3. Set the value to an enforcing policy, for example:
+
+            ```text
+            v=DMARC1; p=reject; rua=mailto:dmarc-reports@example.com; pct=100
+            ```
+
+            4. Start with `p=quarantine` and a reporting address, monitor the aggregate reports, then move to `p=reject` once legitimate senders are aligned.
+        - id: cli
+          desc: |
+            **Using CLI tools**
+
+            DMARC records are TXT records managed at your DNS provider. Use the example for your provider:
+
+            **Using Azure DNS CLI:**
+            ```bash
+            az network dns record-set txt add-record \
+              --resource-group <resource-group> \
+              --zone-name <domain.com> \
+              --record-set-name "_dmarc" \
+              --value "v=DMARC1; p=reject; rua=mailto:dmarc-reports@domain.com; pct=100"
+            ```
+
+            **Using AWS Route 53 CLI:**
+            ```bash
+            aws route53 change-resource-record-sets \
+              --hosted-zone-id <zone-id> \
+              --change-batch '{
+                "Changes": [{
+                  "Action": "UPSERT",
+                  "ResourceRecordSet": {
+                    "Name": "_dmarc.domain.com",
+                    "Type": "TXT",
+                    "TTL": 3600,
+                    "ResourceRecords": [{"Value": "\"v=DMARC1; p=reject; rua=mailto:dmarc-reports@domain.com; pct=100\""}]
+                  }
+                }]
+              }'
+            ```
+
+            **Using Google Cloud DNS:**
+            ```bash
+            gcloud dns record-sets create _dmarc.domain.com. \
+              --zone=<zone-name> \
+              --type=TXT \
+              --ttl=3600 \
+              --rrdatas="v=DMARC1; p=reject; rua=mailto:dmarc-reports@domain.com; pct=100"
+            ```
+        - id: terraform
+          desc: |
+            **Using Terraform**
+
+            Publish the DMARC TXT record at your DNS provider:
+
+            **Azure DNS:**
+            ```hcl
+            resource "azurerm_dns_txt_record" "dmarc" {
+              name                = "_dmarc"
+              zone_name           = azurerm_dns_zone.example.name
+              resource_group_name = azurerm_resource_group.example.name
+              ttl                 = 3600
+
+              record {
+                value = "v=DMARC1; p=reject; rua=mailto:dmarc-reports@example.com; pct=100"
+              }
+            }
+            ```
+
+            **AWS Route 53:**
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.example.zone_id
+              name    = "_dmarc.example.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=reject; rua=mailto:dmarc-reports@example.com; pct=100"]
+            }
+            ```
+
+            **Google Cloud DNS:**
+            ```hcl
+            resource "google_dns_record_set" "dmarc" {
+              name         = "_dmarc.example.com."
+              managed_zone = google_dns_managed_zone.example.name
+              type         = "TXT"
+              ttl          = 3600
+              rrdatas      = ["v=DMARC1; p=reject; rua=mailto:dmarc-reports@example.com; pct=100"]
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dmarc-configure
+        title: Set up DMARC to validate the From address domain
+      - url: https://learn.microsoft.com/en-us/defender-office-365/email-authentication-about
+        title: Email authentication in Microsoft 365


### PR DESCRIPTION
## Summary

Adds five high-impact security checks to the **Mondoo Microsoft 365 Security** policy, ordered by risk reduction (blast radius). These close detection and account-takeover gaps the policy currently leaves open. All five map to resources the `ms365`/`microsoft` provider already exposes — no provider changes needed.

| # | Check | Impact | Closes |
|---|-------|--------|--------|
| 1 | Ensure the Microsoft 365 unified audit log is enabled | 95 | No incident detection or forensic trail tenant-wide |
| 2 | Ensure automatic external email forwarding is blocked | 90 | BEC data-exfiltration via attacker forwarding rules |
| 3 | Ensure users cannot consent to applications accessing company data | 90 | OAuth consent phishing → token-based mailbox takeover |
| 4 | Ensure privileged roles are managed with Privileged Identity Management | 85 | Standing global-admin assignments as a permanent takeover target |
| 5 | Ensure DMARC records are published for all Exchange domains | 80 | Domain spoofing / business email compromise |

A new **Audit & Logging** group hosts check #1; #2 and #5 join **Email Security**, #3 joins **Application Security**, and #4 joins **Authentication & Access Control**.

## Compliance tags

Every check ships with `compliance/*` tags **verified against the authoritative control text** in `cnspec-enterprise-policies/frameworks/`, across all 13 frameworks the policy already maps (BSI SYS.1.5, CSA CCM 4, DORA, HIPAA, ISO 27001:2022, NIS2, NIST CSF 1/2, NIST 800-53 rev5, NIST 800-171, PCI DSS 4, SOC 2 2017, VDA ISA 5). Controls with no strict fit are tagged `false` rather than guessed — for example DMARC (email anti-spoofing) has no clean home in SOC 2, NIST CSF, HIPAA, or ISO 27001:2022, so those are `false`; PCI DSS 4 Req 5.4.1 (which names DMARC explicitly) and NIST 800-53 SI-8 are the genuine fits.

## Notes for reviewers

- **DMARC check uses live DNS.** Microsoft's `serviceConfigurationRecords` (used by the existing SPF check) does not include `_dmarc` records, so check #5 resolves the `_dmarc` TXT record at runtime via the `network` provider's `dns` resource — the same pattern as `mondoo-email-security.mql.yaml`. `network` is therefore added to the policy `require` block.
- **Impact of #5 vs. its SPF sibling (60).** DMARC is set to 80 rather than anchoring to SPF, because DMARC is the *enforcement* layer — SPF and DKIM without an enforcing DMARC policy do not block inbound spoofing of your own domain.
- **No Terraform variants.** M365 tenant configuration has no Terraform analog; each check carries a `# No Terraform variants:` comment. The DMARC check still ships Terraform remediation (DNS records), matching the existing SPF check.
- **`content/CLAUDE.md` hardening.** Adds a rule: a new check is not done until it carries verified compliance tags, and an empty search for the framework repo means *ask for its path*, not ship untagged checks.
- Rebased on current `main` (picks up #2544 / #2546, including the `compliance/bsi-sys-1-5` key rename). `cnspec policy lint` passes; the three remaining warnings are pre-existing and unrelated.

These are Tier 1 of a broader set of 22 recommended M365 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)