### PR TITLE
:memo: Bring the Junos policy up to authoring standards

### DIFF
--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -131,6 +131,19 @@ queries:
         - The principle of least privilege is violated, increasing the blast radius of a compromised credential.
 
         By denying root login, organizations enforce individual accountability and reduce the risk of unauthorized privileged access to the device.
+      audit: |
+        To verify the root login setting from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the `root-login` statement in the output.
+
+        If `root-login` is set to `deny` or `deny-password`, the check passes. If `root-login` is set to `allow` or the statement is absent (the configuration defaults to allowing root login), the check fails.
       remediation:
         - id: cli
           desc: |
@@ -193,6 +206,19 @@ queries:
         - Modern security standards and compliance frameworks require AES-128 or stronger encryption for management traffic.
 
         By restricting SSH to strong ciphers, organizations ensure that management sessions remain confidential and resistant to known cryptographic attacks.
+      audit: |
+        To verify the configured SSH ciphers from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the `ciphers` statements in the output.
+
+        If no `ciphers` statement lists `arcfour`, `arcfour128`, `arcfour256`, `3des-cbc`, `blowfish-cbc`, or `cast128-cbc`, the check passes. If any of these weak ciphers is configured, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -251,6 +277,19 @@ queries:
         - NIST and industry standards require SHA-256 or stronger algorithms for integrity verification.
 
         By configuring only strong MACs, organizations protect the integrity of management sessions and meet compliance requirements for cryptographic controls.
+      audit: |
+        To verify the configured SSH MACs from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the `macs` statements in the output.
+
+        If no `macs` statement lists `hmac-md5`, `hmac-md5-96`, `hmac-sha1-96`, `hmac-md5-etm@openssh.com`, or `hmac-md5-96-etm@openssh.com`, the check passes. If any of these weak MACs is configured, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -305,6 +344,19 @@ queries:
         - Without strong key exchange, forward secrecy is undermined, meaning past sessions could be decrypted if long-term keys are later compromised.
 
         By restricting key exchange to strong algorithms, organizations ensure secure session negotiation and maintain forward secrecy for all management connections.
+      audit: |
+        To verify the configured SSH key exchange algorithms from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the `key-exchange` statements in the output.
+
+        If no `key-exchange` statement lists `diffie-hellman-group1-sha1` or `diffie-hellman-group-exchange-sha1`, the check passes. If either of these weak algorithms is configured, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -356,6 +408,19 @@ queries:
         - Compromised accounts can be leveraged to pivot through the network device and reach otherwise isolated network segments.
 
         By disabling TCP forwarding, organizations prevent the SSH service from being misused as a network proxy and maintain the integrity of their firewall and segmentation controls.
+      audit: |
+        To verify the SSH TCP forwarding setting from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the output for the `no-tcp-forwarding` statement.
+
+        If the `no-tcp-forwarding` statement is present, the check passes. If it is absent (the configuration defaults to permitting TCP forwarding), the check fails.
       remediation:
         - id: cli
           desc: |
@@ -403,6 +468,19 @@ queries:
         - Legitimate administrators may be unable to connect to the device during an active attack due to resource exhaustion.
 
         By setting a connection limit, organizations ensure that the SSH service remains available to authorized users even during brute-force or denial-of-service attempts.
+      audit: |
+        To verify the SSH connection limit from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the output for the `connection-limit` statement.
+
+        If the `connection-limit` statement is present with a value greater than zero, the check passes. If it is absent, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -450,6 +528,19 @@ queries:
         - Attackers face no throttling penalty, making brute-force attacks significantly more likely to succeed.
 
         By configuring a rate limit, organizations slow down automated attacks and reduce the likelihood of successful credential compromise while keeping the SSH service responsive for authorized administrators.
+      audit: |
+        To verify the SSH rate limit from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SSH service configuration:
+
+           ```
+           show configuration system services ssh
+           ```
+
+        3. Inspect the output for the `rate-limit` statement.
+
+        If the `rate-limit` statement is present with a value greater than zero, the check passes. If it is absent, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -500,6 +591,19 @@ queries:
         - Credentialless accounts are trivial targets that require no effort for an attacker to exploit.
 
         By ensuring every account has credentials, organizations close a fundamental authentication gap and prevent unauthorized access through unprotected accounts.
+      audit: |
+        To verify that every local user has authentication credentials from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the login configuration:
+
+           ```
+           show configuration system login
+           ```
+
+        3. For each `user` block, confirm an `authentication` statement is present with either an `encrypted-password` or one or more SSH public keys.
+
+        If every user account has a password or SSH key configured, the check passes. If any user account has no `authentication` statement, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -554,6 +658,19 @@ queries:
         - A compromised super-user account gives an attacker complete control over the device, and limiting these accounts reduces that exposure.
 
         By restricting the number of super-user accounts, organizations minimize the risk of privileged credential compromise and enforce least-privilege access across their network infrastructure.
+      audit: |
+        To verify how many users hold the super-user login class from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the login configuration:
+
+           ```
+           show configuration system login
+           ```
+
+        3. Count the `user` blocks whose `class` statement is set to `super-user`.
+
+        If three or fewer accounts are assigned the `super-user` class, the check passes. If more than three accounts hold the `super-user` class, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -613,6 +730,19 @@ queries:
         - Data transmitted over Telnet has no integrity verification, meaning commands and responses can be silently altered in transit.
 
         By disabling Telnet and using SSH exclusively, organizations protect management credentials and session data from interception and tampering.
+      audit: |
+        To verify that the Telnet service is disabled from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the configured system services:
+
+           ```
+           show configuration system services
+           ```
+
+        3. Inspect the output for a `telnet` statement.
+
+        If no `telnet` statement is present, the check passes. If `telnet` appears under `system services`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -661,6 +791,19 @@ queries:
         - FTP server implementations have a long history of exploitable vulnerabilities that can provide an additional attack vector.
 
         By disabling FTP and using SCP instead, organizations ensure that file transfers to and from the device are encrypted and authenticated.
+      audit: |
+        To verify that the FTP service is disabled from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the configured system services:
+
+           ```
+           show configuration system services
+           ```
+
+        3. Inspect the output for an `ftp` statement.
+
+        If no `ftp` statement is present, the check passes. If `ftp` appears under `system services`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -720,6 +863,19 @@ queries:
         - The protocol provides no authentication or access controls, meaning anyone with network access can query it.
 
         By disabling the finger service, organizations eliminate an unnecessary information disclosure vector and reduce the data available for attacker reconnaissance.
+      audit: |
+        To verify that the finger service is disabled from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the configured system services:
+
+           ```
+           show configuration system services
+           ```
+
+        3. Inspect the output for a `finger` statement.
+
+        If no `finger` statement is present, the check passes. If `finger` appears under `system services`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -772,6 +928,19 @@ queries:
         - If a default read-write community string is present, attackers can remotely modify the device configuration to create backdoors or disable security features.
 
         By replacing default community strings with unique, complex values, organizations prevent trivial unauthorized access to device information through SNMP.
+      audit: |
+        To verify that default SNMP community strings are not configured from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SNMP configuration:
+
+           ```
+           show configuration snmp
+           ```
+
+        3. Inspect each `community` statement for the names `public` and `private`.
+
+        If no community is named `public` or `private`, the check passes. If either default community name is configured, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -822,6 +991,19 @@ queries:
         - SNMPv1 and v2c community strings are transmitted in clear text, meaning read-write credentials can be captured from network traffic.
 
         By restricting all SNMP communities to read-only access, organizations prevent unauthorized remote configuration changes and limit the impact of a compromised community string.
+      audit: |
+        To verify the authorization level of each SNMP community from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SNMP configuration:
+
+           ```
+           show configuration snmp
+           ```
+
+        3. Inspect the `authorization` statement under each `community` block.
+
+        If every community has `authorization` set to `read-only`, the check passes. If any community has `authorization read-write`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -869,6 +1051,19 @@ queries:
         - Unrestricted access makes it easier for attackers to conduct brute-force community string guessing from any location on the network.
 
         By restricting SNMP access to specific management hosts or networks, organizations reduce the attack surface and add a layer of access control beyond perimeter firewalls.
+      audit: |
+        To verify that SNMP communities restrict client access from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the SNMP configuration:
+
+           ```
+           show configuration snmp
+           ```
+
+        3. Inspect each `community` block for `clients` statements that list permitted source addresses or prefixes.
+
+        If every community has at least one `clients` entry, the check passes. If any community has no `clients` restriction, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -921,6 +1116,19 @@ queries:
         - Integration with SIEM platforms and security monitoring tools is not possible without remote log forwarding.
 
         By configuring remote syslog, organizations create a tamper-resistant audit trail that supports threat detection, incident response, and compliance requirements.
+      audit: |
+        To verify that a remote syslog host is configured from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the syslog configuration:
+
+           ```
+           show configuration system syslog
+           ```
+
+        3. Inspect the output for one or more `host` statements.
+
+        If at least one `host` statement is present under `system syslog`, the check passes. If no `host` statement is configured, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -971,6 +1179,19 @@ queries:
         - TLS transport provides both encryption and reliable delivery, addressing all of these concerns.
 
         By requiring TCP or TLS transport for syslog, organizations ensure that audit data is delivered reliably and protected from interception or manipulation.
+      audit: |
+        To verify the transport protocol of each syslog host from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the syslog configuration:
+
+           ```
+           show configuration system syslog
+           ```
+
+        3. Inspect the `transport` statement under each `host` block.
+
+        If every syslog host uses `transport tcp` or `transport tls`, the check passes. If any host uses UDP transport (the default when no `transport` statement is present), the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1029,6 +1250,19 @@ queries:
         - Forensic reconstruction of attack timelines requires session logs that document the sequence of permitted and denied connections.
 
         By enabling session logging on all security policies, organizations gain the visibility needed for threat detection, incident response, and compliance auditing.
+      audit: |
+        To verify that security policies have session logging enabled from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the security policy configuration:
+
+           ```
+           show configuration security policies
+           ```
+
+        3. Inspect the `then` action of each policy for a `log session-init` or `log session-close` statement.
+
+        If every policy has at least `session-init` or `session-close` logging configured, the check passes. If any policy has no logging statement, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1078,6 +1312,19 @@ queries:
         - Attack traffic that could be efficiently dropped at the perimeter instead consumes resources during full policy evaluation.
 
         By applying screen profiles to untrust zones, organizations establish a high-performance first line of defense that mitigates common network attacks before they reach the policy engine.
+      audit: |
+        To verify that untrust security zones have a screen profile applied from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the security zone configuration:
+
+           ```
+           show configuration security zones
+           ```
+
+        3. Inspect the `untrust` zone block for a `screen` statement.
+
+        If every zone named `untrust` has a `screen` profile assigned, the check passes. If an untrust zone has no `screen` statement, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1139,6 +1386,19 @@ queries:
         - Using the "all" keyword enables every host-inbound service, including insecure ones, creating maximum exposure.
 
         By restricting host-inbound services on the untrust zone to only essential encrypted protocols, organizations minimize the control plane attack surface exposed to untrusted networks.
+      audit: |
+        To verify the host-inbound services on the untrust zone from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the security zone configuration:
+
+           ```
+           show configuration security zones
+           ```
+
+        3. Inspect the `host-inbound-traffic system-services` statements under the `untrust` zone block.
+
+        If the untrust zone exposes none of `telnet`, `ftp`, `finger`, `http`, `snmp`, or `all`, the check passes. If any of these insecure services is permitted, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1194,6 +1454,19 @@ queries:
         - Junos SYN flood protection uses SYN proxy to validate connections before committing device resources, efficiently mitigating these attacks.
 
         By enabling SYN flood protection, organizations defend against a common and effective denial-of-service attack vector while ensuring continued availability of critical services.
+      audit: |
+        To verify that screen profiles have TCP SYN flood protection from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for a `tcp syn-flood` statement.
+
+        If every screen profile has `tcp syn-flood` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1243,6 +1516,19 @@ queries:
         - An entire class of ICMP-based attacks is left unmitigated at the perimeter, allowing them to reach internal systems.
 
         By enabling ping-of-death protection, organizations block oversized ICMP packets at the perimeter and protect internal systems from this class of attacks.
+      audit: |
+        To verify that screen profiles have ICMP ping-of-death protection from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for an `icmp ping-death` statement.
+
+        If every screen profile has `icmp ping-death` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1291,6 +1577,19 @@ queries:
         - There is no legitimate use case for source routing in modern production networks, so blocking it carries no operational impact.
 
         By blocking source-routed packets, organizations eliminate an attack technique that can bypass firewalls and enable spoofing, with no impact on legitimate traffic.
+      audit: |
+        To verify that screen profiles block the IP source route option from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for an `ip source-route-option` statement.
+
+        If every screen profile has `ip source-route-option` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1338,6 +1637,19 @@ queries:
         - Land attacks are a well-known and easily executed attack type that should be blocked at the perimeter as a basic security measure.
 
         By enabling land attack protection, organizations block a well-known denial-of-service technique and prevent unnecessary resource consumption on their network devices.
+      audit: |
+        To verify that screen profiles have TCP land attack protection from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for a `tcp land` statement.
+
+        If every screen profile has `tcp land` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1385,6 +1697,19 @@ queries:
         - Leaving this protection disabled allows an entire class of IP fragmentation attacks to pass through the perimeter unmitigated.
 
         By enabling teardrop protection, organizations block malformed fragmented packets at the perimeter and prevent fragmentation-based attacks from reaching internal systems.
+      audit: |
+        To verify that screen profiles have IP teardrop protection from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for an `ip tear-drop` statement.
+
+        If every screen profile has `ip tear-drop` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1432,6 +1757,19 @@ queries:
         - An entire class of OOB-based TCP attacks passes through the perimeter unblocked, potentially affecting any vulnerable internal system.
 
         By enabling WinNuke protection, organizations block out-of-band TCP attacks at the perimeter and protect internal systems from this class of exploits.
+      audit: |
+        To verify that screen profiles have TCP WinNuke protection from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the screen configuration:
+
+           ```
+           show configuration security screen
+           ```
+
+        3. Inspect each `ids-option` block for a `tcp winnuke` statement.
+
+        If every screen profile has `tcp winnuke` protection configured, the check passes. If any screen profile omits it, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1482,6 +1820,19 @@ queries:
         - Security features required for regulatory compliance may stop functioning, creating compliance gaps that go unnoticed until the next audit.
 
         By monitoring license status and renewing before expiration, organizations ensure that all licensed security features remain active and the device continues to provide the expected level of protection.
+      audit: |
+        To verify the status of installed feature licenses from the Junos CLI:
+
+        1. Open an SSH session to the device and enter operational mode.
+        2. Display the installed licenses and their state:
+
+           ```
+           show system license
+           ```
+
+        3. Inspect the state reported for each license entry.
+
+        If no license is reported as `expired`, the check passes. If any license shows an expired state, the check fails.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## Summary

Audits `content/mondoo-junos-security.mql.yaml` against `content/CLAUDE.md` and fixes the one systematic conformance violation found.

## Violation found and fixed

**Missing `audit:` block (requirement C)** — all 27 checks in the policy carried only `desc:` and `remediation:` in their `docs:` block. The authoring standard requires every check to include all three of `desc:`, `audit:`, and `remediation:`.

Each check now has an `audit:` block that:

- uses only Junos CLI vendor-native tooling (`show configuration ...`, `show system license`) — no `cnspec`, `mql`, or Mondoo console references
- gives an auditor a short numbered procedure to reproduce the finding
- ends with an explicit passing-vs-failing sentence
- uses a single CLI path with no H3 headers, since Junos is managed exclusively through the Junos CLI

## Not changed

Titles (all within 75 chars and consistent with their MQL/desc), impacts (within sensible bands and consistent with siblings), `compliance/*` tags (already use the unquoted `false` boolean), MQL, UIDs, versions, and the already-conformant `remediation:` blocks were left untouched.

`cnspec policy lint` ends with `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)