### PR TITLE
:memo: Bring the macOS policy up to authoring standards

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -62,6 +62,7 @@ awsconfigchanges
 awslogs
 awsorganizationschanges
 awsutils
+axc
 azconfig
 AZFW
 azuredatabricks
@@ -290,7 +291,13 @@ gbs
 GCMAES
 gcmp
 gcs
+getblockall
 getenv
+getglobalpolicy
+getglobalstate
+getloggingmode
+getremoteappleevents
+getstealthmode
 ggml
 gguf
 glueetl

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -137,6 +137,23 @@ queries:
           - Compliance with security best practices and standards
 
         Without these protections, audit logs may be vulnerable to unauthorized changes, undermining their reliability and the overall security posture of the system.
+      audit: |
+        Verify the ownership and permissions of the audit configuration file and audit logs from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Check the configuration file:
+
+           ```bash
+           ls -le /etc/security/audit_control
+           ```
+
+        3. Check the audit log directory:
+
+           ```bash
+           ls -le /var/audit/
+           ```
+
+        A passing result shows `/etc/security/audit_control` and every entry under `/var/audit/` owned by `root:wheel` with no read, write, or execute access for other users. A failing result shows another owner or group, or any permission granted to group or other beyond the expected read-only access.
       remediation:
         - id: cli
           desc: |
@@ -234,6 +251,25 @@ queries:
         Disabling Bluetooth Sharing reduces the attack surface of the system by preventing unauthorized file exchanges and mitigating risks associated with Bluetooth-based exploits. This is particularly important in environments where sensitive data is handled or where devices are exposed to untrusted networks.
 
         By ensuring Bluetooth Sharing is disabled, organizations can enhance the security posture of macOS systems and align with best practices for minimizing unnecessary services and features that could be exploited by attackers.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Bluetooth Sharing** setting.
+
+        A passing result shows **Bluetooth Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the current host Bluetooth preference:
+
+           ```bash
+           defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled
+           ```
+
+        A passing result returns `0` or reports that the key does not exist. A failing result returns `1`.
       remediation:
         - id: cli
           desc: |
@@ -336,6 +372,17 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Bonjour advertising may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify that multicast advertising is disabled from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Read the `mDNSResponder` preference:
+
+           ```bash
+           defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements
+           ```
+
+        A passing result returns `1`. A failing result returns `0` or reports that the key does not exist.
       remediation:
         - id: cli
           desc: |
@@ -436,6 +483,25 @@ queries:
           - Compliance with security best practices and organizational policies
 
         Without these protections, Content Caching may inadvertently expose sensitive data or consume unnecessary resources, undermining the overall security and efficiency of the system.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Content Caching** setting.
+
+        A passing result shows **Content Caching** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the Content Caching status:
+
+           ```bash
+           AssetCacheManagerUtil status
+           ```
+
+        A passing result reports `Activated: false` and `Active: false`. A failing result reports `Activated: true`.
       remediation:
         - id: cli
           desc: |
@@ -519,6 +585,25 @@ queries:
           - Compliance with security best practices and organizational policies
 
         Without these protections, SMB file sharing could expose sensitive data and increase the risk of exploitation, undermining the overall security posture of the system.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **File Sharing** setting.
+
+        A passing result shows **File Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Check whether the SMB daemon is loaded:
+
+           ```bash
+           sudo launchctl list | grep com.apple.smbd
+           ```
+
+        A passing result returns no output, confirming the SMB service is not loaded. A failing result lists `com.apple.smbd`.
       remediation:
         - id: cli
           desc: |
@@ -613,6 +698,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Internet Sharing may inadvertently expose the system and its networks to potential threats, undermining their overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Internet Sharing** setting.
+
+        A passing result shows **Internet Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the NAT preference:
+
+           ```bash
+           defaults read /Library/Preferences/SystemConfiguration/com.apple.nat NAT
+           ```
+
+        A passing result reports `Enabled = 0` or that the file does not exist. A failing result reports `Enabled = 1`.
       remediation:
         - id: cli
           desc: |
@@ -706,6 +810,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Media Sharing may inadvertently expose sensitive content or allow unauthorized devices to access shared media, undermining the overall security posture of the system.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Media Sharing** setting.
+
+        A passing result shows **Media Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the media sharing preference for the logged-in user:
+
+           ```bash
+           defaults read com.apple.amp.mediasharingd home-sharing-enabled
+           ```
+
+        A passing result returns `0` or reports that the key does not exist. A failing result returns `1`.
       remediation:
         - id: cli
           desc: |
@@ -785,6 +908,25 @@ queries:
           - The overall security posture of the system is enhanced
 
         Without these protections, Printer Sharing may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Printer Sharing** setting.
+
+        A passing result shows **Printer Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the CUPS printer sharing setting:
+
+           ```bash
+           cupsctl | grep _share_printers
+           ```
+
+        A passing result returns `_share_printers=0`. A failing result returns `_share_printers=1`.
       remediation:
         - id: cli
           desc: |
@@ -864,6 +1006,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Remote Apple Events may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Remote Apple Events** setting.
+
+        A passing result shows **Remote Apple Events** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the Remote Apple Events status:
+
+           ```bash
+           sudo systemsetup -getremoteappleevents
+           ```
+
+        A passing result returns `Remote Apple Events: Off`. A failing result returns `Remote Apple Events: On`.
       remediation:
         - id: cli
           desc: |
@@ -943,6 +1104,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Remote Login may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Remote Login** setting.
+
+        A passing result shows **Remote Login** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the Remote Login status:
+
+           ```bash
+           sudo systemsetup -getremotelogin
+           ```
+
+        A passing result returns `Remote Login: Off`. A failing result returns `Remote Login: On`.
       remediation:
         - id: cli
           desc: |
@@ -1022,6 +1202,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Remote Management may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Remote Management** setting.
+
+        A passing result shows **Remote Management** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Check whether the Apple Remote Desktop agent is running:
+
+           ```bash
+           ps -axc | grep ARDAgent
+           ```
+
+        A passing result returns no output, confirming the agent is not running. A failing result lists `ARDAgent`.
       remediation:
         - id: cli
           desc: |
@@ -1101,6 +1300,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, Screen Sharing may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Sharing**.
+        3. Review the **Screen Sharing** setting.
+
+        A passing result shows **Screen Sharing** turned off. A failing result shows it turned on.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Check whether the screen sharing daemon is loaded:
+
+           ```bash
+           sudo launchctl list | grep com.apple.screensharing
+           ```
+
+        A passing result returns no output, confirming the service is not loaded. A failing result lists `com.apple.screensharing`.
       remediation:
         - id: cli
           desc: |
@@ -1177,6 +1395,17 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, an enabled root account may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify that the root account is disabled from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Query the root account's authentication authority:
+
+           ```bash
+           dscl . -read /Users/root AuthenticationAuthority
+           ```
+
+        A passing result reports `No such key: AuthenticationAuthority`, confirming the root account is disabled. A failing result returns an `AuthenticationAuthority` value, indicating the root account is enabled.
       remediation:
         - id: cli
           desc: |
@@ -1268,6 +1497,25 @@ queries:
           - Compliance with security best practices and organizational policies
 
         Without FileVault, the system's data is vulnerable to unauthorized access, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Privacy & Security**.
+        3. Review the **FileVault** section.
+
+        A passing result shows FileVault turned on for the startup disk. A failing result shows FileVault turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the FileVault status:
+
+           ```bash
+           fdesetup status
+           ```
+
+        A passing result returns `FileVault is On`. A failing result returns `FileVault is Off`.
       remediation:
         - id: cli
           desc: |
@@ -1357,6 +1605,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, the system may be vulnerable to unauthorized access, compromising its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Network**, then **Firewall**.
+        3. Review the firewall toggle.
+
+        A passing result shows the firewall turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the global firewall state:
+
+           ```bash
+           /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+           ```
+
+        A passing result reports `Firewall is enabled`. A failing result reports `Firewall is disabled`.
       remediation:
         - id: cli
           desc: |
@@ -1437,6 +1704,25 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, the system may inadvertently expose itself to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Network**, then **Firewall**.
+        3. Select **Options** and review **Enable stealth mode**.
+
+        A passing result shows **Enable stealth mode** turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the firewall stealth mode setting:
+
+           ```bash
+           /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
+           ```
+
+        A passing result reports `Stealth mode enabled`. A failing result reports `Stealth mode disabled`.
       remediation:
         - id: cli
           desc: |
@@ -1530,6 +1816,25 @@ queries:
           - Prevent accidental execution of potentially harmful software
 
         Without these protections, macOS systems may inadvertently run unverified applications, increasing the risk of malware infections and unauthorized access.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Privacy & Security**.
+        3. Review the **Allow applications downloaded from** setting.
+
+        A passing result shows **App Store and identified developers** selected. A failing result shows **Anywhere** or that Gatekeeper is otherwise disabled.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the Gatekeeper assessment status:
+
+           ```bash
+           spctl --status
+           ```
+
+        A passing result returns `assessments enabled`. A failing result returns `assessments disabled`.
       remediation:
         - id: cli
           desc: |
@@ -1611,6 +1916,17 @@ queries:
           - Comply with security best practices and standards
 
         Without these protections, critical system events may go unrecorded, reducing visibility into potential security incidents and undermining the overall security posture of the system.
+      audit: |
+        Verify that the audit daemon is enabled from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Check whether the `auditd` daemon is loaded:
+
+           ```bash
+           sudo launchctl list | grep com.apple.auditd
+           ```
+
+        A passing result lists `com.apple.auditd`, confirming the audit service is loaded. A failing result returns no output.
       remediation:
         - id: cli
           desc: |
@@ -1698,6 +2014,25 @@ queries:
           - Enhance usability for systems with wireless network interfaces
 
         Without this feature enabled, users may have to navigate through system settings to check their Wi-Fi status, which can be less efficient and inconvenient.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Control Center**.
+        3. Review the **Wi-Fi** menu bar setting.
+
+        A passing result shows Wi-Fi set to **Show in Menu Bar**. A failing result shows it hidden from the menu bar.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the Control Center Wi-Fi preference for the logged-in user:
+
+           ```bash
+           defaults -currentHost read com.apple.controlcenter.plist WiFi
+           ```
+
+        A passing result returns `18` or `2`. A failing result returns another value or reports that the key does not exist.
       remediation:
         - id: cli
           desc: |
@@ -1815,6 +2150,25 @@ queries:
           - Enhance privacy and security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, AirDrop may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        ### Audit via Finder
+
+        1. Open **Finder**.
+        2. Select **Go**, then **AirDrop**.
+        3. Review the **Allow me to be discovered by** setting.
+
+        A passing result shows **No One** selected. A failing result shows **Contacts Only** or **Everyone**.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the AirDrop preference for the logged-in user:
+
+           ```bash
+           defaults read com.apple.NetworkBrowser DisableAirDrop
+           ```
+
+        A passing result returns `1`. A failing result returns `0` or reports that the key does not exist.
       remediation:
         - id: cli
           desc: |
@@ -1910,6 +2264,25 @@ queries:
           - Enhance security posture by monitoring and analyzing firewall logs
 
         Without logging enabled, critical information about network activity may be lost, reducing the ability to detect and respond to potential threats.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Network**, then **Firewall**.
+        3. Select **Options** and review the firewall logging setting.
+
+        A passing result shows firewall logging turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the firewall logging mode:
+
+           ```bash
+           /usr/libexec/ApplicationFirewall/socketfilterfw --getloggingmode
+           ```
+
+        A passing result reports `Log mode is on`. A failing result reports `Log mode is off`.
       remediation:
         - id: cli
           desc: |
@@ -1995,6 +2368,17 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, the HTTP server may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify that the Apache HTTP server is not running from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Check whether the Apache daemon is loaded:
+
+           ```bash
+           sudo launchctl list | grep org.apache.httpd
+           ```
+
+        A passing result returns no output, confirming the HTTP server is not loaded. A failing result lists `org.apache.httpd`.
       remediation:
         - id: cli
           desc: |
@@ -2078,6 +2462,17 @@ queries:
           - Enhance security posture in environments handling sensitive data or exposed to untrusted networks
 
         Without these protections, the NFS server may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify that the NFS server is not running from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Query the NFS daemon status:
+
+           ```bash
+           sudo nfsd status
+           ```
+
+        A passing result reports that `nfsd` is disabled and not running. A failing result reports that `nfsd` is enabled or running.
       remediation:
         - id: cli
           desc: |
@@ -2164,6 +2559,17 @@ queries:
           - Enhance system monitoring and accountability
 
         Without these protections, critical audit records may be lost, reducing visibility into potential security incidents and undermining the overall security posture of the system.
+      audit: |
+        Verify the audit retention policy from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Read the `expire-after` setting from the audit configuration file:
+
+           ```bash
+           grep expire-after /etc/security/audit_control
+           ```
+
+        A passing result shows `expire-after` set to at least `60d` or `1G`. A failing result shows a shorter retention period or no `expire-after` line.
       remediation:
         - id: cli
           desc: |
@@ -2266,6 +2672,17 @@ queries:
           - Enhance overall security posture by ensuring periodic password updates
 
         Without these protections, attackers may exploit exposed or reused passwords, increasing the likelihood of unauthorized access and compromising the system's security.
+      audit: |
+        Verify the maximum password age from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Read the global password policy:
+
+           ```bash
+           pwpolicy -n /Local/Default -getglobalpolicy
+           ```
+
+        A passing result shows `maxMinutesUntilChangePassword` set to `525600` (365 days) or fewer minutes. A failing result shows a larger value or no expiration policy.
       remediation:
         - id: cli
           desc: |
@@ -2367,6 +2784,17 @@ queries:
           - Enhance security posture by ensuring unique passwords for each change
 
         Without these protections, users may reuse old passwords, increasing the risk of unauthorized access and compromising the system's security.
+      audit: |
+        Verify the password history depth from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Read the global password policy:
+
+           ```bash
+           pwpolicy -n /Local/Default -getglobalpolicy
+           ```
+
+        A passing result shows `usingHistory` set to `15` or greater. A failing result shows a smaller value or no history policy.
       remediation:
         - id: cli
           desc: |
@@ -2455,6 +2883,17 @@ queries:
           - Prevent misuse of elevated privileges in environments handling sensitive data
 
         Without these protections, the sudo grace period may inadvertently expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify the sudo authentication timeout from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Display the sudo configuration:
+
+           ```bash
+           sudo -V | grep "Authentication timestamp timeout"
+           ```
+
+        A passing result reports `Authentication timestamp timeout: 0.0 minutes`. A failing result reports a non-zero timeout.
       remediation:
         - id: cli
           desc: |
@@ -2537,6 +2976,17 @@ queries:
           - Enhance system monitoring and accountability
 
         Without these protections, critical log data may be lost, reducing visibility into potential security incidents and undermining the overall security posture of the system.
+      audit: |
+        Verify the install log retention policy from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Display the install log configuration:
+
+           ```bash
+           cat /etc/asl/com.apple.install
+           ```
+
+        A passing result shows the `file` line with `ttl` set to `365` or greater and no `all_max` setting. A failing result shows a shorter `ttl`, a missing `ttl`, or an `all_max` value present.
       remediation:
         - id: cli
           desc: |
@@ -2628,6 +3078,17 @@ queries:
           - Align with best practices for password policies
 
         Without these protections, short passwords may expose the system to potential threats, undermining its overall security posture.
+      audit: |
+        Verify the minimum password length from the macOS shell.
+
+        1. Open the **Terminal** app.
+        2. Read the global password policy:
+
+           ```bash
+           pwpolicy -n /Local/Default -getglobalpolicy
+           ```
+
+        A passing result shows `minChars` set to `15` or greater. A failing result shows a smaller value or no minimum length policy.
       remediation:
         - id: cli
           desc: |
@@ -2712,6 +3173,25 @@ queries:
           - Enhance overall system security and compliance with best practices
 
         Without these protections, the system may remain vulnerable to known threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Software Update**.
+        3. Select the info button next to **Automatic updates** and review **Check for updates**.
+
+        A passing result shows **Check for updates** turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the automatic check preference:
+
+           ```bash
+           defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled
+           ```
+
+        A passing result returns `1`. A failing result returns `0`.
       remediation:
         - id: cli
           desc: |
@@ -2807,6 +3287,25 @@ queries:
           - Enhance overall system security and compliance with best practices
 
         Without these protections, the system may remain vulnerable to known threats, undermining its overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Software Update**.
+        3. Select the info button next to **Automatic updates** and review **Download new updates when available**.
+
+        A passing result shows **Download new updates when available** turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the automatic download preference:
+
+           ```bash
+           defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload
+           ```
+
+        A passing result returns `1`. A failing result returns `0`.
       remediation:
         - id: cli
           desc: |
@@ -2901,6 +3400,26 @@ queries:
           - Enhance overall system security and compliance with best practices
 
         Without these protections, macOS systems may remain vulnerable to known threats, undermining their overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Software Update**.
+        3. Select the info button next to **Automatic updates** and review **Install Security Responses and system files**.
+
+        A passing result shows **Install Security Responses and system files** turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Read the critical update preferences:
+
+           ```bash
+           defaults read /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall
+           defaults read /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall
+           ```
+
+        A passing result returns `1` for both keys. A failing result returns `0` for either key.
       remediation:
         - id: cli
           desc: |
@@ -2982,6 +3501,25 @@ queries:
           - Align with security best practices and compliance requirements
 
         Without these protections, outdated macOS systems may remain vulnerable to known threats, undermining their overall security posture.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **General**, then **Software Update**.
+        3. Review whether any updates are listed as available.
+
+        A passing result shows the system reporting that macOS is up to date. A failing result shows one or more pending updates.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. List available software updates:
+
+           ```bash
+           softwareupdate -l
+           ```
+
+        A passing result reports `No new software available`. A failing result lists one or more recommended updates.
       remediation:
         - id: cli
           desc: |
@@ -3069,7 +3607,7 @@ queries:
       macos.firewall.blockAllIncoming == true
     docs:
       desc: |
-        This check verifies that the macOS firewall is configured to block all incoming connections. When enabled, only essential system services (like DHCP and Bonjour) can receive incoming connections.
+        This check verifies that the macOS firewall is configured to block all incoming connections. When enabled, only essential system services such as DHCP and Bonjour can receive incoming connections.
 
         **Why this matters**
 
@@ -3087,6 +3625,25 @@ queries:
         - Enable the "Block all incoming connections" setting via System Settings or the `socketfilterfw` CLI.
         - Apply this setting on high-security endpoints that do not need to accept inbound connections.
         - Use MDM profiles to enforce this setting across managed devices and prevent users from disabling it.
+      audit: |
+        ### Audit via System Settings
+
+        1. Open **System Settings**.
+        2. Select **Network**, then **Firewall**.
+        3. Select **Options** and review **Block all incoming connections**.
+
+        A passing result shows **Block all incoming connections** turned on. A failing result shows it turned off.
+
+        ### Audit via CLI
+
+        1. Open the **Terminal** app.
+        2. Query the firewall block-all setting:
+
+           ```bash
+           /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
+           ```
+
+        A passing result reports `Block all DISABLED! is not set`, meaning block all incoming connections is enabled. A failing result reports `Block all DISABLED! is set`.
       remediation:
         - id: cli
           desc: |

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -3643,7 +3643,7 @@ queries:
            /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
            ```
 
-        A passing result reports `Block all DISABLED! is not set`, meaning block all incoming connections is enabled. A failing result reports `Block all DISABLED! is set`.
+        A passing result reports `Firewall has block all state set to enabled.` A failing result reports `Firewall has block all state set to disabled.`
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## Summary

Audits `content/mondoo-macos-security.mql.yaml` for conformance with `content/CLAUDE.md` and fixes the one systemic violation found.

## Violations found and fixed

- **Missing `audit:` section (all 34 checks).** `content/CLAUDE.md` requires every check's `docs:` block to include all three of `desc:`, `audit:`, and `remediation:`. No check in the policy had an `audit:` section. Added a tailored `audit:` block to every check.
- **Parenthetical aside.** Removed a `(...)` aside from the `desc:` of `mondoo-macos-security-firewall-block-all-incoming`.

## Audit block design

- Verification uses only vendor-native tooling: macOS **System Settings** click-paths and the macOS shell (`defaults`, `launchctl`, `pwpolicy`, `socketfilterfw`, `systemsetup`, `spctl`, `fdesetup`, `cupsctl`, `AssetCacheManagerUtil`, `nfsd`, `dscl`). No references to `cnspec`, MQL, or the Mondoo console.
- Where both a graphical and a CLI verification path exist, the audit uses H3 `### Audit via System Settings` / `### Audit via CLI` (or `### Audit via Finder` for AirDrop) headers; each path ends with its own passing-vs-failing sentence.
- Each audit step matches the assertion in the check's `mql` and `desc`.

## Not changed

- No `uid:` renames, no `version:` bump, MQL preserved exactly.
- `remediation:` blocks already conform (`gui`/`cli`/`script`/`ansible`, with `gui` correct for an OS target) and were left untouched.
- Compliance tags, titles, and impact values already conform and were left untouched.

## Validation

`cnspec policy lint content/mondoo-macos-security.mql.yaml` → `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)