### PR TITLE
:bug: Fix BSI SYS.1.5 compliance tag key to match framework UID

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -138,6 +138,8 @@ When adding or changing compliance tags, follow this process for **each** framew
 4. **If no control fits, tag it with the YAML boolean `false`** — unquoted, like `compliance/soc2-2017: false`. **Not** `"false"` (the string), not `false-fit`, not `n/a`, not omitting the key. The unquoted boolean is the established repo convention (grep `compliance/.*: false` for ~150+ examples) and is what downstream tooling expects. A missing mapping is strictly better than a wrong one — wrong mappings get caught in compliance audits and create trust debt.
 5. **Cite the control you chose.** When you present tags to the user, include the control title and a short quote from the control description so the user can verify.
 
+**The `<framework>` in the key must exactly match the framework's `uid:` field** — the value declared inside the framework YAML, *not* the file name. They are not always the same: `cnspec-enterprise-policies/frameworks/bsi-grundschutz-sys15.mql.yaml` declares `uid: bsi-sys-1-5`, so the tag is `compliance/bsi-sys-1-5`. A key that matches no real framework `uid` generates a framework map with a dangling `framework_owner`, which fails bundle migration in `cnspec-enterprise-policies` with `cannot find framework owner`. Likewise the `<control-uid>` value must be a `uid` that exists under that framework's `controls:`.
+
 Known high-value anchors (verify before using):
 
 - Identity proofing / email verification: `iso-27001-2022-a-5-16` (Identity management), `nist-csf-2-pr-aa-02` ("Identities are proofed and bound to credentials"), `nist-sp-800-53-rev5-ia-12` (Identity Proofing). No direct equivalent in NIST CSF 1.x, NIST 800-171 rev2, NIS2 Article 21(2), or SOC 2 2017.

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -95,7 +95,7 @@ queries:
     title: No unapproved AI agent processes are running
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -161,7 +161,7 @@ queries:
     title: No unapproved AI tools installed via package managers
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -226,7 +226,7 @@ queries:
     filters: asset.platform == "macos"
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -268,7 +268,7 @@ queries:
     title: Cursor editor is not configured on this endpoint
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -319,7 +319,7 @@ queries:
     title: Windsurf editor is not configured on this endpoint
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -368,7 +368,7 @@ queries:
     title: Goose AI agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -413,7 +413,7 @@ queries:
     title: Zed editor is not configured on this endpoint
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -453,7 +453,7 @@ queries:
     title: Cline agent is not configured on this endpoint
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -497,7 +497,7 @@ queries:
     title: Roo Code agent is not configured on this endpoint
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -541,7 +541,7 @@ queries:
     title: Continue agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -585,7 +585,7 @@ queries:
     title: Trae agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -629,7 +629,7 @@ queries:
     title: OpenCode agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -673,7 +673,7 @@ queries:
     title: Kiro agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -717,7 +717,7 @@ queries:
     title: Pi agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -761,7 +761,7 @@ queries:
     title: Mistral Vibe is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -805,7 +805,7 @@ queries:
     title: Antigravity agent is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -849,7 +849,7 @@ queries:
     title: IBM Bob is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -893,7 +893,7 @@ queries:
     title: OpenClaw is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -937,7 +937,7 @@ queries:
     title: Snowflake Cortex Code is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -981,7 +981,7 @@ queries:
     title: Junie is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1025,7 +1025,7 @@ queries:
     title: Augment is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1069,7 +1069,7 @@ queries:
     title: Warp AI terminal is not configured on this endpoint
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1113,7 +1113,7 @@ queries:
     title: Kilo Code is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1157,7 +1157,7 @@ queries:
     title: OpenHands is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1201,7 +1201,7 @@ queries:
     title: Qwen Code is not configured on this endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1248,7 +1248,7 @@ queries:
     title: No Codeium extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1344,7 +1344,7 @@ queries:
     title: No Tabnine extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1403,7 +1403,7 @@ queries:
     title: No Supermaven extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1462,7 +1462,7 @@ queries:
     title: No Continue extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1521,7 +1521,7 @@ queries:
     title: No Cline extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1580,7 +1580,7 @@ queries:
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1639,7 +1639,7 @@ queries:
     title: No OpenAI Codex extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1698,7 +1698,7 @@ queries:
     title: No Claude extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1757,7 +1757,7 @@ queries:
     title: No Cursor-specific extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1816,7 +1816,7 @@ queries:
     title: No Roo Code extensions in VS Code-compatible editors
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1878,7 +1878,7 @@ queries:
     title: No unapproved MCP servers across all AI agents
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -1962,7 +1962,7 @@ queries:
     title: No local LLM runtimes are running
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -2019,7 +2019,7 @@ queries:
     title: No local LLM inference servers are listening
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -129,7 +129,7 @@ queries:
     title: Ensure AAA accounting is enabled for commands
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -182,7 +182,7 @@ queries:
     title: Ensure AAA accounting is enabled for exec sessions
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -229,7 +229,7 @@ queries:
     title: Ensure AAA accounting is enabled for system events
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -276,7 +276,7 @@ queries:
     title: Ensure AAA authentication is enabled
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -327,7 +327,7 @@ queries:
     title: Ensure authentication failures are logged
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -381,7 +381,7 @@ queries:
     title: Ensure AAA authorization is enabled for console
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -429,7 +429,7 @@ queries:
     title: Ensure an admin account of last resort exists
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -480,7 +480,7 @@ queries:
     title: Ensure console timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -527,7 +527,7 @@ queries:
     title: Ensure domain name is configured
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -575,7 +575,7 @@ queries:
     title: Ensure exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -623,7 +623,7 @@ queries:
     title: Ensure hostname is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -674,7 +674,7 @@ queries:
     title: Ensure HTTP API is disabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -726,7 +726,7 @@ queries:
     impact: 85
     filters: arista.eos.runningConfig.content.contains("management api http-commands") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -775,7 +775,7 @@ queries:
     impact: 60
     filters: arista.eos.interfaces != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -827,7 +827,7 @@ queries:
     title: Ensure buffered logging is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -873,7 +873,7 @@ queries:
     title: Ensure logging is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -921,7 +921,7 @@ queries:
     title: Ensure remote syslog server is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -970,7 +970,7 @@ queries:
     title: Ensure appropriate logging level is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1018,7 +1018,7 @@ queries:
     title: Ensure login banner is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1072,7 +1072,7 @@ queries:
     title: Ensure users have appropriate privilege levels
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1129,7 +1129,7 @@ queries:
     title: Ensure MOTD banner is configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1178,7 +1178,7 @@ queries:
     title: Ensure multifactor authentication is configured for privileged access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1227,7 +1227,7 @@ queries:
     title: Ensure no user accounts are configured without passwords
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1277,7 +1277,7 @@ queries:
     title: Ensure NTP synchronization is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1327,7 +1327,7 @@ queries:
     title: Ensure NTP servers are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1377,7 +1377,7 @@ queries:
     title: Ensure password minimum length is configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1429,7 +1429,7 @@ queries:
     title: Ensure password encryption service is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1478,7 +1478,7 @@ queries:
     title: Ensure SNMP community strings are not using defaults
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1536,7 +1536,7 @@ queries:
     impact: 70
     filters: arista.eos.snmp.enabled == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1584,7 +1584,7 @@ queries:
     title: Ensure SSH is enabled for secure management
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1639,7 +1639,7 @@ queries:
     title: Ensure Telnet is disabled
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1695,7 +1695,7 @@ queries:
     title: Ensure timezone is configured to UTC or GMT
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1743,7 +1743,7 @@ queries:
     impact: 80
     filters: arista.eos.interfaces != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1798,7 +1798,7 @@ queries:
     impact: 75
     filters: arista.eos.vlans != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1845,7 +1845,7 @@ queries:
     title: Ensure all user passwords are encrypted with strong algorithms
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1897,7 +1897,7 @@ queries:
     impact: 60
     filters: arista.eos.vlans != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1948,7 +1948,7 @@ queries:
     impact: 85
     filters: arista.eos.switchports != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2001,7 +2001,7 @@ queries:
     impact: 90
     filters: arista.eos.runningConfig.content.contains("router bgp") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2058,7 +2058,7 @@ queries:
     impact: 85
     filters: arista.eos.runningConfig.content.contains("router bgp") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2115,7 +2115,7 @@ queries:
     impact: 60
     filters: arista.eos.runningConfig.content.contains("router bgp") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2168,7 +2168,7 @@ queries:
     impact: 70
     filters: arista.eos.runningConfig.content.contains("router bgp") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2229,7 +2229,7 @@ queries:
     impact: 85
     filters: arista.eos.runningConfig.content.contains("ip access-list") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2285,7 +2285,7 @@ queries:
     impact: 75
     filters: arista.eos.runningConfig.content.contains("ip access-list") == true
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -672,7 +672,7 @@ queries:
     title: Ensure EKS clusters use KMS for Kubernetes secrets encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -843,7 +843,7 @@ queries:
     title: Ensure Amazon EKS clusters are configured with private endpoint access only
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -985,7 +985,7 @@ queries:
     title: Ensure no root user account access key exists
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1131,7 +1131,7 @@ queries:
     title: Ensure MFA is enabled for the "root user" account
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1302,7 +1302,7 @@ queries:
     title: Ensure strong account password policy requirements are used
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1514,7 +1514,7 @@ queries:
     title: Ensure IAM user access keys are rotated
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1653,7 +1653,7 @@ queries:
     title: Ensure MFA is enabled for all IAM users with console access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1832,7 +1832,7 @@ queries:
     title: Ensure IAM groups are utilized by assigning at least one user
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1994,7 +1994,7 @@ queries:
     title: Ensure IAM users have only one active access key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2168,7 +2168,7 @@ queries:
     title: Ensure IAM users receive permissions only through groups
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2359,7 +2359,7 @@ queries:
     title: Ensure the default security group of every VPC restricts all traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2516,7 +2516,7 @@ queries:
     title: Ensure EBS volume encryption is enabled by default
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -2648,7 +2648,7 @@ queries:
     title: Ensure public access to S3 buckets is blocked at the account level
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2793,7 +2793,7 @@ queries:
     title: Ensure Amazon S3 buckets have public access restrictions enforced
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3040,7 +3040,7 @@ queries:
     title: Ensure no public IPs are associated with EC2 instances
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3201,7 +3201,7 @@ queries:
     title: Ensure EC2 instances use IMDSv2 for metadata access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -3366,7 +3366,7 @@ queries:
     title: Ensure VPC Block Public Access (BPA) is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3518,7 +3518,7 @@ queries:
     title: Ensure VPC flow logging is enabled in all VPCs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3691,7 +3691,7 @@ queries:
     title: Ensure DynamoDB tables are encrypted with AWS Key Management Service (KMS)
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -3891,7 +3891,7 @@ queries:
     title: Ensure Lambda functions have concurrent execution limits
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4043,7 +4043,7 @@ queries:
     title: Ensure the policy attached to the lambda function prohibits public access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4214,7 +4214,7 @@ queries:
     impact: 90
     filters: asset.platform == "aws-rds-dbinstance"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4336,7 +4336,7 @@ queries:
     title: Ensure all RDS instances are enabled for encryption-at-rest
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -4526,7 +4526,7 @@ queries:
     title: Ensure RDS cluster parameter groups enforce encryption in transit
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4758,7 +4758,7 @@ queries:
     impact: 90
     filters: asset.platform == "aws-rds-dbcluster"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4908,7 +4908,7 @@ queries:
     title: Ensure all RDS clusters are set to be encrypted-at-rest
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5136,7 +5136,7 @@ queries:
     title: Ensure all RDS clusters are not publicly accessible
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5353,7 +5353,7 @@ queries:
     title: Ensure all RDS instances are not publicly accessible
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5521,7 +5521,7 @@ queries:
     title: Ensure Redshift clusters are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5679,7 +5679,7 @@ queries:
     title: Ensure EBS volumes delete on EC2 instance termination
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -5839,7 +5839,7 @@ queries:
     title: Ensure EBS snapshots are not publicly restorable
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5960,7 +5960,7 @@ queries:
     title: Ensure EBS Snapshots are configured to be encrypted at-rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6158,7 +6158,7 @@ queries:
     title: Ensure attached EBS volumes are configured to be encrypted at-rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6414,7 +6414,7 @@ queries:
     title: Ensure EBS volumes use KMS encryption instead of default
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6605,7 +6605,7 @@ queries:
     title: Ensure EFS is configured to encrypt file data using KMS
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6761,7 +6761,7 @@ queries:
     title: Ensure CloudWatch Logs are encrypted at rest using KMS CMKs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6910,7 +6910,7 @@ queries:
     title: Ensure ALBs are configured with a secure TLS policy
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7112,7 +7112,7 @@ queries:
     title: Ensure Application Load Balancers are configured with HTTPS listeners
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7338,7 +7338,7 @@ queries:
     title: Ensure Application Load Balancers have logging enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7578,7 +7578,7 @@ queries:
     title: Ensure Application Load Balancers have deletion protection
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -7730,7 +7730,7 @@ queries:
     title: Ensure Elasticsearch Service domains have encryption at rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -7894,7 +7894,7 @@ queries:
     title: Ensure Amazon Elasticsearch Service domains use node-to-node encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8038,7 +8038,7 @@ queries:
     title: Ensure rotation for customer-managed keys (CMKs) is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -8177,7 +8177,7 @@ queries:
     title: Ensure SageMaker notebook instances are configured to use KMS
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -8334,7 +8334,7 @@ queries:
     title: Ensure CloudTrail log file validation is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -8548,7 +8548,7 @@ queries:
     title: Ensure CloudTrail trails use KMS server-side encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -8703,7 +8703,7 @@ queries:
     title: Ensure security groups restrict incoming SSH traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8875,7 +8875,7 @@ queries:
     title: Ensure security groups restrict incoming VNC traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -9060,7 +9060,7 @@ queries:
     title: Ensure security groups restrict incoming RDP traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -9234,7 +9234,7 @@ queries:
     title: Ensure security groups restrict access to specific IPs and ports
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -9416,7 +9416,7 @@ queries:
     title: Ensure Terraform AWS providers do not contain hard-coded credentials
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9528,7 +9528,7 @@ queries:
     title: Ensure API Gateway cache is enabled and encrypted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -9677,7 +9677,7 @@ queries:
     title: Ensure API Gateway stages have execution logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9772,7 +9772,7 @@ queries:
     title: Ensure API Gateway methods require authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9909,7 +9909,7 @@ queries:
     title: Ensure API Gateway uses TLS 1.2 or higher
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -10049,7 +10049,7 @@ queries:
     title: Ensure API Gateway X-Ray tracing is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -10183,7 +10183,7 @@ queries:
     title: Ensure EC2 instance user data does not contain secrets
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10327,7 +10327,7 @@ queries:
     title: Ensure IAM policies do not use wildcards and apply least privilege
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10546,7 +10546,7 @@ queries:
     title: Ensure S3 bucket versioning is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -10685,7 +10685,7 @@ queries:
     title: Ensure S3 bucket logging is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -10830,7 +10830,7 @@ queries:
     title: Ensure S3 bucket server-side encryption is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -10987,7 +10987,7 @@ queries:
     title: Ensure S3 buckets do not allow public read access via ACLs
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11122,7 +11122,7 @@ queries:
     title: Ensure S3 bucket static website hosting is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11235,7 +11235,7 @@ queries:
     title: Ensure CloudTrail is enabled in all regions with a multi-region trail
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -11380,7 +11380,7 @@ queries:
     title: Ensure CloudFront distributions require HTTPS for viewer connections
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11566,7 +11566,7 @@ queries:
     title: Ensure Amazon EKS control plane logging is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -11728,7 +11728,7 @@ queries:
     title: Ensure OpenSearch Service domains have encryption at rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11892,7 +11892,7 @@ queries:
     title: Ensure Amazon OpenSearch Service domains enforce HTTPS
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12037,7 +12037,7 @@ queries:
     title: Ensure Amazon OpenSearch Service domains use node-to-node encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12182,7 +12182,7 @@ queries:
     title: Ensure Amazon OpenSearch Service domains use TLS 1.2 or higher
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12329,7 +12329,7 @@ queries:
     title: Ensure OpenSearch Service domains have fine-grained access control
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -12499,7 +12499,7 @@ queries:
     title: Ensure Amazon OpenSearch Service domains have audit logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -12658,7 +12658,7 @@ queries:
     title: Ensure Amazon OpenSearch Service domains are deployed within a VPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12815,7 +12815,7 @@ queries:
     title: Ensure OpenSearch Service domains block anonymous authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -12965,7 +12965,7 @@ queries:
     title: Ensure ECR repositories have image scanning on push enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -13107,7 +13107,7 @@ queries:
     title: Ensure ECR repositories have image tag immutability enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -13241,7 +13241,7 @@ queries:
     title: Ensure ECS task definitions do not allow privileged containers
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -13393,7 +13393,7 @@ queries:
     title: Ensure ECS task definitions use read-only root filesystems
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -13558,7 +13558,7 @@ queries:
     title: Ensure ECS task definitions have logging configured for all containers
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -13737,7 +13737,7 @@ queries:
     title: Ensure EFS file systems have automatic backups enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -13878,7 +13878,7 @@ queries:
     title: Ensure Application Load Balancers drop invalid HTTP headers
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14031,7 +14031,7 @@ queries:
     title: Ensure SageMaker notebook instances do not have direct internet access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14183,7 +14183,7 @@ queries:
     title: Ensure Amazon EKS public endpoint is not accessible to 0.0.0.0/0
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14347,7 +14347,7 @@ queries:
     title: Ensure Amazon EKS clusters have deletion protection enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -14494,7 +14494,7 @@ queries:
     title: Ensure CodeBuild projects do not run in privileged mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -14654,7 +14654,7 @@ queries:
     title: Ensure CodeBuild projects do not store plaintext credentials
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -14891,7 +14891,7 @@ queries:
     title: Ensure Neptune DB clusters are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -15050,7 +15050,7 @@ queries:
     title: Ensure Amazon GuardDuty is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -15183,7 +15183,7 @@ queries:
     title: Ensure GuardDuty findings are published at least every 15 minutes
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -15307,7 +15307,7 @@ queries:
     title: Ensure AWS Security Hub is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -15404,7 +15404,7 @@ queries:
     title: Ensure AWS Config recorder is enabled and recording
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -15521,7 +15521,7 @@ queries:
     title: Ensure AWS Config records all supported resource types
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -15660,7 +15660,7 @@ queries:
     title: Ensure Secrets Manager secrets have automatic rotation enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -15782,7 +15782,7 @@ queries:
     title: Ensure Secrets Manager secrets use customer-managed KMS keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -15908,7 +15908,7 @@ queries:
     title: Ensure IAM Access Analyzer is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -16021,7 +16021,7 @@ queries:
     title: Ensure SNS topics are encrypted with KMS
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -16150,7 +16150,7 @@ queries:
     title: Ensure SNS topics use signature version 2 for message verification
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -16274,7 +16274,7 @@ queries:
     title: Ensure SQS queues are encrypted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -16398,7 +16398,7 @@ queries:
     title: Ensure SQS queues have a dead letter queue configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -16539,7 +16539,7 @@ queries:
     title: Ensure ElastiCache clusters have encryption at rest enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -16673,7 +16673,7 @@ queries:
     title: Ensure ElastiCache clusters have encryption in transit enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16805,7 +16805,7 @@ queries:
     title: Ensure ElastiCache Redis clusters require authentication
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -16940,7 +16940,7 @@ queries:
     title: Ensure AWS Backup vaults are encrypted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17062,7 +17062,7 @@ queries:
     title: Ensure FSx file systems are encrypted at rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17191,7 +17191,7 @@ queries:
     title: Ensure Redshift clusters are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17320,7 +17320,7 @@ queries:
     title: Ensure Redshift clusters have audit logging enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -17457,7 +17457,7 @@ queries:
     title: Ensure Redshift clusters use enhanced VPC routing
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17583,7 +17583,7 @@ queries:
     title: Ensure CloudFront distributions use TLS 1.2 or higher
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17716,7 +17716,7 @@ queries:
     title: Ensure CloudFront distributions have WAF web ACL associated
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17840,7 +17840,7 @@ queries:
     title: Ensure RDS snapshots are encrypted at rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17974,7 +17974,7 @@ queries:
     title: Ensure AMIs owned by the account are not publicly shared
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -18113,7 +18113,7 @@ queries:
     title: Ensure ECS task definitions specify a non-root user for containers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -18273,7 +18273,7 @@ queries:
     title: Ensure ECS task definitions enforce transit encryption for EFS volumes
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18454,7 +18454,7 @@ queries:
     title: Ensure CloudWatch log groups have a retention period configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -18588,7 +18588,7 @@ queries:
     title: Ensure Redshift clusters require SSL for connections
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18760,7 +18760,7 @@ queries:
     title: Ensure VPC subnets do not automatically assign public IP addresses
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18904,7 +18904,7 @@ queries:
     title: Ensure EC2 instances have IMDS hop limit set to 1
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -19059,7 +19059,7 @@ queries:
     title: Ensure GuardDuty protection features are enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -19256,7 +19256,7 @@ queries:
     title: Ensure Neptune DB clusters have IAM database authentication enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -19392,7 +19392,7 @@ queries:
     title: Ensure KMS key grants do not include the CreateGrant permission
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -19521,7 +19521,7 @@ queries:
     title: Ensure KMS key grants do not use wildcard principals
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -19644,7 +19644,7 @@ queries:
     title: Ensure customer-managed KMS keys use AWS_KMS origin
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -19801,7 +19801,7 @@ queries:
     title: Ensure CodeBuild projects have SSL verification enabled for source fetches
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19953,7 +19953,7 @@ queries:
     title: Ensure ElastiCache serverless caches use CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -20104,7 +20104,7 @@ queries:
     title: Ensure Amazon Inspector is enabled for EC2 instance scanning
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20202,7 +20202,7 @@ queries:
     title: Ensure Amazon Inspector is enabled for ECR container image scanning
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20299,7 +20299,7 @@ queries:
     title: Ensure Amazon Inspector is enabled for Lambda function scanning
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20396,7 +20396,7 @@ queries:
     title: Ensure SSM SecureString parameters use KMS encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -20515,7 +20515,7 @@ queries:
     title: Ensure DMS replication instances are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20637,7 +20637,7 @@ queries:
     title: Ensure DMS replication instances use encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -20754,7 +20754,7 @@ queries:
     title: Ensure DRS replication configurations use EBS encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -20848,7 +20848,7 @@ queries:
     title: Ensure Amazon Timestream databases use KMS encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -20965,7 +20965,7 @@ queries:
     title: Ensure Timestream InfluxDB instances are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21100,7 +21100,7 @@ queries:
     title: Ensure Timestream InfluxDB instances have log delivery enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -21240,7 +21240,7 @@ queries:
     title: Ensure network ACLs do not allow unrestricted inbound SSH or RDP access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21388,7 +21388,7 @@ queries:
     title: Ensure the default network ACL restricts all traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21488,7 +21488,7 @@ queries:
     title: Ensure EC2 key pairs use ED25519 or RSA key types
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -21605,7 +21605,7 @@ queries:
     title: Ensure RDS database instances have IAM authentication enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -21726,7 +21726,7 @@ queries:
     title: Ensure EBS encryption by default is enabled for EKS node group volumes
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -21868,7 +21868,7 @@ queries:
     title: Ensure EKS clusters use API-based IAM authentication mode
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -22001,7 +22001,7 @@ queries:
     title: Ensure EKS cluster add-ons are in a healthy state
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -22079,7 +22079,7 @@ queries:
     title: Ensure ECS clusters have Container Insights enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -22206,7 +22206,7 @@ queries:
     title: Ensure ECS clusters use KMS encryption for Fargate ephemeral storage
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22331,7 +22331,7 @@ queries:
     title: Ensure ACM certificates use RSA-2048 or higher or ECDSA key algorithms
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22456,7 +22456,7 @@ queries:
     title: Ensure Lambda functions use KMS encryption for environment variables
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22603,7 +22603,7 @@ queries:
     title: Ensure Lambda functions have code signing configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22765,7 +22765,7 @@ queries:
     title: Ensure SageMaker notebook instances use IMDSv2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -22902,7 +22902,7 @@ queries:
     title: Ensure SageMaker notebook instances do not allow root access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -23038,7 +23038,7 @@ queries:
     title: Ensure S3 buckets use KMS customer managed keys for encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -23201,7 +23201,7 @@ queries:
     title: Ensure CodeBuild projects use KMS CMKs for artifact encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -23354,7 +23354,7 @@ queries:
     title: Ensure Neptune DB cluster snapshots are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -23500,7 +23500,7 @@ queries:
     title: Ensure EC2 instances have source/destination check enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23639,7 +23639,7 @@ queries:
     title: Ensure EC2 instances use UEFI boot mode
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -23733,7 +23733,7 @@ queries:
     title: Ensure EC2 instances use HVM virtualization
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -23860,7 +23860,7 @@ queries:
     title: Ensure EBS encryption by default is enabled when EC2 hibernation is in use
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -23969,7 +23969,7 @@ queries:
     title: Ensure Route 53 public hosted zones have DNSSEC signing enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -24089,7 +24089,7 @@ queries:
     title: Ensure Route 53 public hosted zones have query logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24212,7 +24212,7 @@ queries:
     title: Ensure Route 53 health checks are not disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -24352,7 +24352,7 @@ queries:
     title: Ensure Route 53 endpoint health checks use HTTPS
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -24492,7 +24492,7 @@ queries:
     title: Ensure AppStream 2.0 fleets do not have default internet access enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -24637,7 +24637,7 @@ queries:
     title: Ensure AppStream 2.0 fleets enforce a maximum session duration
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -24766,7 +24766,7 @@ queries:
     title: Ensure AppStream 2.0 fleets have idle disconnect timeout configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -24899,7 +24899,7 @@ queries:
     title: Ensure AppStream 2.0 image builders disable default internet access
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -25039,7 +25039,7 @@ queries:
     title: Ensure Directory Service directories use SERVER_2019 or newer
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -25182,7 +25182,7 @@ queries:
     title: Ensure Directory Service directories have SSO enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -25259,7 +25259,7 @@ queries:
     title: Ensure Directory Service Managed AD has RADIUS MFA enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -25367,7 +25367,7 @@ queries:
     title: Ensure DocumentDB clusters are encrypted at rest
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -25517,7 +25517,7 @@ queries:
     title: Ensure DocumentDB clusters are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -25665,7 +25665,7 @@ queries:
     title: Ensure DocumentDB instances have automatic minor version upgrades enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -25803,7 +25803,7 @@ queries:
     title: Ensure DocumentDB instances are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -25967,7 +25967,7 @@ queries:
     title: Ensure Cognito user pools enforce multi-factor authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26109,7 +26109,7 @@ queries:
     title: Ensure Cognito user pools have advanced security features in enforced mode
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -26250,7 +26250,7 @@ queries:
     title: Ensure Cognito identity pools do not allow unauthenticated identities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -26389,7 +26389,7 @@ queries:
     title: Ensure Cognito identity pools disable Basic (Classic) auth flow
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26530,7 +26530,7 @@ queries:
     title: Ensure Route 53 registered domains have transfer lock enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -26637,7 +26637,7 @@ queries:
     title: Ensure Route 53 registered domains have contact privacy protection enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -26751,7 +26751,7 @@ queries:
     title: Ensure Route 53 registered domains have auto-renew enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -26857,7 +26857,7 @@ queries:
     title: Ensure MemoryDB clusters have encryption in transit (TLS) enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26995,7 +26995,7 @@ queries:
     title: Ensure MemoryDB clusters are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27138,7 +27138,7 @@ queries:
     title: Ensure MemoryDB clusters have automatic minor version upgrades enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -27276,7 +27276,7 @@ queries:
     title: Ensure Kinesis data streams have server-side encryption enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27415,7 +27415,7 @@ queries:
     title: Ensure Kinesis data streams are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27559,7 +27559,7 @@ queries:
     title: Ensure Kinesis Firehose delivery streams are encrypted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27715,7 +27715,7 @@ queries:
     title: Ensure Athena workgroups enforce workgroup configuration
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -27857,7 +27857,7 @@ queries:
     title: Ensure Athena workgroups encrypt query results
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28020,7 +28020,7 @@ queries:
     title: Ensure WorkSpaces instances have root and user volume encryption enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28172,7 +28172,7 @@ queries:
     title: Ensure WorkSpaces directories deny web access by default
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -28294,7 +28294,7 @@ queries:
     title: Ensure WorkSpaces directories have maintenance mode enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -28417,7 +28417,7 @@ queries:
     title: Ensure WorkSpaces security groups do not allow unrestricted inbound access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -28535,7 +28535,7 @@ queries:
     title: Ensure Neptune DB instances are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -28672,7 +28672,7 @@ queries:
     title: Ensure OpenSearch domains have automatic software updates enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -28814,7 +28814,7 @@ queries:
     title: Ensure OpenSearch domain custom endpoint certificate is not expiring
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -28935,7 +28935,7 @@ queries:
     title: Ensure Neptune DB clusters are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29088,7 +29088,7 @@ queries:
     title: Ensure Redshift clusters are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29240,7 +29240,7 @@ queries:
     title: Ensure Redshift clusters are on the current maintenance track
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -29384,7 +29384,7 @@ queries:
     title: Ensure FSx file systems are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29540,7 +29540,7 @@ queries:
     title: Ensure OpenSearch domains are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29694,7 +29694,7 @@ queries:
     title: Ensure AWS Glue jobs have a security configuration assigned
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29864,7 +29864,7 @@ queries:
     title: Ensure AWS Glue crawlers have a security configuration assigned
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30014,7 +30014,7 @@ queries:
     title: Ensure AWS Glue Data Catalog encryption at rest is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30186,7 +30186,7 @@ queries:
     title: Ensure AWS Glue security configurations encrypt S3 targets
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30340,7 +30340,7 @@ queries:
     title: Ensure AWS Glue security configurations encrypt CloudWatch logs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30492,7 +30492,7 @@ queries:
     title: Ensure AWS Glue security configurations encrypt job bookmarks
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30644,7 +30644,7 @@ queries:
     title: Ensure AWS Glue jobs use a supported Glue version
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -30784,7 +30784,7 @@ queries:
     title: Ensure Elastic Beanstalk environments use enhanced health reporting
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -30933,7 +30933,7 @@ queries:
     title: Ensure RDS proxies require TLS for client connections
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -31085,7 +31085,7 @@ queries:
     title: Ensure RDS proxies do not have debug logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -31230,7 +31230,7 @@ queries:
     title: Ensure DocumentDB cluster snapshots are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -31338,7 +31338,7 @@ queries:
     title: Ensure MemoryDB snapshots are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -31464,7 +31464,7 @@ queries:
     title: Ensure MemoryDB clusters do not use the default open-access ACL
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -31618,7 +31618,7 @@ queries:
     title: Ensure SNS topic subscriptions use HTTPS protocol
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -31758,7 +31758,7 @@ queries:
     title: Ensure SageMaker models have network isolation enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -31896,7 +31896,7 @@ queries:
     title: Ensure SageMaker models are deployed within a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32045,7 +32045,7 @@ queries:
     title: Ensure SageMaker training jobs have network isolation enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32122,7 +32122,7 @@ queries:
     title: Ensure SageMaker training jobs encrypt inter-container traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32199,7 +32199,7 @@ queries:
     title: Ensure SageMaker training jobs are deployed within a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32276,7 +32276,7 @@ queries:
     title: Ensure SageMaker processing jobs have network isolation enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32350,7 +32350,7 @@ queries:
     title: Ensure SageMaker processing jobs encrypt inter-container traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32423,7 +32423,7 @@ queries:
     title: Ensure SageMaker processing jobs are deployed within a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32496,7 +32496,7 @@ queries:
     title: Ensure SageMaker domains are encrypted with a KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -32654,7 +32654,7 @@ queries:
     title: Ensure SageMaker training hyperparameters do not contain AWS credentials
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -32736,7 +32736,7 @@ queries:
     title: Ensure public-sourced SageMaker hub content includes review documentation
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -32814,7 +32814,7 @@ queries:
     title: Ensure approved SageMaker model packages are validated and documented
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -32892,7 +32892,7 @@ queries:
     title: Ensure SageMaker code repositories reference a Secrets Manager secret
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -33005,7 +33005,7 @@ queries:
     title: Ensure SageMaker monitoring jobs enforce network isolation and encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -33198,7 +33198,7 @@ queries:
     title: Ensure SageMaker domain default execution role is not AdministratorAccess
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -33274,7 +33274,7 @@ queries:
     title: Ensure SageMaker notebook instance IAM role is not AdministratorAccess
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -33345,7 +33345,7 @@ queries:
     title: Ensure SageMaker training/processing job roles are not AdministratorAccess
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -33419,7 +33419,7 @@ queries:
     title: Ensure Amazon MQ brokers have audit logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -33560,7 +33560,7 @@ queries:
     title: Ensure Amazon MQ brokers have general logging enabled
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -33701,7 +33701,7 @@ queries:
     title: Ensure Amazon MQ brokers are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -33845,7 +33845,7 @@ queries:
     title: Ensure MSK clusters use a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -33992,7 +33992,7 @@ queries:
     title: Ensure MSK clusters encrypt data in transit with TLS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34143,7 +34143,7 @@ queries:
     title: Ensure MSK clusters have logging enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -34298,7 +34298,7 @@ queries:
     title: Ensure MSK replicators encrypt data in transit to external Kafka
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34396,7 +34396,7 @@ queries:
     title: Ensure CloudTrail S3 bucket is not publicly accessible
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34504,7 +34504,7 @@ queries:
     title: Ensure CloudTrail S3 bucket has access logging enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -34610,7 +34610,7 @@ queries:
     title: Ensure DynamoDB tables have point-in-time recovery enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -34752,7 +34752,7 @@ queries:
     title: Ensure log metric filter exists for unauthorized API calls
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -34928,7 +34928,7 @@ queries:
     title: Ensure log metric filter exists for console sign-in without MFA
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35104,7 +35104,7 @@ queries:
     title: Ensure log metric filter exists for root account usage
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35280,7 +35280,7 @@ queries:
     title: Ensure log metric filter exists for IAM policy changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35456,7 +35456,7 @@ queries:
     title: Ensure log metric filter exists for CloudTrail config changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35632,7 +35632,7 @@ queries:
     title: Ensure log metric filter exists for console auth failures
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35808,7 +35808,7 @@ queries:
     title: Ensure log metric filter exists for CMK disable or deletion
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -35984,7 +35984,7 @@ queries:
     title: Ensure log metric filter exists for S3 bucket policy changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -36160,7 +36160,7 @@ queries:
     title: Ensure log metric filter exists for AWS Config changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -36336,7 +36336,7 @@ queries:
     title: Ensure log metric filter exists for security group changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -36512,7 +36512,7 @@ queries:
     title: Ensure log metric filter exists for NACL changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -36688,7 +36688,7 @@ queries:
     title: Ensure log metric filter exists for network gateway changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -36864,7 +36864,7 @@ queries:
     title: Ensure log metric filter exists for route table changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -37040,7 +37040,7 @@ queries:
     title: Ensure log metric filter exists for VPC changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -37216,7 +37216,7 @@ queries:
     title: Ensure log metric filter exists for organization changes
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -37392,7 +37392,7 @@ queries:
     title: Ensure security groups do not allow unrestricted egress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -37559,7 +37559,7 @@ queries:
     title: Ensure root account has a hardware MFA device enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -37652,7 +37652,7 @@ queries:
     title: Ensure expired SSL/TLS certificates are removed from IAM
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -37732,7 +37732,7 @@ queries:
     title: Ensure a support role has been created for AWS Support access
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -37889,7 +37889,7 @@ queries:
     title: Ensure unused IAM credentials are disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -38007,7 +38007,7 @@ queries:
     title: Ensure Lambda functions have X-Ray tracing enabled
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -38168,7 +38168,7 @@ queries:
     title: Ensure Lambda permissions specify a source ARN
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -38331,7 +38331,7 @@ queries:
     title: Ensure S3 buckets have MFA delete enabled
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -38479,7 +38479,7 @@ queries:
     title: Ensure Elasticsearch domains enforce HTTPS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -38622,7 +38622,7 @@ queries:
     title: Ensure Elasticsearch domains use TLS 1.2 or higher
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -38767,7 +38767,7 @@ queries:
     title: Ensure Elasticsearch domains have audit logging enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -38913,7 +38913,7 @@ queries:
     title: Ensure EMR clusters have at-rest encryption enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -39090,7 +39090,7 @@ queries:
     title: Ensure EMR clusters have in-transit encryption enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -39253,7 +39253,7 @@ queries:
     title: Ensure EMR clusters have logging enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -39408,7 +39408,7 @@ queries:
     title: Ensure DynamoDB DAX clusters have encryption at rest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -39558,7 +39558,7 @@ queries:
     title: Ensure SQS queues do not allow wildcard access policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -39724,7 +39724,7 @@ queries:
     title: Ensure ECS task definitions do not contain plaintext secrets
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -39859,7 +39859,7 @@ queries:
     title: Ensure the default VPC is not used
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -39939,7 +39939,7 @@ queries:
     title: Ensure EMR clusters have local disk encryption enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -40115,7 +40115,7 @@ queries:
     title: Ensure CloudTrail trails deliver logs to CloudWatch
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -40271,7 +40271,7 @@ queries:
     title: Ensure ElastiCache clusters have backup retention
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -40416,7 +40416,7 @@ queries:
     title: Ensure RDS DB instances have backup retention enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -40559,7 +40559,7 @@ queries:
     title: Ensure RDS instances have Performance Insights enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -40706,7 +40706,7 @@ queries:
     title: Ensure RDS DB instances have deletion protection
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -40849,7 +40849,7 @@ queries:
     title: Ensure RDS DB clusters have deletion protection enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -40994,7 +40994,7 @@ queries:
     title: Ensure ECR repositories use KMS encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -41139,7 +41139,7 @@ queries:
     title: Ensure Neptune clusters have audit log export enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -41278,7 +41278,7 @@ queries:
     title: Ensure DocumentDB clusters have audit log export enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -41430,7 +41430,7 @@ queries:
     title: Ensure AWS Config aggregator is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -41563,7 +41563,7 @@ queries:
     title: Ensure AWS Config aggregator covers all regions
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -41713,7 +41713,7 @@ queries:
     title: Ensure ECR repositories do not allow public access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -41879,7 +41879,7 @@ queries:
     title: Ensure EC2 launch templates do not contain secrets
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -42041,7 +42041,7 @@ queries:
     title: Ensure CloudTrail trails are actively logging
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -42140,7 +42140,7 @@ queries:
     title: Ensure EBS snapshots are not publicly shared
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -42274,7 +42274,7 @@ queries:
     title: Ensure launch configuration EBS volumes are encrypted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -42435,7 +42435,7 @@ queries:
     title: Ensure launch configurations do not assign public IPs
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -42571,7 +42571,7 @@ queries:
     title: Ensure launch configurations enforce IMDSv2
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -42720,7 +42720,7 @@ queries:
     title: Ensure RDS instances use customer-managed KMS encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -42876,7 +42876,7 @@ queries:
     title: Ensure RDS clusters use customer-managed KMS encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -43034,7 +43034,7 @@ queries:
     title: Ensure RDS snapshots use customer-managed KMS encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -43141,7 +43141,7 @@ queries:
     title: Ensure EMR clusters are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -43295,7 +43295,7 @@ queries:
     title: Ensure EMR cluster logs are encrypted with CMK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -43473,7 +43473,7 @@ queries:
     title: Ensure Neptune clusters do not use default security groups
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -43616,7 +43616,7 @@ queries:
     title: Ensure DocumentDB clusters do not use default security groups
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -43763,7 +43763,7 @@ queries:
     title: Ensure Redshift managed passwords use CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -43909,7 +43909,7 @@ queries:
     title: Ensure CloudFront distributions use SNI-only SSL
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -44046,7 +44046,7 @@ queries:
     title: Ensure CloudFront distributions have access logging enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -44183,7 +44183,7 @@ queries:
     title: Ensure DAX clusters enforce encryption in transit
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -44327,7 +44327,7 @@ queries:
     title: Ensure ECS containers enable init process
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -44466,7 +44466,7 @@ queries:
     title: Ensure Lambda functions are deployed within a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -44621,7 +44621,7 @@ queries:
     title: Ensure ECR repository policies restrict access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -44778,7 +44778,7 @@ queries:
     title: Ensure ElastiCache clusters use CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -44927,7 +44927,7 @@ queries:
     title: Ensure Kinesis streams use customer-managed KMS keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -45075,7 +45075,7 @@ queries:
     title: Ensure DynamoDB tables use customer-managed KMS keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -45224,7 +45224,7 @@ queries:
     title: Ensure Keyspaces tables use customer-managed KMS keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -45364,7 +45364,7 @@ queries:
     title: Ensure Keyspaces tables have point-in-time recovery enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -45501,7 +45501,7 @@ queries:
     title: Ensure AppStream stacks have URL redirection disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -45565,7 +45565,7 @@ queries:
     title: Ensure VPC DHCP options use custom DNS servers
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -45710,7 +45710,7 @@ queries:
     title: Ensure VPC endpoints have security groups attached
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -45837,7 +45837,7 @@ queries:
     title: Ensure VPC endpoint services require acceptance
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -45962,7 +45962,7 @@ queries:
     title: Ensure VPC subnets have flow logs enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -46068,7 +46068,7 @@ queries:
     title: Ensure VPC flow logs have an IAM role for CloudWatch delivery
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -46222,7 +46222,7 @@ queries:
     title: Ensure Client VPN endpoints have security groups
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -46366,7 +46366,7 @@ queries:
     title: Ensure managed prefix lists do not contain overly broad CIDRs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -46521,7 +46521,7 @@ queries:
     title: Ensure SSM documents are not publicly shared
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -46635,7 +46635,7 @@ queries:
     title: Ensure SSM patch baselines block rejected patches
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -46774,7 +46774,7 @@ queries:
     title: Ensure SSM maintenance windows do not allow unassociated targets
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -46925,7 +46925,7 @@ queries:
     title: Ensure CloudWatch log destinations restrict access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -47047,7 +47047,7 @@ queries:
     title: Ensure VPC endpoint services restrict allowed principals
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -47160,7 +47160,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -47315,7 +47315,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/soc2-2017: soc2-control-cc6-1-10
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -47468,7 +47468,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -47598,7 +47598,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -47735,7 +47735,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -47867,7 +47867,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -48007,7 +48007,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -48143,7 +48143,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -48267,7 +48267,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -48400,7 +48400,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -48542,7 +48542,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -48649,7 +48649,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -48760,7 +48760,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -48887,7 +48887,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -49056,7 +49056,7 @@ queries:
     title: Ensure EC2 serial console access is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -49155,7 +49155,7 @@ queries:
     title: Ensure AMI block public access is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -49252,7 +49252,7 @@ queries:
     title: Ensure EC2 launch templates require IMDSv2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -49395,7 +49395,7 @@ queries:
     title: Ensure S3 buckets enforce bucket owner ownership
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -49520,7 +49520,7 @@ queries:
     title: Ensure CloudTrail Insights is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -49663,7 +49663,7 @@ queries:
     title: Ensure Security Hub has standards enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -49785,7 +49785,7 @@ queries:
     title: Ensure SNS topics do not allow public access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -49951,7 +49951,7 @@ queries:
     title: Ensure DRS uses private IP for data replication
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50060,7 +50060,7 @@ queries:
     title: Ensure DRS recovery instances have no public IPs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50189,7 +50189,7 @@ queries:
           mondoo.com/filter-title: CloudFormation
           mondoo.com/filter-icon: cloudformation
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -50321,7 +50321,7 @@ queries:
           mondoo.com/filter-title: CloudFormation
           mondoo.com/filter-icon: cloudformation
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -50435,7 +50435,7 @@ queries:
     title: Ensure security groups restrict incoming PostgreSQL traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50584,7 +50584,7 @@ queries:
     title: Ensure security groups restrict incoming MySQL/MariaDB/Aurora traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50721,7 +50721,7 @@ queries:
     title: Ensure security groups restrict incoming Microsoft SQL Server traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50858,7 +50858,7 @@ queries:
     title: Ensure security groups restrict incoming Oracle Database traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -50991,7 +50991,7 @@ queries:
     title: Ensure security groups restrict incoming MongoDB traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51125,7 +51125,7 @@ queries:
     title: Ensure security groups restrict incoming Redis traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51258,7 +51258,7 @@ queries:
     title: Ensure security groups restrict incoming Memcached traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51391,7 +51391,7 @@ queries:
     title: Ensure security groups restrict incoming Elasticsearch/OpenSearch traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51525,7 +51525,7 @@ queries:
     title: Ensure security groups restrict incoming WinRM traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51658,7 +51658,7 @@ queries:
     title: Ensure security groups restrict incoming Docker daemon traffic
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51794,7 +51794,7 @@ queries:
     title: Ensure security groups restrict incoming Kubernetes API server traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -51930,7 +51930,7 @@ queries:
     title: Ensure security groups restrict incoming Kubernetes kubelet traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -52063,7 +52063,7 @@ queries:
     title: Ensure security groups restrict incoming etcd traffic
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -52197,7 +52197,7 @@ queries:
     title: Ensure S3 bucket policies do not grant access to anonymous principals
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -52349,7 +52349,7 @@ queries:
     title: Ensure S3 bucket policies enforce secure transport
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -52543,7 +52543,7 @@ queries:
     title: Ensure S3 buckets disable ACLs by enforcing bucket-owner ownership
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -52659,7 +52659,7 @@ queries:
     title: Ensure SNS topics are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -52794,7 +52794,7 @@ queries:
     title: Ensure SQS queues are encrypted with a customer-managed KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -52920,7 +52920,7 @@ queries:
     title: Ensure customer-built AppStream images are not publicly visible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -52985,7 +52985,7 @@ queries:
     title: Ensure AppStream stack embedHostDomains do not contain wildcards
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53092,7 +53092,7 @@ queries:
     title: Ensure WorkSpaces Web IP access settings exclude public CIDR ranges
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53204,7 +53204,7 @@ queries:
     title: Ensure CloudFront origin mTLS certificates are not expired or expiring
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53270,7 +53270,7 @@ queries:
     title: Ensure CloudFront trust stores contain at least one CA certificate
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53333,7 +53333,7 @@ queries:
     title: Ensure CloudFront distributions to internal origins use origin mTLS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53401,7 +53401,7 @@ queries:
     title: Ensure CloudFront trust stores have been refreshed within the last year
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53469,7 +53469,7 @@ queries:
     title: Ensure Transfer Family connectors use accessRoles without wildcards
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53545,7 +53545,7 @@ queries:
     title: Ensure Transfer Family connectors have a loggingRole configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53653,7 +53653,7 @@ queries:
     title: Ensure Transfer Family Web Apps are not exposed via PUBLIC endpoints
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53715,7 +53715,7 @@ queries:
     title: Ensure Transfer workflows with DECRYPT or COPY define onExceptionSteps
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -53780,7 +53780,7 @@ queries:
     title: Ensure Bedrock custom models use a customer-managed KMS key
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -53895,7 +53895,7 @@ queries:
     title: Ensure WAF Web ACLs include SQLi, XSS, and known-bad input rules
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-02
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -54163,7 +54163,7 @@ queries:
     title: Ensure AWS Batch job definitions do not run privileged containers
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -54255,7 +54255,7 @@ queries:
     title: Ensure AWS Batch job definitions use approved private registries
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -54363,7 +54363,7 @@ queries:
     title: Ensure AWS Batch compute environments use private subnets
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -54434,7 +54434,7 @@ queries:
     title: Ensure AWS Batch job roles avoid wildcard permissions and inline policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
@@ -54508,7 +54508,7 @@ queries:
     title: Ensure Step Functions state machine roles do not allow wildcard resources
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
@@ -54580,7 +54580,7 @@ queries:
     title: Ensure Private CAs use SHA256 or stronger signing algorithms
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -54715,7 +54715,7 @@ queries:
     title: Ensure Private CA private keys use FIPS 140-2 Level 3 HSM-backed storage
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-08
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -54851,7 +54851,7 @@ queries:
     title: Ensure Lightsail instances do not expose sensitive ports to the internet
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -55008,7 +55008,7 @@ queries:
     title: Ensure Lightsail managed databases are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -55112,7 +55112,7 @@ queries:
     title: Ensure API Gateway v2 routes require an authorizer
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -55242,7 +55242,7 @@ queries:
     title: Ensure API Gateway v2 custom domains enforce TLS 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -55374,7 +55374,7 @@ queries:
     title: Ensure Glue Data Catalog encryption uses SSE-KMS with a CMK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -55533,7 +55533,7 @@ queries:
     title: Ensure Glue security configs encrypt bookmarks and S3 outputs with CMK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -55721,7 +55721,7 @@ queries:
     title: Ensure Athena workgroups encrypt query results with a KMS-backed CMK
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -55894,7 +55894,7 @@ queries:
     title: Ensure Lambda function URLs require authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -56013,7 +56013,7 @@ queries:
     title: Ensure API Gateway CORS does not pair wildcard origins with credentials
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -56143,7 +56143,7 @@ queries:
     title: Ensure API Gateway v2 WebSocket routes require authorization
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -56214,7 +56214,7 @@ queries:
     title: Ensure EventBridge event bus policies do not grant public access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -56373,7 +56373,7 @@ queries:
     title: Ensure Glue connections do not store plaintext credentials
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -56479,7 +56479,7 @@ queries:
     title: Ensure Cloud9 EC2 environments use no-ingress SSM connections
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -56572,7 +56572,7 @@ queries:
     title: Ensure Elastic Beanstalk environments expose an HTTPS listener
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -56714,7 +56714,7 @@ queries:
     title: Ensure Route 53 Resolver query logging is associated with VPCs
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -56806,7 +56806,7 @@ queries:
     title: Ensure DynamoDB PITR backups are encrypted with a customer-managed key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -56977,7 +56977,7 @@ queries:
     title: Ensure ElastiCache snapshots are encrypted with a KMS key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -57122,7 +57122,7 @@ queries:
     title: Ensure Kinesis Video Streams use a customer-managed KMS key
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -57220,7 +57220,7 @@ queries:
     title: Ensure EMR Studio workspace storage uses a customer-managed KMS key
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -57361,7 +57361,7 @@ queries:
     title: Ensure DataSync tasks log to an encrypted CloudWatch log group
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -57460,7 +57460,7 @@ queries:
     title: Ensure CloudFront S3 origins are reached via origin access control
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -57630,7 +57630,7 @@ queries:
     title: Ensure ALB and NLB TLS listeners use a TLS 1.2 (or higher) security policy
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -57791,7 +57791,7 @@ queries:
     title: Ensure SQS queue policies enforce secure transport
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -57986,7 +57986,7 @@ queries:
     title: Ensure SNS topic policies enforce secure transport
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58182,7 +58182,7 @@ queries:
     title: Ensure API Gateway v2 WebSocket custom domains require TLS 1.2 or higher
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58292,7 +58292,7 @@ queries:
     title: Ensure DMS endpoints require SSL connections
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58423,7 +58423,7 @@ queries:
     title: Ensure App Mesh virtual node listeners require TLS
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58617,7 +58617,7 @@ queries:
     title: Ensure IoT Core domain configurations require TLS 1.2 or higher
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58724,7 +58724,7 @@ queries:
     title: Ensure Secrets Manager rotation Lambdas run inside a VPC
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -58852,7 +58852,7 @@ queries:
     title: Ensure CodeArtifact domains use a customer-managed KMS key
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -372,7 +372,7 @@ queries:
     title: Ensure Azure VM OS disks are encrypted with CMK
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -626,7 +626,7 @@ queries:
     title: Ensure that SSH access is restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -839,7 +839,7 @@ queries:
     title: Ensure that RDP access is restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1051,7 +1051,7 @@ queries:
     title: Ensure that VNC access is restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1263,7 +1263,7 @@ queries:
     title: Mandate HTTPS for Secure Data Transfer to Azure storage accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1405,7 +1405,7 @@ queries:
     title: Ensure blob anonymous access and storage public access are disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1579,7 +1579,7 @@ queries:
     title: Enforce Deny as Default Network Access for Azure Storage Accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1749,7 +1749,7 @@ queries:
     title: Ensure "Trusted Microsoft Services" have access to Azure storage accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1909,7 +1909,7 @@ queries:
     title: Ensure minimum 30-Day retention for SQL server Audit Logs
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2036,7 +2036,7 @@ queries:
     title: Ensure no SQL Databases allow ingress 0.0.0.0/0 (ANY IP)
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2228,7 +2228,7 @@ queries:
     title: Ensure App Service managed identities are enabled for Entra ID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2408,7 +2408,7 @@ queries:
     title: Ensure Key Vaults are configured with Recovery features
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -2529,7 +2529,7 @@ queries:
     title: Ensure that Web Apps use the latest available version of TLS encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2712,7 +2712,7 @@ queries:
     title: Ensure expiration dates are set for all Key Vault keys and secrets
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2898,7 +2898,7 @@ queries:
     title: Ensure all operations in Azure Key Vault are logged
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3129,7 +3129,7 @@ queries:
     title: Ensure activity log alerts exist for NSG create, update, and delete
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3361,7 +3361,7 @@ queries:
     title: Ensure that "Notify about alerts with high severity" is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3536,7 +3536,7 @@ queries:
     title: Ensure SSL connection enabled for PostgreSQL database servers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3703,7 +3703,7 @@ queries:
     title: Ensure SSL is enabled with latest TLS for MySQL Database Server
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3875,7 +3875,7 @@ queries:
     title: Ensure SQL server public access is disabled or limited to selected networks
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4006,7 +4006,7 @@ queries:
     title: Ensure Key Vault public access is disabled or limited to selected networks
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4144,7 +4144,7 @@ queries:
     title: Ensure that all activities on SQL server are audited
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -4285,7 +4285,7 @@ queries:
     title: Ensure that transparent data encryption is enabled for SQL Server databases
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -4414,7 +4414,7 @@ queries:
     title: Ensure that diagnostic settings exist for the subscription
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -4597,7 +4597,7 @@ queries:
     title: Ensure that diagnostic settings collect essential security categories
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -4827,7 +4827,7 @@ queries:
     title: Ensure direct UDP access to Resources from the internet is restricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5075,7 +5075,7 @@ queries:
     title: Ensure blob soft delete is enabled for Azure Storage accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -5216,7 +5216,7 @@ queries:
     title: Ensure container soft delete is enabled for Azure Storage accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -5357,7 +5357,7 @@ queries:
     title: Ensure Azure Storage accounts enforce minimum TLS 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5491,7 +5491,7 @@ queries:
     title: Ensure threat detection is enabled on Azure SQL servers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5596,7 +5596,7 @@ queries:
     title: Ensure an Entra ID administrator is configured for SQL servers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5709,7 +5709,7 @@ queries:
     title: Ensure Azure Key Vault uses RBAC authorization
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5817,7 +5817,7 @@ queries:
     title: Ensure Key Vault keys have auto-rotation enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5954,7 +5954,7 @@ queries:
     title: Ensure Azure Key Vault has private endpoint connections configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6090,7 +6090,7 @@ queries:
     title: Ensure Azure VM data disks are encrypted with CMK
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6230,7 +6230,7 @@ queries:
     title: Ensure Network Watcher flow logs are enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6376,7 +6376,7 @@ queries:
     title: Ensure Microsoft Defender for Servers is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6504,7 +6504,7 @@ queries:
     title: Ensure Microsoft Defender for App Service is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6631,7 +6631,7 @@ queries:
     title: Ensure Microsoft Defender for Azure SQL Databases is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6758,7 +6758,7 @@ queries:
     title: Ensure Microsoft Defender for Storage is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6885,7 +6885,7 @@ queries:
     title: Ensure Microsoft Defender for Key Vault is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7012,7 +7012,7 @@ queries:
     title: Ensure Microsoft Defender for Containers is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7139,7 +7139,7 @@ queries:
     title: Ensure Microsoft Defender for Resource Manager is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7266,7 +7266,7 @@ queries:
     title: Ensure auto-provisioning of the monitoring agent is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7389,7 +7389,7 @@ queries:
     title: Ensure RBAC is enabled on Azure Kubernetes Service clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7531,7 +7531,7 @@ queries:
     title: Ensure AKS API server has authorized IP ranges configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7685,7 +7685,7 @@ queries:
     title: Ensure AKS clusters have a network policy configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7836,7 +7836,7 @@ queries:
     title: Ensure App Service web apps enforce HTTPS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7983,7 +7983,7 @@ queries:
     title: Ensure App Service FTP basic auth publishing credentials are disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -8132,7 +8132,7 @@ queries:
     title: Ensure App Service SCM basic auth publishing credentials are disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -8281,7 +8281,7 @@ queries:
     title: Ensure Azure Cache for Redis disables the non-SSL port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8398,7 +8398,7 @@ queries:
     title: Ensure Azure Cache for Redis disables public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8514,7 +8514,7 @@ queries:
     title: Ensure AKS clusters are configured as private clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8670,7 +8670,7 @@ queries:
     title: Ensure run command is disabled on AKS clusters
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8826,7 +8826,7 @@ queries:
     title: Ensure Azure Policy add-on is enabled for AKS clusters
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8985,7 +8985,7 @@ queries:
     title: Ensure private AKS clusters do not expose a public FQDN
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -9144,7 +9144,7 @@ queries:
     title: Ensure Microsoft Defender profile is enabled for AKS clusters
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9282,7 +9282,7 @@ queries:
     title: Ensure Image Cleaner is enabled for AKS clusters
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9416,7 +9416,7 @@ queries:
     title: Ensure workload identity is enabled for AKS clusters
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9553,7 +9553,7 @@ queries:
     title: Ensure AKS agent pool nodes have encryption at host enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -9702,7 +9702,7 @@ queries:
     title: Ensure AKS clusters use Azure CNI or overlay networking instead of kubenet
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -9832,7 +9832,7 @@ queries:
     title: Ensure Container Insights monitoring is enabled for AKS clusters
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9965,7 +9965,7 @@ queries:
     title: Ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10097,7 +10097,7 @@ queries:
     title: Ensure client certificate auth is enabled for App Service web apps
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10259,7 +10259,7 @@ queries:
     title: Ensure remote debugging is disabled for App Service web apps
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10424,7 +10424,7 @@ queries:
     title: Ensure HTTP 2.0 is enabled for App Service web apps
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10587,7 +10587,7 @@ queries:
     title: Ensure App Service apps require FTPS for file deployment
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -10739,7 +10739,7 @@ queries:
     title: Ensure App Service apps do not allow CORS access from all origins
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10903,7 +10903,7 @@ queries:
     title: Ensure Azure Function apps have authentication enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11052,7 +11052,7 @@ queries:
     title: Ensure Azure Function apps use private endpoints
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11206,7 +11206,7 @@ queries:
     title: Ensure Azure Cache for Redis uses minimum TLS version 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11334,7 +11334,7 @@ queries:
     title: Ensure Azure Cache for Redis uses a supported version
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11463,7 +11463,7 @@ queries:
     title: Ensure Azure Cache for Redis requires authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11581,7 +11581,7 @@ queries:
     title: Ensure cross-tenant replication is disabled for Azure Storage accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11729,7 +11729,7 @@ queries:
     title: Ensure SFTP is disabled on Azure Storage accounts unless required
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11877,7 +11877,7 @@ queries:
     title: Ensure shared key access is disabled for Azure Storage accounts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -12025,7 +12025,7 @@ queries:
     title: Ensure virtual machines do not have public IP addresses directly attached
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12212,7 +12212,7 @@ queries:
     title: Ensure virtual machines use managed disks
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -12398,7 +12398,7 @@ queries:
     title: Ensure unattached disks are encrypted with Customer Managed Keys
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -12557,7 +12557,7 @@ queries:
     title: Ensure DDoS Protection is enabled on virtual networks
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12729,7 +12729,7 @@ queries:
     title: Ensure VM protection is enabled on virtual networks
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12879,7 +12879,7 @@ queries:
     title: Ensure default outbound access is disabled on subnets
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13028,7 +13028,7 @@ queries:
     title: Ensure database ports are restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13249,7 +13249,7 @@ queries:
     title: Ensure Microsoft Defender for Cosmos DB is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -13389,7 +13389,7 @@ queries:
     title: Ensure Microsoft Defender for open-source relational databases is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -13529,7 +13529,7 @@ queries:
     title: Ensure Microsoft Defender Cloud Security Posture Management is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -13671,7 +13671,7 @@ queries:
     title: Ensure public network access is disabled for Azure Cosmos DB accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13816,7 +13816,7 @@ queries:
     title: Ensure local authentication is disabled for Azure Cosmos DB accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -13961,7 +13961,7 @@ queries:
     title: Ensure virtual network filtering is enabled for Azure Cosmos DB accounts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14118,7 +14118,7 @@ queries:
     title: Ensure key-based metadata write access is disabled for Cosmos DB
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -14262,7 +14262,7 @@ queries:
     title: Ensure automatic failover is enabled for Azure Cosmos DB accounts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -14415,7 +14415,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts use minimum TLS version 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14559,7 +14559,7 @@ queries:
     title: Ensure Azure Cosmos DB network ACL bypass is set to None
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14703,7 +14703,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts use customer-managed keys for encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -14848,7 +14848,7 @@ queries:
     title: Ensure public Cosmos DB accounts have IP firewall rules configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14987,7 +14987,7 @@ queries:
     title: Ensure Cosmos DB accounts have private endpoints configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -15084,7 +15084,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts do not allow wildcard CORS origins
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -15228,7 +15228,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts use continuous backup policy
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -15363,7 +15363,7 @@ queries:
     title: Ensure multi-region Cosmos DB accounts have multi-region write enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -15505,7 +15505,7 @@ queries:
     title: Ensure Azure Cosmos DB accounts use bounded staleness or strong consistency
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -15640,7 +15640,7 @@ queries:
     title: Ensure Azure Firewall threat intelligence is set to Deny mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -15791,7 +15791,7 @@ queries:
     title: Ensure Azure Firewall uses Premium SKU for advanced threat protection
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -15938,7 +15938,7 @@ queries:
     title: Ensure Azure Firewall has a firewall policy attached
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16108,7 +16108,7 @@ queries:
     title: Ensure Azure Firewall Policy has IDPS set to Deny mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16267,7 +16267,7 @@ queries:
     title: Ensure public network access is disabled for Azure Batch accounts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16411,7 +16411,7 @@ queries:
     title: Ensure Azure Batch accounts use Entra ID authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -16566,7 +16566,7 @@ queries:
     title: Ensure Azure Batch accounts use customer-managed encryption keys
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -16726,7 +16726,7 @@ queries:
     title: Ensure Azure Batch accounts have diagnostic settings enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -16892,7 +16892,7 @@ queries:
     title: Ensure Azure Batch accounts have private endpoint connections configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17057,7 +17057,7 @@ queries:
     title: Ensure Azure Batch pools have disk encryption enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17226,7 +17226,7 @@ queries:
     title: Ensure Azure SQL servers enforce minimal TLS version 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17329,7 +17329,7 @@ queries:
     title: Ensure PostgreSQL flexible servers disable public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17434,7 +17434,7 @@ queries:
     title: Ensure PostgreSQL flexible servers enforce customer-managed key encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17552,7 +17552,7 @@ queries:
     title: Ensure PostgreSQL servers enforce minimum TLS version 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17651,7 +17651,7 @@ queries:
     title: Ensure MySQL flexible servers disable public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17757,7 +17757,7 @@ queries:
     title: Ensure MySQL flexible servers enforce customer-managed key encryption
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17875,7 +17875,7 @@ queries:
     title: Ensure MySQL servers enforce minimum TLS version 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17974,7 +17974,7 @@ queries:
     title: Ensure Microsoft Defender for SQL Servers on Machines is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -18091,7 +18091,7 @@ queries:
     title: Ensure AKS clusters have disk CSI driver enabled for node pool encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -18229,7 +18229,7 @@ queries:
     title: Ensure Application Gateways enforce TLS 1.2 or higher
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18385,7 +18385,7 @@ queries:
     title: Ensure VPN gateways use route-based type for IKEv2 protocol support
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18534,7 +18534,7 @@ queries:
     title: Ensure Azure Databricks workspaces disable public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18667,7 +18667,7 @@ queries:
     title: Ensure Microsoft Defender for Endpoint integration is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -18793,7 +18793,7 @@ queries:
     title: Ensure Microsoft Defender for APIs is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -18916,7 +18916,7 @@ queries:
     title: Ensure App Service web apps use a strong minimum TLS cipher suite
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19066,7 +19066,7 @@ queries:
     title: Ensure end-to-end encryption is enabled for App Service web apps
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19144,7 +19144,7 @@ queries:
     title: Ensure AKS clusters have node OS auto-upgrade enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -19283,7 +19283,7 @@ queries:
     title: Ensure local accounts are disabled on AKS clusters
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -19434,7 +19434,7 @@ queries:
     title: Ensure public network access is disabled on AKS clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19592,7 +19592,7 @@ queries:
     title: Ensure AKS clusters have auto-upgrade enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -19727,7 +19727,7 @@ queries:
     title: Ensure password-only auth is disabled on PostgreSQL flexible servers
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -19833,7 +19833,7 @@ queries:
     title: Ensure Azure Storage accounts only allow SMB 3.0 and later
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19974,7 +19974,7 @@ queries:
     title: Ensure Azure Storage accounts use strong SMB channel encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20115,7 +20115,7 @@ queries:
     title: Ensure VPN gateways use Generation2 for stronger cryptographic standards
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20264,7 +20264,7 @@ queries:
     title: Ensure public network access is disabled for Azure managed disks
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21139,7 +21139,7 @@ queries:
     title: Ensure AKS node resource group access is restricted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -21276,7 +21276,7 @@ queries:
     title: Ensure AKS uses WireGuard for transit encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21363,7 +21363,7 @@ queries:
     title: Ensure AKS etcd is encrypted with Key Vault KMS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -21496,7 +21496,7 @@ queries:
     title: Ensure App Service has SSH access disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21566,7 +21566,7 @@ queries:
     title: Ensure App Service disables public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21687,7 +21687,7 @@ queries:
     title: Ensure App Service SCM endpoint uses TLS 1.2+
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21812,7 +21812,7 @@ queries:
     title: Ensure App Service routes all traffic through VNet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21941,7 +21941,7 @@ queries:
     title: Ensure App Service IP restrictions default to deny
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22087,7 +22087,7 @@ queries:
     title: Ensure storage accounts use customer-managed keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22234,7 +22234,7 @@ queries:
     title: Ensure SQL Server uses Azure AD-only authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -22365,7 +22365,7 @@ queries:
     title: Ensure SQL Server TDE uses customer-managed keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22483,7 +22483,7 @@ queries:
     title: Ensure PostgreSQL Flexible Server uses CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22619,7 +22619,7 @@ queries:
     title: Ensure PostgreSQL Flexible Server has geo-redundant backup
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -22744,7 +22744,7 @@ queries:
     title: Ensure MySQL Flexible Server uses CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -22880,7 +22880,7 @@ queries:
     title: Ensure Azure Cache for Redis uses CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -23039,7 +23039,7 @@ queries:
     title: Ensure Application Gateway enforces TLS 1.2+
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23178,7 +23178,7 @@ queries:
     title: Ensure Application Gateway has no weak SSL ciphers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23327,7 +23327,7 @@ queries:
     title: Ensure public IP addresses have DDoS protection
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23470,7 +23470,7 @@ queries:
     title: Ensure NSG rules do not allow unrestricted egress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23651,7 +23651,7 @@ queries:
     title: Ensure network interface IP forwarding is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23785,7 +23785,7 @@ queries:
     title: Ensure sensitive ports are not exposed to the entire network
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -23973,7 +23973,7 @@ queries:
     title: Ensure password authentication is disabled on Linux VMs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -24120,7 +24120,7 @@ queries:
     title: Ensure PostgreSQL 'log_connections' is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24234,7 +24234,7 @@ queries:
     title: Ensure PostgreSQL 'log_checkpoints' is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24349,7 +24349,7 @@ queries:
     title: Ensure PostgreSQL 'connection_throttling' is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -24463,7 +24463,7 @@ queries:
     title: Ensure SQL audit log retention is at least 90 days
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24584,7 +24584,7 @@ queries:
     title: Ensure SQL threat alert email addresses are configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24706,7 +24706,7 @@ queries:
     title: Ensure SQL threat detection types are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24824,7 +24824,7 @@ queries:
     title: Ensure activity log retention is at least 365 days
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24969,7 +24969,7 @@ queries:
     title: Ensure activity logs capture events from all locations
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -25111,7 +25111,7 @@ queries:
     title: Ensure log profile captures all activity categories
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -25256,7 +25256,7 @@ queries:
     title: Ensure security contact notification emails are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -25375,7 +25375,7 @@ queries:
     title: Ensure security contacts are enabled and active
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -25493,7 +25493,7 @@ queries:
     title: Ensure custom RBAC roles use least privilege actions
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -25643,7 +25643,7 @@ queries:
     title: Ensure custom roles do not allow role creation
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -25791,7 +25791,7 @@ queries:
     title: Ensure Queue Services logging is enabled for storage
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -25930,7 +25930,7 @@ queries:
     title: Ensure Data Factory disables public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26051,7 +26051,7 @@ queries:
     title: Ensure Data Factory uses customer-managed key encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -26192,7 +26192,7 @@ queries:
     title: Ensure Data Factory uses managed identity
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26317,7 +26317,7 @@ queries:
     title: Ensure Synapse Analytics disables public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26451,7 +26451,7 @@ queries:
     title: Ensure Synapse Analytics uses managed virtual network
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26589,7 +26589,7 @@ queries:
     title: Ensure Synapse uses Azure AD-only authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26735,7 +26735,7 @@ queries:
     title: Ensure Synapse uses customer-managed key encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -26885,7 +26885,7 @@ queries:
     title: Ensure ACR admin user is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27019,7 +27019,7 @@ queries:
     title: Ensure ACR public network access is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -27153,7 +27153,7 @@ queries:
     title: Ensure ACR content trust is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -27285,7 +27285,7 @@ queries:
     title: Ensure ACR uses customer-managed key encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27455,7 +27455,7 @@ queries:
     title: Ensure ACR network rule default action is Deny
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -27600,7 +27600,7 @@ queries:
     title: Ensure ACR has private endpoint connections configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -27770,7 +27770,7 @@ queries:
     title: Ensure ACR quarantine policy is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -27898,7 +27898,7 @@ queries:
     title: Ensure ACR export policy is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -28031,7 +28031,7 @@ queries:
     title: Ensure ACR retention policy is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -28162,7 +28162,7 @@ queries:
     title: Ensure ACR encryption key auto-rotation is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28336,7 +28336,7 @@ queries:
     title: Ensure storage encryption scopes use customer-managed keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28488,7 +28488,7 @@ queries:
     title: Ensure storage encryption scopes require infra encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28624,7 +28624,7 @@ queries:
     title: Ensure disk encryption sets use customer-managed keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28775,7 +28775,7 @@ queries:
     title: Ensure disk encryption sets have auto key rotation enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28918,7 +28918,7 @@ queries:
     title: Ensure Managed HSM has soft delete enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -29060,7 +29060,7 @@ queries:
     title: Ensure Managed HSM has purge protection enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -29206,7 +29206,7 @@ queries:
     title: Ensure Managed HSM public network access is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29347,7 +29347,7 @@ queries:
     title: Ensure Managed HSM has private endpoints configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29520,7 +29520,7 @@ queries:
     title: Ensure disk access resources have private endpoints
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29707,7 +29707,7 @@ queries:
     title: Ensure Log Analytics workspaces disable local authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -29849,7 +29849,7 @@ queries:
     title: Ensure Log Analytics workspaces disable public ingestion
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29982,7 +29982,7 @@ queries:
     title: Ensure Log Analytics workspaces disable public query access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -30114,7 +30114,7 @@ queries:
     title: Ensure Log Analytics workspaces enforce CMK for queries
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30250,7 +30250,7 @@ queries:
     title: Ensure Recovery Services Vaults have soft delete enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -30391,7 +30391,7 @@ queries:
     title: Ensure Recovery Services Vaults have immutability enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -30535,7 +30535,7 @@ queries:
     title: Ensure Recovery Services Vaults have enhanced security
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -30630,7 +30630,7 @@ queries:
     title: Ensure Recovery Services Vaults disable public access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -30762,7 +30762,7 @@ queries:
     title: Ensure Recovery Services Vaults have private endpoints
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -30931,7 +30931,7 @@ queries:
     title: Ensure Recovery Services Vaults use CMK encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -31094,7 +31094,7 @@ queries:
     title: Ensure Recovery Services Vaults alert on job failures
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -31240,7 +31240,7 @@ queries:
     title: Ensure Recovery Services Vaults have backup policies
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -31432,7 +31432,7 @@ queries:
     title: Ensure Recovery Vaults alert on critical operations
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -31578,7 +31578,7 @@ queries:
     title: Ensure Service Bus namespaces disable local authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -31706,7 +31706,7 @@ queries:
     title: Ensure Event Hubs namespaces disable local authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -31834,7 +31834,7 @@ queries:
     title: Ensure Event Hubs namespaces enforce TLS 1.2 or higher
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -31960,7 +31960,7 @@ queries:
     title: Ensure Function Apps enforce HTTPS-only traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32089,7 +32089,7 @@ queries:
     title: Ensure Function Apps require client certificates
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -32220,7 +32220,7 @@ queries:
     title: Ensure Function Apps use managed identity
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -32353,7 +32353,7 @@ queries:
     title: Ensure private DNS zones restrict auto-registration
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32487,7 +32487,7 @@ queries:
     title: Ensure Front Door origins use HTTPS only
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -32575,7 +32575,7 @@ queries:
     title: Ensure Azure SQL Server auditing has a log destination configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -32710,7 +32710,7 @@ queries:
     title: Ensure auditing is enabled for every Azure SQL database
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -32839,7 +32839,7 @@ queries:
     title: Ensure DevOps auditing is enabled on Azure SQL Server
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -32965,7 +32965,7 @@ queries:
     title: Ensure MySQL Flexible Server geo-redundant backup uses CMK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -33120,7 +33120,7 @@ queries:
     title: Ensure Container Apps enforce HTTPS for ingress traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -33296,7 +33296,7 @@ queries:
     title: Ensure Container Apps pull images using managed identity
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -33485,7 +33485,7 @@ queries:
     title: Ensure Container Apps pin container images by digest
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -33646,7 +33646,7 @@ queries:
     title: Ensure Container Instances pull images from Azure Container Registry
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -33848,7 +33848,7 @@ queries:
     title: Ensure Service Bus namespaces disable public network access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -33987,7 +33987,7 @@ queries:
     title: Ensure Event Hubs namespaces disable public network access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34126,7 +34126,7 @@ queries:
     title: Ensure Function Apps disable public network access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34266,7 +34266,7 @@ queries:
     title: Ensure Azure AI Search services disable public network access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34391,7 +34391,7 @@ queries:
     title: Ensure API Management uses VNet integration
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34544,7 +34544,7 @@ queries:
     title: Ensure App Configuration stores disable public network access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34670,7 +34670,7 @@ queries:
     title: Ensure Cognitive Services accounts disable public network access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34797,7 +34797,7 @@ queries:
     title: Ensure Application Gateways have at least one private frontend
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -34988,7 +34988,7 @@ queries:
     title: Ensure Service Bus namespaces use customer-managed encryption keys
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35150,7 +35150,7 @@ queries:
     title: Ensure Event Hubs namespaces use customer-managed encryption keys
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35313,7 +35313,7 @@ queries:
     title: Ensure Azure AI Search services enforce customer-managed key encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35444,7 +35444,7 @@ queries:
     title: Ensure App Configuration stores use customer-managed encryption keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35593,7 +35593,7 @@ queries:
     title: Ensure Function Apps reference a managed identity for Key Vault access
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35748,7 +35748,7 @@ queries:
     title: Ensure Log Analytics workspaces use a CMK-enabled dedicated cluster
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -35918,7 +35918,7 @@ queries:
     title: Ensure Service Bus namespaces enforce TLS 1.2 or higher
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -36046,7 +36046,7 @@ queries:
     title: Ensure Function Apps enforce minimum TLS 1.2 on the site
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -36182,7 +36182,7 @@ queries:
     title: Ensure API Management gateway disables TLS 1.0 and TLS 1.1
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -36360,7 +36360,7 @@ queries:
     title: Ensure VPN gateway connections use IKEv2 and strong IPsec ciphers
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -52,7 +52,7 @@ queries:
     title: Ensure SSL certificates are not expired
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -119,7 +119,7 @@ queries:
     title: Ensure SSL certificates use strong key sizes
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -180,7 +180,7 @@ queries:
     title: Ensure SSL keys use strong key sizes
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -243,7 +243,7 @@ queries:
     title: Ensure client SSL profiles use secure ciphers
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -312,7 +312,7 @@ queries:
     title: Ensure server SSL profiles use secure ciphers
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -374,7 +374,7 @@ queries:
     title: Ensure server SSL profiles authenticate backend servers
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -437,7 +437,7 @@ queries:
     title: Ensure VLAN source checking is enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -498,7 +498,7 @@ queries:
     title: Ensure route domains use strict isolation
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -561,7 +561,7 @@ queries:
     title: Ensure SNMP allowed addresses are restricted
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -56,7 +56,7 @@ queries:
     title: Ensure /etc/chef/ is owned by root with 750 permissions
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -132,7 +132,7 @@ queries:
     title: Ensure /var/chef/ is owned by root with 750 permissions
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -208,7 +208,7 @@ queries:
     title: Ensure /var/log/chef/ is owned by root with 750 permissions
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -285,7 +285,7 @@ queries:
     title: Ensure /etc/chef/client.rb is owned by root with 640 permissions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -363,7 +363,7 @@ queries:
     title: Ensure /etc/chef/client.pem is owned by root with 640 permissions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -446,7 +446,7 @@ queries:
     title: Ensure /etc/chef/validation.pem is not present
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -513,7 +513,7 @@ queries:
     title: Ensure a non-EOL Chef Infra Client or Cinc Client release is used
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -608,7 +608,7 @@ queries:
     title: Disable support for less secure Encrypted Data Bag versions
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -681,7 +681,7 @@ queries:
     title: Avoid storing Automate tokens in the client.rb config
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -764,7 +764,7 @@ queries:
     title: Ensure SSL verification is not disabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -61,7 +61,7 @@ queries:
     title: Ensure /etc/opscode/ is owned by root:root with 755 permissions
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -137,7 +137,7 @@ queries:
     title: Ensure pivotal.pem has correct ownership and 600 permissions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -217,7 +217,7 @@ queries:
     title: Ensure private-chef-secrets.json has correct ownership and 600 perms
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -302,7 +302,7 @@ queries:
     title: Ensure webui_priv.pem has correct ownership and 600 permissions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -383,7 +383,7 @@ queries:
     title: Ensure chef-server.rb has correct ownership and 640 permissions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -468,7 +468,7 @@ queries:
     title: Ensure a non-EOL Chef Infra Server release is used
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -528,7 +528,7 @@ queries:
     title: Ensure EOL Reporting add-on package is not installed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -598,7 +598,7 @@ queries:
     title: Ensure EOL Push Jobs Server add-on package is not installed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -671,7 +671,7 @@ queries:
     title: Ensure EOL Analytics add-on package is not installed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -743,7 +743,7 @@ queries:
     title: Ensure EOL Chef HA add-on package is not installed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -816,7 +816,7 @@ queries:
     title: Ensure TLS versions before 1.2 are disabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -904,7 +904,7 @@ queries:
     title: Disable insecure_addon_compat feature
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -989,7 +989,7 @@ queries:
     title: Ensure embedded PostgreSQL is not bound to external interfaces
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1028,7 +1028,7 @@ queries:
     title: Ensure embedded search is not bound to external interfaces
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1066,7 +1066,7 @@ queries:
     title: Remediate against CVE-2023-28864
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -112,7 +112,7 @@ queries:
     title: Ensure SSH is enabled
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -161,7 +161,7 @@ queries:
     title: Ensure SSH version 2 is configured
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -207,7 +207,7 @@ queries:
     title: Ensure SSH timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -253,7 +253,7 @@ queries:
     title: Ensure RSA key is at least 2048 bits
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -298,7 +298,7 @@ queries:
     title: Ensure AAA new model is enabled
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -345,7 +345,7 @@ queries:
     title: Ensure AAA authentication login is configured
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -394,7 +394,7 @@ queries:
     title: Ensure AAA accounting is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -441,7 +441,7 @@ queries:
     title: Ensure users use secret instead of password
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -495,7 +495,7 @@ queries:
     title: Ensure enable secret is configured (not enable password)
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -542,7 +542,7 @@ queries:
     title: Ensure service password encryption is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -588,7 +588,7 @@ queries:
     title: Ensure HTTP server is disabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -634,7 +634,7 @@ queries:
     title: Ensure HTTPS server is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -679,7 +679,7 @@ queries:
     title: Ensure CDP is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -725,7 +725,7 @@ queries:
     title: Ensure BOOTP service is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -770,7 +770,7 @@ queries:
     title: Ensure IP source routing is disabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -816,7 +816,7 @@ queries:
     title: Ensure PAD service is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -861,7 +861,7 @@ queries:
     title: Ensure NTP authentication is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -910,7 +910,7 @@ queries:
     title: Ensure NTP servers are configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -957,7 +957,7 @@ queries:
     title: Ensure configuration change logging is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1005,7 +1005,7 @@ queries:
     title: Ensure remote logging hosts are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1053,7 +1053,7 @@ queries:
     title: Ensure failed login logging is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1099,7 +1099,7 @@ queries:
     title: Ensure SNMP does not use default community strings
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1150,7 +1150,7 @@ queries:
     title: Ensure SNMP communities have ACLs applied
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1197,7 +1197,7 @@ queries:
     title: Ensure VTY lines use SSH transport only
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1247,7 +1247,7 @@ queries:
     title: Ensure VTY exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1296,7 +1296,7 @@ queries:
     title: Ensure VTY lines have ACLs configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1344,7 +1344,7 @@ queries:
     title: Ensure auxiliary line has exec disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1391,7 +1391,7 @@ queries:
     title: Ensure console exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1437,7 +1437,7 @@ queries:
     title: Ensure a login banner is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1483,7 +1483,7 @@ queries:
     title: Ensure MOTD banner is configured
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1528,7 +1528,7 @@ queries:
     title: Ensure hostname is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1576,7 +1576,7 @@ queries:
     title: Ensure domain name is configured
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1622,7 +1622,7 @@ queries:
     title: Ensure TCP keepalives-in is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1667,7 +1667,7 @@ queries:
     title: Ensure TCP keepalives-out is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1712,7 +1712,7 @@ queries:
     title: Ensure BGP neighbors have authentication configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1760,7 +1760,7 @@ queries:
     title: Ensure OSPF areas have authentication configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -99,7 +99,7 @@ queries:
     title: Ensure SSH version 2 is configured
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -147,7 +147,7 @@ queries:
     title: Ensure SSH session timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -195,7 +195,7 @@ queries:
     title: Ensure RSA key is at least 2048 bits
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -240,7 +240,7 @@ queries:
     title: Ensure AAA authentication login is configured
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -290,7 +290,7 @@ queries:
     title: Ensure AAA accounting is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -339,7 +339,7 @@ queries:
     title: Ensure AAA authorization is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -388,7 +388,7 @@ queries:
     title: Ensure line authentication is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -438,7 +438,7 @@ queries:
     title: Ensure all users have encrypted passwords
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -489,7 +489,7 @@ queries:
     title: Ensure password policies are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -548,7 +548,7 @@ queries:
     title: Ensure Type 6 password encryption is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -597,7 +597,7 @@ queries:
     title: Ensure NTP authentication is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -648,7 +648,7 @@ queries:
     title: Ensure NTP servers are configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -698,7 +698,7 @@ queries:
     title: Ensure logging is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -749,7 +749,7 @@ queries:
     title: Ensure remote syslog hosts are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -798,7 +798,7 @@ queries:
     title: Ensure logging buffer is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -845,7 +845,7 @@ queries:
     title: Ensure SNMP does not use default community strings
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -900,7 +900,7 @@ queries:
     title: Ensure SNMPv3 users are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -948,7 +948,7 @@ queries:
     title: Ensure SNMP communities have ACLs applied
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -999,7 +999,7 @@ queries:
     title: Ensure a login banner is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1048,7 +1048,7 @@ queries:
     title: Ensure console exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1097,7 +1097,7 @@ queries:
     title: Ensure hostname is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1146,7 +1146,7 @@ queries:
     title: Ensure CDP is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1193,7 +1193,7 @@ queries:
     title: Ensure small servers are disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1245,7 +1245,7 @@ queries:
     title: Ensure VTY lines use SSH transport only
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1297,7 +1297,7 @@ queries:
     title: Ensure VTY lines have ACLs configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1347,7 +1347,7 @@ queries:
     title: Ensure BGP neighbors have authentication configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1400,7 +1400,7 @@ queries:
     title: Ensure OSPF areas have authentication configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -109,7 +109,7 @@ queries:
     title: Ensure SSH key uses a strong algorithm
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -161,7 +161,7 @@ queries:
     title: Ensure SSH RSA key is at least 2048 bits
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -208,7 +208,7 @@ queries:
     title: Ensure SSH login attempts limit is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -255,7 +255,7 @@ queries:
     title: Ensure AAA authentication login is configured
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -303,7 +303,7 @@ queries:
     title: Ensure AAA group servers are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -351,7 +351,7 @@ queries:
     title: Ensure password strength check is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -397,7 +397,7 @@ queries:
     title: Ensure encryption service is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -445,7 +445,7 @@ queries:
     title: Ensure all users have encrypted credentials
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -499,7 +499,7 @@ queries:
     title: Ensure minimum passphrase length is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -545,7 +545,7 @@ queries:
     title: Ensure system login block is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -594,7 +594,7 @@ queries:
     title: Ensure NTP servers are configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -641,7 +641,7 @@ queries:
     title: Ensure timezone is configured
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -686,7 +686,7 @@ queries:
     title: Ensure remote logging servers are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -734,7 +734,7 @@ queries:
     title: Ensure logging timestamps are configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -780,7 +780,7 @@ queries:
     title: Ensure logging source interface is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -826,7 +826,7 @@ queries:
     title: Ensure SNMP does not use default community strings
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -875,7 +875,7 @@ queries:
     title: Ensure SNMPv3 encryption is enforced globally
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -921,7 +921,7 @@ queries:
     title: Ensure SNMP communities have ACLs applied
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -970,7 +970,7 @@ queries:
     title: Ensure POAP is disabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1016,7 +1016,7 @@ queries:
     title: Ensure CoPP uses a strict profile
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1063,7 +1063,7 @@ queries:
     title: Ensure VTY exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1112,7 +1112,7 @@ queries:
     title: Ensure console exec timeout is configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1160,7 +1160,7 @@ queries:
     title: Ensure VTY lines have ACLs configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1208,7 +1208,7 @@ queries:
     title: Ensure MOTD banner is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1254,7 +1254,7 @@ queries:
     title: Ensure exec banner is configured
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1299,7 +1299,7 @@ queries:
     title: Ensure hostname is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1347,7 +1347,7 @@ queries:
     title: Ensure IP source routing is disabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1392,7 +1392,7 @@ queries:
     title: Ensure IP directed broadcast is disabled on interfaces
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1440,7 +1440,7 @@ queries:
     title: Ensure BGP neighbors have authentication configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1491,7 +1491,7 @@ queries:
     title: Ensure BGP log neighbor changes is enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1540,7 +1540,7 @@ queries:
     title: Ensure OSPF interfaces use authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -64,7 +64,7 @@ queries:
     title: Ensure SSL/TLS encryption is not disabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -118,7 +118,7 @@ queries:
     title: Ensure SSL/TLS encryption mode is Full (Strict)
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -175,7 +175,7 @@ queries:
     title: Ensure Always Use HTTPS is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -230,7 +230,7 @@ queries:
     title: Ensure minimum TLS version is 1.2 or higher
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -286,7 +286,7 @@ queries:
     title: Ensure TLS 1.3 is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -339,7 +339,7 @@ queries:
     title: Ensure Automatic HTTPS Rewrites is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -393,7 +393,7 @@ queries:
     title: Ensure Web Application Firewall (WAF) is enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -449,7 +449,7 @@ queries:
     title: Ensure security level is not set to essentially off
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -504,7 +504,7 @@ queries:
     title: Ensure Browser Integrity Check is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -556,7 +556,7 @@ queries:
     title: Ensure Email Address Obfuscation is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -608,7 +608,7 @@ queries:
     title: Ensure Hotlink Protection is enabled
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -663,7 +663,7 @@ queries:
     title: Ensure Opportunistic Encryption is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -717,7 +717,7 @@ queries:
     title: Ensure two-factor authentication is enforced on the account
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -774,7 +774,7 @@ queries:
     title: Ensure DNSSEC is active on every zone
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -830,7 +830,7 @@ queries:
     title: Ensure HSTS is enabled on every zone
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -885,7 +885,7 @@ queries:
     title: Ensure HSTS max-age is at least one year on HSTS-enabled zones
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -941,7 +941,7 @@ queries:
     title: Ensure HSTS includes subdomains on HSTS-enabled zones
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -996,7 +996,7 @@ queries:
     title: Ensure HSTS preload is enabled on HSTS-enabled zones
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1053,7 +1053,7 @@ queries:
     title: Ensure R2 buckets are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1109,7 +1109,7 @@ queries:
     title: Ensure API tokens have an expiration set
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1173,7 +1173,7 @@ queries:
     title: Ensure API tokens have an IP allowlist configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1228,7 +1228,7 @@ queries:
     title: Ensure active API tokens have been rotated within the last 365 days
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -95,7 +95,7 @@ queries:
     title: Ensure the DigitalOcean account email is verified
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -134,7 +134,7 @@ queries:
     title: Ensure Droplets are deployed inside a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -191,7 +191,7 @@ queries:
     title: Ensure every Droplet is covered by a Cloud Firewall
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -243,7 +243,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound SSH (port 22)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -300,7 +300,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound RDP (port 3389)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -355,7 +355,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound on common database ports
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -414,7 +414,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound on all ports
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -468,7 +468,7 @@ queries:
     title: Ensure managed databases restrict access via Trusted Sources
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -516,7 +516,7 @@ queries:
     title: Ensure managed databases are attached to a private network
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -564,7 +564,7 @@ queries:
     title: Ensure managed database engines are not running an EOL version
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -655,7 +655,7 @@ queries:
     title: Ensure load balancers redirect HTTP traffic to HTTPS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -703,7 +703,7 @@ queries:
     title: Ensure load balancers are deployed inside a VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -807,7 +807,7 @@ queries:
     title: Ensure DOKS clusters have auto-upgrade enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -852,7 +852,7 @@ queries:
     title: Ensure DOKS clusters run a supported Kubernetes minor version
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -905,7 +905,7 @@ queries:
     title: Ensure DOKS clusters have SSO configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -960,7 +960,7 @@ queries:
     title: Ensure DOKS clusters require SSO for cluster authentication
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1010,7 +1010,7 @@ queries:
     title: Ensure TLS certificates are not expired
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1058,7 +1058,7 @@ queries:
     title: Ensure CDN endpoints with a custom domain have a TLS certificate attached
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1103,7 +1103,7 @@ queries:
     title: Ensure Spaces access keys are scoped with bucket grants
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1150,7 +1150,7 @@ queries:
     title: Ensure App Platform apps are served over HTTPS
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -44,7 +44,7 @@ queries:
     impact: 60
     filters: domainName.fqdn == domainName.effectiveTLDPlusOne
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -84,7 +84,7 @@ queries:
     title: Ensure NS and MX records are not pointing to IP addresses
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -135,7 +135,7 @@ queries:
     title: Ensure legacy MX records are not used with Microsoft 365
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -188,7 +188,7 @@ queries:
     title: Ensure the correct MX records are used with Google Workspace
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -242,7 +242,7 @@ queries:
     title: Ensure DNSSEC is enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -285,7 +285,7 @@ queries:
     title: Ensure no wildcard DNS records are configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -325,7 +325,7 @@ queries:
     title: Ensure at least two NS records exist
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -371,7 +371,7 @@ queries:
     title: Ensure DNS record TTLs are not suspiciously low
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -78,7 +78,7 @@ queries:
     title: Don't expose management ports
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -124,7 +124,7 @@ queries:
     title: Don't disable certificate validation in APT
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -165,7 +165,7 @@ queries:
     title: Don't disable certificate validation in curl
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -208,7 +208,7 @@ queries:
     title: Don't disable certificate validation in Wget
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -249,7 +249,7 @@ queries:
     title: Don't run commands using sudo
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -291,7 +291,7 @@ queries:
     title: Don't skip GPG validation in YUM/DNF/zypper
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -333,7 +333,7 @@ queries:
     title: Don't run containers as root user
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -381,7 +381,7 @@ queries:
     title: Use COPY instead of ADD in Dockerfiles
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -425,7 +425,7 @@ queries:
     title: Don't build containers from latest tags
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -466,7 +466,7 @@ queries:
     title: Don't set container user to root UID (0)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -507,7 +507,7 @@ queries:
     title: Ensure FROM base images specify a version tag
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -558,7 +558,7 @@ queries:
     title: Don't store secrets in Dockerfile ENV instructions
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -617,7 +617,7 @@ queries:
     title: Don't mount sensitive host directories as volumes
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -677,7 +677,7 @@ queries:
     title: Ensure exposed ports are within valid range
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -727,7 +727,7 @@ queries:
     title: Don't use 'apt-get dist-upgrade' in Dockerfiles
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -780,7 +780,7 @@ queries:
     title: Set org.opencontainers.image.source to the build repo URL
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -840,7 +840,7 @@ queries:
     title: Set org.opencontainers.image.authors to the responsible team
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -891,7 +891,7 @@ queries:
     title: Don't set WORKDIR to system directories
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -41,7 +41,7 @@ queries:
     title: Ensure EDR Agent is installed
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-09
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -104,7 +104,7 @@ queries:
     title: Ensure EDR Agent is running
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-09
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -69,7 +69,7 @@ queries:
     title: Ensure Reverse IP Lookup PTR record is set (DNS Forward confirmed)
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -156,7 +156,7 @@ queries:
     title: Domain Apex should have a TXT record
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -216,7 +216,7 @@ queries:
     title: Domain Apex should have an anchor (A) record
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -263,7 +263,7 @@ queries:
     title: Ensure SPF record is set
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -314,7 +314,7 @@ queries:
     title: Ensure there are not multiple SPF records
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -361,7 +361,7 @@ queries:
     title: Ensure SPF record is not too long
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -406,7 +406,7 @@ queries:
     title: Ensure SPF record does not contain any excess whitespace
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -451,7 +451,7 @@ queries:
     title: SPF should be set to fail or soft fail all
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -494,7 +494,7 @@ queries:
     title: Ensure SPF does not use permissive +all
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -569,7 +569,7 @@ queries:
     title: Do not use deprecated SPF DNS Record Type
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -614,7 +614,7 @@ queries:
     title: Ensure DMARC DNS entry exists
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -662,7 +662,7 @@ queries:
     title: Ensure DMARC version 1
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -721,7 +721,7 @@ queries:
     title: Ensure DMARC policy is set to quarantine or reject
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -774,7 +774,7 @@ queries:
     title: Ensure DMARC RUA tag
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -827,7 +827,7 @@ queries:
     title: Ensure DMARC RUF tag
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -880,7 +880,7 @@ queries:
     title: Ensure DKIM is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -97,7 +97,7 @@ queries:
     title: Ensure firmware is a General Availability release
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -162,7 +162,7 @@ queries:
     title: Ensure firmware has reached mature release status
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -225,7 +225,7 @@ queries:
     title: Ensure firmware is a supported major version
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -301,7 +301,7 @@ queries:
     title: Ensure admin session timeout is 5 minutes or less
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -351,7 +351,7 @@ queries:
     title: Ensure HTTPS admin port is non-default
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -405,7 +405,7 @@ queries:
     title: Ensure SSH admin port is non-default
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -455,7 +455,7 @@ queries:
     title: Ensure SCP admin access is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -507,7 +507,7 @@ queries:
     title: Ensure high availability mode is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -565,7 +565,7 @@ queries:
     title: Ensure HA session pickup is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -618,7 +618,7 @@ queries:
     title: Ensure DNS-over-TLS is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -670,7 +670,7 @@ queries:
     title: Ensure NTP synchronization is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -729,7 +729,7 @@ queries:
     title: Ensure NTP servers are configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -789,7 +789,7 @@ queries:
     title: Ensure implicit deny traffic is logged
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -840,7 +840,7 @@ queries:
     title: Ensure denied local-in unicast traffic is logged
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -891,7 +891,7 @@ queries:
     title: Ensure extended log format is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -944,7 +944,7 @@ queries:
     title: Ensure user anonymization is disabled in logs
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -997,7 +997,7 @@ queries:
     title: Ensure syslog forwarding is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1054,7 +1054,7 @@ queries:
     title: Ensure an external log destination is configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1127,7 +1127,7 @@ queries:
     title: Ensure FortiAnalyzer uses strong encryption
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1179,7 +1179,7 @@ queries:
     title: Ensure FortiAnalyzer reliable logging is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1231,7 +1231,7 @@ queries:
     title: Ensure no firewall policies are disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1295,7 +1295,7 @@ queries:
     title: Ensure no allow-all firewall rules exist
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1369,7 +1369,7 @@ queries:
     title: Ensure traffic logging is enabled on accept rules
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1425,7 +1425,7 @@ queries:
     title: Ensure UTM profiles are enabled on accept rules
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1491,7 +1491,7 @@ queries:
     title: Ensure SSL/SSH inspection is set on accept rules
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1551,7 +1551,7 @@ queries:
     title: Ensure WAN interfaces restrict management access
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1615,7 +1615,7 @@ queries:
     title: Ensure no interfaces allow telnet access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1683,7 +1683,7 @@ queries:
     title: Ensure BGP neighbor changes are logged
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1734,7 +1734,7 @@ queries:
     title: Ensure BGP graceful restart is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1790,7 +1790,7 @@ queries:
     title: Ensure OSPF neighbor changes are logged
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1841,7 +1841,7 @@ queries:
     title: Ensure FortiGuard antispam subscription is active
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1902,7 +1902,7 @@ queries:
     title: Ensure FortiGuard web filter subscription is active
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1963,7 +1963,7 @@ queries:
     title: Ensure FortiGuard outbreak prevention is active
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -130,7 +130,7 @@ queries:
     title: Ensure address space layout randomization (ASLR) is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -198,7 +198,7 @@ queries:
     title: Ensure core dump backtraces are disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -253,7 +253,7 @@ queries:
     title: Ensure core dump storage is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -305,7 +305,7 @@ queries:
     title: Ensure IP forwarding is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -378,7 +378,7 @@ queries:
     title: Ensure packet redirect sending is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -451,7 +451,7 @@ queries:
     title: Ensure ICMP redirects are not accepted
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -524,7 +524,7 @@ queries:
     title: Ensure source routed packets are not accepted
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -590,7 +590,7 @@ queries:
     title: Ensure TCP SYN cookies are enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -656,7 +656,7 @@ queries:
     title: Ensure IPv6 router advertisements are not accepted
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -722,7 +722,7 @@ queries:
     title: Ensure broadcast and multicast ICMP requests are ignored
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -788,7 +788,7 @@ queries:
     title: Ensure FTP server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -850,7 +850,7 @@ queries:
     title: Ensure telnet server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -905,7 +905,7 @@ queries:
     title: Ensure NIS server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -960,7 +960,7 @@ queries:
     title: Ensure rpcbind is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1015,7 +1015,7 @@ queries:
     title: Ensure NFS server is not enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1072,7 +1072,7 @@ queries:
     title: Ensure SNMP server is not enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1133,7 +1133,7 @@ queries:
     title: Ensure TFTP server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1188,7 +1188,7 @@ queries:
     title: Ensure IMAP and POP3 server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1249,7 +1249,7 @@ queries:
     title: Ensure web proxy server is not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1310,7 +1310,7 @@ queries:
     title: Ensure mail transfer agent is configured for local-only mode
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1383,7 +1383,7 @@ queries:
     title: Ensure permissions on /etc/ssh/sshd_config are configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1446,7 +1446,7 @@ queries:
     title: Ensure permissions on SSH private host key files are configured
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1510,7 +1510,7 @@ queries:
     title: Ensure permissions on SSH public host key files are configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1571,7 +1571,7 @@ queries:
     title: Ensure only strong ciphers are used
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1639,7 +1639,7 @@ queries:
     title: Ensure only strong MAC algorithms are used
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1707,7 +1707,7 @@ queries:
     title: Ensure only strong key exchange algorithms are used
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1775,7 +1775,7 @@ queries:
     title: Ensure SSH root login is disabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1843,7 +1843,7 @@ queries:
     title: Ensure SSH PermitEmptyPasswords is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1911,7 +1911,7 @@ queries:
     title: Ensure SSH HostbasedAuthentication is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1979,7 +1979,7 @@ queries:
     title: Ensure SSH PermitUserEnvironment is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2047,7 +2047,7 @@ queries:
     title: Ensure SSH IgnoreRhosts is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2115,7 +2115,7 @@ queries:
     title: Ensure SSH MaxAuthTries is set to 4 or less
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2183,7 +2183,7 @@ queries:
     title: Ensure SSH LoginGraceTime is configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2252,7 +2252,7 @@ queries:
     title: Ensure SSH LogLevel is appropriate
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2320,7 +2320,7 @@ queries:
     title: Ensure SSH idle timeout interval is configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2402,7 +2402,7 @@ queries:
     title: Ensure SSH DisableForwarding is enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2470,7 +2470,7 @@ queries:
     title: Ensure SSH UsePAM is enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2538,7 +2538,7 @@ queries:
     title: Ensure permissions on /etc/passwd are configured
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2600,7 +2600,7 @@ queries:
     title: Ensure permissions on /etc/group are configured
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2662,7 +2662,7 @@ queries:
     title: Ensure permissions on /etc/master.passwd are configured
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2726,7 +2726,7 @@ queries:
     title: Ensure permissions on /etc/shells are configured
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2787,7 +2787,7 @@ queries:
     title: Ensure permissions on bootloader config are configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2851,7 +2851,7 @@ queries:
     title: Ensure root is the only UID 0 account
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -2914,7 +2914,7 @@ queries:
     title: Ensure no duplicate UIDs exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -2975,7 +2975,7 @@ queries:
     title: Ensure no duplicate GIDs exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3036,7 +3036,7 @@ queries:
     title: Ensure no duplicate user names exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3095,7 +3095,7 @@ queries:
     title: Ensure no duplicate group names exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3154,7 +3154,7 @@ queries:
     title: Ensure all groups in /etc/passwd exist in /etc/group
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3220,7 +3220,7 @@ queries:
     title: Ensure syslogd is enabled and running
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3275,7 +3275,7 @@ queries:
     title: Ensure syslogd is not accepting remote messages
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3335,7 +3335,7 @@ queries:
     title: Ensure sudo is installed
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3390,7 +3390,7 @@ queries:
     title: Ensure sudo commands use a pseudo terminal
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3465,7 +3465,7 @@ queries:
     title: Ensure NOPASSWD is not configured in sudoers
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3546,7 +3546,7 @@ queries:
     title: Ensure a firewall is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -411,7 +411,7 @@ queries:
     title: Ensure that instances are not configured to use the default service account
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -568,7 +568,7 @@ queries:
     title: Ensure instances do not use default service account with full API access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -738,7 +738,7 @@ queries:
     title: Ensure oslogin is enabled for compute instances
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -887,7 +887,7 @@ queries:
     title: Ensure Cloud Storage buckets are not anonymously or publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1022,7 +1022,7 @@ queries:
     title: Ensure that Cloud Storage buckets have uniform bucket-level access enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1121,7 +1121,7 @@ queries:
     title: Ensure that Cloud Storage buckets enforce public access prevention
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1226,7 +1226,7 @@ queries:
     title: Ensure Cloud Storage buckets are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1350,7 +1350,7 @@ queries:
     title: Ensure that Cloud Storage buckets have a locked retention policy configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1474,7 +1474,7 @@ queries:
     title: Ensure that BigQuery datasets are not anonymously or publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1639,7 +1639,7 @@ queries:
     title: Ensure a default CMEK is specified for all BigQuery datasets
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1765,7 +1765,7 @@ queries:
     title: Ensure all BigQuery tables are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1908,7 +1908,7 @@ queries:
     title: Ensure all BigQuery models are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -2039,7 +2039,7 @@ queries:
     title: Ensure that BigQuery views do not use Legacy SQL
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2164,7 +2164,7 @@ queries:
     title: Ensure that BigQuery datasets do not grant domain-wide access
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2294,7 +2294,7 @@ queries:
     title: Ensure Cloud SQL MySQL instances are not publicly exposed
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2442,7 +2442,7 @@ queries:
     title: Ensure Cloud SQL MySQL connections require SSL/TLS
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2599,7 +2599,7 @@ queries:
     title: Ensure 'skip_show_database' flag is enabled for Cloud SQL MySQL
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2742,7 +2742,7 @@ queries:
     title: Ensure 'local_infile' flag is disabled for Cloud SQL MySQL
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2887,7 +2887,7 @@ queries:
     title: Ensure Cloud SQL PostgreSQL 'log_error_verbosity' is DEFAULT or verbose
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3043,7 +3043,7 @@ queries:
     title: Ensure 'log_connections' flag is enabled for Cloud SQL PostgreSQL
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3189,7 +3189,7 @@ queries:
     title: Ensure 'log_disconnections' flag is enabled for Cloud SQL PostgreSQL
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3340,7 +3340,7 @@ queries:
     title: Ensure public IP addresses are not assigned to VM instances
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3514,7 +3514,7 @@ queries:
     title: Ensure the default service account is not used on VM instances
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3705,7 +3705,7 @@ queries:
     title: Ensure "Block Project-Wide SSH Keys" is enabled for VM instances
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -3855,7 +3855,7 @@ queries:
     title: Ensure Confidential VM Service is enabled for all VM instances
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -4037,7 +4037,7 @@ queries:
     title: Ensure Secure Boot is enabled for all VM instances
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -4220,7 +4220,7 @@ queries:
     title: Ensure vTPM is enabled for all VM instances
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -4405,7 +4405,7 @@ queries:
     title: Ensure Integrity Monitoring is enabled for all VM instances
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -4596,7 +4596,7 @@ queries:
     title: Ensure Cloud SQL PostgreSQL instances are not publicly exposed
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4755,7 +4755,7 @@ queries:
     title: Ensure Cloud SQL for SQL Server instances are not publicly exposed
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4909,7 +4909,7 @@ queries:
     title: Ensure Cloud SQL PostgreSQL connections require SSL/TLS
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5067,7 +5067,7 @@ queries:
     title: Ensure Cloud SQL for SQL Server connections require SSL/TLS
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5225,7 +5225,7 @@ queries:
     title: Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5402,7 +5402,7 @@ queries:
     title: Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5538,7 +5538,7 @@ queries:
     title: Ensure KMS crypto keys have a destroy scheduled duration of 24h+
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5665,7 +5665,7 @@ queries:
     title: Ensure KMS keyrings are not in the global location
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5794,7 +5794,7 @@ queries:
     title: Ensure KMS ENCRYPT_DECRYPT crypto keys have automatic rotation configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -5936,7 +5936,7 @@ queries:
     title: Ensure That DNSSEC Is Enabled for Cloud DNS
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6071,7 +6071,7 @@ queries:
     title: Ensure That RSASHA1 Is Not Used for the Key-Signing Key in Cloud DNS DNSSEC
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6228,7 +6228,7 @@ queries:
     title: Ensure RSASHA1 is not used for the zone-signing key in Cloud DNS
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6384,7 +6384,7 @@ queries:
     title: Ensure DNSSEC uses NSEC3 for authenticated denial-of-existence
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6540,7 +6540,7 @@ queries:
     title: Ensure SSH access is restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6703,7 +6703,7 @@ queries:
     title: Ensure RDP access is restricted from the internet
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6849,7 +6849,7 @@ queries:
     title: Ensure firewall rules do not allow unrestricted ingress on all protocols
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7002,7 +7002,7 @@ queries:
     title: Ensure firewall rules block internet ingress to database ports
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7157,7 +7157,7 @@ queries:
     title: Ensure firewall rules do not allow unrestricted internet ingress
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7307,7 +7307,7 @@ queries:
     title: Ensure legacy authorization (ABAC) is disabled on GKE clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7417,7 +7417,7 @@ queries:
     title: Ensure master authorized networks are enabled on GKE clusters
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7532,7 +7532,7 @@ queries:
     title: Ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7641,7 +7641,7 @@ queries:
     title: Ensure network policy is enabled on GKE clusters
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7762,7 +7762,7 @@ queries:
     title: Ensure Kubernetes alpha features are disabled on GKE clusters
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7871,7 +7871,7 @@ queries:
     title: Ensure Workload Identity is enabled on GKE clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -7990,7 +7990,7 @@ queries:
     title: Ensure private cluster is enabled on GKE clusters
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8111,7 +8111,7 @@ queries:
     title: Ensure shielded GKE nodes are enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -8240,7 +8240,7 @@ queries:
     title: Ensure GKE clusters use a release channel for version management
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8362,7 +8362,7 @@ queries:
     title: Ensure legacy networks do not exist in the project
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8475,7 +8475,7 @@ queries:
     title: Ensure VPC Flow Logs are enabled on subnetworks
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8592,7 +8592,7 @@ queries:
     title: Ensure Private Google Access is enabled on subnetworks
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -8703,7 +8703,7 @@ queries:
     title: Ensure authentication is enabled for Cloud Redis instances
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -8819,7 +8819,7 @@ queries:
     title: Ensure Cloud Redis instances are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -8967,7 +8967,7 @@ queries:
     title: Ensure user-managed service account keys are not created
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9103,7 +9103,7 @@ queries:
     title: Ensure default Compute Engine and App Engine service accounts are disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9288,7 +9288,7 @@ queries:
     title: Ensure service account keys are rotated within 90 days
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9443,7 +9443,7 @@ queries:
     title: Ensure there are no disabled service account keys left undeleted
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9565,7 +9565,7 @@ queries:
     title: Ensure Cloud Logging log buckets have at least 30-day retention
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9680,7 +9680,7 @@ queries:
     title: Ensure Cloud Logging log buckets are locked to prevent tampering
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9803,7 +9803,7 @@ queries:
     title: Ensure Cloud Logging log buckets are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -9923,7 +9923,7 @@ queries:
     title: Ensure Cloud Logging has at least one sink configured for log export
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -10032,7 +10032,7 @@ queries:
     title: Ensure Pub/Sub topics are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -10143,7 +10143,7 @@ queries:
     title: Ensure Pub/Sub subscriptions have an expiration policy configured
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10252,7 +10252,7 @@ queries:
     title: Ensure Pub/Sub topics are not anonymously or publicly accessible
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10375,7 +10375,7 @@ queries:
     title: Ensure Pub/Sub subscriptions are not anonymously or publicly accessible
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10498,7 +10498,7 @@ queries:
     title: Ensure Cloud Functions do not allow all ingress traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -10617,7 +10617,7 @@ queries:
     title: Ensure Cloud Functions do not use the default service account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10745,7 +10745,7 @@ queries:
     title: Ensure Cloud Functions have a VPC connector configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -10866,7 +10866,7 @@ queries:
     title: Ensure Cloud Functions use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -10985,7 +10985,7 @@ queries:
     title: Ensure Cloud Run services do not allow all ingress traffic
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11105,7 +11105,7 @@ queries:
     title: Ensure Cloud Run services use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11224,7 +11224,7 @@ queries:
     title: Ensure Cloud Run services do not use the default service account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11365,7 +11365,7 @@ queries:
     title: Ensure Cloud Run services have VPC access configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11488,7 +11488,7 @@ queries:
     title: Ensure Cloud Run jobs do not use the default service account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11639,7 +11639,7 @@ queries:
     title: Ensure Cloud Run jobs use customer-managed encryption keys (CMEK)
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11762,7 +11762,7 @@ queries:
     title: Ensure Dataproc clusters have disk encryption configured with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11880,7 +11880,7 @@ queries:
     title: Ensure Dataproc clusters use internal IP addresses only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -12005,7 +12005,7 @@ queries:
     title: Ensure Dataproc clusters have Shielded VM features enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -12156,7 +12156,7 @@ queries:
     title: Ensure Dataproc clusters do not use the default service account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -12294,7 +12294,7 @@ queries:
     title: Ensure Binary Authorization default rule does not allow all images
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -12423,7 +12423,7 @@ queries:
     title: Ensure Binary Authorization global policy evaluation is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -12539,7 +12539,7 @@ queries:
     title: Ensure API keys have API target restrictions configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -12665,7 +12665,7 @@ queries:
     title: Ensure API keys have application restrictions configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -12813,7 +12813,7 @@ queries:
     title: Ensure API keys have been rotated within 90 days
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -12907,7 +12907,7 @@ queries:
     title: Ensure the default network does not exist in the project
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13039,7 +13039,7 @@ queries:
     title: Ensure DNS logging is enabled for VPC networks
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -13157,7 +13157,7 @@ queries:
     title: Ensure subnetworks do not use overly broad IP CIDR ranges
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13277,7 +13277,7 @@ queries:
     title: Ensure in-transit encryption is enabled for Cloud Memorystore for Redis
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -13411,7 +13411,7 @@ queries:
     title: Ensure Cloud Redis instances use the Standard HA tier
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -13520,7 +13520,7 @@ queries:
     title: Ensure IAM authentication is enabled for Memorystore Redis Cluster
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -13638,7 +13638,7 @@ queries:
     title: Ensure deletion protection is enabled for Memorystore Redis Cluster
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -13752,7 +13752,7 @@ queries:
     title: Ensure Secret Manager secrets are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -13911,7 +13911,7 @@ queries:
     title: Ensure Secret Manager secrets have rotation configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -14052,7 +14052,7 @@ queries:
     title: Ensure Secret Manager secrets do not have overly permissive IAM policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -14214,7 +14214,7 @@ queries:
     title: Ensure IP forwarding is not enabled on compute instances
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14333,7 +14333,7 @@ queries:
     title: Ensure interactive serial port access is disabled on compute instances
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -14468,7 +14468,7 @@ queries:
     title: Ensure Compute Engine disks are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -14589,7 +14589,7 @@ queries:
     title: Ensure external forwarding rules do not forward all ports
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14709,7 +14709,7 @@ queries:
     title: Ensure Cloud SQL authorized networks are not overly permissive
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -14871,7 +14871,7 @@ queries:
     title: Ensure Cloud SQL instances have a password policy enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -15019,7 +15019,7 @@ queries:
     title: Ensure Cloud SQL instances are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -15150,7 +15150,7 @@ queries:
     title: Ensure GKE cluster has application-layer secrets encryption enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -15268,7 +15268,7 @@ queries:
     title: Ensure GKE cluster node pools have Secure Boot enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -15411,7 +15411,7 @@ queries:
     title: Ensure Cloud Functions do not store secrets in plaintext env vars
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -15575,7 +15575,7 @@ queries:
     title: Ensure Cloud Functions use a user-managed Artifact Registry repository
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -15697,7 +15697,7 @@ queries:
     title: Ensure Cloud Armor security policy rules are not in preview-only mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -15819,7 +15819,7 @@ queries:
     title: Ensure Cloud Armor security policy default rule does not allow all traffic
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -15961,7 +15961,7 @@ queries:
     title: Ensure SSL policies enforce a minimum TLS version of 1.2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16068,7 +16068,7 @@ queries:
     title: Ensure SSL policies use MODERN or RESTRICTED profile
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16172,7 +16172,7 @@ queries:
     title: Ensure SSL certificates are not expired or expiring within 30 days
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16276,7 +16276,7 @@ queries:
     title: Ensure Cloud NAT does not use endpoint-independent mapping
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16390,7 +16390,7 @@ queries:
     title: Ensure audit logging is enabled for all services
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -16527,7 +16527,7 @@ queries:
     title: Ensure VM external IP access is restricted via organization policy
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -16662,7 +16662,7 @@ queries:
     title: Ensure serial port access is disabled via organization policy
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -16784,7 +16784,7 @@ queries:
     title: Ensure uniform bucket-level access is enforced via organization policy
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -16906,7 +16906,7 @@ queries:
     title: Ensure Firestore databases are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17020,7 +17020,7 @@ queries:
     title: Ensure Spanner databases are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17130,7 +17130,7 @@ queries:
     title: Ensure Bigtable clusters are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17244,7 +17244,7 @@ queries:
     title: Ensure AlloyDB clusters are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -17359,7 +17359,7 @@ queries:
     title: Ensure AlloyDB instances do not have public IP addresses
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17475,7 +17475,7 @@ queries:
     title: Ensure GKE clusters have Security Posture enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -17601,7 +17601,7 @@ queries:
     title: Ensure VPN tunnels use IKE version 2
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -17718,7 +17718,7 @@ queries:
     title: Ensure GKE node pools have an upgrade strategy configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -17881,7 +17881,7 @@ queries:
     title: Ensure Cloud SQL instances require Cloud SQL connectors for all connections
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18026,7 +18026,7 @@ queries:
     title: Ensure Backup & DR vault access is restricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -18139,7 +18139,7 @@ queries:
     title: Ensure Vertex AI endpoints are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -18263,7 +18263,7 @@ queries:
     title: Ensure Vertex AI endpoints use Private Service Connect
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18384,7 +18384,7 @@ queries:
     title: Ensure Vertex AI models are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -18469,7 +18469,7 @@ queries:
     title: Ensure Vertex AI datasets are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -18599,7 +18599,7 @@ queries:
     title: Ensure Vertex AI pipeline jobs are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -18708,7 +18708,7 @@ queries:
     title: Ensure Vertex AI pipeline jobs use a VPC network
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -18807,7 +18807,7 @@ queries:
     title: Ensure Vertex AI pipeline jobs don't use default SA
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -18919,7 +18919,7 @@ queries:
     title: Ensure Vertex AI feature online stores use CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -19055,7 +19055,7 @@ queries:
     title: Ensure firewall rules do not allow unrestricted egress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19191,7 +19191,7 @@ queries:
     title: Ensure egress firewall rules do not allow all ports
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -19332,7 +19332,7 @@ queries:
     title: Ensure legacy metadata endpoints are disabled on GKE nodes
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -19444,7 +19444,7 @@ queries:
     title: Ensure GKE legacy client authentication is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -19569,7 +19569,7 @@ queries:
     title: Ensure GKE node auto-upgrade is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -19679,7 +19679,7 @@ queries:
     title: Ensure GKE node auto-repair is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -19789,7 +19789,7 @@ queries:
     title: Ensure GKE nodes use a dedicated service account
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -19909,7 +19909,7 @@ queries:
     title: Ensure GKE clusters use VPC-native IP aliasing
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20017,7 +20017,7 @@ queries:
     title: Ensure GKE nodes use Container-Optimized OS
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20136,7 +20136,7 @@ queries:
     title: Ensure Cloud SQL instances have automated backups enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -20256,7 +20256,7 @@ queries:
     title: Ensure cross-database ownership chaining is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20386,7 +20386,7 @@ queries:
     title: Ensure contained database authentication is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -20517,7 +20517,7 @@ queries:
     title: Ensure 'log_lock_waits' is enabled for Cloud SQL PostgreSQL
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -20646,7 +20646,7 @@ queries:
     title: Ensure firewall rules do not allow full port range access
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20782,7 +20782,7 @@ queries:
     title: Ensure default network firewall rules are restricted
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -20916,7 +20916,7 @@ queries:
     title: Ensure Compute Engine disks are encrypted with CSEK
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -21034,7 +21034,7 @@ queries:
     title: Ensure GKE workload metadata concealment is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -21163,7 +21163,7 @@ queries:
     title: Ensure GKE control plane uses a private endpoint
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21300,7 +21300,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21386,7 +21386,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21488,7 +21488,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21585,7 +21585,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -21684,7 +21684,7 @@ queries:
     title: Ensure Cloud Storage buckets have soft delete retention enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -21806,7 +21806,7 @@ queries:
     impact: 70
     filters: asset.platform == 'gcp'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -21879,7 +21879,7 @@ queries:
     title: Ensure KMS key access justifications exclude customer-initiated support
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -22009,7 +22009,7 @@ queries:
     title: Ensure no custom routes send 0.0.0.0/0 to the default internet gateway
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22134,7 +22134,7 @@ queries:
     title: Ensure PSC service attachments do not accept connections automatically
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -22260,7 +22260,7 @@ queries:
     title: Ensure Cloud SQL users authenticate via Cloud IAM, not built-in passwords
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -22388,7 +22388,7 @@ queries:
     title: Ensure Target SSL proxies have an explicit SSL policy attached
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22501,7 +22501,7 @@ queries:
     title: Ensure GKE network policy has a provider specified
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22642,7 +22642,7 @@ queries:
     impact: 60
     filters: asset.platform == "gcp-gke-cluster"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22732,7 +22732,7 @@ queries:
     impact: 70
     filters: asset.platform == 'gcp'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -22822,7 +22822,7 @@ queries:
     title: Ensure Vertex AI index endpoints are not publicly accessible
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -22940,7 +22940,7 @@ queries:
     impact: 80
     filters: asset.platform == 'gcp'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -23028,7 +23028,7 @@ queries:
     title: Ensure IAP tunnel destination groups do not use overly broad CIDR ranges
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -23147,7 +23147,7 @@ queries:
     impact: 70
     filters: asset.platform == 'gcp'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23250,7 +23250,7 @@ queries:
     title: Ensure DLP inspect templates include common credential info types
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23412,7 +23412,7 @@ queries:
     title: Ensure Model Armor templates enable prompt injection filtering
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23488,7 +23488,7 @@ queries:
     title: Ensure Model Armor templates enable malicious URI filtering
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23561,7 +23561,7 @@ queries:
     title: Ensure Model Armor templates have RAI filters configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23653,7 +23653,7 @@ queries:
     title: Ensure Model Armor templates have Sensitive Data Protection
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23736,7 +23736,7 @@ queries:
     title: Ensure Model Armor templates enforce blocking mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23809,7 +23809,7 @@ queries:
     title: Ensure Model Armor templates log sanitize operations
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -23880,7 +23880,7 @@ queries:
     title: Ensure Model Armor RAI filters use adequate confidence
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -23975,7 +23975,7 @@ queries:
     title: Ensure SCC notification configs are configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24054,7 +24054,7 @@ queries:
     title: Ensure SCC BigQuery exports are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24133,7 +24133,7 @@ queries:
     title: Ensure AlloyDB instances have audit logging database flags enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -24279,7 +24279,7 @@ queries:
     filters: |
       asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -24362,7 +24362,7 @@ queries:
     title: Ensure BigQuery AWS and Azure connections use identity federation
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -24535,7 +24535,7 @@ queries:
     impact: 60
     filters: asset.platform == 'gcp-bigquery-dataset'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -24617,7 +24617,7 @@ queries:
     impact: 80
     filters: asset.platform == 'gcp-bigquery-dataset'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -24717,7 +24717,7 @@ queries:
     title: Ensure Spanner backup schedules use customer-managed encryption
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -24861,7 +24861,7 @@ queries:
     title: Ensure Spanner instance and database IAM grant no primitive roles
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -25054,7 +25054,7 @@ queries:
     title: Ensure Spanner IAM has no public or anonymous principals
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -25221,7 +25221,7 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances require IAM authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -25327,7 +25327,7 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances enable in-transit encryption
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -25429,7 +25429,7 @@ queries:
     title: Ensure Memorystore (Valkey/Redis) instances are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -25539,7 +25539,7 @@ queries:
     title: Ensure Memorystore backup collections are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -25594,7 +25594,7 @@ queries:
     title: Ensure Memorystore Private Service Connect endpoints are not public
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -25662,7 +25662,7 @@ queries:
     title: Ensure Memorystore engineConfigs keep protected-mode enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -25774,7 +25774,7 @@ queries:
     title: Ensure Memorystore engine version is not a known-vulnerable release
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -25844,7 +25844,7 @@ queries:
     title: Ensure Datastream streams are encrypted with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -25953,7 +25953,7 @@ queries:
     title: Ensure Datastream profiles avoid static service IP connectivity
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26078,7 +26078,7 @@ queries:
     title: Ensure Datastream connection profiles do not use forward SSH connectivity
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26171,7 +26171,7 @@ queries:
     title: Ensure Datastream source profiles store credentials in Secret Manager
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -26365,7 +26365,7 @@ queries:
     title: Ensure Datastream private-connection routes do not advertise public CIDRs
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26482,7 +26482,7 @@ queries:
     title: Ensure Datastream GCS destination buckets are hardened
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -26537,7 +26537,7 @@ queries:
     title: Ensure Datastream private connections do not peer the default VPC
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26654,7 +26654,7 @@ queries:
     title: Ensure Memorystore for Memcached instances are not on the default VPC
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26771,7 +26771,7 @@ queries:
     title: Ensure Memorystore for Memcached discovery endpoints are RFC1918 addresses
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -26815,7 +26815,7 @@ queries:
     title: Ensure Memcached engine version is not a known-vulnerable release
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -26918,7 +26918,7 @@ queries:
     title: Ensure Compute Engine snapshot IAM has no public principals
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27054,7 +27054,7 @@ queries:
     title: Ensure Compute Engine snapshot IAM grants no primitive roles
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27193,7 +27193,7 @@ queries:
     title: Ensure Compute Engine custom image IAM has no public principals
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27323,7 +27323,7 @@ queries:
     title: Ensure Compute Engine custom image IAM grants no primitive roles
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27462,7 +27462,7 @@ queries:
     title: Ensure Artifact Registry repositories are encrypted with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -27577,7 +27577,7 @@ queries:
     title: Ensure Artifact Registry repositories are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -27717,7 +27717,7 @@ queries:
     title: Ensure container repositories have vulnerability scanning enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -27850,7 +27850,7 @@ queries:
     title: Ensure Cloud Build triggers do not store plaintext secrets in substitutions
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -28002,7 +28002,7 @@ queries:
     title: Ensure Cloud Build worker pools run privately with no public egress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -28150,7 +28150,7 @@ queries:
     title: Ensure Cloud Build triggers do not run as the default Compute Engine SA
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -28272,7 +28272,7 @@ queries:
     title: Ensure Dataflow jobs run on workers with no public IPs
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -28411,7 +28411,7 @@ queries:
     title: Ensure Dataflow jobs use a custom worker service account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -28560,7 +28560,7 @@ queries:
     title: Ensure Filestore instances are encrypted with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -28690,7 +28690,7 @@ queries:
     title: Ensure project IAM does not grant Datastore roles to public principals
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -28826,7 +28826,7 @@ queries:
     title: Ensure Vertex AI custom jobs do not run as the default Compute Engine SA
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -28891,7 +28891,7 @@ queries:
     title: Ensure Essential Contacts cover the SECURITY notification category
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-sef-08
       compliance/dora: dora-art-17
       compliance/hipaa: hipaa-security-ss164-308-a-6-ii-security-incident-procedures-response-and-reporting
@@ -29015,7 +29015,7 @@ queries:
     title: Ensure App Engine apps require IAP or internal-only ingress
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29150,7 +29150,7 @@ queries:
     title: Ensure API Gateway configs reference at least one OpenAPI document
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -29264,7 +29264,7 @@ queries:
     title: Ensure CDN-enabled backend services require signed URLs
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -29412,7 +29412,7 @@ queries:
     title: Ensure Cloud Workstations clusters use a private endpoint
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29524,7 +29524,7 @@ queries:
     title: Ensure Vertex AI Workbench instances do not have public IP addresses
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -29654,7 +29654,7 @@ queries:
     title: Ensure Cloud Composer environments are encrypted with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29775,7 +29775,7 @@ queries:
     title: Ensure Cloud Dataflow jobs are encrypted with CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -29905,7 +29905,7 @@ queries:
     title: Ensure Cloud Healthcare datasets are encrypted with CMEK
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30010,7 +30010,7 @@ queries:
     title: Ensure Cloud Logging project log buckets use CMEK
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30123,7 +30123,7 @@ queries:
     title: Ensure Vertex AI training and runtime assets are encrypted with CMEK
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -30319,7 +30319,7 @@ queries:
     title: Ensure HTTPS load balancer target proxies attach a strong SSL policy
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -30470,7 +30470,7 @@ queries:
     title: Ensure App Engine standard version handlers require HTTPS
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -152,7 +152,7 @@ queries:
     title: Enable Two-factor authentication for all users in the organization
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -223,7 +223,7 @@ queries:
     title: Organization should have a verified domain attached
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -279,7 +279,7 @@ queries:
     title: Ensure GitHub Organization has base permissions configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -348,7 +348,7 @@ queries:
     title: Ensure repository defines a security policy
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -446,7 +446,7 @@ queries:
     title: Ensure GitHub repository default branch is protected
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -539,7 +539,7 @@ queries:
     title: Ensure GitHub repository release branches are protected
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -635,7 +635,7 @@ queries:
     title: Ensure repository does not allow force pushes to the default branch
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -722,7 +722,7 @@ queries:
     title: Ensure repository does not allow force pushes to any release branches
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -814,7 +814,7 @@ queries:
     title: Ensure branch protection requires conversation resolution before merging
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -901,7 +901,7 @@ queries:
     title: Ensure status checks are passing before merging PRs on the default branch
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -990,7 +990,7 @@ queries:
     title: Ensure repository branch protection requires signed commits
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -1067,7 +1067,7 @@ queries:
     title: Ensure repository does not allow bypassing of branch protection rules
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -1142,7 +1142,7 @@ queries:
     title: Ensure repository defines a security policy
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1219,7 +1219,7 @@ queries:
     title: Ensure repository does not generate binary artifacts
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1271,7 +1271,7 @@ queries:
     title: Ensure a GitHub Actions workflow exists for Dependabot
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1363,7 +1363,7 @@ queries:
     title: Ensure organization members cannot fork private repositories
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1433,7 +1433,7 @@ queries:
     title: Ensure secret scanning is enabled for new repositories
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1503,7 +1503,7 @@ queries:
     title: Ensure secret scanning push protection is enabled for new repositories
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1569,7 +1569,7 @@ queries:
     title: Ensure Dependabot alerts are enabled for new repositories
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1635,7 +1635,7 @@ queries:
     title: Ensure Dependabot security updates are enabled for new repositories
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1701,7 +1701,7 @@ queries:
     title: Ensure organization members cannot change repository visibility
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1772,7 +1772,7 @@ queries:
     title: Ensure organization members cannot delete repositories
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1842,7 +1842,7 @@ queries:
     title: Ensure repository has no open secret scanning alerts
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1910,7 +1910,7 @@ queries:
     title: Ensure repository webhooks use SSL verification
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1989,7 +1989,7 @@ queries:
     title: Ensure GitHub Actions require SHA pinning
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -2067,7 +2067,7 @@ queries:
     title: Ensure repository has no open code scanning alerts
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2135,7 +2135,7 @@ queries:
     title: Ensure repository has no open critical Dependabot alerts
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2206,7 +2206,7 @@ queries:
     title: Ensure repository default branch requires pull request reviews
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -2292,7 +2292,7 @@ queries:
     title: Ensure repository default branch blocks direct creations
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -2395,7 +2395,7 @@ queries:
     title: Ensure environment protection rules prevent self-review
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -2475,7 +2475,7 @@ queries:
     title: Ensure advanced security is enabled for new repositories
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2542,7 +2542,7 @@ queries:
     title: Ensure dependency graph is enabled for new repositories
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -68,7 +68,7 @@ queries:
   - uid: mondoo-gitlab-security-private-group
     title: Ensure the group is private
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -143,7 +143,7 @@ queries:
   - uid: mondoo-gitlab-security-require-two-factor
     title: Ensure two-factor authentication is required
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -220,7 +220,7 @@ queries:
   - uid: mondoo-gitlab-security-private-projects
     title: Ensure all projects are private
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -327,7 +327,7 @@ queries:
   - uid: mondoo-gitlab-security-private-project
     title: Ensure the project is private
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -404,7 +404,7 @@ queries:
     title: Ensure merge request approvals are required
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -483,7 +483,7 @@ queries:
     title: Ensure merge request authors cannot approve their own requests
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -557,7 +557,7 @@ queries:
     title: Ensure approvals are reset when new commits are pushed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -631,7 +631,7 @@ queries:
     title: Ensure committers cannot approve merge requests they contributed to
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -705,7 +705,7 @@ queries:
     title: Ensure force push is disabled on the default branch
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -782,7 +782,7 @@ queries:
     title: Ensure pipeline must succeed before merging
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -856,7 +856,7 @@ queries:
     title: Ensure group prevents forking projects outside the group
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -931,7 +931,7 @@ queries:
     title: Ensure project access tokens have expiration dates
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1016,7 +1016,7 @@ queries:
     title: Ensure group access tokens have expiration dates
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1101,7 +1101,7 @@ queries:
     title: Ensure project deploy keys do not have push access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1181,7 +1181,7 @@ queries:
     title: Ensure continuous vulnerability scanning is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -58,7 +58,7 @@ queries:
     title: Ensure 2-step verification (MFA) is enforced for all users
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -109,7 +109,7 @@ queries:
     title: Ensure fewer than four users have super admin permissions
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -147,7 +147,7 @@ queries:
     title: Ensure more than one user has super admin permissions
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -185,7 +185,7 @@ queries:
     title: Users should not be allowed less secure app access
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -225,7 +225,7 @@ queries:
     title: Super users should use hardware-based security keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -265,7 +265,7 @@ queries:
     title: Ensure no connected apps have full Gmail or Drive access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -318,7 +318,7 @@ queries:
     title: Ensure all domains are verified
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -370,7 +370,7 @@ queries:
     title: Ensure calendar sharing is not set to public
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -429,7 +429,7 @@ queries:
     title: Ensure no users have IP whitelisting enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -479,7 +479,7 @@ queries:
     title: Ensure admin accounts are not guest users
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -529,7 +529,7 @@ queries:
     title: Ensure all admin accounts have completed 2-step verification enrollment
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -582,7 +582,7 @@ queries:
     title: Ensure no admin accounts have a pending forced password change
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -57,7 +57,7 @@ queries:
     title: Ensure service accounts do not use the Admin role
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -95,7 +95,7 @@ queries:
     title: Ensure all service account tokens have an expiration date
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -142,7 +142,7 @@ queries:
     title: Ensure no expired service account tokens exist
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -186,7 +186,7 @@ queries:
     title: Ensure disabled service accounts have no active tokens
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -226,7 +226,7 @@ queries:
     title: Ensure the number of organization administrators is limited
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -265,7 +265,7 @@ queries:
     title: Ensure the default admin login has been changed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -309,7 +309,7 @@ queries:
     title: Ensure datasources use proxy access mode
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -345,7 +345,7 @@ queries:
     title: Ensure datasources do not use basic authentication
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -385,7 +385,7 @@ queries:
     title: Ensure datasource connections use TLS
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -436,7 +436,7 @@ queries:
     title: Ensure notification policy has a default receiver configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -471,7 +471,7 @@ queries:
     title: Ensure contact points do not disable resolve messages
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -58,7 +58,7 @@ queries:
     title: Ensure servers are attached to a private network
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -167,7 +167,7 @@ queries:
     title: Ensure servers have at least one firewall applied
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -272,7 +272,7 @@ queries:
     impact: 70
     filters: asset.platform == "hetzner-project"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -336,7 +336,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound SSH (port 22)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -458,7 +458,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound RDP (port 3389)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -578,7 +578,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound on common database ports
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -702,7 +702,7 @@ queries:
     title: Ensure no firewall allows unrestricted inbound on all ports
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -820,7 +820,7 @@ queries:
     title: Ensure load balancers redirect HTTP traffic to HTTPS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -921,7 +921,7 @@ queries:
     title: Ensure HTTPS load balancer services have a TLS certificate attached
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1031,7 +1031,7 @@ queries:
     impact: 100
     filters: asset.platform == "hetzner-project"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1098,7 +1098,7 @@ queries:
     impact: 70
     filters: asset.platform == "hetzner-project"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -1139,7 +1139,7 @@ queries:
     impact: 70
     filters: asset.platform == "hetzner-project"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -56,7 +56,7 @@ queries:
     title: Set X-Content-Type-Options HTTP header to 'nosniff'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -139,7 +139,7 @@ queries:
     title: Set Content Security Policy (CSP) HTTP header
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -221,7 +221,7 @@ queries:
     title: Set Strict-Transport-Security (HSTS) HTTP header
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -303,7 +303,7 @@ queries:
     title: Remove or obfuscate the Server header
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -384,7 +384,7 @@ queries:
     title: Remove all X-Powered-By headers
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -464,7 +464,7 @@ queries:
     title: Remove all X-AspNet-Version headers
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -544,7 +544,7 @@ queries:
     title: Remove all X-AspNetMvc-Version headers
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -624,7 +624,7 @@ queries:
     title: The header Public-Key-Pins is deprecated and should not be used
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -706,7 +706,7 @@ queries:
     title: Set X-Frame-Options HTTP header
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -788,7 +788,7 @@ queries:
     title: Set Referrer-Policy HTTP header
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -870,7 +870,7 @@ queries:
     title: Ensure HSTS max-age is at least one year
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -951,7 +951,7 @@ queries:
     title: Ensure HSTS includes subdomains
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1030,7 +1030,7 @@ queries:
     title: Ensure HSTS preload is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -102,7 +102,7 @@ queries:
     title: Ensure root login via SSH is denied
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -157,7 +157,7 @@ queries:
     title: Ensure weak SSH ciphers are not configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -216,7 +216,7 @@ queries:
     title: Ensure weak SSH MACs are not configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -273,7 +273,7 @@ queries:
     title: Ensure weak SSH key exchange algorithms are not configured
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -328,7 +328,7 @@ queries:
     title: Ensure SSH TCP forwarding is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -375,7 +375,7 @@ queries:
     title: Ensure SSH connection limit is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -422,7 +422,7 @@ queries:
     title: Ensure SSH rate limit is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -472,7 +472,7 @@ queries:
     title: Ensure all local users have authentication credentials
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -526,7 +526,7 @@ queries:
     title: Ensure minimal number of users have super-user privileges
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -585,7 +585,7 @@ queries:
     title: Ensure Telnet service is disabled
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -633,7 +633,7 @@ queries:
     title: Ensure FTP service is disabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -692,7 +692,7 @@ queries:
     title: Ensure finger service is disabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -742,7 +742,7 @@ queries:
     title: Ensure SNMP default community strings are not used
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -794,7 +794,7 @@ queries:
     title: Ensure SNMP communities do not have read-write access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -841,7 +841,7 @@ queries:
     title: Ensure SNMP communities restrict client access
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -892,7 +892,7 @@ queries:
     title: Ensure remote syslog host is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -942,7 +942,7 @@ queries:
     title: Ensure syslog uses secure transport
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1000,7 +1000,7 @@ queries:
     title: Ensure security policies have session logging enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1049,7 +1049,7 @@ queries:
     title: Ensure untrust security zones have screen profiles applied
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1101,7 +1101,7 @@ queries:
     title: Ensure untrust zone does not expose insecure host-inbound services
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1165,7 +1165,7 @@ queries:
     title: Ensure screen profiles have TCP SYN flood protection enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1215,7 +1215,7 @@ queries:
     title: Ensure screen profiles have ICMP ping-of-death protection enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1262,7 +1262,7 @@ queries:
     title: Ensure screen profiles have IP source route option protection enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1310,7 +1310,7 @@ queries:
     title: Ensure screen profiles have TCP land attack protection enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1357,7 +1357,7 @@ queries:
     title: Ensure screen profiles have IP teardrop protection enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1404,7 +1404,7 @@ queries:
     title: Ensure screen profiles have TCP WinNuke protection enabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1454,7 +1454,7 @@ queries:
     title: Ensure no security feature licenses are expired
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -251,7 +251,7 @@ queries:
     title: Disable anonymous authentication for kubelet
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -290,7 +290,7 @@ queries:
     title: Configure kubelet to capture all event creation
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -329,7 +329,7 @@ queries:
     title: Configure kubelet to ensure IPTables rules are set on host
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -368,7 +368,7 @@ queries:
     title: Configure kubelet to protect kernel defaults
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -407,7 +407,7 @@ queries:
     title: Do not allow unauthenticated read-only port on kubelet
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -446,7 +446,7 @@ queries:
     title: Ensure the kubelet does not use AlwaysAllow authorization mode
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -487,7 +487,7 @@ queries:
     title: Configure kubelet to use only strong cryptography
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -550,7 +550,7 @@ queries:
     title: Run kubelet with a user-provided certificate/key
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -598,7 +598,7 @@ queries:
     title: Run kubelet with automatic certificate rotation
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -637,7 +637,7 @@ queries:
     title: Ownership and permissions of kubelet configuration should be restricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -737,7 +737,7 @@ queries:
     title: Ensure kubelet CA file is configured with proper ownership/perms
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -837,7 +837,7 @@ queries:
     title: Set secure file permissions on the API server pod specification file
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -927,7 +927,7 @@ queries:
     title: Set secure directory permissions on the etcd data directory
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1008,7 +1008,7 @@ queries:
     title: Set secure file permissions on the admin.conf file
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1098,7 +1098,7 @@ queries:
     title: Set secure file permissions on the scheduler.conf file
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1188,7 +1188,7 @@ queries:
     title: Set secure file permissions on the controller-manager.conf file
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1278,7 +1278,7 @@ queries:
     title: Ensure that the Kubernetes PKI/SSL directory is owned by root:root
     impact: 65
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1341,7 +1341,7 @@ queries:
     title: Ensure the kube-apiserver is not listening on an insecure HTTP port
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1384,7 +1384,7 @@ queries:
     title: Ensure the kube-apiserver does not allow anonymous authentication
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1427,7 +1427,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1496,7 +1496,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1565,7 +1565,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1631,7 +1631,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1697,7 +1697,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1763,7 +1763,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1829,7 +1829,7 @@ queries:
     title: Container should not mount the Docker socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1895,7 +1895,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1961,7 +1961,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2027,7 +2027,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2093,7 +2093,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2159,7 +2159,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2225,7 +2225,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2291,7 +2291,7 @@ queries:
     title: Container should not mount the containerd socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2357,7 +2357,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2423,7 +2423,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2489,7 +2489,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2555,7 +2555,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2621,7 +2621,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2687,7 +2687,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2753,7 +2753,7 @@ queries:
     title: Container should not mount the CRI-O socket
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2819,7 +2819,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2884,7 +2884,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2948,7 +2948,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3012,7 +3012,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3076,7 +3076,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3140,7 +3140,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3204,7 +3204,7 @@ queries:
     title: Container should not allow privilege escalation
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3272,7 +3272,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3349,7 +3349,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3425,7 +3425,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3501,7 +3501,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3577,7 +3577,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3653,7 +3653,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3729,7 +3729,7 @@ queries:
     title: Container should not run as a privileged container
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3805,7 +3805,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3870,7 +3870,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3934,7 +3934,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3998,7 +3998,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4062,7 +4062,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4126,7 +4126,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4190,7 +4190,7 @@ queries:
     title: Container should use an immutable root filesystem
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4254,7 +4254,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4354,7 +4354,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4451,7 +4451,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4547,7 +4547,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4643,7 +4643,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4740,7 +4740,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4836,7 +4836,7 @@ queries:
     title: Container should not run as root
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4932,7 +4932,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4993,7 +4993,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5054,7 +5054,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5115,7 +5115,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5176,7 +5176,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5237,7 +5237,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5299,7 +5299,7 @@ queries:
     title: Pod should not run with hostNetwork
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5361,7 +5361,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5420,7 +5420,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5479,7 +5479,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5538,7 +5538,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5597,7 +5597,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5656,7 +5656,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5715,7 +5715,7 @@ queries:
     title: Pod should not run with hostPID
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5775,7 +5775,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5835,7 +5835,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5895,7 +5895,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5955,7 +5955,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6003,7 +6003,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6052,7 +6052,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6101,7 +6101,7 @@ queries:
     title: Pod should not run with hostIPC
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6150,7 +6150,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6240,7 +6240,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6330,7 +6330,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6420,7 +6420,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6510,7 +6510,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6600,7 +6600,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6690,7 +6690,7 @@ queries:
     title: Pod should not run with the default service account
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6780,7 +6780,7 @@ queries:
     title: Pod container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -6846,7 +6846,7 @@ queries:
     title: CronJob container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -6909,7 +6909,7 @@ queries:
     title: StatefulSet container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -6972,7 +6972,7 @@ queries:
     title: Deployment container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7045,7 +7045,7 @@ queries:
     title: Job container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7118,7 +7118,7 @@ queries:
     title: ReplicaSet container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7191,7 +7191,7 @@ queries:
     title: DaemonSet container image pull should be consistent
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7264,7 +7264,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7331,7 +7331,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7398,7 +7398,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7465,7 +7465,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7532,7 +7532,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7599,7 +7599,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7666,7 +7666,7 @@ queries:
     title: Container should have a CPU limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7733,7 +7733,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7802,7 +7802,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7860,7 +7860,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7929,7 +7929,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7998,7 +7998,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8067,7 +8067,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8136,7 +8136,7 @@ queries:
     title: Container should have a memory limit
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8205,7 +8205,7 @@ queries:
     title: Pods should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8289,7 +8289,7 @@ queries:
     title: DaemonSets should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8373,7 +8373,7 @@ queries:
     title: ReplicaSets should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8457,7 +8457,7 @@ queries:
     title: Jobs should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8540,7 +8540,7 @@ queries:
     title: Deployments should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8624,7 +8624,7 @@ queries:
     title: StatefulSets should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8708,7 +8708,7 @@ queries:
     title: CronJobs should not run with NET_RAW capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8796,7 +8796,7 @@ queries:
     title: Pods should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8857,7 +8857,7 @@ queries:
     title: DaemonSets should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8918,7 +8918,7 @@ queries:
     title: ReplicaSets should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8969,7 +8969,7 @@ queries:
     title: Jobs should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9030,7 +9030,7 @@ queries:
     title: Deployments should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9090,7 +9090,7 @@ queries:
     title: StatefulSets should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9151,7 +9151,7 @@ queries:
     title: CronJobs should not run with SYS_ADMIN capability
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9214,7 +9214,7 @@ queries:
     title: Pods should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9278,7 +9278,7 @@ queries:
     title: DaemonSets should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9343,7 +9343,7 @@ queries:
     title: ReplicaSets should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9408,7 +9408,7 @@ queries:
     title: Jobs should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9473,7 +9473,7 @@ queries:
     title: Deployments should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9538,7 +9538,7 @@ queries:
     title: StatefulSets should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9603,7 +9603,7 @@ queries:
     title: CronJobs should not bind to a host port
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9670,7 +9670,7 @@ queries:
     title: Pods should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9785,7 +9785,7 @@ queries:
     title: DaemonSets should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9866,7 +9866,7 @@ queries:
     title: ReplicaSets should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9947,7 +9947,7 @@ queries:
     title: Jobs should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10028,7 +10028,7 @@ queries:
     title: Deployments should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10109,7 +10109,7 @@ queries:
     title: StatefulSets should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10190,7 +10190,7 @@ queries:
     title: CronJobs should mount any host path volumes as read-only
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10271,7 +10271,7 @@ queries:
     title: Deployments should not run Tiller (Helm v2)
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10315,7 +10315,7 @@ queries:
     title: Pods should not run Tiller (Helm v2)
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10361,7 +10361,7 @@ queries:
     title: Pods should not run Kubernetes dashboard
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10407,7 +10407,7 @@ queries:
     title: Pods should not run Kubernetes dashboard
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10455,7 +10455,7 @@ queries:
     title: Pods should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10515,7 +10515,7 @@ queries:
     title: DaemonSets should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10576,7 +10576,7 @@ queries:
     title: ReplicaSets should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10637,7 +10637,7 @@ queries:
     title: Jobs should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10698,7 +10698,7 @@ queries:
     title: Deployments should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10759,7 +10759,7 @@ queries:
     title: StatefulSets should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10820,7 +10820,7 @@ queries:
     title: CronJobs should drop ALL capabilities
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10883,7 +10883,7 @@ queries:
     title: Ensure PersistentVolumes do not use hostPath
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10951,7 +10951,7 @@ queries:
     title: Ensure the kube-apiserver enforces Node and RBAC authorization
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -10997,7 +10997,7 @@ queries:
     title: Ensure the kube-apiserver does not enable the AlwaysAdmit admission plugin
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11031,7 +11031,7 @@ queries:
     title: Ensure the kube-apiserver enables the NodeRestriction admission plugin
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11065,7 +11065,7 @@ queries:
     title: Ensure the kube-apiserver enables the PodSecurity admission plugin
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11099,7 +11099,7 @@ queries:
     title: Ensure the kube-apiserver enables the EventRateLimit admission plugin
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11133,7 +11133,7 @@ queries:
     title: Ensure the kube-apiserver writes audit logs to a file
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -11167,7 +11167,7 @@ queries:
     title: Ensure the kube-apiserver loads an audit policy file
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -11201,7 +11201,7 @@ queries:
     title: Ensure the kube-apiserver retains audit logs for at least 30 days
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -11235,7 +11235,7 @@ queries:
     title: Ensure the kube-apiserver encrypts secrets at rest in etcd
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11273,7 +11273,7 @@ queries:
     title: Ensure the kube-apiserver enforces TLS 1.2 or higher
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11308,7 +11308,7 @@ queries:
     title: Ensure the kube-apiserver only negotiates strong TLS cipher suites
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11349,7 +11349,7 @@ queries:
     title: Ensure the kube-apiserver verifies clients with a CA certificate
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11383,7 +11383,7 @@ queries:
     title: Ensure the kube-apiserver authenticates to kubelets with a client certificate
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11419,7 +11419,7 @@ queries:
     title: Ensure the kube-apiserver communicates with kubelets over HTTPS
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11452,7 +11452,7 @@ queries:
     title: Ensure the kube-apiserver verifies kubelet certificates with a CA bundle
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -11486,7 +11486,7 @@ queries:
     title: Ensure the kube-apiserver authenticates to etcd with TLS client certificates
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -11521,7 +11521,7 @@ queries:
     title: Ensure the kube-apiserver validates ServiceAccount tokens against the API
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11554,7 +11554,7 @@ queries:
     title: Ensure the kube-apiserver loads a dedicated ServiceAccount signing key
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11588,7 +11588,7 @@ queries:
     title: Ensure the kube-apiserver disables the profiling endpoint
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11621,7 +11621,7 @@ queries:
     title: Ensure the kube-apiserver does not use a static token authentication file
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -199,7 +199,7 @@ queries:
     title: Ensure Advanced Intrusion Detection Environment (AIDE) is installed
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -310,7 +310,7 @@ queries:
     title: Ensure filesystem integrity is regularly checked using AIDE
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -526,7 +526,7 @@ queries:
     title: Ensure core dumps are restricted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -698,7 +698,7 @@ queries:
     title: Ensure address space layout randomization (ASLR) is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -800,7 +800,7 @@ queries:
     title: Restrict access to kernel addresses
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -900,7 +900,7 @@ queries:
     title: Prevent mapping of low memory addresses
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1004,7 +1004,7 @@ queries:
     title: Ensure dmesg access is restricted
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1106,7 +1106,7 @@ queries:
     title: Prevent non-privileged eBPF access
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1210,7 +1210,7 @@ queries:
     title: Restrict non-privileged access to ptrace
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1316,7 +1316,7 @@ queries:
     title: Ensure loading of the ATM module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1411,7 +1411,7 @@ queries:
     title: Ensure loading of the CAN module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1505,7 +1505,7 @@ queries:
     title: Ensure loading of the DCCP module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1599,7 +1599,7 @@ queries:
     title: Ensure loading of the RDS module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1693,7 +1693,7 @@ queries:
     title: Ensure loading of the SCTP module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1787,7 +1787,7 @@ queries:
     title: Ensure loading of the TIPC module is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1881,7 +1881,7 @@ queries:
     title: Ensure prelink is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1983,7 +1983,7 @@ queries:
     title: Ensure X Window System is not installed
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2106,7 +2106,7 @@ queries:
     title: Ensure Avahi server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2197,7 +2197,7 @@ queries:
     title: Ensure CUPS is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2288,7 +2288,7 @@ queries:
     title: Ensure DHCP server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2379,7 +2379,7 @@ queries:
     title: Ensure LDAP server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2462,7 +2462,7 @@ queries:
     title: Ensure NFS and RPC are stopped and not enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2562,7 +2562,7 @@ queries:
     title: Ensure DNS server is stopped and not enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2655,7 +2655,7 @@ queries:
     title: Ensure FTP servers are stopped and not enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2754,7 +2754,7 @@ queries:
     title: Ensure HTTP servers are stopped and not enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2855,7 +2855,7 @@ queries:
     title: Ensure IMAP and POP3 servers are stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2948,7 +2948,7 @@ queries:
     title: Ensure Samba is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3041,7 +3041,7 @@ queries:
     title: Ensure HTTP Proxy server is stopped and not enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3134,7 +3134,7 @@ queries:
     title: Ensure SNMP server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3227,7 +3227,7 @@ queries:
     title: Ensure mail transfer agent is configured for local-only mode
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3390,7 +3390,7 @@ queries:
     title: Ensure NIS server is stopped and not enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3483,7 +3483,7 @@ queries:
     title: Ensure rsh server is stopped and not enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3583,7 +3583,7 @@ queries:
     title: Ensure Telnet server is stopped and not enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3666,7 +3666,7 @@ queries:
     title: Ensure TFTP server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3749,7 +3749,7 @@ queries:
     title: Ensure rsync service is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3832,7 +3832,7 @@ queries:
     title: Ensure talk server is stopped and not enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3925,7 +3925,7 @@ queries:
     title: Ensure IP forwarding is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4051,7 +4051,7 @@ queries:
     title: Ensure packet redirect sending is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4170,7 +4170,7 @@ queries:
     title: Ensure source routed packets are not accepted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4324,7 +4324,7 @@ queries:
     title: Ensure ICMP redirects are not accepted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4477,7 +4477,7 @@ queries:
     title: Ensure secure ICMP redirects are not accepted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4600,7 +4600,7 @@ queries:
     title: Ensure suspicious packets are logged
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4715,7 +4715,7 @@ queries:
     title: Ensure broadcast ICMP requests are ignored
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4817,7 +4817,7 @@ queries:
     title: Ensure bogus ICMP responses are ignored
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4919,7 +4919,7 @@ queries:
     title: Ensure reverse path filtering is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5034,7 +5034,7 @@ queries:
     title: Ensure TCP SYN cookies are enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5146,7 +5146,7 @@ queries:
     title: Ensure IPv6 router advertisements are not accepted
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5274,7 +5274,7 @@ queries:
     title: Ensure auditd is installed, enabled, and running
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5415,7 +5415,7 @@ queries:
     title: Ensure auditing for processes that start prior to auditd is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5565,7 +5565,7 @@ queries:
     title: Ensure audit log storage size is configured
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5694,7 +5694,7 @@ queries:
     title: Ensure audit logs are not automatically deleted
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5819,7 +5819,7 @@ queries:
     title: Ensure system is disabled when audit logs are full
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -5969,7 +5969,7 @@ queries:
     title: Ensure changes to system administration scope (sudoers) is audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6102,7 +6102,7 @@ queries:
     title: Ensure login and logout events are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6308,7 +6308,7 @@ queries:
     title: Ensure session initiation information is audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6450,7 +6450,7 @@ queries:
     title: Ensure events that modify date and time information are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6613,7 +6613,7 @@ queries:
     title: Ensure Mandatory Access Control modification events are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6771,7 +6771,7 @@ queries:
     title: Ensure events that modify the system's network environment are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7023,7 +7023,7 @@ queries:
     title: Ensure DAC permission modification events are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7239,7 +7239,7 @@ queries:
     title: Ensure unsuccessful unauthorized file access attempts are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7463,7 +7463,7 @@ queries:
     title: Ensure events that modify user/group information are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7609,7 +7609,7 @@ queries:
     title: Ensure successful file system mounts are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7751,7 +7751,7 @@ queries:
     title: Ensure file deletion events by users are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7955,7 +7955,7 @@ queries:
     title: Ensure kernel module loading and unloading is audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8099,7 +8099,7 @@ queries:
     title: Ensure system administrator actions (sudolog) are audited
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8224,7 +8224,7 @@ queries:
     title: Ensure the audit configuration is immutable
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8350,7 +8350,7 @@ queries:
     title: Ensure sudo logging is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8482,7 +8482,7 @@ queries:
     title: Ensure secure permissions on /etc/ssh/sshd_config are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -8574,7 +8574,7 @@ queries:
     title: Ensure rsyslog is installed
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8684,7 +8684,7 @@ queries:
     title: Ensure rsyslog default file permissions are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8807,7 +8807,7 @@ queries:
     title: Ensure journald is configured to send logs to rsyslog
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -8905,7 +8905,7 @@ queries:
     title: Ensure journald is configured to compress large log files
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9003,7 +9003,7 @@ queries:
     title: Ensure journald is configured to write logfiles to persistent disk
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9101,7 +9101,7 @@ queries:
     title: Ensure secure permissions on all log files are set
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -9281,7 +9281,7 @@ queries:
     title: Ensure secure permissions on SSH private host key files are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9378,7 +9378,7 @@ queries:
     title: Ensure secure permissions on SSH public host key files are set
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -9473,7 +9473,7 @@ queries:
     title: Ensure SSH Protocol is set to 2
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9584,7 +9584,7 @@ queries:
     title: Ensure SSH LogLevel is appropriate
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9695,7 +9695,7 @@ queries:
     title: Ensure SSH X11 forwarding is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -9801,7 +9801,7 @@ queries:
     title: Ensure SSH MaxAuthTries is set to 4 or less
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -9908,7 +9908,7 @@ queries:
     title: Ensure SSH IgnoreRhosts is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10015,7 +10015,7 @@ queries:
     title: Ensure SSH HostbasedAuthentication is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10122,7 +10122,7 @@ queries:
     title: Ensure SSH root login is disabled or set to prohibit-password
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10235,7 +10235,7 @@ queries:
     title: Ensure SSH PermitEmptyPasswords is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10342,7 +10342,7 @@ queries:
     title: Ensure SSH PermitUserEnvironment is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -10449,7 +10449,7 @@ queries:
     title: Ensure only strong ciphers are used
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10555,7 +10555,7 @@ queries:
     title: Ensure only strong MAC algorithms are used
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10658,7 +10658,7 @@ queries:
     title: Ensure only strong key exchange algorithms are used
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10848,7 +10848,7 @@ queries:
     title: Ensure SSH Idle Timeout Interval is configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -10978,7 +10978,7 @@ queries:
     title: Ensure SSH LoginGraceTime is set to one minute or less
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -11071,7 +11071,7 @@ queries:
     title: Ensure SSH access is limited
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11208,7 +11208,7 @@ queries:
     title: Ensure SSH warning banner is configured
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -11301,7 +11301,7 @@ queries:
     title: Ensure secure permissions on /etc/passwd are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11395,7 +11395,7 @@ queries:
     title: Ensure secure permissions on /etc/shadow are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11492,7 +11492,7 @@ queries:
     title: Ensure secure permissions on /etc/group are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11579,7 +11579,7 @@ queries:
     title: Ensure secure permissions on /etc/gshadow are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11669,7 +11669,7 @@ queries:
     title: Ensure secure permissions on /etc/passwd- are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11771,7 +11771,7 @@ queries:
     title: Ensure secure permissions on /etc/shadow- are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11872,7 +11872,7 @@ queries:
     title: Ensure secure permissions on /etc/group- are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -11981,7 +11981,7 @@ queries:
     title: Ensure secure permissions on /etc/gshadow- are set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -12089,7 +12089,7 @@ queries:
     title: Ensure no duplicate UIDs exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12140,7 +12140,7 @@ queries:
     title: Ensure no duplicate user names exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12191,7 +12191,7 @@ queries:
     title: Ensure no duplicate GIDs exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12242,7 +12242,7 @@ queries:
     title: Ensure no duplicate group names exist
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12293,7 +12293,7 @@ queries:
     title: Ensure default group for the root account is GID 0
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12369,7 +12369,7 @@ queries:
     title: Ensure each user is a member of a group
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12420,7 +12420,7 @@ queries:
     title: Ensure all GIDs in /etc/passwd exist in /etc/group
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -12471,7 +12471,7 @@ queries:
     title: Ensure UID_MIN is set to 1000
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12554,7 +12554,7 @@ queries:
     title: Ensure shadow group is empty
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12654,7 +12654,7 @@ queries:
     title: Ensure root group is empty
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12758,7 +12758,7 @@ queries:
     title: Ensure system accounts are non-login
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -12870,7 +12870,7 @@ queries:
     title: Ensure access to the su command is restricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -12991,7 +12991,7 @@ queries:
     title: Ensure SELinux is in enforcing mode
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -13062,7 +13062,7 @@ queries:
     title: Ensure SELinux config is set to enforcing
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -60,7 +60,7 @@ queries:
     title: Ensure permissions on bootloader config are configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -274,7 +274,7 @@ queries:
     title: Ensure Secure Boot is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -308,7 +308,7 @@ queries:
     title: Ensure / and /home are encrypted
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -352,7 +352,7 @@ queries:
     title: Ensure AES encryption algorithm is used
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -392,7 +392,7 @@ queries:
     title: Ensure system BIOS is running the latest available version
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -86,7 +86,7 @@ queries:
     title: Enable Azure AD Identity Protection sign-in risk policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -285,7 +285,7 @@ queries:
     title: Enable Azure AD Identity Protection user risk policies
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -481,7 +481,7 @@ queries:
     title: Enable Conditional Access policies to block legacy authentication
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -661,7 +661,7 @@ queries:
     title: Ensure MFA is enabled for all users in administrative roles
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -903,7 +903,7 @@ queries:
     title: Ensure multi-factor authentication (MFA) is enabled for all users
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1079,7 +1079,7 @@ queries:
     title: Ensure Security Defaults is disabled on Azure Active Directory
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-01
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1170,7 +1170,7 @@ queries:
     title: Ensure that between two and four global admins are designated
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1311,7 +1311,7 @@ queries:
     title: Ensure that Android mobile device encryption is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-08
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1415,7 +1415,7 @@ queries:
     title: Ensure minimum password length is set to prevent brute force
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1542,7 +1542,7 @@ queries:
     title: Ensure password expiration policy is set to never expire
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1641,7 +1641,7 @@ queries:
     title: Ensure that SPF records are published for all Exchange Domains
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1788,7 +1788,7 @@ queries:
     title: Ensure that no third party integrated applications are allowed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1881,7 +1881,7 @@ queries:
     title: Ensure DKIM signing is enabled for all Exchange domains
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-i-transmission-security-integrity-controls
@@ -1965,7 +1965,7 @@ queries:
     title: Ensure Safe Links policies are configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -2062,7 +2062,7 @@ queries:
     title: Ensure Safe Attachments policies are configured
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -2157,7 +2157,7 @@ queries:
     title: Ensure anti-phishing policies are enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
@@ -2255,7 +2255,7 @@ queries:
     title: Ensure SharePoint external sharing is restricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2346,7 +2346,7 @@ queries:
     title: Ensure Exchange transport rules enforce TLS for external email
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -85,7 +85,7 @@ queries:
     title: Control access to audit records
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -199,7 +199,7 @@ queries:
     title: Disable Bluetooth Sharing
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -294,7 +294,7 @@ queries:
     title: Disable Bonjour advertising service
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -391,7 +391,7 @@ queries:
     title: Disable Content Caching
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -489,7 +489,7 @@ queries:
     title: Disable File Sharing
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -570,7 +570,7 @@ queries:
     title: Disable Internet Sharing
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -664,7 +664,7 @@ queries:
     title: Disable Media Sharing
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -757,7 +757,7 @@ queries:
     title: Disable Printer Sharing
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -836,7 +836,7 @@ queries:
     title: Disable Remote Apple Events
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -915,7 +915,7 @@ queries:
     title: Disable Remote Login
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -994,7 +994,7 @@ queries:
     title: Disable Remote Management
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1073,7 +1073,7 @@ queries:
     title: Disable Screen Sharing
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1148,7 +1148,7 @@ queries:
     title: Do not enable the "root" account
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1229,7 +1229,7 @@ queries:
     title: Enable FileVault
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1331,7 +1331,7 @@ queries:
     title: Enable Firewall
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1409,7 +1409,7 @@ queries:
     title: Enable Firewall Stealth Mode
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1489,7 +1489,7 @@ queries:
     title: Enable Gatekeeper
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1582,7 +1582,7 @@ queries:
     title: Enable security auditing
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1651,7 +1651,7 @@ queries:
     title: Enable "Show Wi-Fi status in menu bar"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1773,7 +1773,7 @@ queries:
     title: Ensure AirDrop Is Disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1882,7 +1882,7 @@ queries:
     title: Ensure Firewall is configured to log
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1963,7 +1963,7 @@ queries:
     title: Ensure http server is not running
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2046,7 +2046,7 @@ queries:
     title: Ensure NFS server is not running
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2130,7 +2130,7 @@ queries:
     title: Ensure security auditing retention
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2224,7 +2224,7 @@ queries:
     title: Password Age
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2324,7 +2324,7 @@ queries:
     title: Password History
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2425,7 +2425,7 @@ queries:
     title: Reduce the sudo timeout period
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2505,7 +2505,7 @@ queries:
     title: Retain install.log for 365 or more days with no maximum size
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2588,7 +2588,7 @@ queries:
     title: Set a minimum password length
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2670,7 +2670,7 @@ queries:
     title: Ensure automatic checking of software updates enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2765,7 +2765,7 @@ queries:
     title: Ensure automatic download of software updates enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2856,7 +2856,7 @@ queries:
     title: Ensure critical updates are installed automatically
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2953,7 +2953,7 @@ queries:
     title: Ensure macOS is up to date
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3052,7 +3052,7 @@ queries:
     title: Ensure macOS firewall blocks all incoming connections
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -43,7 +43,7 @@ queries:
   - uid: mondoo-mcp-pii-detection
     title: Detect personally identifiable information in MCP content
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -100,7 +100,7 @@ queries:
   - uid: mondoo-mcp-prompt-injection-detection
     title: Detect prompt injection attacks in MCP content
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -158,7 +158,7 @@ queries:
   - uid: mondoo-mcp-link-detection
     title: Detect embedded URLs in MCP content
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -213,7 +213,7 @@ queries:
   - uid: mondoo-mcp-tool-parameters
     title: Ensure tool parameters have proper validation constraints
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -278,7 +278,7 @@ queries:
   - uid: mondoo-mcp-content-filtering
     title: Filter inappropriate and explicit content in tool definitions
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -329,7 +329,7 @@ queries:
   - uid: mondoo-mcp-unicode-validation
     title: Validate Unicode character usage for security
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -400,7 +400,7 @@ queries:
   - uid: mondoo-mcp-resource-validation
     title: Validate MCP resource and resource template security
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-04
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -132,7 +132,7 @@ queries:
     impact: 90
     filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -195,7 +195,7 @@ queries:
     impact: 60
     filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE" && oci.identity.user.email != ""
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -249,7 +249,7 @@ queries:
     title: Ensure no IAM policies grant manage all-resources in tenancy
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -383,7 +383,7 @@ queries:
     impact: 80
     filters: asset.platform == "oci-identity-user" && oci.identity.user.state != "ACTIVE"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -444,7 +444,7 @@ queries:
     impact: 80
     filters: asset.platform == "oci-identity-user" && oci.identity.user.state != "ACTIVE"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -503,7 +503,7 @@ queries:
     title: Ensure Object Storage buckets are not publicly accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -611,7 +611,7 @@ queries:
     title: Ensure Object Storage buckets have versioning enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -719,7 +719,7 @@ queries:
     title: Ensure Object Storage buckets have event logging enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -827,7 +827,7 @@ queries:
     title: Ensure Object Storage buckets use customer-managed encryption keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -950,7 +950,7 @@ queries:
     title: Ensure VCN security lists block unrestricted ingress from 0.0.0.0/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1072,7 +1072,7 @@ queries:
     title: Ensure VCN security lists block unrestricted TCP ingress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1208,7 +1208,7 @@ queries:
     title: Ensure VCN security lists block unrestricted egress to 0.0.0.0/0
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1328,7 +1328,7 @@ queries:
     impact: 70
     filters: asset.platform == "oci-identity-user" && oci.identity.user.state == "ACTIVE" && oci.identity.user.lastLogin != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1391,7 +1391,7 @@ queries:
     title: Ensure no IAM policies grant manage all-resources in compartment
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1514,7 +1514,7 @@ queries:
     title: Ensure Object Storage buckets have replication enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1621,7 +1621,7 @@ queries:
     title: Ensure Object Storage archive buckets have versioning enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1726,7 +1726,7 @@ queries:
     title: Ensure VCN security lists block SSH ingress from 0.0.0.0/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1866,7 +1866,7 @@ queries:
     title: Ensure VCN security lists block RDP ingress from 0.0.0.0/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2006,7 +2006,7 @@ queries:
     title: Ensure VCN security lists block unrestricted UDP ingress
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2132,7 +2132,7 @@ queries:
     title: Ensure VCN security lists have no stateless rules from internet
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2250,7 +2250,7 @@ queries:
     title: Ensure VCN security lists block unrestricted TCP egress
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2370,7 +2370,7 @@ queries:
     title: Ensure compute instances have freeform tags applied
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -2492,7 +2492,7 @@ queries:
     impact: 70
     filters: asset.platform == "oci-identity-user"
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2560,7 +2560,7 @@ queries:
     impact: 70
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2620,7 +2620,7 @@ queries:
     title: Ensure NSGs do not permit SSH or RDP ingress from 0.0.0.0/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2810,7 +2810,7 @@ queries:
     title: Ensure compute VNICs with a public IP have at least one NSG attached
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2944,7 +2944,7 @@ queries:
     title: Ensure compute instances have the legacy IMDSv1 endpoints disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3076,7 +3076,7 @@ queries:
     title: Ensure compute instance metadata does not contain credentials
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -3242,7 +3242,7 @@ queries:
     title: Ensure load balancer HTTPS listeners only allow TLS 1.2 or newer
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3391,7 +3391,7 @@ queries:
     title: Ensure load balancer listeners use a modern cipher suite
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3539,7 +3539,7 @@ queries:
     impact: 70
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3610,7 +3610,7 @@ queries:
     title: Ensure OKE cluster Kubernetes API endpoints are not exposed to the internet
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3742,7 +3742,7 @@ queries:
     impact: 70
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3800,7 +3800,7 @@ queries:
     title: Ensure OKE clusters enable container image signature verification
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -3930,7 +3930,7 @@ queries:
     impact: 80
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4032,7 +4032,7 @@ queries:
     title: Ensure OKE node pool worker nodes have NSGs attached
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4170,7 +4170,7 @@ queries:
     title: Ensure Autonomous Databases require mTLS or restrict access via ACL / NSG
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4307,7 +4307,7 @@ queries:
     title: Ensure Autonomous Databases do not expose public management URLs
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4437,7 +4437,7 @@ queries:
     impact: 90
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4502,7 +4502,7 @@ queries:
     impact: 80
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4564,7 +4564,7 @@ queries:
     title: Ensure OCI Vault secrets older than a year have scheduled rotation enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4704,7 +4704,7 @@ queries:
     impact: 60
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4763,7 +4763,7 @@ queries:
     title: Ensure OCI Functions applications do not store credentials in config
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4929,7 +4929,7 @@ queries:
     title: Ensure container instances pull images from the tenancy's OCIR registry
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -5071,7 +5071,7 @@ queries:
     title: Ensure object storage bucket retention rules are locked
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -5206,7 +5206,7 @@ queries:
     title: Ensure object storage retention rules are at least 30 days
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -5354,7 +5354,7 @@ queries:
     title: Ensure no IAM policies grant access to any-user
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5470,7 +5470,7 @@ queries:
     title: Ensure no IAM policies grant cross-tenancy access via Endorse or Admit
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5600,7 +5600,7 @@ queries:
     title: Ensure VCN security lists block database port ingress from 0.0.0.0/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5766,7 +5766,7 @@ queries:
     title: Ensure VCN security lists block legacy admin port ingress from 0.0.0.0/0
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -5930,7 +5930,7 @@ queries:
     title: Ensure VCN security lists block unrestricted ICMP ingress from 0.0.0.0/0
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6060,7 +6060,7 @@ queries:
     title: Ensure VCN security lists block unrestricted IPv6 ingress from ::/0
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6230,7 +6230,7 @@ queries:
     title: Ensure database backups are encrypted with customer-managed keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -6400,7 +6400,7 @@ queries:
     title: Ensure API Gateway deployments do not allow anonymous access
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6554,7 +6554,7 @@ queries:
     title: Ensure API Gateway deployments require authentication
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -6718,7 +6718,7 @@ queries:
     title: Ensure API Gateway mTLS deployments verify client certificates
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6876,7 +6876,7 @@ queries:
     title: Ensure API Gateway deployments do not use wildcard CORS origins
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -7029,7 +7029,7 @@ queries:
     impact: 80
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -7089,7 +7089,7 @@ queries:
     title: Ensure managed certificates use strong key algorithms
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7234,7 +7234,7 @@ queries:
     title: Ensure managed certificates use strong signature algorithms
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7400,7 +7400,7 @@ queries:
     title: Ensure managed certificates have auto-renewal enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -7535,7 +7535,7 @@ queries:
     title: Ensure certificate authorities use customer-managed KMS keys
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -7682,7 +7682,7 @@ queries:
     impact: 90
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7773,7 +7773,7 @@ queries:
     title: Ensure OCI Cache clusters have Network Security Groups attached
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7890,7 +7890,7 @@ queries:
     title: Ensure OCI Cache clusters use a supported software version
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8009,7 +8009,7 @@ queries:
     impact: 80
     filters: asset.platform == 'oci'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -8077,7 +8077,7 @@ queries:
     title: Ensure Cloud Guard security zones inherit protection after deletion
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -94,7 +94,7 @@ queries:
     title: Limit the number of super admins
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -158,7 +158,7 @@ queries:
     title: Enable Okta ThreatInsight to block suspicious IP addresses
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -274,7 +274,7 @@ queries:
     title: Disable weaker MFA factors in factor enrollment policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -398,7 +398,7 @@ queries:
     title: Enable Okta Verify (with Push if available) for MFA
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -489,7 +489,7 @@ queries:
     title: Require at least one factor in every MFA enrollment policy
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -612,7 +612,7 @@ queries:
     title: Enforce a limited session lifetime for all policies
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -724,7 +724,7 @@ queries:
     title: Enable SAML or OIDC authentication for supported apps
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -854,7 +854,7 @@ queries:
     title: Enable Suspicious Activity Reporting
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -956,7 +956,7 @@ queries:
     title: Enable sign-on notifications for end users
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1044,7 +1044,7 @@ queries:
     title: Enable factor enrollment notifications for end users
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1129,7 +1129,7 @@ queries:
     title: Enable factor reset notifications for end users
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1214,7 +1214,7 @@ queries:
     title: Enable password changed notification for end users
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1299,7 +1299,7 @@ queries:
     title: Enable strong password settings for password policies - minimum length
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1380,7 +1380,7 @@ queries:
     title: Enforce strong password policy - max lockout attempts
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1463,7 +1463,7 @@ queries:
     title: Enable strong password settings for password policies - minimum lowercase
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1538,7 +1538,7 @@ queries:
     title: Enable strong password settings for password policies - minimum number
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1613,7 +1613,7 @@ queries:
     title: Enable strong password settings for password policies - minimum symbols
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1688,7 +1688,7 @@ queries:
     title: Enable strong password settings for password policies - minimum age
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1764,7 +1764,7 @@ queries:
     title: Enable strong password settings for password policies - exclude username
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1840,7 +1840,7 @@ queries:
     title: Enable strong password settings for password policies - exclude first name
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1916,7 +1916,7 @@ queries:
     title: Enable strong password settings for password policies - exclude last name
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1992,7 +1992,7 @@ queries:
     title: Enable strong password settings for password policies - dictionary lookup
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2068,7 +2068,7 @@ queries:
     title: Enable strong password settings for password policies - max age
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2144,7 +2144,7 @@ queries:
     title: Enable strong password settings for password policies - expiration warning
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2220,7 +2220,7 @@ queries:
     title: Enable strong password settings for password policies - history count
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2296,7 +2296,7 @@ queries:
     title: Enable strong password settings for password policies - auto unlock
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2372,7 +2372,7 @@ queries:
     title: Enforce strong password policy - show lockout failures
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2448,7 +2448,7 @@ queries:
     title: Enable strong password settings for password policies - email recovery
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2524,7 +2524,7 @@ queries:
     title: Enable strong password settings for password policies - sms recovery
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2600,7 +2600,7 @@ queries:
     title: Enable strong password settings for password policies - question recovery
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2676,7 +2676,7 @@ queries:
     title: Ensure ThreatInsight is configured to block suspicious login attempts
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2773,7 +2773,7 @@ queries:
     title: Ensure all active trusted origins use HTTPS
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2869,7 +2869,7 @@ queries:
     title: Ensure sign-on policy rules require MFA
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -2979,7 +2979,7 @@ queries:
     title: Limit the number of organization admins
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -66,7 +66,7 @@ queries:
     title: Ensure application credentials are not unrestricted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-09
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -161,7 +161,7 @@ queries:
     title: Ensure application credentials have an expiration set
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-09
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -255,7 +255,7 @@ queries:
     title: Ensure compute servers are launched with an SSH keypair
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-09
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -354,7 +354,7 @@ queries:
     title: Ensure compute servers have at least one security group attached
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -450,7 +450,7 @@ queries:
     title: Ensure no security group allows unrestricted inbound SSH (port 22)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -550,7 +550,7 @@ queries:
     title: Ensure no security group allows unrestricted inbound RDP (port 3389)
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -650,7 +650,7 @@ queries:
     title: Ensure no security group allows unrestricted inbound database ports
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -778,7 +778,7 @@ queries:
     title: Ensure no security group allows unrestricted inbound traffic to all ports
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -881,7 +881,7 @@ queries:
     title: Ensure Neutron ports have port security enabled
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -974,7 +974,7 @@ queries:
     title: Ensure Cinder block-storage volumes are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -1020,7 +1020,7 @@ queries:
     title: Ensure project-owned Glance images are not publicly visible
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1115,7 +1115,7 @@ queries:
     title: Ensure project-owned Glance images carry signature properties
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
@@ -1221,7 +1221,7 @@ queries:
     title: Ensure Swift containers are not publicly readable
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1312,7 +1312,7 @@ queries:
     title: Ensure Octavia HTTPS listeners disable legacy TLS protocol versions
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -102,7 +102,7 @@ queries:
     title: Ensure antivirus content version is installed
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -165,7 +165,7 @@ queries:
     title: Ensure application content version is installed
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -230,7 +230,7 @@ queries:
     impact: 75
     filters: panos.licenses != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -292,7 +292,7 @@ queries:
     impact: 90
     filters: panos.licenses != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -352,7 +352,7 @@ queries:
     title: Ensure device operational mode is normal
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -418,7 +418,7 @@ queries:
     title: Ensure threat content version is installed
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -485,7 +485,7 @@ queries:
     impact: 95
     filters: panos.licenses != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -551,7 +551,7 @@ queries:
     impact: 80
     filters: panos.licenses != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -615,7 +615,7 @@ queries:
     title: Ensure WildFire content version is installed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -682,7 +682,7 @@ queries:
     impact: 85
     filters: panos.licenses != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -752,7 +752,7 @@ queries:
     impact: 90
     filters: panos.zones != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -815,7 +815,7 @@ queries:
     impact: 80
     filters: panos.zones != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -878,7 +878,7 @@ queries:
     impact: 70
     filters: panos.zones != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -937,7 +937,7 @@ queries:
     impact: 95
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1011,7 +1011,7 @@ queries:
     impact: 85
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1074,7 +1074,7 @@ queries:
     impact: 90
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1152,7 +1152,7 @@ queries:
     impact: 80
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1215,7 +1215,7 @@ queries:
     impact: 75
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1276,7 +1276,7 @@ queries:
     impact: 60
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1335,7 +1335,7 @@ queries:
     impact: 80
     filters: panos.securityRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1400,7 +1400,7 @@ queries:
     impact: 85
     filters: panos.ethernetInterfaces != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1467,7 +1467,7 @@ queries:
     impact: 65
     filters: panos.ethernetInterfaces != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1530,7 +1530,7 @@ queries:
     impact: 90
     filters: panos.ethernetInterfaces != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1594,7 +1594,7 @@ queries:
     impact: 80
     filters: panos.ikeGateways != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1657,7 +1657,7 @@ queries:
     impact: 85
     filters: panos.ikeGateways != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -1722,7 +1722,7 @@ queries:
     impact: 70
     filters: panos.ikeGateways != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1782,7 +1782,7 @@ queries:
     impact: 80
     filters: panos.ikeGateways != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1844,7 +1844,7 @@ queries:
     impact: 75
     filters: panos.ipsecTunnels != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1905,7 +1905,7 @@ queries:
     impact: 65
     filters: panos.ipsecTunnels != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1970,7 +1970,7 @@ queries:
     impact: 85
     filters: panos.decryptionRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2034,7 +2034,7 @@ queries:
     impact: 70
     filters: panos.decryptionRules != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2098,7 +2098,7 @@ queries:
     impact: 70
     filters: panos.virtualRouters != empty
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2163,7 +2163,7 @@ queries:
     filters: |
       panos.virtualRouters.any(ospf.enable == true)
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2225,7 +2225,7 @@ queries:
     filters: |
       panos.virtualRouters.any(ospf.enable == true && ospfAreas.any(virtualLinks().length > 0))
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2287,7 +2287,7 @@ queries:
     filters: |
       panos.virtualRouters.any(ospf.enable == true)
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2348,7 +2348,7 @@ queries:
     filters: |
       panos.virtualRouters.any(ospf.enable == true)
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -170,7 +170,7 @@ queries:
     title: Ensure two-factor authentication is configured
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -265,7 +265,7 @@ queries:
     title: Ensure the Administrator role is assigned sparingly
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -364,7 +364,7 @@ queries:
     title: Ensure /etc/pve/user.cfg is not world-readable
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -439,7 +439,7 @@ queries:
     title: Ensure SSH root login is key-only (Proxmox-adapted)
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -539,7 +539,7 @@ queries:
     title: Ensure SSH password authentication is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -632,7 +632,7 @@ queries:
     title: Ensure root is the only UID 0 account
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -725,7 +725,7 @@ queries:
     title: Ensure no password field is empty in /etc/shadow
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -819,7 +819,7 @@ queries:
     title: Ensure cluster firewall is enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -893,7 +893,7 @@ queries:
     title: Ensure firewall default input policy is DROP
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -998,7 +998,7 @@ queries:
     title: Ensure host firewall is enabled on each node
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1070,7 +1070,7 @@ queries:
     title: Ensure at least one firewall rule is configured
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1181,7 +1181,7 @@ queries:
     title: Ensure PVE uses a trusted TLS certificate (not cluster-internal CA)
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1284,7 +1284,7 @@ queries:
     title: Ensure TLS certificate does not expire within 30 days
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1378,7 +1378,7 @@ queries:
     title: Ensure all LXC containers are unprivileged
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1487,7 +1487,7 @@ queries:
     title: Ensure container nesting is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1597,7 +1597,7 @@ queries:
     title: Ensure containers do not disable AppArmor
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1689,7 +1689,7 @@ queries:
     title: Ensure container network interfaces have firewall enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1792,7 +1792,7 @@ queries:
     title: Ensure containers do not allow mknod
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1898,7 +1898,7 @@ queries:
     title: Ensure containers do not allow FUSE mounts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2004,7 +2004,7 @@ queries:
     title: Ensure all containers have a memory limit
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2104,7 +2104,7 @@ queries:
     title: Ensure VMs have Spectre/Meltdown CPU mitigations
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2207,7 +2207,7 @@ queries:
     title: Ensure VM network interfaces have firewall enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2308,7 +2308,7 @@ queries:
     title: Ensure VMs do not use raw QEMU arguments
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2404,7 +2404,7 @@ queries:
     title: Ensure Corosync cluster communication is encrypted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2532,7 +2532,7 @@ queries:
     title: Ensure live migration traffic is encrypted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2610,7 +2610,7 @@ queries:
     title: Ensure VLAN segmentation is used
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2723,7 +2723,7 @@ queries:
     title: Ensure PBS backups are encrypted
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -2824,7 +2824,7 @@ queries:
     title: Ensure PBS master key is configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -2936,7 +2936,7 @@ queries:
     title: Ensure Kernel Samepage Merging (KSM) is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3028,7 +3028,7 @@ queries:
     title: Ensure PCI ACS override is not enabled
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3140,7 +3140,7 @@ queries:
     title: Ensure IOMMU is enabled for PCI passthrough isolation
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3252,7 +3252,7 @@ queries:
     title: Ensure audit rules monitor /etc/pve/ changes
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3354,7 +3354,7 @@ queries:
     title: Ensure a PVE update repository is configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3490,7 +3490,7 @@ queries:
     title: Ensure unattended-upgrades is installed
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3587,7 +3587,7 @@ queries:
     title: Ensure unprivileged BPF is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3670,7 +3670,7 @@ queries:
     title: Ensure kexec_load is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3749,7 +3749,7 @@ queries:
     title: Ensure perf_event_paranoid is at least 2
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3827,7 +3827,7 @@ queries:
     title: Ensure TTY line discipline autoload is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3905,7 +3905,7 @@ queries:
     title: Ensure TCP RFC1337 protection is enabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3978,7 +3978,7 @@ queries:
     title: Ensure unprivileged user namespaces setting is explicit
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4064,7 +4064,7 @@ queries:
     title: Ensure password expiration is 365 days or less
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4166,7 +4166,7 @@ queries:
     title: Ensure minimum days between password changes is 1 or more
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4258,7 +4258,7 @@ queries:
     title: Ensure password hashing algorithm is SHA-512 or YESCRYPT
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4354,7 +4354,7 @@ queries:
     title: Ensure permissions on /etc/crontab are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4437,7 +4437,7 @@ queries:
     title: Ensure permissions on /etc/cron.d are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4514,7 +4514,7 @@ queries:
     title: Ensure permissions on /etc/cron.hourly are configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -38,7 +38,7 @@ queries:
     title: Verify Shodan membership
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -97,7 +97,7 @@ queries:
     title: Ensure no ports are open
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -156,7 +156,7 @@ queries:
     title: Ensure no vulnerabilities are detected
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -48,7 +48,7 @@ queries:
     title: Ensure that between 2 and 4 users have admin permissions
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -89,7 +89,7 @@ queries:
     title: Ensure that admins use the most secure 2FA method
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -130,7 +130,7 @@ queries:
     title: Ensure all users use 2FA
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -171,7 +171,7 @@ queries:
     title: Use clear naming for external channels
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -217,7 +217,7 @@ queries:
     title: Ensure there is at least one internal channel per workspace
     impact: 20
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -264,7 +264,7 @@ queries:
     title: Ensure at least one internal channel exists with no external members
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -318,7 +318,7 @@ queries:
     title: Ensure domain is enforced on internal channels
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -363,7 +363,7 @@ queries:
     title: Ensure all active users have confirmed their email address
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -61,7 +61,7 @@ queries:
     impact: 90
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -161,7 +161,7 @@ queries:
     impact: 80
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -229,7 +229,7 @@ queries:
     impact: 60
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -299,7 +299,7 @@ queries:
     impact: 80
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -373,7 +373,7 @@ queries:
     impact: 80
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -455,7 +455,7 @@ queries:
     impact: 80
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -542,7 +542,7 @@ queries:
     impact: 90
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -612,7 +612,7 @@ queries:
     impact: 80
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -681,7 +681,7 @@ queries:
     impact: 70
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -761,7 +761,7 @@ queries:
     impact: 70
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -835,7 +835,7 @@ queries:
     impact: 60
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -908,7 +908,7 @@ queries:
     impact: 60
     filters: asset.platform == 'snowflake'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -54,7 +54,7 @@ queries:
     title: Ensure all devices are authorized to join the tailnet
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -119,7 +119,7 @@ queries:
     title: Ensure device key expiry is not disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -194,7 +194,7 @@ queries:
     title: Ensure devices are running up-to-date Tailscale client software
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -269,7 +269,7 @@ queries:
     title: Ensure no devices have tailnet lock errors
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -338,7 +338,7 @@ queries:
     impact: 70
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -389,7 +389,7 @@ queries:
     impact: 70
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -438,7 +438,7 @@ queries:
     impact: 50
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -487,7 +487,7 @@ queries:
     impact: 70
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -539,7 +539,7 @@ queries:
     impact: 70
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -591,7 +591,7 @@ queries:
     impact: 60
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -643,7 +643,7 @@ queries:
     impact: 70
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -695,7 +695,7 @@ queries:
     impact: 90
     filters: asset.platform == 'tailscale'
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -65,7 +65,7 @@ queries:
     title: Certificate's domain name must match
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -222,7 +222,7 @@ queries:
     title: Certificate is valid
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -361,7 +361,7 @@ queries:
     title: Certificate is not near expiration or expired
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -506,7 +506,7 @@ queries:
     title: None of the certificates (intermediate or root) have expired
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -663,7 +663,7 @@ queries:
     title: Do not use a self-signed certificate
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -828,7 +828,7 @@ queries:
     title: Do not use revoked certificates
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1011,7 +1011,7 @@ queries:
     title: Do not use weak certificate signatures
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1176,7 +1176,7 @@ queries:
     title: Avoid weak SSL and TLS versions
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1340,7 +1340,7 @@ queries:
     title: Avoid RC4 ciphers
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1452,7 +1452,7 @@ queries:
     title: Avoid NULL cipher suites
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1567,7 +1567,7 @@ queries:
     title: Avoid export cipher suites
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1679,7 +1679,7 @@ queries:
     title: Avoid anonymous Diffie-Hellman suites
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1791,7 +1791,7 @@ queries:
     title: Avoid weak block ciphers
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1906,7 +1906,7 @@ queries:
     title: Avoid weak block cipher modes
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2023,7 +2023,7 @@ queries:
     title: Avoid cipher suites with RSA key exchange
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2138,7 +2138,7 @@ queries:
     title: Avoid old cipher suites
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2254,7 +2254,7 @@ queries:
     title: Preferred ciphers must include AEAD ciphers
     impact: 85
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2373,7 +2373,7 @@ queries:
     title: Preferred ciphers must include perfect forward secrecy (PFS)
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2494,7 +2494,7 @@ queries:
     title: Mitigate BEAST attacks on the server-side
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2633,7 +2633,7 @@ queries:
     title: Ensure the certificate chain is verified and trusted
     impact: 95
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2805,7 +2805,7 @@ queries:
     title: Ensure TLS 1.3 is supported
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2913,7 +2913,7 @@ queries:
     title: Ensure OCSP responder is configured for the certificate
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3062,7 +3062,7 @@ queries:
     title: Ensure non-SNI connections do not expose a different certificate
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -91,7 +91,7 @@ queries:
     title: Ensure no wireless networks use open authentication
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -134,7 +134,7 @@ queries:
     title: Ensure wireless networks use WPA2 or WPA3 encryption
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -183,7 +183,7 @@ queries:
     title: Ensure WPA3 support is enabled on wireless networks
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -227,7 +227,7 @@ queries:
     title: Ensure Protected Management Frames are enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -274,7 +274,7 @@ queries:
     title: Ensure WLANs use strong WPA encryption ciphers
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -317,7 +317,7 @@ queries:
     title: Ensure WPA group rekey interval is configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -359,7 +359,7 @@ queries:
     title: Ensure L2 isolation is enabled on guest WLANs
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -406,7 +406,7 @@ queries:
     title: Ensure guest wireless networks use guest mode
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -454,7 +454,7 @@ queries:
     title: Ensure Intrusion Prevention System is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -502,7 +502,7 @@ queries:
     title: Ensure DNS filtering is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -545,7 +545,7 @@ queries:
     title: Ensure the internal honeypot is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -587,7 +587,7 @@ queries:
     title: Ensure UPnP is disabled on the gateway
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -634,7 +634,7 @@ queries:
     title: Ensure broadcast ping response is disabled
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -676,7 +676,7 @@ queries:
     title: Ensure ICMP redirects are disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -718,7 +718,7 @@ queries:
     title: Ensure SYN cookies are enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -759,7 +759,7 @@ queries:
     title: Ensure DHCP snooping is enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -804,7 +804,7 @@ queries:
     title: Ensure Spanning Tree Protocol is using RSTP
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -850,7 +850,7 @@ queries:
     title: Ensure SSH access to devices is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -897,7 +897,7 @@ queries:
     title: Ensure SSH password authentication is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -940,7 +940,7 @@ queries:
     title: Ensure debug tools are disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -981,7 +981,7 @@ queries:
     title: Ensure automatic backups are enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
@@ -1023,7 +1023,7 @@ queries:
     title: Ensure automatic firmware upgrades are enabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1069,7 +1069,7 @@ queries:
     title: Ensure analytics data collection is disabled
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -1109,7 +1109,7 @@ queries:
     title: Ensure remote syslog is configured
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1158,7 +1158,7 @@ queries:
     title: Ensure no port forwards expose management interfaces
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1203,7 +1203,7 @@ queries:
     title: Ensure DNS over HTTPS is enabled
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1248,7 +1248,7 @@ queries:
     title: Ensure network isolation is enabled on guest networks
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1296,7 +1296,7 @@ queries:
     title: Ensure IGMP snooping is enabled on LAN networks
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1344,7 +1344,7 @@ queries:
     title: Ensure VPN servers use modern protocols
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1387,7 +1387,7 @@ queries:
     title: Ensure enabled VPN tunnels are connected
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1431,7 +1431,7 @@ queries:
     title: Ensure VPN clients use modern protocols
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1475,7 +1475,7 @@ queries:
     title: Ensure all devices are running latest firmware
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -66,7 +66,7 @@ queries:
     title: Ensure CORS does not allow arbitrary origins
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -99,7 +99,7 @@ queries:
     title: Ensure non-v1 inference routes are not anonymously accessible
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -132,7 +132,7 @@ queries:
     title: Ensure development routes are not exposed
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-05
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -163,7 +163,7 @@ queries:
     title: Ensure FastAPI documentation is not exposed
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -194,7 +194,7 @@ queries:
     title: Ensure load tracking is not anonymously exposed
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -225,7 +225,7 @@ queries:
     title: Ensure Prometheus metrics are not anonymously exposed
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -256,7 +256,7 @@ queries:
     title: Ensure OpenAI-compatible routes require authentication
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -289,7 +289,7 @@ queries:
     title: Ensure the OpenAPI specification is not exposed
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -320,7 +320,7 @@ queries:
     title: Ensure operational control routes are not anonymously accessible
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -351,7 +351,7 @@ queries:
     title: Ensure profiler routes are not exposed
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -382,7 +382,7 @@ queries:
     title: Ensure tokenization routes are not anonymously accessible
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -413,7 +413,7 @@ queries:
     title: Ensure tokenizer information is not exposed
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -444,7 +444,7 @@ queries:
     title: Ensure the vLLM API is served over TLS
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: "false"
@@ -477,7 +477,7 @@ queries:
     title: Ensure the vLLM version endpoint is not exposed
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: "false"
+      compliance/bsi-sys-1-5: "false"
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: "false"

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -87,7 +87,7 @@ queries:
     title: Ensure account lockout is set to 15 minutes
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
@@ -159,7 +159,7 @@ queries:
     title: Ensure all loaded ESXi kernel modules are signed
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -241,7 +241,7 @@ queries:
     title: Ensure bidirectional CHAP authentication for iSCSI traffic is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
@@ -328,7 +328,7 @@ queries:
     title: Ensure DNS is statically configured on the ESXi host
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -404,7 +404,7 @@ queries:
     title: Ensure dvfilter API is not configured if not used
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -482,7 +482,7 @@ queries:
     title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
@@ -559,7 +559,7 @@ queries:
     title: Ensure Managed Object Browser (MOB) is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -631,7 +631,7 @@ queries:
     title: Ensure Normal Lockdown mode is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a5
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -703,7 +703,7 @@ queries:
     title: Ensure NTP time synchronization is configured properly
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a7
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a7
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
       compliance/dora: false
       compliance/hipaa: false
@@ -779,7 +779,7 @@ queries:
     title: Ensure persistent logging is configured for all ESXi hosts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -852,7 +852,7 @@ queries:
     title: Ensure port groups are not configured to the value of the native VLAN
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: false
       compliance/hipaa: false
@@ -949,7 +949,7 @@ queries:
     title: Ensure port groups avoid VLAN 4095 and 0 except for VGT
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: false
       compliance/hipaa: false
@@ -1044,7 +1044,7 @@ queries:
     title: Ensure remote logging is configured for ESXi hosts
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1117,7 +1117,7 @@ queries:
     title: Ensure SSH is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1194,7 +1194,7 @@ queries:
     title: Ensure Strict Lockdown mode is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a5
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1267,7 +1267,7 @@ queries:
     title: Ensure the DCUI timeout is set to 600 seconds or less
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
@@ -1336,7 +1336,7 @@ queries:
     title: Ensure the default value of individual salt per vm is configured
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1411,7 +1411,7 @@ queries:
     title: Ensure the ESXi host firewall restricts access to running services
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1480,7 +1480,7 @@ queries:
     title: Ensure the ESXi host SSL certificate is not expired or expiring soon
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
@@ -1547,7 +1547,7 @@ queries:
     title: Ensure the ESXi shell is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1619,7 +1619,7 @@ queries:
     title: Ensure the Image Profile VIB acceptance level is configured properly
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1693,7 +1693,7 @@ queries:
     title: Ensure the maximum failed login attempts is set to 5
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
@@ -1766,7 +1766,7 @@ queries:
     title: Ensure the shell services timeout is set to 1 hour or less
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
@@ -1840,7 +1840,7 @@ queries:
     title: Ensure the SLP service is disabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1917,7 +1917,7 @@ queries:
     title: Ensure the SNMP service is disabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1993,7 +1993,7 @@ queries:
     title: Ensure the vSwitch Forged Transmits policy is set to reject
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: false
       compliance/hipaa: false
@@ -2096,7 +2096,7 @@ queries:
     title: Ensure the vSwitch MAC Address Change policy is set to reject
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: false
       compliance/hipaa: false
@@ -2199,7 +2199,7 @@ queries:
     title: Ensure the vSwitch Promiscuous Mode policy is set to reject
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a4
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: false
       compliance/hipaa: false
@@ -2303,7 +2303,7 @@ queries:
     title: Ensure UEFI Secure Boot is enabled on the ESXi host
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -101,7 +101,7 @@ queries:
     title: Ensure a virtual Trusted Platform Module is present
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -193,7 +193,7 @@ queries:
     title: Ensure Autologon is disabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -291,7 +291,7 @@ queries:
     title: Ensure BIOS BBS is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -386,7 +386,7 @@ queries:
     title: Ensure Drag and Drop Version Get is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -485,7 +485,7 @@ queries:
     title: Ensure Drag and Drop Version Set is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -584,7 +584,7 @@ queries:
     title: Ensure GetCreds is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -683,7 +683,7 @@ queries:
     title: Ensure Guest Host Interaction Launch Menu is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -782,7 +782,7 @@ queries:
     title: Ensure Guest Host Interaction Protocol Handler is set to disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -881,7 +881,7 @@ queries:
     title: Ensure Guest Host Interaction Tray Icon is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -980,7 +980,7 @@ queries:
     title: Ensure hardware-based 3D acceleration is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1078,7 +1078,7 @@ queries:
     title: Ensure Host Guest File System Server is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1177,7 +1177,7 @@ queries:
     title: Ensure host information is not sent to guests
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1275,7 +1275,7 @@ queries:
     title: Ensure informational messages from the VM to the VMX file are limited
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1364,7 +1364,7 @@ queries:
     title: Ensure memSchedFakeSampleStats is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1464,7 +1464,7 @@ queries:
     title: Ensure nonpersistent disks are limited
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1534,7 +1534,7 @@ queries:
     title: Ensure only one remote console connection is permitted to a VM at any time
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1638,7 +1638,7 @@ queries:
     title: Ensure PCI and PCIe device pass-through is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1701,7 +1701,7 @@ queries:
     title: Ensure Request Disk Topology is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1800,7 +1800,7 @@ queries:
     title: Ensure Shell Action is disabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -1899,7 +1899,7 @@ queries:
     title: Ensure the number of VM log files is configured properly
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: false
       compliance/hipaa: false
@@ -1998,7 +1998,7 @@ queries:
     title: Ensure Trash Folder State is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2097,7 +2097,7 @@ queries:
     title: Ensure UEFI Secure Boot is enabled for virtual machines
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2189,7 +2189,7 @@ queries:
     title: Ensure unauthorized connection of devices is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2275,7 +2275,7 @@ queries:
     title: Ensure unauthorized modification and disconnection of devices is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2361,7 +2361,7 @@ queries:
     title: Ensure Unity Active is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2460,7 +2460,7 @@ queries:
     title: Ensure Unity Interlock is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2559,7 +2559,7 @@ queries:
     title: Ensure Unity is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2658,7 +2658,7 @@ queries:
     title: Ensure Unity Push Update is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2757,7 +2757,7 @@ queries:
     title: Ensure Unity Taskbar is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2856,7 +2856,7 @@ queries:
     title: Ensure Unity Window Contents is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -2956,7 +2956,7 @@ queries:
     title: Ensure unnecessary CD/DVD devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3020,7 +3020,7 @@ queries:
     title: Ensure unnecessary floppy devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3084,7 +3084,7 @@ queries:
     title: Ensure unnecessary parallel ports are disconnected
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3149,7 +3149,7 @@ queries:
     title: Ensure unnecessary serial ports are disconnected
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3214,7 +3214,7 @@ queries:
     title: Ensure unnecessary USB devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3277,7 +3277,7 @@ queries:
     title: Ensure virtual disk shrinking is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3376,7 +3376,7 @@ queries:
     title: Ensure virtual disk wiping is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3472,7 +3472,7 @@ queries:
     title: Ensure virtual machine encryption is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a28
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -3542,7 +3542,7 @@ queries:
     title: Ensure Virtualization-Based Security is enabled
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a3
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3636,7 +3636,7 @@ queries:
     title: Ensure VM Console Copy operations are disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3731,7 +3731,7 @@ queries:
     title: Ensure VM Console Drag and Drop operations is disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3826,7 +3826,7 @@ queries:
     title: Ensure VM Console GUI Options is disabled
     impact: 75
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -3921,7 +3921,7 @@ queries:
     title: Ensure VM Console Paste operations are disabled
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a16
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: false
       compliance/hipaa: false
@@ -4016,7 +4016,7 @@ queries:
     title: Ensure VM log file size is limited
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: bsi-sys-1-5-a6
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: false
       compliance/hipaa: false

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -140,7 +140,7 @@ queries:
     title: Ensure 'Debug programs' is not set
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -250,7 +250,7 @@ queries:
     title: Ensure additional LSA protection is enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -345,7 +345,7 @@ queries:
     title: Ensure 'Always prompt for password upon connection' is set to 'Enabled'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -438,7 +438,7 @@ queries:
     title: "Ensure 'Application: Control Event Log max size behavior' is disabled"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -531,7 +531,7 @@ queries:
     title: "Ensure Application log file size is set to 32,768 KB or greater"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -628,7 +628,7 @@ queries:
     title: Ensure UAC restrictions apply to local accounts on network logons
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -719,7 +719,7 @@ queries:
     title: Ensure 'Audit Account Lockout' is set to include 'Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -825,7 +825,7 @@ queries:
     title: Ensure 'Audit Application Group Management' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -932,7 +932,7 @@ queries:
     title: Ensure 'Audit Audit Policy Change' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1045,7 +1045,7 @@ queries:
     title: Ensure 'Audit Authentication Policy Change' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1151,7 +1151,7 @@ queries:
     title: Ensure 'Audit Authorization Policy Change' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1251,7 +1251,7 @@ queries:
     title: Ensure 'Audit Credential Validation' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1350,7 +1350,7 @@ queries:
     title: Ensure 'Audit Detailed File Share' is set to include 'Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1446,7 +1446,7 @@ queries:
     title: Ensure 'Audit File Share' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1543,7 +1543,7 @@ queries:
     title: "Ensure audit policy subcategory settings override category settings"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1623,7 +1623,7 @@ queries:
     title: Ensure 'Audit Group Membership' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1720,7 +1720,7 @@ queries:
     title: Ensure 'Audit IPsec Driver' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1826,7 +1826,7 @@ queries:
     title: Ensure 'Audit Logoff' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -1923,7 +1923,7 @@ queries:
     title: Ensure 'Audit Logon' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2022,7 +2022,7 @@ queries:
     title: "Ensure 'Audit MPSSVC Rule-Level Policy Change' is Success/Failure"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2132,7 +2132,7 @@ queries:
     title: Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2237,7 +2237,7 @@ queries:
     title: Ensure 'Audit Other Object Access Events' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2345,7 +2345,7 @@ queries:
     title: Ensure 'Audit Other Policy Change Events' is set to include 'Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2449,7 +2449,7 @@ queries:
     title: Ensure 'Audit Other System Events' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2557,7 +2557,7 @@ queries:
     title: Ensure 'Audit PNP Activity' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2654,7 +2654,7 @@ queries:
     title: Ensure 'Audit Process Creation' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2754,7 +2754,7 @@ queries:
     title: Ensure 'Audit Removable Storage' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2851,7 +2851,7 @@ queries:
     title: Ensure 'Audit Security Group Management' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -2962,7 +2962,7 @@ queries:
     title: Ensure 'Audit Security State Change' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3061,7 +3061,7 @@ queries:
     title: Ensure 'Audit Security System Extension' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3161,7 +3161,7 @@ queries:
     title: Ensure 'Audit Sensitive Privilege Use' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3275,7 +3275,7 @@ queries:
     title: "Ensure 'Audit: Shut down if unable to log audits' is disabled"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3352,7 +3352,7 @@ queries:
     title: Ensure 'Audit Special Logon' is set to include 'Success'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3448,7 +3448,7 @@ queries:
     title: Ensure 'Audit System Integrity' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3553,7 +3553,7 @@ queries:
     title: Ensure 'Audit User Account Management' is set to 'Success and Failure'
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -3666,7 +3666,7 @@ queries:
     filters: |
       windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3749,7 +3749,7 @@ queries:
     filters: |
       windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3835,7 +3835,7 @@ queries:
     title: Ensure 'Do not allow COM port redirection' is set to 'Enabled'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3913,7 +3913,7 @@ queries:
     title: Ensure 'Do not allow drive redirection' is set to 'Enabled'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3995,7 +3995,7 @@ queries:
     title: Ensure 'Do not allow LPT port redirection' is set to 'Enabled'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4073,7 +4073,7 @@ queries:
     title: Ensure 'Do not allow passwords to be saved' is set to 'Enabled'
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4154,7 +4154,7 @@ queries:
     title: Ensure Plug and Play device redirection is disabled for RDS
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4232,7 +4232,7 @@ queries:
     title: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4313,7 +4313,7 @@ queries:
     title: Ensure SEHOP is enabled
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4393,7 +4393,7 @@ queries:
     title: Ensure 'Enforce password history' is set to '24 or more password(s)'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4474,7 +4474,7 @@ queries:
     title: Ensure 'Maximum password age' is set to '365 or fewer days, but not 0'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4557,7 +4557,7 @@ queries:
     title: Ensure 'Minimum password age' is set to '1 or more day(s)'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4636,7 +4636,7 @@ queries:
     title: Ensure 'Minimum password length' is set to '14 or more character(s)'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -4731,7 +4731,7 @@ queries:
     title: "Ensure NetBT NodeType is set to P-node"
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -4826,7 +4826,7 @@ queries:
     title: "Ensure anonymous SID/Name translation is disabled"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4898,7 +4898,7 @@ queries:
     title: "Ensure anonymous enumeration of SAM accounts is not allowed"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4976,7 +4976,7 @@ queries:
     title: "Ensure anonymous enumeration of SAM accounts and shares is blocked"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5054,7 +5054,7 @@ queries:
     title: "Ensure network credential and password storage is disabled"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5132,7 +5132,7 @@ queries:
     title: "Ensure Everyone permissions do not apply to anonymous users"
     impact: 70
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5207,7 +5207,7 @@ queries:
     title: "Ensure no Named Pipes can be accessed anonymously"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5289,7 +5289,7 @@ queries:
     title: "Ensure anonymous access to Named Pipes and Shares is restricted"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5383,7 +5383,7 @@ queries:
     title: "Ensure remote SAM access is restricted to Administrators only"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5464,7 +5464,7 @@ queries:
     title: "Ensure no shares can be accessed anonymously"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5539,7 +5539,7 @@ queries:
     title: "Ensure local accounts use Classic sharing and security model"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -5617,7 +5617,7 @@ queries:
     title: "Ensure Local System uses computer identity for NTLM"
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5692,7 +5692,7 @@ queries:
     title: "Ensure LocalSystem NULL session fallback is disabled"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -5767,7 +5767,7 @@ queries:
     title: "Ensure PKU2U online identity authentication requests are disabled"
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5849,7 +5849,7 @@ queries:
     title: "Ensure Kerberos encryption types are limited to AES and newer"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -5943,7 +5943,7 @@ queries:
     title: "Ensure LAN Manager hash value is not stored on password change"
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6021,7 +6021,7 @@ queries:
     title: "Ensure LAN Manager auth is set to NTLMv2 only, refuse LM/NTLM"
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6104,7 +6104,7 @@ queries:
     title: "Ensure LDAP client signing is set to 'Negotiate signing' or higher"
     impact: 40
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6186,7 +6186,7 @@ queries:
     title: "Ensure NTLM SSP server requires NTLMv2 and 128-bit encryption"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6266,7 +6266,7 @@ queries:
     title: "Ensure NTLM SSP client requires NTLMv2 and 128-bit encryption"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6346,7 +6346,7 @@ queries:
     title: Ensure 'Password must meet complexity requirements' is set to 'Enabled'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6466,7 +6466,7 @@ queries:
     title: Ensure 'Relax minimum password length limits' is set to 'Enabled'
     impact: 60
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -6552,7 +6552,7 @@ queries:
     title: Ensure 'Require secure RPC communication' is set to 'Enabled'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -6632,7 +6632,7 @@ queries:
     title: "Ensure RDP connections use SSL security layer"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -6719,7 +6719,7 @@ queries:
     title: Ensure Network Level Authentication is required for RDP
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -6815,7 +6815,7 @@ queries:
     title: "Ensure 'Security: Control Event Log max size behavior' is disabled"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6900,7 +6900,7 @@ queries:
     title: "Ensure Security log file size is set to 196,608 KB or greater"
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -6985,7 +6985,7 @@ queries:
     title: "Ensure RDP client connection encryption is set to High Level"
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7075,7 +7075,7 @@ queries:
     title: "Ensure idle RDS sessions time out in 15 minutes or less"
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7175,7 +7175,7 @@ queries:
     title: "Ensure disconnected RDS sessions time out in 1 minute"
     impact: 50
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -7265,7 +7265,7 @@ queries:
     title: "Ensure 'Setup: Control Event Log max size behavior' is disabled"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7350,7 +7350,7 @@ queries:
     title: "Ensure Setup log file size is set to 32,768 KB or greater"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7435,7 +7435,7 @@ queries:
     title: Ensure 'Store passwords using reversible encryption' is set to 'Disabled'
     impact: 90
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -7537,7 +7537,7 @@ queries:
     title: "Ensure 'System: Control Event Log max size behavior' is disabled"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7621,7 +7621,7 @@ queries:
     title: "Ensure System log file size is set to 32,768 KB or greater"
     impact: 30
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
@@ -7718,7 +7718,7 @@ queries:
     title: Ensure 'Turn off multicast name resolution' is set to 'Enabled'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -7809,7 +7809,7 @@ queries:
     title: Ensure 'WDigest Authentication' is set to 'Disabled'
     impact: 80
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -48,7 +48,7 @@ queries:
     title: Ensure BitLocker Encryption is Enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -112,7 +112,7 @@ queries:
     title: Ensure Secure Boot is enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -146,7 +146,7 @@ queries:
     title: Ensure Automatic Windows Update is enabled
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -255,7 +255,7 @@ queries:
     title: Ensure AntiVirus is installed, enabled and up-to-date
     impact: 100
     tags:
-      compliance/bsi-grundschutz-sys15: false
+      compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
       compliance/dora: dora-art-9
       compliance/hipaa: false


### PR DESCRIPTION
## Problem

The bundle update PR [mondoohq/cnspec-enterprise-policies#2461](https://github.com/mondoohq/cnspec-enterprise-policies/pull/2461) fails its migration test with:

```
failed to validate framework map: cannot find framework owner 'bsi-grundschutz-sys15'
in this bundle, referenced by framework map bsi-grundschutz-sys15-cnspec-mapping
```

The enterprise framework file `frameworks/bsi-grundschutz-sys15.mql.yaml` declares its `uid:` as **`bsi-sys-1-5`** — the file name says `grundschutz-sys15`, but the uid (and every control uid, `bsi-sys-1-5-aXX`) says `bsi-sys-1-5`.

Content policies tagged checks with `compliance/bsi-grundschutz-sys15`, keying off the file name rather than the framework `uid`. This stayed invisible because every occurrence was the `: false` placeholder, which generates no framework map. Once the VMware vSphere policies (#2541 / #2542) added **real** control values, the bundle generator produced a framework map `bsi-grundschutz-sys15-cnspec-mapping` with `framework_owner.uid: bsi-grundschutz-sys15` — a framework that does not exist — and migration validation rejected it.

## Fix

- Rename the tag key `compliance/bsi-grundschutz-sys15` → `compliance/bsi-sys-1-5` across all `content/` policies (2220 occurrences, 48 files). All occurrences are changed — not just the real mappings in the vSphere policies — so the `: false` placeholders don't re-trigger this the next time one is mapped to a control.
- Document in `content/CLAUDE.md` that the `<framework>` in a `compliance/<framework>` key must match the framework's `uid:` field, **not** its file name.

## Verification

- `cnspec policy lint` passes on the affected vSphere / vLLM policies.
- No `compliance/bsi-grundschutz-sys15` keys remain in `content/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)