### PR TITLE
:memo: Bring the Shodan policy up to authoring standards

### DIFF
--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -76,20 +76,26 @@ queries:
         2. Open your [account overview](https://account.shodan.io/).
         3. Review the **Account Type** and any displayed query and scan credits.
 
+        A passing account shows an active membership tier; a failing account shows a free or expired plan.
+
         ### Audit via the Shodan CLI
 
         1. Run `shodan info`.
         2. Review the output for `Membership: True` and the remaining query and scan credits.
 
-        A passing result shows an active membership; a failing result shows a free or expired account.
-      remediation: |
-        Verify and maintain your organization's Shodan membership:
+        A passing account reports `Membership: True`; a failing account reports `Membership: False`.
+      remediation:
+        - id: console
+          desc: |
+            **Using the Shodan website**
 
-        1. Log in to your Shodan account at [shodan.io](https://www.shodan.io/).
-        2. Navigate to your account settings and verify that your membership is active.
-        3. Confirm that the membership tier provides the features your organization requires (e.g., API access, scanning credits, network monitoring).
-        4. If the membership has expired, renew it through the Shodan billing portal.
-        5. If no membership exists, purchase an appropriate plan based on your organization's security monitoring needs.
+            Verify and maintain your organization's Shodan membership:
+
+            1. Log in to your Shodan account at [shodan.io](https://www.shodan.io/).
+            2. Navigate to your account settings and verify that your membership is active.
+            3. Confirm that the membership tier provides the features your organization requires, such as API access, scanning credits, and network monitoring.
+            4. If the membership has expired, renew it through the Shodan billing portal.
+            5. If no membership exists, purchase an appropriate plan based on your organization's security monitoring needs.
     refs:
       - url: https://www.shodan.io/
         title: Shodan
@@ -136,19 +142,25 @@ queries:
         1. Browse to `https://www.shodan.io/host/<ip-address>`, replacing `<ip-address>` with the host's public IP address.
         2. Review the **Ports** panel for any reachable services.
 
+        A passing host shows no ports in the panel; a failing host lists one or more reachable services.
+
         ### Audit via the Shodan CLI
 
         1. Run `shodan host <ip-address>`.
         2. Review the `Ports:` line in the output.
 
-        A passing result lists no open ports; a failing result lists one or more ports reachable from the internet.
-      remediation: |
-        Review the open ports identified by Shodan and close any that are not required for the system's operation:
+        A passing host shows no ports; a failing host lists one or more ports reachable from the internet.
+      remediation:
+        - id: host
+          desc: |
+            **On the affected host**
 
-        1. Identify the services running on each open port.
-        2. Disable unnecessary services and close their corresponding ports using firewall rules.
-        3. For required services, ensure they are properly secured with authentication, encryption, and access controls.
-        4. Re-scan the host to verify that the ports have been closed.
+            Review the open ports identified by Shodan and close any that are not required for the system's operation:
+
+            1. Identify the services running on each open port.
+            2. Disable unnecessary services and close their corresponding ports using firewall rules.
+            3. For required services, ensure they are properly secured with authentication, encryption, and access controls.
+            4. Re-scan the host to verify that the ports have been closed.
     refs:
       - url: https://www.shodan.io/
         title: Shodan
@@ -195,19 +207,25 @@ queries:
         1. Browse to `https://www.shodan.io/host/<ip-address>`, replacing `<ip-address>` with the host's public IP address.
         2. Review the **Vulnerabilities** section for any listed CVEs.
 
+        A passing host shows no Vulnerabilities section; a failing host lists one or more CVEs.
+
         ### Audit via the Shodan CLI
 
         1. Run `shodan host <ip-address>`.
         2. Review the output for a `Vulnerabilities:` section.
 
-        A passing result lists no vulnerabilities; a failing result lists one or more CVEs.
-      remediation: |
-        Review the vulnerabilities identified by Shodan and remediate them:
+        A passing host shows no `Vulnerabilities:` section; a failing host lists one or more CVEs.
+      remediation:
+        - id: host
+          desc: |
+            **On the affected host**
 
-        1. Cross-reference the detected CVEs with vendor advisories and the National Vulnerability Database (NVD).
-        2. Apply available patches and updates to affected services.
-        3. If patches are not available, implement compensating controls such as network segmentation or Web Application Firewalls (WAFs).
-        4. Re-scan the host to verify that the vulnerabilities have been addressed.
+            Review the vulnerabilities identified by Shodan and remediate them:
+
+            1. Cross-reference the detected CVEs with vendor advisories and the National Vulnerability Database (NVD).
+            2. Apply available patches and updates to affected services.
+            3. If patches are not available, implement compensating controls such as network segmentation or Web Application Firewalls (WAFs).
+            4. Re-scan the host to verify that the vulnerabilities have been addressed.
     refs:
       - url: https://www.shodan.io/
         title: Shodan


### PR DESCRIPTION
## Summary

Brings `content/mondoo-shodan.mql.yaml` into conformance with the policy-authoring standards in `content/CLAUDE.md`. The policy's descriptions, audit sections, and compliance mappings were already standardized (#2540, #2541); this closes the two remaining structural gaps.

## Changes

- **Remediation format.** Each check's `remediation:` was a plain string block. `content/CLAUDE.md` specifies remediation as a list of `- id: <method>` entries, one per management surface. Converted all three:
  - `mondoo-shodan-membership` → `- id: console` (the Shodan account website).
  - `mondoo-shodan-no-port` / `mondoo-shodan-vulnerabilities` → `- id: host` (the affected host — these are observation checks against arbitrary internet hosts with no single vendor management surface).
- **Audit pass/fail per section.** Each `audit:` block had one combined pass/fail sentence after both the website and CLI sections. Split so each `### Audit via ...` path ends with its own pass/fail result, matching the documented audit structure.
- **Parenthetical aside removed** from the membership remediation in favor of plain prose.

No `uid`, `mql`, `impact`, or compliance-tag changes. `cnspec policy lint` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)