### PR TITLE
:memo: Bring the Cisco IOS XE/XR/NX-OS policies up to authoring standards

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -435,6 +435,7 @@ mwezi
 myacr
 myapp
 myimage
+mypubkey
 myservice
 mysqladmin
 nameid

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -93,6 +93,13 @@ jobs:
           tflint_version: v0.61.0
 
       - name: Validate terraform remediation blocks
+        env:
+          # `tflint --init` downloads ruleset plugins from GitHub releases.
+          # Without an authenticated token it uses the 60-request/hour
+          # anonymous GitHub API limit, which is exhausted partway through
+          # plugin init and fails the google/azurerm rulesets. The token
+          # raises the limit to 5000/hour.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 content/validation/validate_terraform_remediation.py --github-actions
 
   validate-ansible:

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -140,6 +140,17 @@ queries:
         - Compliance with security frameworks requiring encrypted management access cannot be met.
 
         Enabling SSH ensures that secure, encrypted remote management access is available.
+      audit: |-
+        To verify that SSH is enabled on the device:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the SSH server status:
+
+           ```
+           show ip ssh
+           ```
+
+        The device passes when the output reports `SSH Enabled` along with a protocol version. Output reporting `SSH Disabled` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -189,6 +200,17 @@ queries:
         - Compliance with modern security frameworks cannot be met.
 
         Enforcing SSH version 2 ensures all remote management sessions use strong cryptographic protections.
+      audit: |-
+        To verify that SSH version 2 is enforced:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the SSH server status:
+
+           ```
+           show ip ssh
+           ```
+
+        The device passes when the output reports `SSH Enabled - version 2.0`. Any output reporting version 1.5, 1.99, or compatibility mode is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -235,6 +257,17 @@ queries:
         - Slow brute-force attacks can keep connections open for extended periods.
 
         Configuring an SSH timeout limits the authentication window and reduces resource consumption.
+      audit: |-
+        To verify that an SSH login timeout is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the SSH configuration:
+
+           ```
+           show ip ssh
+           ```
+
+        The device passes when the reported `Authentication timeout` is greater than 0 and 120 seconds or less. A timeout of 0 or greater than 120 seconds is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -280,6 +313,17 @@ queries:
         - Compliance with NIST and other standards requiring minimum 2048-bit RSA keys cannot be met.
 
         Using RSA keys of at least 2048 bits ensures adequate cryptographic strength.
+      audit: |-
+        To verify the RSA key modulus size:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the device crypto keys:
+
+           ```
+           show crypto key mypubkey rsa
+           ```
+
+        The device passes when at least one key pair reports a modulus of 2048 bits or larger. If every key pair reports a modulus smaller than 2048 bits, it is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -327,6 +371,17 @@ queries:
         - Compliance with security frameworks requiring centralized authentication cannot be achieved.
 
         Enabling the AAA new model is the prerequisite for all AAA functionality.
+      audit: |-
+        To verify that the AAA new model is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the AAA setting:
+
+           ```
+           show running-config | include aaa new-model
+           ```
+
+        The device passes when the output contains `aaa new-model`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -373,6 +428,17 @@ queries:
         - Audit trails for authentication events are incomplete.
 
         Configuring AAA authentication login ensures proper authentication is enforced for all access methods.
+      audit: |-
+        To verify that AAA authentication login method lists are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured AAA authentication login lists:
+
+           ```
+           show running-config | include aaa authentication login
+           ```
+
+        The device passes when at least one `aaa authentication login` method list is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -422,6 +488,17 @@ queries:
         - Accountability for privileged operations is lost.
 
         Enabling AAA accounting ensures that all activity is logged for audit and compliance.
+      audit: |-
+        To verify that AAA accounting is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured AAA accounting entries:
+
+           ```
+           show running-config | include aaa accounting
+           ```
+
+        The device passes when at least one `aaa accounting` entry is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -471,6 +548,17 @@ queries:
         - An attacker with read access to the configuration obtains all credentials.
 
         Using `secret` for all user accounts ensures that credentials are stored with a one-way hash.
+      audit: |-
+        To verify that local users use `secret` rather than `password`:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured user accounts:
+
+           ```
+           show running-config | include ^username
+           ```
+
+        The device passes when every `username` line uses the `secret` keyword. Any `username` line using `password` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -523,6 +611,17 @@ queries:
         - Full administrative access to the device is compromised.
 
         Using `enable secret` ensures the privileged mode credential is protected with a one-way hash.
+      audit: |-
+        To verify that privileged EXEC access uses `enable secret`:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the enable credential:
+
+           ```
+           show running-config | include enable
+           ```
+
+        The device passes when the output contains an `enable secret` line and no `enable password` line. An `enable password` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -570,6 +669,17 @@ queries:
         - Configuration backups contain clear-text passwords.
 
         Enabling service password encryption provides a basic layer of protection against casual observation.
+      audit: |-
+        To verify that service password encryption is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the service setting:
+
+           ```
+           show running-config | include service password-encryption
+           ```
+
+        The device passes when the output contains `service password-encryption`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -616,6 +726,17 @@ queries:
         - The HTTP service increases the attack surface with potential web vulnerabilities.
 
         Disabling HTTP and using only HTTPS ensures that all web-based management is encrypted.
+      audit: |-
+        To verify that the HTTP server is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the HTTP server:
+
+           ```
+           show running-config | include ip http server
+           ```
+
+        The device passes when the output contains `no ip http server` or no `ip http server` line at all. An `ip http server` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -661,6 +782,17 @@ queries:
         - Compliance requirements for encrypted management interfaces cannot be met.
 
         Enabling HTTPS ensures that web-based management uses encrypted communications.
+      audit: |-
+        To verify that the HTTPS server is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the secure HTTP server:
+
+           ```
+           show running-config | include ip http secure-server
+           ```
+
+        The device passes when the output contains `ip http secure-server`. Empty output or `no ip http secure-server` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -707,6 +839,17 @@ queries:
         - This information enables targeted attacks against specific platform vulnerabilities.
 
         Disabling CDP prevents unnecessary information disclosure.
+      audit: |-
+        To verify that CDP is disabled globally:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the global CDP status:
+
+           ```
+           show cdp
+           ```
+
+        The device passes when the output reports that CDP is not enabled. Output reporting `CDP is enabled globally` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -752,6 +895,17 @@ queries:
         - It can be exploited for network reconnaissance or denial-of-service attacks.
 
         Disabling BOOTP removes an unnecessary service and reduces the attack surface.
+      audit: |-
+        To verify that the BOOTP service is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the BOOTP server:
+
+           ```
+           show running-config all | include ip bootp server
+           ```
+
+        The device passes when the output contains `no ip bootp server`. An `ip bootp server` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -798,6 +952,17 @@ queries:
         - Network access controls can be circumvented.
 
         Disabling source routing prevents attackers from manipulating packet routing paths.
+      audit: |-
+        To verify that IP source routing is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the source-route setting:
+
+           ```
+           show running-config all | include ip source-route
+           ```
+
+        The device passes when the output contains `no ip source-route`. An `ip source-route` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -843,6 +1008,17 @@ queries:
         - The attack surface is increased with a rarely monitored legacy service.
 
         Disabling PAD removes an unnecessary legacy service.
+      audit: |-
+        To verify that the PAD service is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the PAD service:
+
+           ```
+           show running-config all | include service pad
+           ```
+
+        The device passes when the output contains `no service pad`. A `service pad` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -889,6 +1065,17 @@ queries:
         - Time-sensitive security mechanisms can be compromised.
 
         Enabling NTP authentication ensures the device only accepts time updates from verified sources.
+      audit: |-
+        To verify that NTP authentication is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for NTP authentication:
+
+           ```
+           show running-config | include ntp authenticate
+           ```
+
+        The device passes when the output contains `ntp authenticate`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -938,6 +1125,17 @@ queries:
         - Event correlation across multiple devices is impossible.
 
         Configuring NTP servers ensures accurate, synchronized time.
+      audit: |-
+        To verify that NTP servers are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured NTP associations:
+
+           ```
+           show ntp associations
+           ```
+
+        The device passes when at least one NTP server association is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -985,6 +1183,17 @@ queries:
         - Compliance requirements for change management cannot be met.
 
         Enabling configuration change logging provides visibility into all configuration modifications.
+      audit: |-
+        To verify that configuration change logging is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configuration archive logging status:
+
+           ```
+           show archive log config all
+           ```
+
+        The device passes when the configuration logger is enabled and records change entries. Output reporting that the logger is not enabled is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1033,6 +1242,17 @@ queries:
         - Centralized log correlation is not possible.
 
         Configuring remote logging hosts ensures logs are preserved centrally.
+      audit: |-
+        To verify that remote logging hosts are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the logging configuration:
+
+           ```
+           show logging
+           ```
+
+        The device passes when at least one remote syslog host is listed under `Trap logging`. No configured logging host is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1081,6 +1301,17 @@ queries:
         - Real-time alerting on suspicious activity is not possible.
 
         Enabling failed login logging captures authentication failures for security monitoring.
+      audit: |-
+        To verify that failed login logging is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for login logging:
+
+           ```
+           show running-config | include login on-failure
+           ```
+
+        The device passes when the output contains `login on-failure log`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1130,6 +1361,17 @@ queries:
         - Automated scanning tools will immediately exploit default strings.
 
         Removing default community strings and using unique values ensures SNMP access is restricted.
+      audit: |-
+        To verify that default SNMP community strings are not in use:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show running-config | include snmp-server community
+           ```
+
+        The device passes when no community named `public` or `private` is listed. A `public` or `private` community string is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1179,6 +1421,17 @@ queries:
         - Write-access community strings allow remote configuration changes from any host.
 
         Applying ACLs restricts SNMP access to authorized management stations.
+      audit: |-
+        To verify that SNMP communities have ACLs applied:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show running-config | include snmp-server community
+           ```
+
+        The device passes when every `snmp-server community` line ends with an ACL number or name. Any community string with no ACL applied is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1228,6 +1481,17 @@ queries:
         - Compliance with encrypted management requirements cannot be met.
 
         Restricting VTY transport to SSH ensures all remote sessions are encrypted.
+      audit: |-
+        To verify that VTY lines accept only SSH transport:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the VTY line configuration:
+
+           ```
+           show running-config | section line vty
+           ```
+
+        The device passes when every VTY line reports `transport input ssh`. A VTY line allowing `telnet` or `all` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1277,6 +1541,17 @@ queries:
         - Compliance requirements for session management cannot be met.
 
         Configuring exec timeouts on VTY lines ensures idle sessions are terminated.
+      audit: |-
+        To verify that VTY lines have an exec timeout configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the VTY line configuration:
+
+           ```
+           show running-config | section line vty
+           ```
+
+        The device passes when every VTY line reports a non-zero `exec-timeout`. A VTY line with `exec-timeout 0 0` or no exec timeout is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1325,6 +1600,17 @@ queries:
         - Management access cannot be restricted to trusted networks.
 
         Applying ACLs to VTY lines restricts access to authorized management stations.
+      audit: |-
+        To verify that VTY lines have an inbound access class configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the VTY line configuration:
+
+           ```
+           show running-config | section line vty
+           ```
+
+        The device passes when every VTY line reports an `access-class <acl> in` entry. A VTY line with no inbound access class is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1372,6 +1658,17 @@ queries:
         - The AUX port bypasses network ACLs and firewall rules.
 
         Disabling exec on the AUX line prevents it from being used as an entry point.
+      audit: |-
+        To verify that the auxiliary line has exec disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the auxiliary line configuration:
+
+           ```
+           show running-config | section line aux
+           ```
+
+        The device passes when the auxiliary line reports `no exec`. An auxiliary line without `no exec` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1418,6 +1715,17 @@ queries:
         - Physical access security requirements cannot be met.
 
         Configuring a console exec timeout ensures idle sessions are terminated.
+      audit: |-
+        To verify that the console line has an exec timeout configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the console line configuration:
+
+           ```
+           show running-config | section line con
+           ```
+
+        The device passes when the console line reports a non-zero `exec-timeout`. A console line with `exec-timeout 0 0` or no exec timeout is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1465,6 +1773,17 @@ queries:
         - Compliance requirements for access warnings cannot be met.
 
         Configuring a login banner ensures all users receive legal notice before accessing the device.
+      audit: |-
+        To verify that a login banner is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the login banner:
+
+           ```
+           show running-config | include banner login
+           ```
+
+        The device passes when a `banner login` entry with text is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1510,6 +1829,17 @@ queries:
         - Legal requirements for displaying access warnings may not be met.
 
         Configuring a MOTD banner ensures users are notified of access policies.
+      audit: |-
+        To verify that a Message of the Day banner is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the MOTD banner:
+
+           ```
+           show running-config | include banner motd
+           ```
+
+        The device passes when a `banner motd` entry with text is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1558,6 +1888,17 @@ queries:
         - Network topology documentation is incomplete.
 
         Setting a descriptive hostname ensures the device is identifiable across all workflows.
+      audit: |-
+        To verify that a unique, descriptive hostname is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured hostname:
+
+           ```
+           show running-config | include ^hostname
+           ```
+
+        The device passes when a hostname is set and is not the generic value `router` or `switch`. An empty or generic hostname is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1604,6 +1945,17 @@ queries:
         - Device identification in DNS is not possible.
 
         Configuring a domain name ensures the device can participate in secured communications.
+      audit: |-
+        To verify that a domain name is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the domain name:
+
+           ```
+           show running-config | include ip domain name
+           ```
+
+        The device passes when an `ip domain name` entry is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1649,6 +2001,17 @@ queries:
         - Dead sessions are not detected and cleaned up.
 
         Enabling TCP keepalives-in ensures dead inbound sessions are detected and removed.
+      audit: |-
+        To verify that TCP keepalives for inbound sessions are enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the service setting:
+
+           ```
+           show running-config all | include service tcp-keepalives-in
+           ```
+
+        The device passes when the output contains `service tcp-keepalives-in`. A `no service tcp-keepalives-in` line or empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1694,6 +2057,17 @@ queries:
         - The device may not detect when a remote peer has become unreachable.
 
         Enabling TCP keepalives-out ensures dead outbound sessions are detected and removed.
+      audit: |-
+        To verify that TCP keepalives for outbound sessions are enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the service setting:
+
+           ```
+           show running-config all | include service tcp-keepalives-out
+           ```
+
+        The device passes when the output contains `service tcp-keepalives-out`. A `no service tcp-keepalives-out` line or empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1741,6 +2115,17 @@ queries:
         - BGP sessions can be disrupted through TCP reset attacks.
 
         Configuring authentication on BGP neighbors ensures only authorized peers can establish sessions.
+      audit: |-
+        To verify that BGP neighbors have authentication configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the BGP configuration:
+
+           ```
+           show running-config | section router bgp
+           ```
+
+        The device passes when every configured `neighbor` has a `password` entry. A BGP neighbor with no password configured is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1792,6 +2177,17 @@ queries:
         - Man-in-the-middle attacks via route injection are possible.
 
         Configuring OSPF authentication ensures only authorized routers participate in the routing domain.
+      audit: |-
+        To verify that OSPF areas have authentication configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the OSPF configuration:
+
+           ```
+           show running-config | section router ospf
+           ```
+
+        The device passes when every configured area has `authentication` or `authentication message-digest` set. An OSPF area with no authentication is a failing result.
       remediation:
         - id: cli
           desc: |

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -128,6 +128,17 @@ queries:
         - Credential exposure risk increases due to weaker key exchange mechanisms.
 
         Enforcing SSH version 2 ensures that all remote management sessions use a secure, modern protocol with strong cryptographic protections.
+      audit: |-
+        To verify that SSH version 2 is enforced:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the SSH server:
+
+           ```
+           show running-config ssh server
+           ```
+
+        The device passes when the output contains `ssh server v2`. Empty output or a version 1 setting is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -176,6 +187,17 @@ queries:
         - Compliance requirements for session management cannot be met.
 
         Configuring an SSH timeout ensures that idle sessions are automatically terminated, reducing the attack surface.
+      audit: |-
+        To verify that an SSH session timeout is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the SSH timeout:
+
+           ```
+           show running-config ssh timeout
+           ```
+
+        The device passes when the configured `ssh timeout` is greater than 0 and 120 seconds or less. A timeout of 0 or greater than 120 seconds is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -223,6 +245,17 @@ queries:
         - The overall security of all SSH sessions to the device is weakened.
 
         Using RSA keys of at least 2048 bits ensures that SSH sessions are protected with adequate cryptographic strength.
+      audit: |-
+        To verify the RSA key modulus size:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured crypto keys:
+
+           ```
+           show crypto key mypubkey rsa
+           ```
+
+        The device passes when the RSA key pair reports a modulus of 2048 bits or larger. A modulus smaller than 2048 bits is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -269,6 +302,17 @@ queries:
         - Compliance with security frameworks requiring centralized authentication cannot be achieved.
 
         Configuring AAA authentication login ensures centralized, scalable authentication with comprehensive audit trails.
+      audit: |-
+        To verify that AAA authentication login method lists are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for AAA authentication login:
+
+           ```
+           show running-config aaa authentication login
+           ```
+
+        The device passes when at least one `aaa authentication login` method list is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -319,6 +363,17 @@ queries:
         - Investigating unauthorized changes becomes significantly harder.
 
         Enabling AAA accounting ensures that all activity is logged and available for audit, investigation, and compliance reporting.
+      audit: |-
+        To verify that AAA accounting is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for AAA accounting:
+
+           ```
+           show running-config aaa accounting
+           ```
+
+        The device passes when at least one `aaa accounting` entry is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -368,6 +423,17 @@ queries:
         - Compliance with access control requirements cannot be met.
 
         Configuring AAA authorization ensures that users can only perform operations appropriate to their role.
+      audit: |-
+        To verify that AAA authorization is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for AAA authorization:
+
+           ```
+           show running-config aaa authorization
+           ```
+
+        The device passes when at least one `aaa authorization` entry is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -416,6 +482,17 @@ queries:
         - Compliance requirements for access control cannot be met.
 
         Configuring line authentication on all lines ensures that every access method requires proper authentication.
+      audit: |-
+        To verify that line authentication is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the line settings:
+
+           ```
+           show running-config line
+           ```
+
+        The device passes when the console and default lines each have a `login authentication` method list applied. A line with no `login authentication` entry is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -468,6 +545,17 @@ queries:
         - An attacker who gains read access to the configuration immediately obtains all credentials.
 
         Ensuring all users have encrypted passwords protects credentials from exposure through configuration access.
+      audit: |-
+        To verify that all local users have encrypted passwords:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured user accounts:
+
+           ```
+           show running-config username
+           ```
+
+        The device passes when every `username` entry stores its credential with a non-clear-text encryption type. A user with a type 0 (clear text) password is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -518,6 +606,17 @@ queries:
         - Compliance with password management requirements cannot be met.
 
         Configuring password policies ensures that all local accounts meet minimum security requirements for password strength.
+      audit: |-
+        To verify that AAA password policies are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for password policies:
+
+           ```
+           show running-config aaa password-policy
+           ```
+
+        The device passes when at least one `aaa password-policy` is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -576,6 +675,17 @@ queries:
         - RADIUS and TACACS+ shared secrets in the configuration are inadequately protected.
 
         Enabling Type 6 encryption ensures that passwords stored in the configuration are protected with AES encryption.
+      audit: |-
+        To verify that Type 6 AES password encryption is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the Type 6 password encryption state:
+
+           ```
+           show type6 server
+           ```
+
+        The device passes when the AES configuration state is reported as `Enabled`. Any other state is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -626,6 +736,17 @@ queries:
         - Time-sensitive security mechanisms such as OTP tokens can be compromised.
 
         Enabling NTP authentication ensures the device only accepts time updates from verified, trusted sources.
+      audit: |-
+        To verify that NTP authentication is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for NTP authentication:
+
+           ```
+           show running-config ntp authenticate
+           ```
+
+        The device passes when the output contains `ntp authenticate`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -676,6 +797,17 @@ queries:
         - Correlation of events across multiple devices becomes impossible.
 
         Configuring NTP servers ensures the device maintains accurate, synchronized time.
+      audit: |-
+        To verify that NTP servers are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured NTP associations:
+
+           ```
+           show ntp associations
+           ```
+
+        The device passes when at least one NTP server association is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -727,6 +859,17 @@ queries:
         - Operational issues cannot be diagnosed from historical data.
 
         Enabling logging ensures that the device records system events for security monitoring and troubleshooting.
+      audit: |-
+        To verify that logging is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the logging configuration and status:
+
+           ```
+           show logging
+           ```
+
+        The device passes when console, monitor, buffer, or trap logging is reported as active. Output reporting that all logging is disabled is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -778,6 +921,17 @@ queries:
         - SIEM integration for real-time security monitoring cannot function.
 
         Configuring remote syslog hosts ensures that logs are preserved in a centralized, tamper-resistant location.
+      audit: |-
+        To verify that remote syslog hosts are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for syslog hosts:
+
+           ```
+           show running-config logging
+           ```
+
+        The device passes when at least one remote syslog host is listed. No configured syslog host is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -826,6 +980,17 @@ queries:
         - There is no local log data available during network outages.
 
         Configuring buffer logging ensures that recent log messages are available locally for review.
+      audit: |-
+        To verify that buffer logging is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for buffered logging:
+
+           ```
+           show running-config logging buffered
+           ```
+
+        The device passes when a `logging buffered` severity level is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -879,6 +1044,17 @@ queries:
         - Sensitive network topology and configuration information is exposed.
 
         Removing default community strings and using unique, complex values ensures SNMP access is properly restricted.
+      audit: |-
+        To verify that default SNMP community strings are not in use:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show running-config snmp-server community
+           ```
+
+        The device passes when no community named `public` or `private` is listed. A `public` or `private` community string is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -928,6 +1104,17 @@ queries:
         - SNMP data can be viewed or modified by anyone who intercepts the community string.
 
         Configuring SNMPv3 users ensures that SNMP communications are authenticated and encrypted.
+      audit: |-
+        To verify that SNMPv3 users are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP users:
+
+           ```
+           show snmp user
+           ```
+
+        The device passes when at least one SNMPv3 user is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -980,6 +1167,17 @@ queries:
         - Write-access community strings without ACLs allow remote configuration changes from any host.
 
         Applying ACLs to SNMP community strings restricts access to authorized management stations only.
+      audit: |-
+        To verify that SNMP communities have ACLs applied:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show running-config snmp-server community
+           ```
+
+        The device passes when every `snmp-server community` line has an ACL applied. Any community string with no ACL is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1029,6 +1227,17 @@ queries:
         - Compliance with organizational and regulatory requirements for access warnings cannot be met.
 
         Configuring a login banner ensures that all users receive legal notice before accessing the device.
+      audit: |-
+        To verify that a login banner is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the login banner:
+
+           ```
+           show running-config banner login
+           ```
+
+        The device passes when a `banner login` entry with text is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1077,6 +1286,17 @@ queries:
         - Compliance requirements for session management are not fulfilled.
 
         Configuring a console exec timeout ensures that idle console sessions are terminated.
+      audit: |-
+        To verify that the console line has an exec timeout configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the console line:
+
+           ```
+           show running-config line console
+           ```
+
+        The device passes when the console line reports a non-zero `exec-timeout`. A console line with `exec-timeout 0 0` or no exec timeout is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1127,6 +1347,17 @@ queries:
         - Network topology documentation is incomplete or ambiguous.
 
         Setting a descriptive hostname ensures the device is easily recognizable across all operational and security workflows.
+      audit: |-
+        To verify that a unique, descriptive hostname is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured hostname:
+
+           ```
+           show running-config hostname
+           ```
+
+        The device passes when a hostname is set and is not the generic value `router` or `ios`. An empty or generic hostname is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1174,6 +1405,17 @@ queries:
         - This information can be used to identify vulnerable devices and plan targeted attacks.
 
         Disabling CDP prevents unnecessary information disclosure on the network.
+      audit: |-
+        To verify that CDP is disabled globally:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for CDP:
+
+           ```
+           show running-config cdp
+           ```
+
+        The device passes when no global `cdp` entry is present. A configured global `cdp` entry is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1223,6 +1465,17 @@ queries:
         - Each enabled service increases the attack surface without providing operational value.
 
         Disabling small servers removes unnecessary services and reduces the attack surface.
+      audit: |-
+        To verify that small servers are disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the small-server services:
+
+           ```
+           show running-config | include small-servers
+           ```
+
+        The device passes when no TCP or UDP small-server service is configured with a non-zero server count. Any enabled small-server service is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1277,6 +1530,17 @@ queries:
         - Compliance with standards requiring encrypted management interfaces cannot be met.
 
         Restricting VTY transport to SSH only ensures that all remote management sessions are encrypted.
+      audit: |-
+        To verify that VTY line templates accept only SSH transport:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the line templates:
+
+           ```
+           show running-config line template
+           ```
+
+        The device passes when every line template reports `transport input ssh`. A template allowing `telnet` is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1327,6 +1591,17 @@ queries:
         - Management access cannot be restricted to authorized management stations.
 
         Applying ACLs to VTY lines ensures that only authorized management stations can establish remote sessions.
+      audit: |-
+        To verify that VTY line templates have ACLs applied:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the line templates:
+
+           ```
+           show running-config line template
+           ```
+
+        The device passes when every line template reports an `access-class ingress` entry. A template with no ingress access class is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1379,6 +1654,17 @@ queries:
         - BGP sessions can be disrupted through TCP reset attacks.
 
         Configuring authentication on all BGP neighbors ensures that only authorized peers can establish sessions.
+      audit: |-
+        To verify that BGP neighbors have authentication configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the BGP configuration:
+
+           ```
+           show running-config router bgp
+           ```
+
+        The device passes when every configured `neighbor` has a `password` entry. A BGP neighbor with no password is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1432,6 +1718,17 @@ queries:
         - An attacker can perform man-in-the-middle attacks by advertising routes through their device.
 
         Configuring OSPF area authentication ensures that only authorized routers can participate in the OSPF routing domain.
+      audit: |-
+        To verify that OSPF areas have authentication configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the OSPF configuration:
+
+           ```
+           show running-config router ospf
+           ```
+
+        The device passes when every configured area has an `authentication keychain` or message-digest key set. An OSPF area with no authentication is a failing result.
       remediation:
         - id: cli
           desc: |

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -137,6 +137,17 @@ queries:
         - Clients configured to reject weak algorithms cannot connect.
 
         Using RSA or ECDSA ensures SSH sessions are protected with strong cryptographic algorithms.
+      audit: |-
+        To verify that the SSH key uses a strong algorithm:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the SSH server key information:
+
+           ```
+           show ssh key
+           ```
+
+        The device passes when the host key is reported as RSA or ECDSA. A DSA key is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -190,6 +201,17 @@ queries:
         - Compliance with NIST and other standards requiring minimum 2048-bit keys cannot be met.
 
         Using RSA keys of at least 2048 bits ensures adequate cryptographic strength for SSH sessions.
+      audit: |-
+        To verify the SSH RSA key modulus size:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the SSH server key information:
+
+           ```
+           show ssh key
+           ```
+
+        The device passes when the RSA host key reports a modulus of 2048 bits or larger. An RSA modulus smaller than 2048 bits is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -237,6 +259,17 @@ queries:
         - The device is more susceptible to credential-guessing attacks.
 
         Configuring an SSH login attempts limit slows down brute-force attacks.
+      audit: |-
+        To verify that an SSH login attempts limit is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the SSH login attempts limit:
+
+           ```
+           show running-config | include ssh login-attempts
+           ```
+
+        The device passes when `ssh login-attempts` is set to a value greater than 0 and 3 or fewer. A limit of 0 or greater than 3 is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -284,6 +317,17 @@ queries:
         - Compliance with security frameworks requiring centralized authentication cannot be met.
 
         Configuring AAA authentication login ensures centralized, scalable authentication.
+      audit: |-
+        To verify that AAA authentication login method lists are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for AAA authentication login:
+
+           ```
+           show running-config aaa | include authentication login
+           ```
+
+        The device passes when at least one `aaa authentication login` method list is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -331,6 +375,17 @@ queries:
         - Centralized user management, access control, and auditing cannot be implemented.
 
         Configuring AAA group servers enables centralized authentication and authorization.
+      audit: |-
+        To verify that AAA group servers are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured AAA server groups:
+
+           ```
+           show aaa groups
+           ```
+
+        The device passes when at least one TACACS+ or RADIUS server group is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -379,6 +434,17 @@ queries:
         - The overall security posture of the device is weakened.
 
         Enabling password strength checking ensures all passwords meet minimum complexity requirements.
+      audit: |-
+        To verify that password strength checking is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the password setting:
+
+           ```
+           show running-config | include password strength-check
+           ```
+
+        The device passes when the output contains `password strength-check`. A `no password strength-check` line or empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -426,6 +492,17 @@ queries:
         - Compliance with encryption requirements cannot be met.
 
         Enabling the encryption service with a master key ensures strong AES encryption for stored passwords.
+      audit: |-
+        To verify that the encryption service is enabled with a master key:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the password encryption status:
+
+           ```
+           show encryption service stat
+           ```
+
+        The device passes when AES encryption is enabled and a master key is configured. A disabled service or missing master key is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -475,6 +552,17 @@ queries:
         - Configuration files in version control or backups expose passwords.
 
         Ensuring all users have encrypted credentials protects them from exposure.
+      audit: |-
+        To verify that all local users have encrypted credentials:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured user accounts:
+
+           ```
+           show running-config | include ^username
+           ```
+
+        The device passes when every `username` credential uses a non-clear-text encryption type. A user with a type 0 (clear text) password is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -527,6 +615,17 @@ queries:
         - Compliance with password length requirements cannot be met.
 
         Setting a minimum passphrase length of at least 8 characters (15+ recommended) ensures passwords have adequate complexity.
+      audit: |-
+        To verify that the minimum passphrase length is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the passphrase setting:
+
+           ```
+           show running-config | include userpassphrase
+           ```
+
+        The device passes when `userpassphrase min-length` is set to 8 or greater. A minimum length below 8 or no setting is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -574,6 +673,17 @@ queries:
         - The device is more susceptible to password-cracking attacks.
 
         Configuring system login blocking introduces a delay after failed attempts, significantly slowing brute-force attacks.
+      audit: |-
+        To verify that the system login block feature is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the login block setting:
+
+           ```
+           show running-config | include system login block-for
+           ```
+
+        The device passes when a `system login block-for` entry with a non-zero block period and attempt count is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -622,6 +732,17 @@ queries:
         - Event correlation across devices is impossible.
 
         Configuring NTP servers ensures accurate, synchronized time.
+      audit: |-
+        To verify that NTP servers are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured NTP peers:
+
+           ```
+           show ntp peers
+           ```
+
+        The device passes when at least one NTP server is listed. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -668,6 +789,17 @@ queries:
         - Correlation with physical events or local schedules is difficult.
 
         Configuring the timezone ensures timestamps are clear and operationally relevant.
+      audit: |-
+        To verify that a timezone is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the clock timezone:
+
+           ```
+           show running-config | include clock timezone
+           ```
+
+        The device passes when a `clock timezone` entry is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -715,6 +847,17 @@ queries:
         - Centralized log correlation and SIEM integration is not possible.
 
         Configuring remote logging ensures logs are preserved centrally.
+      audit: |-
+        To verify that remote logging servers are configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured logging servers:
+
+           ```
+           show logging server
+           ```
+
+        The device passes when remote logging is enabled and at least one syslog server is listed. No configured server is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -762,6 +905,17 @@ queries:
         - Forensic analysis of rapid event sequences is impaired.
 
         Configuring millisecond or microsecond timestamps ensures precise event ordering.
+      audit: |-
+        To verify that logging timestamps use high precision:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the logging timestamp setting:
+
+           ```
+           show logging timestamp
+           ```
+
+        The device passes when the timestamp format is reported as milliseconds or microseconds. A seconds-precision format is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -808,6 +962,17 @@ queries:
         - Syslog messages may be dropped if the egress interface changes.
 
         Configuring a source interface ensures consistent, reliable log delivery.
+      audit: |-
+        To verify that a logging source interface is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the logging source interface:
+
+           ```
+           show running-config | include logging source-interface
+           ```
+
+        The device passes when a `logging source-interface` entry is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -855,6 +1020,17 @@ queries:
         - Automated scanning tools will immediately exploit default strings.
 
         Removing default community strings ensures SNMP access is properly restricted.
+      audit: |-
+        To verify that default SNMP community strings are not in use:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show snmp community
+           ```
+
+        The device passes when no community named `public` or `private` is listed. A `public` or `private` community string is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -903,6 +1079,17 @@ queries:
         - Compliance with standards requiring encrypted management protocols cannot be met.
 
         Enforcing SNMPv3 encryption globally ensures all SNMP communications are authenticated and encrypted.
+      audit: |-
+        To verify that SNMPv3 encryption is enforced globally:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the SNMP privacy setting:
+
+           ```
+           show running-config | include snmp-server globalEnforcePriv
+           ```
+
+        The device passes when the output contains `snmp-server globalEnforcePriv`. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -952,6 +1139,17 @@ queries:
         - Unauthorized SNMP polling exposes configuration and operational information.
 
         Applying ACLs restricts SNMP access to authorized management stations.
+      audit: |-
+        To verify that SNMP communities have ACLs applied:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured SNMP community strings:
+
+           ```
+           show snmp community
+           ```
+
+        The device passes when every community string has an IPv4 or IPv6 ACL applied. Any community with no ACL is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -998,6 +1196,17 @@ queries:
         - A compromised device can be reprovisioned with an attacker-controlled configuration.
 
         Disabling POAP prevents unauthorized auto-provisioning during device boot.
+      audit: |-
+        To verify that POAP is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the boot POAP setting:
+
+           ```
+           show running-config | include boot poap
+           ```
+
+        The device passes when the output contains `no boot poap enable` or no `boot poap enable` line at all. A `boot poap enable` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1045,6 +1254,17 @@ queries:
         - Management access may become unavailable during an attack.
 
         Using a strict or moderate CoPP profile ensures the control plane is adequately protected.
+      audit: |-
+        To verify that CoPP uses a non-lenient profile:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the active CoPP profile:
+
+           ```
+           show copp status
+           ```
+
+        The device passes when the active CoPP profile is `strict`, `moderate`, or `dense`. A `lenient` profile or no profile is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1093,6 +1313,17 @@ queries:
         - Compliance requirements for session management cannot be met.
 
         Configuring exec timeouts on VTY lines ensures idle sessions are terminated.
+      audit: |-
+        To verify that VTY lines have an exec timeout configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the VTY line:
+
+           ```
+           show running-config | section "line vty"
+           ```
+
+        The device passes when the VTY line reports a non-zero `exec-timeout`. A VTY line with `exec-timeout 0` or no exec timeout is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1141,6 +1372,17 @@ queries:
         - Physical access security requirements cannot be met.
 
         Configuring a console exec timeout ensures idle console sessions are terminated.
+      audit: |-
+        To verify that the console line has an exec timeout configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the console line:
+
+           ```
+           show running-config | section "line console"
+           ```
+
+        The device passes when the console line reports a non-zero `exec-timeout`. A console line with `exec-timeout 0` or no exec timeout is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1189,6 +1431,17 @@ queries:
         - Management access cannot be restricted to trusted networks.
 
         Applying ACLs to VTY lines restricts access to authorized management stations.
+      audit: |-
+        To verify that VTY lines have an inbound ACL configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the VTY line:
+
+           ```
+           show running-config | section "line vty"
+           ```
+
+        The device passes when the VTY line reports an `access-class <acl> in` entry. A VTY line with no inbound access class is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1236,6 +1489,17 @@ queries:
         - Compliance requirements for access warnings cannot be met.
 
         Configuring a MOTD banner ensures users receive legal notice before accessing the device.
+      audit: |-
+        To verify that a Message of the Day banner is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the MOTD banner:
+
+           ```
+           show running-config | include banner motd
+           ```
+
+        The device passes when a `banner motd` entry with text is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1281,6 +1545,17 @@ queries:
         - There is no post-authentication notice about monitoring or acceptable use.
 
         Configuring an exec banner reinforces security awareness after authentication.
+      audit: |-
+        To verify that an exec banner is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the exec banner:
+
+           ```
+           show running-config | include banner exec
+           ```
+
+        The device passes when a `banner exec` entry with text is configured. Empty output is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1329,6 +1604,17 @@ queries:
         - Network topology documentation is incomplete.
 
         Setting a descriptive hostname ensures the device is identifiable across all workflows.
+      audit: |-
+        To verify that a unique, descriptive hostname is configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the configured hostname:
+
+           ```
+           show running-config | include ^hostname
+           ```
+
+        The device passes when a hostname is set and is not the generic value `switch` or `nexus`. An empty or generic hostname is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1374,6 +1660,17 @@ queries:
         - Spoofed packets can reach internal networks.
 
         Disabling source routing prevents attackers from manipulating packet routing paths.
+      audit: |-
+        To verify that IP source routing is disabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the running configuration for the source-route setting:
+
+           ```
+           show running-config all | include ip source-route
+           ```
+
+        The device passes when the output contains `no ip source-route`. An `ip source-route` line is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1421,6 +1718,17 @@ queries:
         - Denial-of-service attacks can be amplified through the device.
 
         Disabling directed broadcast on all interfaces prevents amplification attacks.
+      audit: |-
+        To verify that IP directed broadcast is disabled on all interfaces:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the interface configuration:
+
+           ```
+           show running-config interface
+           ```
+
+        The device passes when no interface has `ip directed-broadcast` configured. Any interface with `ip directed-broadcast` enabled is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1471,6 +1779,17 @@ queries:
         - BGP sessions can be disrupted through TCP reset attacks.
 
         Configuring authentication on BGP neighbors ensures only authorized peers establish sessions.
+      audit: |-
+        To verify that BGP neighbors have authentication configured:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the BGP configuration:
+
+           ```
+           show running-config bgp
+           ```
+
+        The device passes when every configured `neighbor` has a `password` entry. A BGP neighbor with no password is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1521,6 +1840,17 @@ queries:
         - Routing stability issues cannot be diagnosed from historical data.
 
         Enabling BGP log neighbor changes ensures routing events are captured for monitoring and troubleshooting.
+      audit: |-
+        To verify that BGP neighbor change logging is enabled:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the BGP configuration:
+
+           ```
+           show running-config bgp
+           ```
+
+        The device passes when every configured BGP instance has `log-neighbor-changes` set. A BGP instance without it is a failing result.
       remediation:
         - id: cli
           desc: |
@@ -1574,6 +1904,17 @@ queries:
         - Man-in-the-middle attacks via route injection are possible.
 
         Configuring OSPF interface authentication ensures only authorized routers participate in the routing domain.
+      audit: |-
+        To verify that OSPF interfaces use authentication:
+
+        1. Open an authenticated session to the device CLI.
+        2. Display the OSPF configuration:
+
+           ```
+           show running-config ospf
+           ```
+
+        The device passes when every OSPF-enabled interface has message-digest authentication or an authentication key chain configured. An OSPF interface with no authentication is a failing result.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## Summary

Audited the three Cisco network-device security policies against the `content/CLAUDE.md` authoring standard. The one systematic violation across all three was that **every check was missing the required `docs.audit:` section** — the standard mandates `desc:`, `audit:`, and `remediation:` in every check's `docs:` block.

This PR adds a vendor-native `audit:` block to all 94 checks, placed between `desc:` and `remediation:`.

## Fixes per policy

**`mondoo-cisco-iosxe-security.mql.yaml`** — added `audit:` to all 36 checks.

**`mondoo-cisco-iosxr-security.mql.yaml`** — added `audit:` to all 27 checks.

**`mondoo-cisco-nxos-security.mql.yaml`** — added `audit:` to all 31 checks.

## Audit block design

- Each audit gives an auditor a CLI-only verification path using Cisco's own `show` commands (`show ip ssh`, `show running-config`, `show snmp community`, `show copp status`, etc.).
- Each ends with a sentence describing the passing versus failing result.
- No audit step references `cnspec`, MQL, or the Mondoo console.
- A single CLI path is used per check (no H3 `### Audit via ...` headers): these devices are managed exclusively through the device CLI, so there is no separate console/GUI path to split out.

## Items reviewed and found already conforming

- **Titles** — all 75 characters or fewer and accurate to the MQL and `desc`.
- **`desc:` structure** — leads with an assertion paragraph followed by a `**Why this matters**` list; no MQL/variant-UID/"this policy" references.
- **`remediation:`** — already in `- id: cli` list form, the realistic management surface for CLI-managed Cisco devices.
- **`impact:`** — values sit in sensible bands per the impact table.
- **Compliance tags** — present on every check; `false` is the unquoted YAML boolean.

No `uid:` values, policy `version:` fields, MQL logic, titles, impact, remediation, or compliance tags were changed. All three files pass `cnspec policy lint` with `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)