### PR TITLE
:memo: Bring the HTTP Security policy up to authoring standards

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -431,6 +431,7 @@ msk
 mssql
 mtls
 Mvc
+mvc
 mwezi
 myacr
 myapp

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -83,6 +83,18 @@ queries:
         - **Improves content integrity**: Ensures that files are processed as intended by the server, reducing the risk of unexpected behavior.
 
         By setting the 'X-Content-Type-Options' header to 'nosniff', the system enforces strict content type handling, enhancing security and reducing the attack surface.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^X-Content-Type-Options:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns `X-Content-Type-Options: nosniff`. A failing result returns no `X-Content-Type-Options` header, or a value other than `nosniff`.
       remediation:
         - id: nginx
           desc: |
@@ -167,6 +179,18 @@ queries:
         - **Enhances security posture**: Implementing CSP demonstrates a proactive approach to securing web applications against common vulnerabilities.
 
         By setting the CSP header, the system enforces strict content loading policies, reducing the attack surface and improving overall application security.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Content-Security-Policy:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns a `Content-Security-Policy` header with a defined directive set. A failing result returns no `Content-Security-Policy` header.
       remediation:
         - id: nginx
           desc: |
@@ -249,6 +273,18 @@ queries:
         - **Improves user trust**: Enforcing HTTPS demonstrates a commitment to security, enhancing user confidence in the application.
 
         By setting the HSTS header, the system enforces secure connections, reduces the attack surface, and strengthens the overall security posture.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site over HTTPS:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Strict-Transport-Security:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns a `Strict-Transport-Security` header. A failing result returns no `Strict-Transport-Security` header.
       remediation:
         - id: nginx
           desc: |
@@ -330,6 +366,18 @@ queries:
         - **Non-compliance with security best practices**: Security guidelines recommend minimizing information disclosure to reduce risks.
 
         By removing or obfuscating the Server header, the system reduces the attack surface, mitigates reconnaissance efforts, and aligns with security best practices.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Server:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns no `Server` header, or a value that does not disclose the underlying server software. A failing result returns a `Server` header that names software such as `nginx`, `Apache`, `Microsoft-IIS`, `LiteSpeed`, or `openresty`.
       remediation:
         - id: nginx
           desc: |
@@ -411,6 +459,18 @@ queries:
         - **Non-compliance with security best practices**: Security guidelines recommend minimizing information disclosure to reduce risks.
 
         By removing the X-Powered-By header, the system reduces the attack surface, mitigates reconnaissance efforts, and aligns with security best practices.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^X-Powered-By:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns no `X-Powered-By` header. A failing result returns an `X-Powered-By` header that discloses the underlying technology stack.
       remediation:
         - id: nginx
           desc: |
@@ -491,6 +551,18 @@ queries:
         - **Non-compliance with security best practices**: Security guidelines recommend minimizing information disclosure to reduce risks.
 
         By removing the X-AspNet-Version header, the system reduces the attack surface, mitigates reconnaissance efforts, and aligns with security best practices.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^X-AspNet-Version:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns no `X-AspNet-Version` header. A failing result returns an `X-AspNet-Version` header that discloses the ASP.NET framework version.
       remediation:
         - id: nginx
           desc: |
@@ -571,6 +643,18 @@ queries:
         - **Non-compliance with security best practices**: Security guidelines recommend minimizing information disclosure to reduce risks.
 
         By removing the X-AspNetMvc-Version header, the system reduces the attack surface, mitigates reconnaissance efforts, and aligns with security best practices.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^X-AspNetMvc-Version:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns no `X-AspNetMvc-Version` header. A failing result returns an `X-AspNetMvc-Version` header that discloses the ASP.NET MVC framework version.
       remediation:
         - id: nginx
           desc: |
@@ -651,6 +735,18 @@ queries:
         - **Better alternatives available**: Modern mechanisms like Certificate Transparency and the use of the Expect-CT header provide safer and more effective ways to achieve similar goals.
 
         By avoiding the use of the HPKP header, the system reduces the risk of misconfiguration, mitigates potential abuse, and aligns with current best practices for secure web communication.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Public-Key-Pins:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns no `Public-Key-Pins` header. A failing result returns a `Public-Key-Pins` header, which uses the deprecated HPKP mechanism.
       remediation:
         - id: nginx
           desc: |
@@ -732,7 +828,19 @@ queries:
         - **UI redressing**: Malicious sites can position transparent iframes over buttons or links, redirecting user interactions to attacker-controlled content.
         - **Session hijacking**: Combined with other vulnerabilities, clickjacking can be used to steal session tokens or credentials.
 
-        Valid values are `DENY` (prevents all framing), `SAMEORIGIN` (allows framing only from the same origin), or `ALLOW-FROM uri` (allows framing from a specific URI).
+        Valid values are `DENY` to prevent all framing, `SAMEORIGIN` to allow framing only from the same origin, or `ALLOW-FROM uri` to allow framing from a specific URI.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^X-Frame-Options:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns an `X-Frame-Options` header with a value such as `DENY` or `SAMEORIGIN`. A failing result returns no `X-Frame-Options` header.
       remediation:
         - id: nginx
           desc: |
@@ -814,7 +922,19 @@ queries:
         - **Privacy concerns**: Referrer information reveals browsing patterns and internal URL structures to external sites.
         - **Data leakage via embedded resources**: Third-party scripts, images, and stylesheets loaded by the page receive the referrer, potentially exposing sensitive URL paths.
 
-        Recommended values include `strict-origin-when-cross-origin` (sends only the origin for cross-origin requests), `no-referrer` (never sends referrer), or `same-origin` (sends referrer only for same-origin requests).
+        Recommended values include `strict-origin-when-cross-origin`, which sends only the origin for cross-origin requests; `no-referrer`, which never sends the referrer; and `same-origin`, which sends the referrer only for same-origin requests.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Referrer-Policy:'
+            ```
+
+        2. Review the output.
+
+        A passing result returns a `Referrer-Policy` header with a defined value. A failing result returns no `Referrer-Policy` header.
       remediation:
         - id: nginx
           desc: |
@@ -896,7 +1016,19 @@ queries:
         - **Browser preload requirement**: To be eligible for browser HSTS preload lists, a max-age of at least 31536000 seconds (1 year) is required.
         - **First-visit vulnerability**: After the HSTS cache expires, the next visit is vulnerable to interception until the browser receives the HSTS header again over a secure connection.
 
-        A max-age of at least 31536000 seconds (1 year) is recommended by OWASP and required for HSTS preload eligibility.
+        A max-age of at least 31536000 seconds, or one year, is recommended by OWASP and required for HSTS preload eligibility.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site over HTTPS:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Strict-Transport-Security:'
+            ```
+
+        2. Review the `max-age` directive in the returned value.
+
+        A passing result returns a `Strict-Transport-Security` header whose `max-age` is at least `31536000`. A failing result returns no header, or a `max-age` below `31536000`.
       remediation:
         - id: nginx
           desc: |
@@ -978,6 +1110,18 @@ queries:
         - **Preload requirement**: The `includeSubDomains` directive is required for HSTS preload list eligibility.
 
         Including subdomains ensures comprehensive HSTS protection across the entire domain hierarchy.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site over HTTPS:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Strict-Transport-Security:'
+            ```
+
+        2. Check whether the returned value contains the `includeSubDomains` directive.
+
+        A passing result returns a `Strict-Transport-Security` header that includes `includeSubDomains`. A failing result returns no header, or a value without the `includeSubDomains` directive.
       remediation:
         - id: nginx
           desc: |
@@ -1057,6 +1201,18 @@ queries:
         - **Browser preload lists**: With the `preload` directive (along with `includeSubDomains` and a sufficient `max-age`), the domain can be submitted to browser preload lists, eliminating the first-visit vulnerability entirely.
 
         Note: Submitting to preload lists is a separate step that must be done at https://hstspreload.org/ after setting the header.
+      audit: |
+        Use `curl` to inspect the response headers returned by the site over HTTPS:
+
+        1. Request the headers from the target host:
+
+            ```bash
+            curl -sI https://example.com | grep -i '^Strict-Transport-Security:'
+            ```
+
+        2. Check whether the returned value contains the `preload` directive.
+
+        A passing result returns a `Strict-Transport-Security` header that includes `preload`. A failing result returns no header, or a value without the `preload` directive.
       remediation:
         - id: nginx
           desc: |


### PR DESCRIPTION
## Summary

Audits `content/mondoo-http-security.mql.yaml` against `content/CLAUDE.md` and brings it into conformance.

### Violations found and fixed

- **Missing `audit:` blocks (all 13 checks).** `content/CLAUDE.md` requires every check's `docs:` block to include `desc:`, `audit:`, and `remediation:`. Every check in this policy had only `desc:` and `remediation:`. Added an `audit:` section to each check that verifies the finding with vendor-native tooling — `curl -sI` piped to `grep` against the response headers — and ends with an explicit passing-vs-failing sentence.
- **Parenthetical asides in `desc:`.** The X-Frame-Options, Referrer-Policy, and HSTS max-age checks closed their descriptions with `(...)` clarifications. Restructured those sentences to drop the parentheticals.

### Audited and already conformant (no change)

- Check titles are all ≤ 75 characters and match their `mql` assertion and `desc`.
- `desc:` blocks lead with a one-paragraph assertion followed by a `**Why this matters**` list.
- `impact:` values sit within sensible bands (info-disclosure headers 30–40, CSP/HSTS/HSTS-max-age 70–80).
- `compliance/*: false` tags already use the unquoted YAML boolean.
- `remediation:` uses plain `- id:` entries for NGINX, Apache, and IIS — appropriate for this external-observation policy class; left unchanged.

Lint passes: `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)