### PR TITLE
:memo: Bring the Kubernetes policies up to authoring standards

### DIFF
--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -1910,7 +1910,7 @@ queries:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
   - uid: mondoo-kubernetes-best-practices-pod-default-namespace
-    title: Workloads should not run in default namespace
+    title: Pods should not run in the default namespace
     impact: 20
     mql: |
       k8s.pod {

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -879,6 +879,14 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the API server pod specification file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+      audit: |
+        On each control plane node, inspect the ownership and permissions of the API server pod specification file:
+
+        ```bash
+        stat -c "%a %U:%G" /etc/kubernetes/manifests/kube-apiserver.yaml
+        ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -984,6 +992,22 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the etcd data directory is owned by the `etcd` user and group and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+      audit: |
+        On the etcd node, identify the data directory and inspect its ownership and permissions:
+
+        1. Find the etcd data directory (the value passed to `--data-dir`, defaulting to `/var/lib/etcd`):
+
+           ```bash
+           ps -ef | grep etcd
+           ```
+
+        2. Inspect the directory:
+
+           ```bash
+           stat -c "%a %U:%G" /var/lib/etcd
+           ```
+
+        If the output is `700 etcd:etcd`, the check passes. If the permissions are more permissive than `700`, or the directory is not owned by `etcd:etcd`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1050,6 +1074,14 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the `admin.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+      audit: |
+        On each control plane node, inspect the ownership and permissions of the `admin.conf` file:
+
+        ```bash
+        stat -c "%a %U:%G" /etc/kubernetes/admin.conf
+        ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1140,6 +1172,14 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the `scheduler.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+      audit: |
+        On each control plane node, inspect the ownership and permissions of the `scheduler.conf` file:
+
+        ```bash
+        stat -c "%a %U:%G" /etc/kubernetes/scheduler.conf
+        ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1230,6 +1270,14 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the `controller-manager.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+      audit: |
+        On each control plane node, inspect the ownership and permissions of the `controller-manager.conf` file:
+
+        ```bash
+        stat -c "%a %U:%G" /etc/kubernetes/controller-manager.conf
+        ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1318,6 +1366,14 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the PKI/SSL directory is owned by `root:root`, organizations can maintain strong access controls and protect the integrity of cluster encryption and authentication.
+      audit: |
+        On each control plane node, inspect the ownership of the Kubernetes PKI/SSL directory:
+
+        ```bash
+        stat -c "%U:%G" /etc/kubernetes/pki
+        ```
+
+        If your PKI/SSL directory is located elsewhere, adjust the path accordingly. If the output is `root:root`, the check passes. If the directory is owned by any other user or group, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -1371,6 +1427,22 @@ queries:
         - Compliance with security best practices and regulatory requirements may be violated.
 
         By ensuring the kube-apiserver does not listen on an insecure HTTP port, organizations can protect sensitive data in transit and maintain a strong security posture for their Kubernetes clusters.
+      audit: |
+        Inspect the API server arguments on each control plane node:
+
+        1. List the running kube-apiserver process and its arguments:
+
+           ```bash
+           ps -ef | grep kube-apiserver
+           ```
+
+        2. On kubeadm clusters, you can also read the static pod manifest:
+
+           ```bash
+           kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep insecure-port
+           ```
+
+        If `--insecure-port` is set to `0` (or the argument is absent on a Kubernetes version where the insecure port has been removed), the check passes. If `--insecure-port` is set to any non-zero value, the check fails.
       remediation: |-
         Find the kube-apiserver process and check the `insecure-port` argument. If the argument is set to `0`, then the kube-apiserver is not listening on an insecure HTTP port:
 
@@ -1414,6 +1486,22 @@ queries:
         - Compliance with security standards and best practices may be compromised.
 
         By ensuring that anonymous authentication is disabled, organizations can maintain strong access controls and protect the security and integrity of their Kubernetes clusters.
+      audit: |
+        Inspect the API server arguments on each control plane node:
+
+        1. List the running kube-apiserver process and its arguments:
+
+           ```bash
+           ps -ef | grep kube-apiserver
+           ```
+
+        2. On kubeadm clusters, you can also read the static pod manifest:
+
+           ```bash
+           kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep anonymous-auth
+           ```
+
+        If `--anonymous-auth` is set to `false`, the check passes. If it is set to `true` or is absent, the check fails.
       remediation: |-
         Find the kube-apiserver process and check the `--anonymous-auth` argument. If the argument is set to `false`, then the kube-apiserver does not allow anonymous authentication:
 
@@ -10913,6 +11001,14 @@ queries:
         - **Multi-tenant risk**: In shared clusters, hostPath volumes bypass all namespace-level isolation boundaries.
 
         Use cloud-native storage provisioners, CSI drivers, or network-attached storage instead of hostPath for persistent data.
+      audit: |
+        List all PersistentVolumes that use a `hostPath` volume source:
+
+        ```bash
+        kubectl get pv -o json | jq -r '.items[] | select(.spec.hostPath != null) | .metadata.name'
+        ```
+
+        If the command returns no output, the check passes. If any PersistentVolume name is listed, that volume uses `hostPath` and the check fails.
       remediation: |
         Replace hostPath PersistentVolumes with a proper storage backend:
 
@@ -10980,6 +11076,14 @@ queries:
         - `AlwaysAllow` makes every request succeed regardless of identity, allowing complete cluster takeover with any valid (or anonymous) credential.
         - Missing `Node` lets a compromised kubelet read Secrets, ConfigMaps, and Pods from other nodes, expanding lateral-movement opportunities.
         - Missing `RBAC` removes the role-based access control plane that limits what tokens, users, and ServiceAccounts can do.
+      audit: |
+        Inspect the API server `--authorization-mode` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep authorization-mode
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--authorization-mode` includes both `Node` and `RBAC` and does not include `AlwaysAllow`, the check passes. If `Node` or `RBAC` is missing, or `AlwaysAllow` is present, the check fails.
       remediation: |-
         Set the API server `--authorization-mode` flag so it includes `Node,RBAC` and never includes `AlwaysAllow`:
 
@@ -11022,6 +11126,14 @@ queries:
         **Why this matters**
 
         Admission controllers are the last line of defense before objects are persisted in etcd. Enabling `AlwaysAdmit` voids policy controls such as `PodSecurity`, `NodeRestriction`, and `ResourceQuota`, allowing privileged or non-compliant workloads to be created.
+      audit: |
+        Inspect the API server `--enable-admission-plugins` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep enable-admission-plugins
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `AlwaysAdmit` does not appear in the `--enable-admission-plugins` list, the check passes. If `AlwaysAdmit` is present, the check fails.
       remediation: |-
         Remove `AlwaysAdmit` from the API server `--enable-admission-plugins` flag and restart the API server.
     refs:
@@ -11056,6 +11168,14 @@ queries:
         **Why this matters**
 
         Without `NodeRestriction`, an attacker who compromises a single node can use the node's kubelet credentials to read or modify Pods, Secrets, and Nodes across the entire cluster.
+      audit: |
+        Inspect the API server `--enable-admission-plugins` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep enable-admission-plugins
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `NodeRestriction` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
       remediation: |-
         Add `NodeRestriction` to the API server `--enable-admission-plugins` flag and restart the API server.
     refs:
@@ -11090,6 +11210,14 @@ queries:
         **Why this matters**
 
         `PodSecurity` is the supported successor to PodSecurityPolicy. Without it, namespaces cannot enforce the baseline/restricted security profiles that block privileged containers, hostPath mounts, and host networking.
+      audit: |
+        Inspect the API server `--enable-admission-plugins` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep enable-admission-plugins
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `PodSecurity` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
       remediation: |-
         Add `PodSecurity` to the API server `--enable-admission-plugins` flag and label namespaces with `pod-security.kubernetes.io/enforce=baseline` (or `restricted`) as appropriate.
     refs:
@@ -11124,6 +11252,14 @@ queries:
         **Why this matters**
 
         A misbehaving or hostile workload can generate millions of events per minute. Without `EventRateLimit`, this load can saturate the API server and etcd, causing cluster-wide instability.
+      audit: |
+        Inspect the API server `--enable-admission-plugins` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep enable-admission-plugins
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `EventRateLimit` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
       remediation: |-
         Add `EventRateLimit` to the API server `--enable-admission-plugins` flag and supply a configuration file via `--admission-control-config-file`.
     refs:
@@ -11158,6 +11294,14 @@ queries:
         **Why this matters**
 
         Without an audit log path, the cluster has no record of who created, modified, or deleted resources, making it impossible to detect or investigate intrusions, privilege abuse, or misconfiguration.
+      audit: |
+        Inspect the API server `--audit-log-path` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep audit-log-path
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-log-path` is set to a non-empty file location, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Set the API server `--audit-log-path` flag to a writable file location such as `/var/log/kubernetes/audit.log` and restart the API server.
     refs:
@@ -11192,6 +11336,14 @@ queries:
         **Why this matters**
 
         Without a policy file, the audit log either is silent or records every event at maximum verbosity, causing valuable signals to be missed or drowned in noise. A tuned policy ensures security-relevant events such as authentication failures, RBAC changes, and Secret access are captured.
+      audit: |
+        Inspect the API server `--audit-policy-file` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep audit-policy-file
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-policy-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Create an audit policy YAML and pass it to the API server via `--audit-policy-file=/etc/kubernetes/audit-policy.yaml`. Restart the API server after the file is in place.
     refs:
@@ -11226,6 +11378,14 @@ queries:
         **Why this matters**
 
         Audit logs are the primary forensic record of activity in the cluster. Truncated retention windows make breach detection and root-cause analysis impossible after the fact.
+      audit: |
+        Inspect the API server `--audit-log-maxage` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep audit-log-maxage
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-log-maxage` is set to `30` or higher, the check passes. If the argument is absent or set to a value below `30`, the check fails.
       remediation: |-
         Set the API server `--audit-log-maxage=30` (or a higher value matching your retention policy) and restart the API server. Forward audit logs to a long-term store such as a SIEM in addition to local retention.
     refs:
@@ -11260,6 +11420,14 @@ queries:
         **Why this matters**
 
         By default, etcd stores Kubernetes Secrets, ConfigMaps, and tokens in plaintext. An attacker with read access to etcd files or backups can recover every credential in the cluster. Encryption at rest defends against offline disclosure of these stores.
+      audit: |
+        Inspect the API server `--encryption-provider-config` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep encryption-provider-config
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--encryption-provider-config` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Create an `EncryptionConfiguration` file specifying a strong provider (`aescbc`, `kms`, or `secretbox`) and pass it to the API server with `--encryption-provider-config=/etc/kubernetes/enc/enc.yaml`. Prefer a KMS provider in production. Re-write existing secrets so they are encrypted with the new keys:
 
@@ -11299,6 +11467,14 @@ queries:
         **Why this matters**
 
         Allowing TLS 1.0/1.1 leaves API server connections vulnerable to BEAST, downgrade, and renegotiation attacks. Modern Kubernetes clients all support TLS 1.2+, so requiring it does not reduce compatibility.
+      audit: |
+        Inspect the API server `--tls-min-version` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep tls-min-version
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--tls-min-version` is set to `VersionTLS12` or `VersionTLS13`, or the argument is absent on a version that defaults to TLS 1.2, the check passes. If it is set to `VersionTLS10` or `VersionTLS11`, the check fails.
       remediation: |-
         Set the API server `--tls-min-version=VersionTLS12` (or `VersionTLS13` if your client population supports it) and restart the API server.
     refs:
@@ -11336,6 +11512,14 @@ queries:
         **Why this matters**
 
         Weak cipher suites such as RC4 and 3DES have known practical attacks. Restricting the API server to AEAD ciphers with PFS (e.g., `TLS_ECDHE_*_WITH_AES_*_GCM_*`, `TLS_CHACHA20_POLY1305_*`) removes that attack surface.
+      audit: |
+        Inspect the API server `--tls-cipher-suites` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep tls-cipher-suites
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--tls-cipher-suites` is set and contains no RC4 or 3DES ciphers (`TLS_RSA_WITH_3DES`, `TLS_RSA_WITH_RC4`, `TLS_ECDHE_RSA_WITH_RC4`, `TLS_ECDHE_ECDSA_WITH_RC4`), the check passes. If the argument is absent or includes any of those weak ciphers, the check fails.
       remediation: |-
         Set `--tls-cipher-suites` to a hardened list, for example:
 
@@ -11374,13 +11558,21 @@ queries:
         **Why this matters**
 
         Without a client CA file, certificate-based authentication for users and components (such as kubelets and admin clients) is disabled or accepts unverified certificates, weakening cluster authentication.
+      audit: |
+        Inspect the API server `--client-ca-file` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep client-ca-file
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--client-ca-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Set the API server `--client-ca-file` to the path of the cluster CA bundle (typically `/etc/kubernetes/pki/ca.crt` on kubeadm clusters) and restart the API server.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
         title: Kubernetes - X.509 client certs
   - uid: mondoo-kubernetes-security-api-server-kubelet-client-cert
-    title: Ensure the kube-apiserver authenticates to kubelets with a client certificate
+    title: Ensure the kube-apiserver uses a client certificate for kubelets
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -11410,6 +11602,14 @@ queries:
         **Why this matters**
 
         Kubelets accept exec, logs, and port-forward requests from the API server. Without mTLS, an attacker who can intercept this traffic could impersonate the API server or extract sensitive workload data.
+      audit: |
+        Inspect the API server kubelet client certificate arguments on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep -E 'kubelet-client-certificate|kubelet-client-key'
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If both `--kubelet-client-certificate` and `--kubelet-client-key` are set to non-empty paths, the check passes. If either argument is absent or empty, the check fails.
       remediation: |-
         Generate an API-server client cert/key signed by the cluster CA and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. Restart the API server.
     refs:
@@ -11443,6 +11643,14 @@ queries:
         **Why this matters**
 
         Plaintext API-server-to-kubelet traffic exposes exec session contents, log streams, and resource metadata to anyone on the management network.
+      audit: |
+        Inspect the API server `--kubelet-https` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep kubelet-https
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--kubelet-https` is absent (the default is `true`) or set to `true`, the check passes. If it is explicitly set to `false`, the check fails.
       remediation: |-
         Remove any `--kubelet-https=false` argument from the API server configuration and restart the API server.
     refs:
@@ -11477,13 +11685,21 @@ queries:
         **Why this matters**
 
         Skipping kubelet certificate verification allows a node-level adversary on the network path to impersonate a kubelet and intercept exec, logs, or port-forward traffic.
+      audit: |
+        Inspect the API server `--kubelet-certificate-authority` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep kubelet-certificate-authority
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--kubelet-certificate-authority` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Pass `--kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt` (or the cluster's kubelet CA bundle) to the API server and restart it.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: API server to kubelet
   - uid: mondoo-kubernetes-security-api-server-etcd-cert-files
-    title: Ensure the kube-apiserver authenticates to etcd with TLS client certificates
+    title: Ensure the kube-apiserver uses TLS client certificates for etcd
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
@@ -11512,6 +11728,14 @@ queries:
         **Why this matters**
 
         etcd contains every Secret, ConfigMap, and resource definition in the cluster. Unauthenticated or unencrypted access permits direct read/write of the entire cluster state, completely bypassing Kubernetes authorization.
+      audit: |
+        Inspect the API server etcd TLS arguments on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep -E 'etcd-cafile|etcd-certfile|etcd-keyfile'
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile` are all set to non-empty paths, the check passes. If any of the three arguments is absent or empty, the check fails.
       remediation: |-
         Generate API-server-to-etcd certs from the etcd CA and pass them as `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile`. Confirm etcd is configured with the matching peer/server certificates.
     refs:
@@ -11545,6 +11769,14 @@ queries:
         **Why this matters**
 
         Long-lived ServiceAccount tokens that survive deletion become attractive targets. Lookup is the mechanism that makes "delete the ServiceAccount" actually revoke its tokens; without it, deleted accounts remain functional until their signing key rotates.
+      audit: |
+        Inspect the API server `--service-account-lookup` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep service-account-lookup
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--service-account-lookup` is absent (the default is `true`) or set to `true`, the check passes. If it is explicitly set to `false`, the check fails.
       remediation: |-
         Either remove the `--service-account-lookup=false` argument or set `--service-account-lookup=true` explicitly, and restart the API server.
     refs:
@@ -11579,6 +11811,14 @@ queries:
         **Why this matters**
 
         Using a separate key pair lets operators rotate the ServiceAccount signing key without re-issuing the API server's TLS cert, and keeps the ServiceAccount trust root scoped to one purpose.
+      audit: |
+        Inspect the API server `--service-account-key-file` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep service-account-key-file
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--service-account-key-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
       remediation: |-
         Configure `--service-account-key-file=/etc/kubernetes/pki/sa.pub` (kubeadm default) and the matching `--service-account-signing-key-file=/etc/kubernetes/pki/sa.key` on the API server, then restart it.
     refs:
@@ -11612,6 +11852,14 @@ queries:
         **Why this matters**
 
         pprof responses can leak goroutine stacks, heap allocations, and request data. Production clusters have no need for the endpoint, and its presence increases the API server's attack surface.
+      audit: |
+        Inspect the API server `--profiling` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep profiling
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--profiling` is set to `false`, the check passes. If it is set to `true` or is absent, the check fails.
       remediation: |-
         Set `--profiling=false` on the API server and restart it.
     refs:
@@ -11645,6 +11893,14 @@ queries:
         **Why this matters**
 
         Tokens in `--token-auth-file` cannot be revoked without restarting the API server, are visible to anyone who can read the file, and predate modern authenticators (OIDC, ServiceAccount, x509).
+      audit: |
+        Inspect the API server `--token-auth-file` argument on each control plane node:
+
+        ```bash
+        kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep token-auth-file
+        ```
+
+        On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--token-auth-file` is absent or empty, the check passes. If the argument is set to a file path, the check fails.
       remediation: |-
         Remove the `--token-auth-file` argument from the API server configuration and migrate users to OIDC, ServiceAccount tokens, or x509 client certificates.
     refs:


### PR DESCRIPTION
## Summary

Audits the two Kubernetes cnspec policies (`mondoo-kubernetes-best-practices.mql.yaml` and `mondoo-kubernetes-security.mql.yaml`) against `content/CLAUDE.md` and fixes the conformance violations found.

## Violations found and fixed

### Missing `audit:` section (criterion C)

29 checks in the Kubernetes security policy carried only `desc:` and `remediation:` — the required `audit:` section was absent. Added a vendor-native `audit:` block to each:

- 6 control-plane file-permission checks (`secure-kube-apiserver-yml`, `secure-etcd-data-dir`, `secure-admin-conf`, `secure-scheduler_conf`, `secure-controller-manager_conf`, `secure-pki-directory`) — verify ownership/permissions with `stat`.
- The `no-hostpath-persistent-volumes` check — lists offending PersistentVolumes with `kubectl` + `jq`.
- 22 `kube-apiserver` flag checks (`https-api-server`, `no-anonymous-auth`, `authorization-mode`, `no-always-admit`, `admission-*`, `audit-*`, `encryption-provider-config`, `tls-min-version`, `strong-cipher-suites`, `client-ca-file`, `kubelet-*`, `etcd-cert-files`, `service-account-*`, `profiling-disabled`, `no-token-auth-file`) — inspect the static pod manifest with `kubectl` or the process with `ps`.

Every new `audit:` uses only vendor-native tooling (`kubectl`, `ps`, `stat`) and ends with an explicit passing-vs-failing result sentence.

### Title length over 75 characters (criterion A)

- `mondoo-kubernetes-security-api-server-kubelet-client-cert` (77 chars) → "Ensure the kube-apiserver uses a client certificate for kubelets".
- `mondoo-kubernetes-security-api-server-etcd-cert-files` (76 chars) → "Ensure the kube-apiserver uses TLS client certificates for etcd".

### Title does not match the assertion (criterion B)

- `mondoo-kubernetes-best-practices-pod-default-namespace` was titled "Workloads should not run in default namespace" while its MQL asserts on `k8s.pod` and every sibling check names its kind. Renamed to "Pods should not run in the default namespace".

## Validation

`cnspec policy lint` reports `valid policy bundle(s)` for both files. No `uid`, `version`, MQL, or compliance mappings were changed; remediation blocks that already conformed were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)