### PR TITLE
:memo: Bring the AWS security policy up to authoring standards

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,7 @@
 AAAAA
 aad
 AAWG
+ABIA
 ACCOUNTADMIN
 acmpca
 acr
@@ -120,6 +121,7 @@ chatgpt
 cheatsheet
 checkend
 chkconfig
+chokepoints
 Cim
 CIMSLP
 cimv
@@ -202,9 +204,11 @@ deauth
 debconf
 decryptable
 definitionally
+defn
 dentries
 denygroups
 denyusers
+deployers
 desiredv
 detokenize
 devtmpfs
@@ -391,6 +395,7 @@ kexts
 keyfile
 keymanager
 keyout
+keystores
 kickstart
 kilocode
 kiro
@@ -449,6 +454,7 @@ microdnf
 MIGf
 minv
 misclick
+misconfigures
 misrouted
 mknod
 MLE
@@ -510,6 +516,7 @@ ocid
 ocir
 ocpus
 odata
+ODBC
 offsite
 oidc
 ollama
@@ -611,6 +618,8 @@ renameat
 replicators
 repointed
 reprovisioned
+requirepass
+rescans
 resourced
 respout
 restrictremotesam
@@ -722,12 +731,15 @@ tacacs
 tailnets
 tailscale
 tallylog
+tbl
 Tbps
 tde
 TDS
 tensorboard
 tfa
 timeadd
+timeframes
+timestamped
 timestream
 timestreaminflux
 timestreamwrite

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.0.0
+    version: 12.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -28826,7 +28826,7 @@ queries:
 
         1. Sign in to the AWS Management Console and navigate to the **AWS Directory Service** console.
         2. In the left navigation pane, select **Directories**.
-        3. Select an active directory.
+        3. Select an Active Directory.
         4. Choose the **Application management** tab.
         5. Locate the **Single sign-on (SSO)** section and review its status.
 

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -683,7 +683,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
@@ -880,7 +880,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-eks-cluster-private-controlplane-aws
         tags:
@@ -1037,7 +1037,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -1045,7 +1045,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -1207,7 +1207,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -1216,9 +1216,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-root-account-mfa-enabled-aws
         tags:
@@ -1403,8 +1403,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooAWSSecurityIamPasswordPolicyMaxPasswordAge
@@ -1624,7 +1624,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -1632,8 +1632,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-9
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
@@ -1789,7 +1789,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -1798,9 +1798,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-aws
         tags:
@@ -2007,7 +2007,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-iam-group-has-users-check-aws
         tags:
@@ -2181,7 +2181,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -2189,7 +2189,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -2387,7 +2387,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-iam-user-no-inline-policies-check-aws
         tags:
@@ -2608,8 +2608,8 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
         tags:
@@ -2920,7 +2920,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -2931,7 +2931,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-aws
         tags:
@@ -3085,7 +3085,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -3096,7 +3096,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-bucket
         tags:
@@ -3363,7 +3363,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-ec2-instance-no-public-ip-aws
         tags:
@@ -3528,7 +3528,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -3720,10 +3720,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-vpc-bpa-enabled-aws
         tags:
@@ -3880,7 +3880,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -4296,14 +4296,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
+      compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
     variants:
       - uid: mondoo-aws-security-lambda-concurrency-check-aws
         tags:
@@ -4474,7 +4474,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -4485,7 +4485,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-lambda-function-public-access-prohibited-aws
         tags:
@@ -4678,7 +4678,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: aws.rds.dbinstance.pendingMaintenanceActions == empty
     docs:
       desc: |
@@ -5028,7 +5028,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
@@ -5295,7 +5295,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       rdsArn = asset.ids.where(_ == /^arn/).first
       aws.rds.allPendingMaintenanceActions.where(resourceArn == rdsArn) == empty
@@ -5721,7 +5721,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-rds-cluster-public-access-check-aws
         tags:
@@ -5967,7 +5967,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-rds-instance-public-access-check-aws
         tags:
@@ -6162,7 +6162,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
         tags:
@@ -6334,11 +6334,11 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: false
     props:
       - uid: mondooAWSSecurityEbsVolumeDeleteOnTermination
         title: Defines whether instances should be configured to delete volumes on termination
@@ -6507,7 +6507,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -6518,7 +6518,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-aws
         tags:
@@ -7145,10 +7145,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-ec2-ebs-kms-encryption-aws
@@ -7531,7 +7531,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-cloudwatch-log-group-encrypted-aws
@@ -8155,8 +8155,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -8405,7 +8405,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
@@ -8413,7 +8413,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -8916,16 +8916,16 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-12
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
@@ -9248,18 +9248,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: dora-art-9
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-09
+      compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-pr-ip-2
-      compliance/nist-csf-2: nist-csf-2-pr-ps-06
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/pci-dss-4: pcidss-requirement-10-3-2
+      compliance/soc2-2017: soc2-control-cc7-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-cloud-trail-log-file-validation-enabled-aws
         tags:
@@ -9658,7 +9658,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-ssh-aws
         tags:
@@ -9845,7 +9845,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-vnc-aws
         tags:
@@ -10043,7 +10043,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-rdp-aws
         tags:
@@ -10232,7 +10232,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restrict-traffic-aws
         tags:
@@ -10418,7 +10418,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -10426,8 +10426,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -10721,8 +10721,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -10834,7 +10834,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -10842,10 +10842,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-api-gw-require-authentication-terraform-hcl
         tags:
@@ -11162,7 +11162,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
@@ -11315,7 +11315,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -11323,8 +11323,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -11481,18 +11481,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-iam-no-wildcards-policies-aws
         tags:
@@ -11890,8 +11890,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -12228,7 +12228,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -12239,7 +12239,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-bucket-public-read-prohibited-aws
         tags:
@@ -12382,7 +12382,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -12390,10 +12390,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-22
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-aws
         tags:
@@ -12518,7 +12518,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
@@ -12888,8 +12888,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -13747,7 +13747,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -13758,7 +13758,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-opensearch-fine-grained-access-control-aws
         tags:
@@ -13944,8 +13944,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -14128,10 +14128,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-opensearch-in-vpc-aws
         tags:
@@ -14299,7 +14299,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -14307,10 +14307,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-opensearch-anonymous-auth-disabled-aws
         tags:
@@ -14471,7 +14471,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-25
@@ -14479,10 +14479,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
-      compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
         tags:
@@ -14631,7 +14631,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -14639,7 +14639,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
@@ -14784,18 +14784,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
         tags:
@@ -14960,18 +14960,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-2
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-06
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
         tags:
@@ -15151,8 +15151,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -15355,7 +15355,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -15509,7 +15509,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -15518,9 +15518,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-elb-drop-invalid-headers-aws
         tags:
@@ -15696,7 +15696,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-notebook-no-direct-internet-aws
         tags:
@@ -15869,8 +15869,8 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-eks-cluster-restrict-public-access-aws
         tags:
@@ -16044,7 +16044,7 @@ queries:
     impact: 50
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
@@ -16052,7 +16052,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -16211,18 +16211,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
         tags:
@@ -16394,7 +16394,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -16402,8 +16402,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -16835,17 +16835,17 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/pci-dss-4: pcidss-requirement-11-5-1
+      compliance/soc2-2017: soc2-control-cc7-2-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-guardduty-enabled-aws
@@ -16991,17 +16991,17 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/pci-dss-4: pcidss-requirement-11-5-1
+      compliance/soc2-2017: soc2-control-cc7-2-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-guardduty-findings-publishing-frequency-aws
@@ -17138,17 +17138,17 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1-1
+      compliance/soc2-2017: soc2-control-cc7-1-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-securityhub-enabled-aws
@@ -17255,17 +17255,17 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-config-recorder-enabled-aws
@@ -17394,17 +17394,17 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-config-recorder-all-resources-aws
@@ -17556,7 +17556,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-12
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
@@ -17564,8 +17564,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-9
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -17711,7 +17711,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-secretsmanager-cmk-encryption-aws
@@ -17851,17 +17851,17 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-iam-access-analyzer-enabled-aws
@@ -18139,18 +18139,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-2
-      compliance/nist-csf-2: nist-csf-2-pr-ps-06
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/pci-dss-4: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-sns-topic-signature-version-aws
         tags:
@@ -18443,7 +18443,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -18922,10 +18922,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cluster
         tags:
@@ -19530,8 +19530,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -19692,10 +19692,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-redshift-cluster-enhanced-vpc-routing-aws
         tags:
@@ -19995,10 +19995,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-cloudfront-waf-enabled-distribution
         tags:
@@ -20286,7 +20286,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -20297,7 +20297,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ec2-ami-public-sharing-prohibited-aws
         tags:
@@ -20445,18 +20445,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ecs-container-non-root-user-aws
         tags:
@@ -20828,16 +20828,16 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-02
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-11
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-5-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -21182,7 +21182,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-vpc-subnet-no-auto-assign-public-ip-aws
         tags:
@@ -21336,7 +21336,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -21512,7 +21512,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -21521,8 +21521,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/pci-dss-4: pcidss-requirement-11-5-1
+      compliance/soc2-2017: soc2-control-cc7-2-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-guardduty-all-features-enabled-aws
@@ -21734,7 +21734,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -21742,10 +21742,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-neptune-cluster-iam-authentication-aws
         tags:
@@ -21893,18 +21893,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
         tags:
@@ -22045,18 +22045,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
         tags:
@@ -22204,7 +22204,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
@@ -22565,7 +22565,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-aws
@@ -22726,7 +22726,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
@@ -22734,10 +22734,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-inspector-ec2-scanning-enabled-aws
         tags:
@@ -22850,7 +22850,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
@@ -22858,10 +22858,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-inspector-ecr-scanning-enabled-aws
         tags:
@@ -22973,7 +22973,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
@@ -22981,10 +22981,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-id-ra-1
       compliance/nist-csf-2: nist-csf-2-id-ra-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-inspector-lambda-scanning-enabled-aws
         tags:
@@ -23252,7 +23252,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-dms-replication-not-public-aws
         tags:
@@ -23808,10 +23808,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-timestream-influxdb-not-public-aws
         tags:
@@ -23965,8 +23965,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-ae-3
-      compliance/nist-csf-2: nist-csf-2-de-ae-03
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -24136,7 +24136,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-aws
         tags:
@@ -24316,7 +24316,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-default-nacl-restrictive-aws
         tags:
@@ -24432,7 +24432,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
@@ -24440,10 +24440,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-11
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-ec2-keypair-type-aws
         tags:
@@ -24573,7 +24573,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -24581,10 +24581,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-rds-instance-iam-auth-aws
         tags:
@@ -24889,7 +24889,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -24897,10 +24897,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-eks-cluster-iam-auth-mode-aws
         tags:
@@ -25054,12 +25054,12 @@ queries:
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ca-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
       compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-aws-security-eks-addon-healthy-aws
@@ -25163,7 +25163,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
@@ -25474,10 +25474,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-11
       compliance/pci-dss-4: pcidss-requirement-4-2-1
-      compliance/soc2-2017: soc2-control-cc6-7-2
-      compliance/vda-isa-5: vda-isa-5-5-1-2
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
         tags:
@@ -25785,16 +25785,16 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-25
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sa-10
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-2
       compliance/soc2-2017: soc2-control-cc8-1-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
@@ -25966,15 +25966,15 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -26121,7 +26121,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -26132,7 +26132,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sagemaker-notebook-no-root-access-aws
         tags:
@@ -26282,10 +26282,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-aws
@@ -26466,7 +26466,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-codebuild-encryption-key-configured-aws
@@ -26800,10 +26800,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-ec2-source-dest-check-aws
         tags:
@@ -26952,7 +26952,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -26961,7 +26961,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/pci-dss-4: false
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
     variants:
@@ -27070,7 +27070,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -27079,7 +27079,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
-      compliance/pci-dss-4: false
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
     variants:
@@ -27366,11 +27366,11 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-20
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
-      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-11
-      compliance/vda-isa-5: vda-isa-5-5-1-2
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-route53-dnssec-enabled-aws
         tags:
@@ -27514,8 +27514,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -27663,14 +27663,14 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
-      compliance/dora: dora-art-12
+      compliance/dora: dora-art-11
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
-      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -27992,12 +27992,12 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-aws
         tags:
@@ -28154,16 +28154,16 @@ queries:
     impact: 50
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
-      compliance/iso-27001-2022: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-18
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -28305,16 +28305,16 @@ queries:
     impact: 50
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
-      compliance/iso-27001-2022: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-18
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -28466,12 +28466,12 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-appstream-image-builder-no-default-internet-access-aws
         tags:
@@ -28634,7 +28634,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-directoryservice-os-version-aws
         tags:
@@ -28788,7 +28788,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -28796,10 +28796,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-directoryservice-sso-enabled-aws
         tags:
@@ -28888,7 +28888,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -28897,9 +28897,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled-aws
         tags:
@@ -29194,10 +29194,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-documentdb-cluster-cmk-encryption-aws
@@ -29376,7 +29376,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-aws
         tags:
@@ -29535,7 +29535,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
         tags:
@@ -29709,7 +29709,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -29718,9 +29718,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-aws
         tags:
@@ -29881,17 +29881,17 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
-      compliance/dora: dora-art-10
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-aws
@@ -30052,7 +30052,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -30060,10 +30060,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated-aws
         tags:
@@ -30221,7 +30221,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -30229,10 +30229,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-cognito-identity-pool-no-classic-flow-aws
         tags:
@@ -30392,7 +30392,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -30401,7 +30401,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     variants:
@@ -30532,14 +30532,14 @@ queries:
       compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: false
       compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-11
+      compliance/iso-27001-2022: iso-27001-2022-a-5-34
       compliance/nis-2: false
-      compliance/nist-csf-1: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc6-1-13
       compliance/vda-isa-5: false
     variants:
       - uid: mondoo-aws-security-route53-domain-contact-privacy-aws
@@ -30666,16 +30666,16 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/dora: dora-art-11
       compliance/hipaa: false
       compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
     variants:
       - uid: mondoo-aws-security-route53-domain-auto-renew-aws
@@ -30957,10 +30957,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-aws
@@ -31134,7 +31134,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-aws
         tags:
@@ -31455,10 +31455,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-aws
@@ -31803,17 +31803,17 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
       compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ip-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
     variants:
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-aws
@@ -32332,7 +32332,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -32343,7 +32343,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-aws
         tags:
@@ -32623,12 +32623,12 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     # NOTE (2026-03-29): Terraform variants not included because aws_security_group cannot be
     # correlated to WorkSpaces-associated security groups in MQL — the check would over-match
     # all security groups in the configuration, not just those attached to WorkSpaces.
@@ -32768,10 +32768,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-neptune-instance-public-access-aws
         tags:
@@ -32927,8 +32927,8 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-opensearch-auto-software-update-aws
         tags:
@@ -33246,10 +33246,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-neptune-cluster-cmk-encryption-aws
@@ -33426,10 +33426,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-aws
@@ -33604,12 +33604,12 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-8
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-12
-      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-aws
         tags:
@@ -33765,10 +33765,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-fsx-filesystem-cmk-encryption-aws
@@ -33949,10 +33949,10 @@ queries:
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-opensearch-cmk-encryption-aws
@@ -35220,7 +35220,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-glue-job-supported-version-aws
         tags:
@@ -35374,10 +35374,10 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ca-7
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-id-ra-1
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-12-3
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
@@ -35724,16 +35724,16 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
-      compliance/dora: dora-art-10
-      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
-      compliance/nist-csf-2: false
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-11
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-rds-proxy-no-debug-logging-aws
@@ -36027,7 +36027,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-memorydb-snapshot-cmk-encryption-aws
@@ -36171,7 +36171,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -36182,7 +36182,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-memorydb-no-open-access-acl-aws
         tags:
@@ -36521,7 +36521,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-aws
         tags:
@@ -36676,10 +36676,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-aws
         tags:
@@ -36849,7 +36849,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-training-job-network-isolation-aws
         tags:
@@ -37046,10 +37046,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
         tags:
@@ -37149,7 +37149,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation-aws
         tags:
@@ -37339,10 +37339,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-5
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured-aws
         tags:
@@ -37606,16 +37606,16 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -37822,7 +37822,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-id-ra-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sr-3
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
+      compliance/pci-dss-4: pcidss-requirement-6-3-2
       compliance/soc2-2017: soc2-control-cc9-2-2
       compliance/vda-isa-5: false
     variants:
@@ -37922,16 +37922,16 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -38062,14 +38062,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-sagemaker-monitoring-job-network-config-aws
         tags:
@@ -38277,7 +38277,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -38286,9 +38286,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sagemaker-domain-default-role-not-admin-aws
         tags:
@@ -38378,7 +38378,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -38387,9 +38387,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sagemaker-notebook-role-not-admin-aws
         tags:
@@ -38475,7 +38475,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -38484,9 +38484,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sagemaker-job-role-not-admin-aws
         tags:
@@ -38582,8 +38582,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -38746,8 +38746,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -38916,7 +38916,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-mq-no-public-access-aws
         tags:
@@ -39086,7 +39086,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-msk-encryption-at-rest-aws
@@ -39427,8 +39427,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -39723,18 +39723,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/pci-dss-4: pcidss-requirement-10-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     # NOTE (2026-03-29): Terraform variants not included because aws_s3_bucket_public_access_block
     # cannot be correlated to the specific CloudTrail S3 bucket in MQL — the check would
     # over-match all S3 public access block resources. A general S3 public access check already
@@ -39861,11 +39861,11 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-3-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     # NOTE (2026-03-29): Terraform variants not included because aws_s3_bucket_logging cannot be
@@ -40154,16 +40154,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -40367,16 +40367,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -40579,16 +40579,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -40792,16 +40792,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -41006,16 +41006,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -41219,16 +41219,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -41432,16 +41432,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -41645,16 +41645,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -41858,16 +41858,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -42071,16 +42071,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -42284,16 +42284,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -42497,16 +42497,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -42710,16 +42710,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -42923,16 +42923,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -43136,16 +43136,16 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-05
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-ae-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -43358,9 +43358,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-aws
         tags:
@@ -43540,7 +43540,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -43549,9 +43549,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-iam-root-hardware-mfa-aws
         tags:
@@ -43654,16 +43654,16 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
@@ -43756,7 +43756,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-iam-support-role-aws
         tags:
@@ -43920,7 +43920,7 @@ queries:
     impact: 50
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-18
@@ -43928,7 +43928,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -44068,7 +44068,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
@@ -44242,7 +44242,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -44253,7 +44253,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-lambda-source-arn-aws
         tags:
@@ -44424,7 +44424,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -44433,9 +44433,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-s3-mfa-delete-aws
         tags:
@@ -44922,8 +44922,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -45489,8 +45489,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -45831,18 +45831,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sqs-no-wildcard-policy-aws
         tags:
@@ -46023,15 +46023,15 @@ queries:
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
-      compliance/iso-27001-2022: iso-27001-2022-a-8-24
-      compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
-      compliance/vda-isa-5: vda-isa-5-5-1-1
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-g
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-aws-security-ecs-task-definition-no-plaintext-secrets-aws
         tags:
@@ -46181,7 +46181,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -46191,8 +46191,8 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-no-default-vpc-aws
         tags:
@@ -46491,11 +46491,11 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-3-3
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -46669,7 +46669,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -46832,7 +46832,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -46990,12 +46990,12 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc7-1-2
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-rds-performance-insights-aws
@@ -47151,7 +47151,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
@@ -47159,7 +47159,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -47312,7 +47312,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
       compliance/iso-27001-2022: iso-27001-2022-a-8-14
@@ -47320,7 +47320,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ip-4
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
-      compliance/nist-sp-800-171: "false"
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
@@ -47485,7 +47485,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-ecr-repository-cmk-encryption-aws
@@ -47643,8 +47643,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -47800,8 +47800,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -47964,17 +47964,17 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-12-3
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-config-aggregator-enabled-aws
@@ -48121,17 +48121,17 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-7
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
-      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-12-3
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-config-aggregator-all-regions-aws
@@ -48296,7 +48296,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -48307,7 +48307,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ecr-no-public-access-aws
         tags:
@@ -48498,15 +48498,15 @@ queries:
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
-      compliance/iso-27001-2022: iso-27001-2022-a-8-24
-      compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-g
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
-      compliance/vda-isa-5: vda-isa-5-5-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-aws-security-ec2-launch-template-no-secrets-aws
         tags:
@@ -48691,7 +48691,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
@@ -48815,7 +48815,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -48826,7 +48826,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ec2-snapshot-not-public-aws
         tags:
@@ -49180,7 +49180,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-ec2-launch-config-no-public-ip-aws
         tags:
@@ -49330,15 +49330,15 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-j
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -49513,7 +49513,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-rds-instance-cmk-encryption-aws
@@ -49700,7 +49700,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-rds-cluster-cmk-encryption-aws
@@ -49889,7 +49889,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-rds-snapshot-cmk-encryption-aws
@@ -50027,7 +50027,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-emr-not-publicly-accessible-aws
         tags:
@@ -50201,8 +50201,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/pci-dss-4: pcidss-requirement-10-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-emr-log-cmk-encryption-aws
@@ -50412,7 +50412,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-neptune-no-default-security-groups-aws
         tags:
@@ -50585,7 +50585,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-documentdb-no-default-security-groups-aws
         tags:
@@ -50761,7 +50761,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
@@ -51092,8 +51092,8 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -51415,7 +51415,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
@@ -51592,10 +51592,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-lambda-in-vpc-aws
         tags:
@@ -51760,7 +51760,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -51771,7 +51771,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-aws
         tags:
@@ -51956,7 +51956,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-elasticache-cmk-encryption-aws
@@ -52134,7 +52134,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-kinesis-cmk-typed-key-aws
@@ -52318,7 +52318,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-dynamodb-cmk-encryption-aws
@@ -52503,7 +52503,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-keyspaces-cmk-encryption-aws
@@ -52834,7 +52834,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
@@ -52842,10 +52842,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-appstream-stack-url-redirection-disabled-aws
         tags:
@@ -52929,11 +52929,11 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-20
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-vpc-dhcp-custom-dns-aws
         tags:
@@ -53096,7 +53096,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -53105,9 +53105,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-vpc-endpoint-security-groups-aws
         tags:
@@ -53245,7 +53245,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -53254,9 +53254,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-vpc-endpoint-service-acceptance-required-aws
         tags:
@@ -53397,7 +53397,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -53532,7 +53532,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -53702,7 +53702,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -53711,9 +53711,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-client-vpn-security-groups-aws
         tags:
@@ -53867,18 +53867,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-prefix-list-no-broad-cidrs-aws
         tags:
@@ -54053,7 +54053,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -54064,7 +54064,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ssm-document-not-public-aws
         tags:
@@ -54210,7 +54210,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-4
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-aws-security-ssm-patch-baseline-reject-action-aws
         tags:
@@ -54369,18 +54369,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-aws-security-ssm-maintenance-window-no-unassociated-aws
         tags:
@@ -54541,7 +54541,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -54550,9 +54550,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-cloudwatch-log-destination-restrict-access-aws
         tags:
@@ -54691,7 +54691,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -54700,9 +54700,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-vpc-endpoint-service-restrict-principals-aws
         tags:
@@ -54827,8 +54827,8 @@ queries:
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-ae-3
-      compliance/nist-csf-2: nist-csf-2-de-cm-01
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/soc2-2017: soc2-control-cc7-2-1
@@ -55015,7 +55015,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
@@ -55192,18 +55192,18 @@ queries:
     impact: 80
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ram-no-external-principals-aws
         tags:
@@ -55344,18 +55344,18 @@ queries:
     impact: 70
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ram-no-wildcard-principals-aws
         tags:
@@ -55514,11 +55514,11 @@ queries:
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
-      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
@@ -55673,18 +55673,18 @@ queries:
     impact: 80
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-b
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-transfer-vpc-endpoint-aws
         tags:
@@ -55842,8 +55842,8 @@ queries:
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-ae-3
-      compliance/nist-csf-2: nist-csf-2-de-cm-01
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/soc2-2017: soc2-control-cc7-2-1
@@ -56007,11 +56007,11 @@ queries:
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
-      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
@@ -56159,18 +56159,18 @@ queries:
     impact: 60
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-transfer-identity-provider-aws
         tags:
@@ -56313,18 +56313,18 @@ queries:
     impact: 70
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-b
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-2
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-appmesh-egress-filter-aws
         tags:
@@ -56478,14 +56478,14 @@ queries:
     impact: 60
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/pci-dss-4: pcidss-requirement-8-6-1
@@ -56615,18 +56615,18 @@ queries:
     impact: 50
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-g
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-identitycenter-no-inline-policy-aws
         tags:
@@ -56756,18 +56756,18 @@ queries:
     impact: 60
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-identitycenter-group-assignments-aws
         tags:
@@ -56909,18 +56909,18 @@ queries:
     impact: 90
     tags:
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-secretsmanager-no-public-policy-aws
         tags:
@@ -57110,7 +57110,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -57119,9 +57119,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-ec2-serial-console-disabled-aws
         tags:
@@ -57234,7 +57234,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
@@ -57245,7 +57245,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-ec2-ami-block-public-access-aws
         tags:
@@ -57356,17 +57356,17 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
       compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-aws-security-ec2-launch-template-imdsv2-aws
@@ -57526,7 +57526,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
@@ -57537,7 +57537,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-ownership-controls-enforced-aws
         tags:
@@ -57677,7 +57677,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -57686,8 +57686,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-ae-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-5
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1-1
+      compliance/soc2-2017: soc2-control-cc7-2-3
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-cloudtrail-insights-enabled-aws
@@ -57846,7 +57846,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -57855,7 +57855,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-12-3
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/pci-dss-4: pcidss-requirement-10-4-1-1
       compliance/soc2-2017: soc2-control-cc7-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
@@ -57993,7 +57993,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
@@ -58004,7 +58004,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-sns-no-public-access-aws
         tags:
@@ -58199,7 +58199,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-6
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-drs-private-replication-aws
         tags:
@@ -58337,10 +58337,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-1-6
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-drs-no-public-recovery-ip-aws
         tags:
@@ -58501,7 +58501,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     docs:
       desc: |
         This check ensures that every Neptune instance in a cluster is configured to receive automatic minor version upgrades. When disabled, instances remain on the engine version they were launched with until an operator manually performs an upgrade, a gap that widens over time as AWS releases new minor patches.
@@ -58653,7 +58653,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     docs:
       desc: |
         This check ensures that every DocumentDB instance belonging to a cluster is configured to receive automatic minor version upgrades. When disabled, instances stay on their launched engine version until manually updated, and the gap between the running version and the current patched release grows with every AWS release cycle.
@@ -58785,7 +58785,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-postgresql-aws
         tags:
@@ -58962,7 +58962,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-mysql-aws
         tags:
@@ -59128,7 +59128,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-mssql-aws
         tags:
@@ -59294,7 +59294,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-oracle-aws
         tags:
@@ -59457,7 +59457,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-mongodb-aws
         tags:
@@ -59620,7 +59620,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-redis-aws
         tags:
@@ -59783,7 +59783,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-memcached-aws
         tags:
@@ -59946,7 +59946,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-aws
         tags:
@@ -60109,7 +60109,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-winrm-aws
         tags:
@@ -60272,7 +60272,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-aws
         tags:
@@ -60437,7 +60437,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-aws
         tags:
@@ -60602,7 +60602,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-kubelet-aws
         tags:
@@ -60764,7 +60764,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secgroup-restricted-etcd-aws
         tags:
@@ -60925,7 +60925,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-aws
         tags:
@@ -61328,7 +61328,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -61339,7 +61339,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-aws
         tags:
@@ -61482,7 +61482,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-sns-topic-cmk-encryption-aws
@@ -61653,7 +61653,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-sqs-queue-cmk-encryption-aws
@@ -61806,18 +61806,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-appstream-image-no-public-visibility-aws
         tags:
@@ -61892,18 +61892,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-appstream-stack-embed-host-domains-no-wildcards-aws
         tags:
@@ -62019,18 +62019,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-workspaces-web-ip-access-no-public-aws
         tags:
@@ -62156,18 +62156,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-aws-security-cloudfront-origin-mtls-cert-not-expired-aws
         tags:
@@ -62256,18 +62256,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-aws
         tags:
@@ -62339,18 +62339,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-aws-security-cloudfront-private-origin-mtls-aws
         tags:
@@ -62427,18 +62427,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-aws-security-cloudfront-trust-store-recently-updated-aws
         tags:
@@ -62515,18 +62515,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-transfer-connector-access-role-no-wildcards-aws
         tags:
@@ -62628,18 +62628,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-aws-security-transfer-connector-logging-role-aws
         tags:
@@ -62766,18 +62766,18 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-transfer-web-app-not-public-aws
         tags:
@@ -62849,16 +62849,16 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/dora: dora-art-11
       compliance/hipaa: false
       compliance/iso-27001-2022: false
       compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-9
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: false
     variants:
       - uid: mondoo-aws-security-transfer-workflow-exception-handling-aws
@@ -62947,7 +62947,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-bedrock-custom-model-cmk-encryption-aws
@@ -63092,7 +63092,7 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-02
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-4
@@ -63515,16 +63515,16 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ais-02
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-23
       compliance/nis-2: nis-2-21-2-d
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-id-ra-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sr-3
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/pci-dss-4: pcidss-requirement-6-3-2
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-1-3-3
     variants:
@@ -63660,9 +63660,9 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -63772,7 +63772,7 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
@@ -63891,7 +63891,7 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
@@ -64010,14 +64010,14 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-11
-      compliance/pci-dss-4: false
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
@@ -64170,11 +64170,11 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-08
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
       compliance/pci-dss-4: pcidss-requirement-3-6-1
@@ -64332,13 +64332,13 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-4-2
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -64523,13 +64523,13 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
-      compliance/hipaa: false
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-4-2
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -64659,8 +64659,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
@@ -64991,7 +64991,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-glue-catalog-encryption-cmk-aws
@@ -65174,7 +65174,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-glue-security-config-cmk-encryption-aws
@@ -65388,7 +65388,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-aws
@@ -65580,7 +65580,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -65588,10 +65588,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-aws-security-lambda-function-url-auth-required-aws
         tags:
@@ -65729,7 +65729,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -65740,7 +65740,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-aws
         tags:
@@ -65894,8 +65894,8 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     filters: asset.platform == "aws"
@@ -65987,7 +65987,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-5-15
@@ -65998,7 +65998,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-eventbridge-bus-policy-no-public-access-aws
         tags:
@@ -66175,15 +66175,15 @@ queries:
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
-      compliance/iso-27001-2022: iso-27001-2022-a-8-24
-      compliance/nis-2: nis-2-21-2-h
-      compliance/nist-csf-1: nist-csf-1-pr-ds-1
-      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-g
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
       compliance/pci-dss-4: pcidss-requirement-8-3-2
-      compliance/soc2-2017: soc2-control-cc6-1-10
-      compliance/vda-isa-5: vda-isa-5-5-2-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-aws-security-glue-connection-no-plaintext-credentials-aws
         tags:
@@ -66312,10 +66312,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-cloud9-environment-no-ingress-terraform-hcl
         tags:
@@ -66605,7 +66605,7 @@ queries:
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
@@ -66730,7 +66730,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-aws
@@ -67107,7 +67107,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-kinesis-video-stream-cmk-encryption-terraform-hcl
@@ -67236,7 +67236,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-emr-studio-cmk-encryption-aws
@@ -67399,15 +67399,15 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
-      compliance/dora: dora-art-9
+      compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
-      compliance/nis-2: nis-2-21-2-h
+      compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
-      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
@@ -67528,7 +67528,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
@@ -67537,9 +67537,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-aws
         tags:
@@ -69018,10 +69018,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
       compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
         tags:
@@ -69180,7 +69180,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
       compliance/pci-dss-4: pcidss-requirement-3-5-1
-      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
       - uid: mondoo-aws-security-codeartifact-domain-cmk-encryption-terraform-hcl

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -708,21 +708,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EKS clusters are configured to use AWS Key Management Service (KMS) for encryption of Kubernetes secrets. By default, EKS uses a default KMS key for encryption, but organizations can create and manage their own customer-managed keys (CMKs) for enhanced security and compliance.
+        This check ensures that Amazon EKS clusters are configured to use a customer-managed KMS key for encrypting Kubernetes secrets at rest. By default, EKS does not encrypt secrets unless an encryption configuration is explicitly provided; when configured, the customer-managed key gives the account owner direct control over key access, rotation, and revocation.
 
         **Why this matters**
 
-        Using KMS for encryption provides several benefits:
-
-        - **Data protection:** Secrets are encrypted at rest using strong encryption algorithms.
-        - **Access control:** Organizations can manage access to the KMS key using IAM policies.
-        - **Auditability:** AWS CloudTrail logs all KMS key usage, providing a detailed audit trail.
+        - **Customer control over key lifecycle:** A customer-managed key can be rotated, disabled, or revoked independently of the cluster, allowing immediate response to a suspected compromise.
+        - **Separation of duties:** IAM key policies for the KMS key can restrict which principals can decrypt secrets, enforcing access controls beyond cluster-level RBAC.
+        - **Audit trail:** Every use of the key is recorded in AWS CloudTrail, providing a cryptographically linked record of when secrets were accessed or decrypted.
+        - **Blast radius reduction:** If the cluster is compromised, rotating or disabling the KMS key invalidates cached decryption of all persisted secrets without destroying the cluster.
 
         **Risk mitigation**
 
-        - **Prevents unauthorized access:** Only authorized users and services can decrypt secrets.
-        - **Ensures compliance:** Meets regulatory requirements for data protection and encryption.
-        - **Enhances security posture:** Reduces the risk of data breaches and unauthorized access to sensitive information.
+        - **Secrets exposure prevention:** Encrypting etcd secrets with a CMK ensures that raw etcd data, snapshot files, or backup volumes cannot be read without key access.
+        - **Regulatory alignment:** Many frameworks require encryption of sensitive data at rest under keys the customer controls; AWS-managed keys satisfy encryption but not customer-key requirements.
+        - **Revocability:** Customer-managed keys can be disabled or scheduled for deletion, making it possible to effectively revoke access to secrets for a compromised cluster.
       audit: |
         ### Audit via Console
 
@@ -1069,23 +1068,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that the AWS root user account does not have an active access key. The AWS root user has full administrative privileges over the AWS account, making it the most powerful identity in AWS. AWS best practices recommend that root user credentials should never be used for everyday operations, and instead, AWS Identity and Access Management (IAM) users or roles should be utilized for all administrative tasks.
+        This check ensures that the AWS root user account has no active access keys. The root user possesses unrestricted privileges over the entire AWS account and its access keys provide programmatic access that bypasses IAM permission boundaries; AWS recommends that the root user never be used for routine operations and that no programmatic credentials exist for it.
 
         **Why this matters**
 
-        Root user access keys pose a high security risk if compromised, as they provide unrestricted access to all AWS resources. If an attacker gains access to a root user's credentials, they can:
-
-        - Delete or modify critical resources.
-        - Access sensitive data across all AWS services.
-        - Disable security controls, logging, and monitoring.
-
-        By ensuring that no root user access keys exist, organizations can enforce security best practices and reduce the risk of unauthorized access.
+        - **Unrestricted blast radius:** Root access keys, if leaked, allow an attacker to perform any action in the account, including deleting resources, disabling security controls, and exfiltrating all data.
+        - **No IAM boundary enforcement:** Service control policies and IAM permission boundaries do not restrict root; a compromised root key is fully outside the normal permission model.
+        - **Phishing and leak exposure:** Long-lived programmatic credentials stored in code repositories, CI pipelines, or local configuration files are a common source of credential leakage.
+        - **Auditability gap:** Actions taken with root credentials are harder to attribute and often treated differently by monitoring tools, making detection more difficult.
 
         **Risk mitigation**
 
-        - **Prevents root key compromise:** Eliminates a major attack vector for AWS account takeovers.
-        - **Ensures compliance:** Aligns with security frameworks like CIS AWS Foundations Benchmark, SOC 2, PCI DSS, and ISO 27001.
-        - **Encourages least privilege:** Promotes the use of IAM users and roles for secure access control.
+        - **Credential elimination:** Removing root access keys removes the single most dangerous credential class in the account; actions previously requiring root should be delegated to IAM roles with least-privilege policies.
+        - **Breach containment:** Without a root access key, an attacker who compromises application or operator credentials cannot escalate to full account control through programmatic means.
+        - **Compliance posture:** Absence of root access keys is a first-pass control checked by virtually every cloud security benchmark and audit framework.
       audit: |
         ### Audit via Console
 
@@ -1242,23 +1238,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Multi-Factor Authentication (MFA) is enabled for the AWS root user account. The root user has full administrative privileges over an AWS account, making it the most critical identity. Enabling MFA significantly enhances security by requiring an additional authentication factor beyond just the password.
+        This check ensures that Multi-Factor Authentication is enabled for the AWS root user account. The root user has full administrative control over every resource and service in the AWS account; by default MFA is not configured and the account is protected only by a password, which can be phished or leaked.
 
         **Why this matters**
 
-        The root user account is the most powerful account in AWS, and if compromised, an attacker can gain full control over all AWS resources. Without MFA, an attacker who obtains the root password (via phishing, credential leaks, or brute-force attacks) can:
-
-        - Delete or modify critical resources.
-        - Disable security controls, logging, and monitoring.
-        - Access and exfiltrate sensitive data.
-
-        By enabling Multi-Factor Authentication (MFA), organizations prevent unauthorized access, even if root credentials are compromised. AWS supports hardware MFA tokens and virtual MFA devices such as Authy or Google Authenticator for added security.
+        - **Account takeover prevention:** A second authentication factor means that a stolen or guessed root password alone is not sufficient for an attacker to gain access.
+        - **Privileged identity protection:** Root-level actions cannot be constrained by IAM policies or SCPs, so protecting the login credential is the primary defense against full account compromise.
+        - **Credential leak resilience:** Password breaches from other services are frequently used in credential-stuffing attacks; MFA breaks the direct path from a leaked password to account access.
 
         **Risk mitigation**
 
-        - **Prevents account takeovers:** Even if the root password is stolen, MFA blocks unauthorized logins.
-        - **Ensures compliance:** Meets security standards such as CIS AWS Foundations Benchmark, SOC 2, ISO 27001, and PCI DSS.
-        - **Strengthens account security:** Adds an extra layer of authentication beyond the password.
+        - **Unauthorized login blocking:** Even if the root password is exposed through a phishing campaign or data breach, the attacker cannot authenticate without the MFA device.
+        - **Lateral escalation barrier:** Attackers who compromise lower-privilege IAM users cannot pivot to root-level access through password guessing alone when MFA is required.
+        - **Incident response window:** MFA buys time to detect and respond to a credential compromise before an attacker can escalate to destructive root actions.
       audit: |
         ### Audit via Console
 
@@ -1455,27 +1447,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS accounts enforce a strong IAM password policy to enhance security by preventing weak or easily guessable passwords. A well-defined password policy helps protect against brute-force attacks, credential stuffing, and unauthorized access.
+        This check ensures that the AWS IAM account password policy enforces strong complexity and rotation requirements for all IAM user passwords. By default, AWS accounts have no password policy set, which means any password length and complexity is accepted; without explicit requirements, users may choose short, simple passwords that are trivially guessable.
 
         **Why this matters**
 
-        Without a strong password policy, IAM users may use weak passwords, increasing the risk of compromised credentials. Implementing a strict password policy ensures that AWS accounts comply with security best practices and regulatory standards such as CIS AWS Foundations Benchmark, NIST, ISO 27001, PCI DSS, and SOC 2.
-
-        A secure IAM password policy should enforce the following requirements:
-
-        - At least one uppercase character
-        - At least one lowercase character
-        - At least one number
-        - At least one symbol such as !@#$%^&*
-        - A minimum password length of 14 characters
-        - Prevention of password reuse for at least the last 24 passwords
-        - Password expiration after 90 days
+        - **Brute-force resistance:** Minimum length and complexity requirements significantly expand the keyspace an attacker must search, making dictionary and brute-force attacks impractical.
+        - **Credential-stuffing defense:** Password reuse prevention ensures that credentials leaked from other services cannot be directly replayed against AWS console logins.
+        - **Credential aging:** Maximum password age limits the window during which a previously leaked password remains valid, capping the dwell time of compromised credentials.
+        - **Compliance baseline:** Most security frameworks require documented password policies with minimum length, complexity, and rotation requirements.
 
         **Risk mitigation**
 
-        - **Prevents brute-force attacks:** Ensures passwords are complex and difficult to guess.
-        - **Reduces credential stuffing risks:** Enforces frequent password changes and prevents password reuse.
-        - **Ensures compliance:** Meets security requirements for regulated industries.
+        - **Weak password elimination:** Policy enforcement prevents IAM users from setting trivially guessable passwords that would otherwise pass default AWS validation.
+        - **Reuse prevention:** Prohibiting reuse of recent passwords prevents users from cycling through a small set of passwords to satisfy rotation without actually changing their credential.
+        - **Reduced exposure window:** Regular expiration ensures that credentials compromised through phishing or shoulder-surfing are automatically invalidated within a bounded period.
       audit: |
         ### Audit via Console
 
@@ -1666,19 +1651,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS IAM user access keys are regularly rotated to reduce the risk of credential compromise. Access keys should be changed periodically to prevent long-term exposure and limit the impact of potential key leaks. AWS best practices recommend rotating IAM access keys every 90 days or less.
+        This check ensures that active AWS IAM user access keys are rotated at least every 90 days. Access keys are long-lived programmatic credentials; once issued, they remain valid indefinitely unless explicitly rotated or deleted, meaning a key leaked months ago may still grant an attacker access to AWS APIs.
 
         **Why this matters**
 
-        IAM access keys provide programmatic access to AWS services. If an access key is compromised, an attacker could gain unauthorized access to AWS resources. Regularly rotating access keys limits the window of opportunity for an attacker to use stolen credentials.
-
-        A strong key rotation policy helps organizations comply with security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, NIST, ISO 27001, and SOC 2.
+        - **Credential exposure window:** The longer an access key exists without rotation, the greater the chance it has been leaked through code commits, log files, or misconfigured storage, and the longer an attacker can exploit it undetected.
+        - **Key hygiene enforcement:** Regular rotation forces teams to audit which applications and scripts hold credentials, surfacing forgotten or orphaned keys.
+        - **Incident response clarity:** Knowing that all active keys are recent makes it easier to determine whether a suspicious API call used a current or previously revoked credential.
 
         **Risk mitigation**
 
-        - Reduces the risk of long-term key exposure
-        - Ensures compliance with security and regulatory standards
-        - Limits the impact of potential credential leaks
+        - **Compromised credential invalidation:** Rotating keys periodically ensures that any key leaked before the last rotation is no longer valid, limiting the damage from past exposures.
+        - **Stale credential cleanup:** The rotation process identifies keys that are no longer in use, prompting their deletion and reducing the total number of active credentials that could be stolen.
+        - **Detection opportunity:** Monitoring for API calls that occur after a key is rotated but before the old key is deleted can surface unauthorized use of the old credential.
       audit: |
         ### Audit via Console
 
@@ -1835,19 +1820,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that all AWS IAM users with console access have Multi-Factor Authentication (MFA) enabled. MFA provides an additional layer of security beyond just a username and password, reducing the risk of unauthorized account access in case credentials are compromised.
+        This check ensures that every IAM user with AWS Management Console access has Multi-Factor Authentication enabled. Console-enabled IAM users authenticate with a username and password; without MFA, a single stolen credential is sufficient for an attacker to log in and perform any action permitted by that user's policies.
 
         **Why this matters**
 
-        IAM users with console access rely on password-based authentication, which is vulnerable to phishing, credential leaks, and brute-force attacks. Without MFA, an attacker who obtains an IAM user's password can gain unauthorized access to AWS resources. Enforcing MFA helps mitigate this risk by requiring a second factor, such as a one-time code from a mobile authenticator app or a hardware security key.
-
-        AWS best practices and security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, NIST, ISO 27001, and SOC 2 require MFA for all users with administrative or privileged access.
+        - **Password theft resilience:** MFA ensures that phished or leaked passwords cannot be used for interactive login without also compromising the physical MFA device.
+        - **Credential stuffing protection:** Passwords reused across services are frequently tested against cloud consoles; MFA breaks the direct path from a leaked password to console access.
+        - **Insider threat mitigation:** MFA makes it harder for someone with knowledge of a colleague's password to access the console without detection, since the MFA prompt creates an additional out-of-band signal.
+        - **Privileged action gating:** Many sensitive console operations such as policy modifications and resource deletion are only accessible through the console; protecting console access with MFA reduces the risk of high-impact accidental or malicious changes.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access due to stolen or weak passwords
-        - Enhances security posture by enforcing multi-layer authentication
-        - Aligns with compliance and security best practices
+        - **Unauthorized access prevention:** An attacker who obtains console credentials through phishing, credential stuffing, or insider access cannot authenticate without the second factor.
+        - **Breach impact reduction:** Requiring MFA for every console user ensures that compromising one credential does not immediately translate into account access, giving security teams time to detect and respond.
+        - **Policy compliance:** Most cloud security benchmarks require MFA for all users with console access as a baseline control.
       audit: |
         ### Audit via Console
 
@@ -2041,21 +2027,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that IAM groups in AWS have at least one assigned user. Empty IAM groups with attached policies represent a privilege escalation risk: an attacker with `iam:AddUserToGroup` permissions can add themselves or a compromised user to an empty group and instantly inherit all of its permissions without creating new policies that would be more visible in audit logs.
+        This check ensures that every AWS IAM group has at least one user assigned to it. IAM groups that have policies attached but no users represent pre-staged permission sets that any attacker or insider with the `iam:AddUserToGroup` permission can exploit to silently escalate privileges by joining the empty group.
 
         **Why this matters**
 
-        Empty IAM groups with policies attached are a latent privilege escalation path:
-
-        - An attacker with `iam:AddUserToGroup` permissions can silently escalate privileges by joining an empty group, inheriting its policies without triggering policy-creation alerts.
-        - Empty groups are often overlooked during access reviews because they appear unused, making them ideal hiding spots for pre-staged permissions.
-        - Groups created for former roles or projects may retain broad permissions that exceed what current workloads require, providing excessive access if exploited.
+        - **Privilege escalation prevention:** An empty group with attached policies is a one-API-call escalation path; joining the group immediately grants all of the group's permissions without creating new policies that would be more visible in access reviews.
+        - **Audit blind spot:** Empty groups often appear benign and are overlooked during access reviews, allowing misconfigured or maliciously planted permission sets to persist undetected.
+        - **Stale permission cleanup:** Groups created for past projects or roles may retain broad permissions that exceed what any current workload needs, providing excessive access if exploited.
 
         **Risk mitigation**
 
-        - **Privilege escalation prevention:** Removing empty groups eliminates pre-staged permission sets that an attacker could exploit with a single API call.
-        - **Access review accuracy:** Ensures all groups with permissions are actively used and reviewed, closing blind spots in security audits.
-        - **Attack surface reduction:** Reduces the number of permission paths an attacker can exploit after initial credential compromise.
+        - **Attack surface reduction:** Removing or depopulating unused groups eliminates pre-staged permission sets, reducing the number of paths an attacker can use to escalate privileges after initial credential compromise.
+        - **Access review accuracy:** Ensuring all groups with permissions have active members means access reviews cover the full set of effective permissions in the account without missing dormant escalation paths.
+        - **Least privilege enforcement:** Regularly auditing group membership forces teams to evaluate whether each group's permissions are still appropriate, driving permission minimization over time.
       audit: |
         ### Audit via Console
 
@@ -2228,23 +2212,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that each AWS IAM user has no more than one active access key. IAM users can have up to two access keys, but maintaining multiple active keys increases the risk of credential leakage and unauthorized access if one of the keys is compromised. Best practices dictate that only one active key should exist per IAM user to reduce attack surfaces and ensure proper key management.
+        This check ensures that each AWS IAM user has no more than one active access key at a time. AWS allows up to two access keys per user to facilitate zero-downtime rotation; however, leaving two keys active simultaneously doubles the attack surface and makes it harder to track which key is in use or when each was last rotated.
 
         **Why this matters**
 
-        Access keys provide programmatic access to AWS services. If multiple active keys exist for a user:
-
-        - The risk of credential exposure increases.
-        - It becomes harder to track and rotate access keys securely.
-        - Unused keys may remain active longer than necessary, violating least privilege principles.
-
-        AWS best practices and security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, NIST, ISO 27001, and SOC 2 recommend that IAM users should have at most one active access key at any time.
+        - **Reduced credential exposure:** Each active access key is an independent credential that could be leaked through a separate channel; minimizing the number of active keys reduces the total number of secrets that must be protected.
+        - **Rotation clarity:** When only one key is active, rotation has a clear starting state and the purpose of a second key is unambiguous; with two permanently active keys, rotation may be deferred indefinitely.
+        - **Auditability:** A single active key per user makes it straightforward to correlate API activity to a specific credential and to determine when that credential was last rotated.
 
         **Risk mitigation**
 
-        - Reduces exposure to key compromise by minimizing unused or unnecessary credentials.
-        - Simplifies access key rotation by ensuring only one key is active at any given time.
-        - Enhances security posture by enforcing least privilege access for IAM users.
+        - **Compromised key isolation:** Limiting each user to one active key means a leaked credential can be identified and revoked without uncertainty about whether a second active key was also exposed.
+        - **Key sprawl prevention:** Requiring users to deactivate old keys before creating new ones prevents credentials from accumulating over time and becoming forgotten attack surfaces.
+        - **Simplified incident response:** With one key per user, revoking access after a compromise is a single operation with no risk of leaving a second active key behind.
       audit: |
         ### Audit via Console
 
@@ -2427,21 +2407,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS IAM users do not have directly attached inline or managed policies and instead receive permissions exclusively through IAM groups. Inline policies attached directly to users are hiding spots for persistent backdoor permissions that are invisible to bulk policy reviews and difficult to discover during security audits.
+        This check ensures that AWS IAM users have no directly attached inline or managed policies and receive all permissions exclusively through IAM group membership. Inline policies attached to individual users are hidden from bulk policy reviews, bypassing the group-based access model and creating persistent permission grants that survive credential rotations.
 
         **Why this matters**
 
-        Inline policies on IAM users create security blind spots:
-
-        - An attacker who gains IAM write access can attach an inline policy to a user as a persistent backdoor, granting themselves access that survives password rotations and access key changes.
-        - Inline policies do not appear in the IAM policy list and require per-user enumeration to discover, making them significantly harder to detect during access reviews.
-        - Directly attached policies bypass group-based access control, allowing individual users to accumulate excessive privileges that are not visible when reviewing group permissions.
+        - **Backdoor concealment:** Inline policies do not appear in the IAM policy list and require per-user enumeration to discover, making them an effective hiding spot for attacker-planted persistent permissions.
+        - **Audit coverage gap:** Access reviews that scan group policies miss per-user inline policies, allowing excessive or malicious permissions to persist undetected through multiple review cycles.
+        - **Privilege creep accumulation:** When permissions are granted directly to users rather than through groups, there is no natural checkpoint for reviewing whether accumulated permissions still reflect least privilege.
+        - **Policy lifecycle management:** Policies attached to groups are managed centrally and changes apply to all members simultaneously; inline policies require per-user remediation, making cleanup slower and less reliable.
 
         **Risk mitigation**
 
-        - **Backdoor detection:** Eliminates inline policies as a hiding spot for attacker-planted persistent permissions.
-        - **Audit visibility:** Ensures all permissions are managed through groups where they are visible to bulk access reviews and automated compliance scanning.
-        - **Privilege creep prevention:** Group-based assignment makes it easier to detect and revoke excessive permissions across multiple users simultaneously.
+        - **Backdoor elimination:** Removing inline policies closes the most common technique for maintaining persistent access after initial IAM compromise, because any permissions granted through groups are visible in bulk reviews.
+        - **Centralized permission control:** Group-based permissions allow security teams to review and modify the full set of a user's permissions in one place, reducing the risk of missed grants during access reviews.
+        - **Privilege escalation prevention:** Without the ability to attach inline policies to specific users, an attacker who gains IAM write access cannot silently expand a user's permissions beyond what their group membership grants.
       audit: |
         ### Audit via Console
 
@@ -2654,23 +2633,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that the default security group (SG) for every AWS Virtual Private Cloud (VPC) is configured to restrict all inbound and outbound traffic. By default, AWS creates a default security group for each VPC, which allows unrestricted communication between instances associated with the group. This can pose a significant security risk if not properly restricted.
+        This check ensures that the default security group for every AWS VPC is configured to allow no inbound or outbound traffic. When a VPC is created, AWS automatically creates a default security group that permits all traffic between instances assigned to the group; any resource inadvertently associated with this group, rather than a purpose-built security group, immediately has unrestricted internal network access.
 
         **Why this matters**
 
-        The default security group in a VPC automatically allows all inbound and outbound traffic between instances using the same security group, which can:
-
-        - Allow unintended access between instances, increasing the risk of lateral movement.
-        - Expose resources to potential unauthorized access if assigned inadvertently.
-        - Violate security best practices and compliance standards such as CIS AWS Foundations Benchmark, NIST, ISO 27001, and PCI DSS.
-
-        To mitigate this risk, the default security group should be modified to restrict all traffic by removing all inbound and outbound rules.
+        - **Inadvertent exposure prevention:** Resources launched without an explicit security group assignment automatically receive the default group; if that group has permissive rules, those resources gain unintended network access to all other resources sharing the group.
+        - **Lateral movement containment:** Unrestricted intra-group traffic means that a compromised instance can reach every other instance in the default group without any additional network controls, facilitating lateral movement.
+        - **Configuration hygiene:** Restricting the default group forces operators to assign purpose-built security groups with explicit rules, making the intended network topology explicit and auditable.
 
         **Risk mitigation**
 
-        - Prevents unintended access by eliminating unrestricted communication between instances.
-        - Enforces least privilege by requiring explicit security group assignments.
-        - Improves network security posture by reducing exposure to internal threats.
+        - **Blast radius reduction:** An attacker who compromises an instance in the default security group gains no implicit network access to other resources, because the empty default group has no inbound rules to exploit.
+        - **Misassignment defense:** Removing all rules from the default group means that accidental association of a new resource with that group results in network isolation rather than unrestricted access.
+        - **Explicit access model enforcement:** Operators must actively choose a security group with defined rules, making the network access model intentional and reviewable rather than permissive by accident.
       audit: |
         ### Audit via Console
 
@@ -2826,21 +2801,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) volume encryption is enabled by default in an AWS account. Enabling default encryption ensures that all newly created EBS volumes are encrypted automatically using AWS Key Management Service (KMS) keys. This eliminates the risk of unencrypted volumes being created inadvertently.
+        This check ensures that Amazon EBS default encryption is enabled at the AWS account level so that every newly created EBS volume is automatically encrypted using a KMS key. By default, EBS encryption is disabled and volumes are created unencrypted unless the requestor explicitly opts in at creation time, meaning a single missed flag can produce an unencrypted volume containing sensitive data.
 
         **Why this matters**
 
-        By default, EBS volumes are not encrypted unless specified during creation. Without default encryption, users may create unencrypted EBS volumes, exposing sensitive data to unauthorized access if the volume is compromised. Enabling default EBS encryption ensures:
-
-        - Consistent enforcement of encryption across all new volumes.
-        - Improved security by protecting data at rest.
-        - Simplified compliance with regulations such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
+        - **Defense against accidental plaintext storage:** Enabling default encryption removes the per-volume decision point; there is no opportunity for a developer or automation script to forget to enable encryption on a sensitive volume.
+        - **Data at rest protection:** Encrypted EBS volumes protect against unauthorized access to the underlying storage hardware, snapshot exports, and volume clones, which might bypass OS-level access controls.
+        - **Consistent compliance posture:** Account-level default encryption ensures that all volumes across all workloads meet encryption requirements without relying on per-team or per-resource configuration discipline.
 
         **Risk mitigation**
 
-        - Prevents accidental creation of unencrypted volumes by enforcing encryption automatically.
-        - Ensures compliance with data protection standards that require encryption at rest.
-        - Reduces the risk of data breaches by protecting data stored on AWS-managed disks.
+        - **Snapshot leak mitigation:** EBS snapshots of encrypted volumes remain encrypted; a snapshot shared or exported accidentally does not expose plaintext data to unauthorized parties.
+        - **Physical access protection:** In the event of physical media recovery from AWS infrastructure, encrypted volumes cannot be read without access to the KMS key, protecting data against hardware-layer attacks.
+        - **Regulatory compliance:** Many data protection standards require encryption of stored data; account-level default encryption provides a reliable, auditable control that satisfies this requirement across all new workloads.
       audit: |
         ### Audit via Console
 
@@ -2978,21 +2951,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon S3 Public Access Block settings are enabled at the account level to prevent accidental or intentional exposure of data stored in S3 buckets. Enforcing this setting at the account level ensures that no S3 bucket or object can be made public, even if bucket policies or ACLs attempt to allow public access.
+        This check ensures that the S3 Block Public Access settings are enabled at the AWS account level, preventing any bucket or object in the account from being made publicly accessible regardless of individual bucket policies or ACL configurations. By default, these account-level settings are not enabled, meaning a misconfigured bucket policy or ACL can expose data publicly.
 
         **Why this matters**
 
-        By default, S3 allows granular control over access policies, but misconfigurations in bucket policies, access control lists (ACLs), or object permissions can lead to data leaks. Enforcing S3 Public Access Block settings at the account level ensures that:
-
-        - All buckets are protected from accidental public exposure.
-        - Individual users cannot override security policies by changing bucket-level settings.
-        - Compliance requirements for data protection and privacy regulations such as CIS AWS Foundations Benchmark, GDPR, PCI DSS, and ISO 27001 are met.
+        - **Account-wide safety net:** Account-level block public access settings override bucket-level policies and ACLs, ensuring that even if a developer misconfigures an individual bucket, the account-level control prevents the data from becoming public.
+        - **Misconfiguration resilience:** S3 bucket policies and ACLs are complex; a single incorrect `Principal: "*"` or overly broad ACL grant can expose an entire bucket; account-level controls provide a backstop.
+        - **Data breach prevention:** Publicly exposed S3 buckets are among the most common causes of cloud data breaches; an account-level block is the most reliable way to prevent accidental public exposure at scale.
 
         **Risk mitigation**
 
-        - Prevents accidental public data exposure by blocking public access to all S3 resources.
-        - Enhances security posture by enforcing organization-wide security policies.
-        - Ensures compliance with regulatory frameworks that require strict data access controls.
+        - **Override protection:** Because the account-level setting takes precedence over bucket-level configurations, it cannot be inadvertently disabled by application deployments or infrastructure-as-code changes that only modify bucket-level settings.
+        - **Centralized governance:** A single account-level setting protects all current and future buckets in the account, eliminating the need to audit and enforce the setting on each bucket individually.
+        - **Insider and automation error defense:** Developers or automated pipelines that attempt to publish data publicly are blocked at the account level, reducing the risk of accidental or unauthorized data disclosure.
       audit: |
         ### Audit via Console
 
@@ -3149,29 +3120,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that each Amazon S3 bucket has public access restrictions enforced to prevent unauthorized exposure of sensitive data. While account-level public access block settings provide a broad safeguard, bucket-level controls ensure that no individual bucket is unintentionally exposed due to misconfigurations in bucket policies, ACLs, or object permissions.
+        This check ensures that every Amazon S3 bucket has public access block settings enabled at the bucket level, preventing the bucket and its objects from being exposed via public bucket policies, ACLs, or cross-account access grants. While an account-level block public access setting provides a broad safeguard, bucket-level controls ensure defense in depth when the account-level setting is absent or later changed.
 
         **Why this matters**
 
-        Amazon S3 buckets can be made publicly accessible through:
-
-        - Bucket policies that allow public s3:GetObject or s3:ListBucket permissions.
-        - Access Control Lists (ACLs) that grant READ or WRITE permissions to AllUsers or AuthenticatedUsers.
-        - Cross-account access where a bucket is unintentionally exposed via an overly permissive policy.
-
-        Unrestricted public access to S3 buckets can result in:
-
-        - Data breaches exposing sensitive files to unauthorized users.
-        - Compliance violations under frameworks such as CIS AWS Foundations Benchmark, GDPR, PCI DSS, and ISO 27001.
-        - Malicious exploitation, including data theft, ransomware attacks, or unauthorized data modifications.
-
-        By enforcing bucket-level public access restrictions, organizations can prevent unintended data exposure while maintaining granular control over access permissions.
+        - **Defense in depth:** Bucket-level block settings provide a second layer of control; if the account-level setting is ever disabled, individual bucket controls prevent immediate exposure of every bucket in the account.
+        - **Granular visibility:** Bucket-level controls make the access posture of each bucket explicit and independently auditable, rather than relying entirely on an account-wide setting that may not be visible during per-bucket reviews.
+        - **ACL and policy override:** Enabling all four block public access options at the bucket level neutralizes misconfigured ACL grants to `AllUsers` or `AuthenticatedUsers` and prevents public bucket policies from being applied, even if attempted by infrastructure automation.
 
         **Risk mitigation**
 
-        - Prevents accidental or intentional data leaks due to misconfigured bucket policies or ACLs.
-        - Strengthens security posture by enforcing explicit access control at the bucket level.
-        - Ensures regulatory compliance with industry data protection standards.
+        - **Data breach prevention:** Restricting public access at the bucket level ensures that sensitive files cannot be accessed anonymously from the internet, even if a bucket policy or ACL is misconfigured.
+        - **Cross-account exposure containment:** Blocking public and cross-account access prevents bucket policies from unintentionally granting access to external AWS accounts or the general public.
+        - **Automated deployment safety:** Infrastructure-as-code pipelines that create or modify bucket policies cannot inadvertently make a bucket public when all four block settings are enforced at the bucket level.
       audit: |
         ### Audit via Console
 
@@ -3426,23 +3387,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EC2 instances do not have public IP addresses to prevent unintended exposure of cloud resources to the internet. Instances with public IPs can be directly accessed from the internet, increasing the risk of security breaches, unauthorized access, and potential data exfiltration.
+        This check ensures that Amazon EC2 instances do not have public IP addresses associated with them, preventing direct internet-reachability of compute resources. By default, instances launched in a VPC public subnet receive an auto-assigned public IP unless this behavior is explicitly disabled, and Elastic IPs can be manually attached to any instance.
 
         **Why this matters**
 
-        By default, EC2 instances launched in a public subnet may receive an auto-assigned public IP unless explicitly disabled. Additionally, Elastic IPs (EIPs) can be manually associated with instances. Direct public access to EC2 instances poses serious security risks, including:
-
-        - Increased attack surface for brute-force, DDoS, or credential stuffing attacks.
-        - Unauthorized access if security groups, ACLs, or instance configurations are misconfigured.
-        - Regulatory non-compliance with standards such as CIS AWS Foundations Benchmark, PCI DSS, and ISO 27001.
-
-        To mitigate these risks, EC2 instances should be placed in private subnets and accessed securely using bastion hosts, AWS Systems Manager Session Manager, or VPNs instead of exposing them directly to the internet.
+        - **Attack surface reduction:** A public IP makes an instance directly reachable from the internet; every open port on the instance becomes an entry point for scanning, exploitation, and credential brute-force attacks.
+        - **Perimeter control bypass prevention:** Placing compute in private subnets and routing external traffic through load balancers, NAT gateways, or VPNs ensures that all access passes through controlled chokepoints with logging and filtering.
+        - **Lateral movement containment:** If an internet-facing instance is compromised, a public IP provides the attacker with a stable egress path for command-and-control; removing public IPs limits outbound connectivity to controlled egress routes.
 
         **Risk mitigation**
 
-        - Reduces exposure to external threats by eliminating direct public access.
-        - Improves security posture by enforcing network segmentation best practices.
-        - Ensures compliance with cloud security frameworks and industry standards.
+        - **Direct exploitation prevention:** Without a public IP, an attacker on the internet has no direct path to the instance; they must first compromise another internet-facing resource before reaching private instances.
+        - **Network segmentation enforcement:** Requiring all external access to flow through managed entry points such as Application Load Balancers or AWS Systems Manager Session Manager maintains a clear network boundary that can be consistently audited and monitored.
+        - **Credential exposure reduction:** Services running on instances without public IPs cannot be directly reached by automated scanning tools that probe for exposed APIs, default credentials, or vulnerable software versions.
       audit: |
         ### Audit via Console
 
@@ -3606,23 +3563,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EC2 instances are configured to use Instance Metadata Service Version 2 (IMDSv2) instead of IMDSv1. IMDSv2 provides enhanced security by requiring session-based authentication using a token, reducing the risk of metadata theft and credential exposure.
+        This check ensures that Amazon EC2 instances are configured to require Instance Metadata Service Version 2 for all metadata requests. IMDSv1 accepts unauthenticated HTTP GET requests to the metadata endpoint, making it exploitable via server-side request forgery; IMDSv2 requires a session token obtained through a PUT request with specific headers that most SSRF attacks cannot replicate.
 
         **Why this matters**
 
-        IMDSv1 allows unauthenticated HTTP requests to retrieve instance metadata, making it vulnerable to server-side request forgery (SSRF) attacks, credential theft, and container breakout scenarios. IMDSv2 mitigates these risks by:
-
-        - Requiring session-based authentication with a limited-time token.
-        - Protecting against open WAF bypasses and SSRF exploitation.
-        - Enforcing request headers to prevent unauthorized access.
-
-        AWS security best practices, as well as CIS AWS Foundations Benchmark, PCI DSS, ISO 27001, and NIST, recommend enforcing IMDSv2-only for all EC2 instances.
+        - **SSRF mitigation:** Many SSRF vulnerabilities allow an attacker to send arbitrary HTTP GET requests from the server; IMDSv2's PUT-first token exchange breaks this pattern because the attacker-controlled GET cannot obtain the required token.
+        - **Credential theft prevention:** Instance metadata contains temporary IAM credentials for the instance's role; without IMDSv2, an SSRF vulnerability can directly expose these credentials and allow lateral movement to other AWS services.
+        - **Container escape barrier:** In containerized environments, an attacker who escapes a container but cannot perform a PUT request with the required hop-limit header cannot retrieve the host instance's IAM credentials through the metadata service.
+        - **Defense against open redirects:** Web application open redirects chained with SSRF to the metadata endpoint are blocked by IMDSv2, because the redirect response cannot satisfy the PUT token requirement.
 
         **Risk mitigation**
 
-        - Prevents unauthorized metadata access by enforcing authenticated API requests.
-        - Mitigates SSRF vulnerabilities that could expose instance credentials.
-        - Aligns with compliance requirements for secure cloud environments.
+        - **Credential exposure prevention:** Requiring IMDSv2 tokens ensures that only software running directly on the instance with the ability to make a PUT request can retrieve IAM credentials, blocking retrieval via SSRF or misconfigured proxies.
+        - **Attack chain disruption:** Many real-world cloud credential theft attacks depend on IMDSv1's unauthenticated access; enforcing IMDSv2 breaks the most common automated exploit chains targeting EC2 instance metadata.
+        - **Hop-limit protection:** IMDSv2 tokens can be issued with a hop limit of 1, preventing the token from being used after passing through a network hop, which blocks token forwarding attacks in multi-tenant or containerized environments.
       audit: |
         ### Audit via Console
 
@@ -3789,30 +3743,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Virtual Private Cloud (VPC) Block Public Access (BPA) is enabled on all VPCs to prevent accidental exposure of resources to the internet. VPC BPA provides a centralized control to block the creation of Internet Gateways, public route table entries, and public security group rules, thereby preventing resources within the VPC from becoming publicly accessible.
+        This check ensures that VPC Block Public Access is enabled at the AWS account level, preventing the creation or activation of internet gateways and public routes that would expose VPC resources directly to the internet. By default, VPC BPA is disabled and any user with sufficient permissions can attach an internet gateway or add a public route to any VPC, potentially exposing workloads that were designed to be private.
 
         **Why this matters**
 
-        Without VPC Block Public Access enabled:
-
-        - Resources may be inadvertently exposed to the internet through misconfigured network settings.
-        - Human error during configuration changes could lead to unintended public access to sensitive workloads.
-        - Compliance frameworks such as CIS AWS Foundations Benchmark, PCI DSS, and SOC 2 recommendations for network isolation may be compromised.
-
-        VPC Block Public Access serves as a guardrail that prevents accidental exposure while still allowing for intentional public-facing workloads when properly configured.
+        - **Centralized internet access governance:** VPC BPA is an account-level guardrail that prevents any VPC from gaining internet connectivity without an explicit exclusion, complementing subnet-level and security group controls.
+        - **Misconfiguration prevention:** Even with correct security group rules and NACLs, attaching an internet gateway and adding a route with `0.0.0.0/0` is sufficient to expose resources; BPA prevents this class of misconfiguration entirely.
+        - **Rapid development guardrails:** In environments where developers have broad VPC permissions, BPA prevents accidental internet exposure during infrastructure experimentation or incident response activities.
 
         **Risk mitigation**
 
-        - **Defense Against Misconfiguration:** Prevents accidental public exposure of resources through configuration errors.
-        - **Consistent Security Posture:** Maintains network isolation across the organization even during rapid development.
-        - **Reduced Attack Surface:** Minimizes the risk of resources being unintentionally exposed to internet-based threats.
-
-        **Important caveats:**
-
-        - VPC BPA will block all new public access, which may disrupt legitimate public-facing workloads like web applications unless exceptions are properly configured.
-        - Enabling BPA does not retroactively remove existing public access; existing Internet Gateways and public routes remain functional.
-        - Service-linked resources managed by AWS such as those for ELB or NAT Gateways require explicit exemptions to continue functioning properly.
-        - There may be organizational impacts requiring coordination across teams before implementation to avoid disrupting business operations.
+        - **Internet gateway attachment blocking:** With BPA in bidirectional block mode, no new internet gateway can be made active in any VPC, eliminating the most direct path to unintentional public exposure of private workloads.
+        - **Public route prevention:** BPA prevents the addition of public routes to route tables, ensuring that even if an internet gateway exists in a detached state, it cannot be activated without removing the BPA setting.
+        - **Blast radius containment:** If an operator account is compromised, BPA prevents the attacker from exposing internal resources to the internet by modifying VPC routing, limiting the attacker's ability to exfiltrate data through newly created public paths.
       audit: |
         ### Audit via Console
 
@@ -3966,23 +3909,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Virtual Private Cloud (VPC) flow logs are enabled for all VPCs to capture network traffic metadata. VPC Flow Logs provide visibility into network traffic patterns, allowing security teams to monitor, detect anomalies, and investigate incidents such as unauthorized access, data exfiltration, and security breaches.
+        This check ensures that Amazon VPC flow logs are enabled for all VPCs and configured to deliver active traffic metadata to a log destination. By default, VPCs do not have flow logging enabled, meaning all network traffic passes through without being recorded.
 
         **Why this matters**
 
-        Without VPC Flow Logs, organizations lack visibility into ingress and egress network traffic within their AWS environment. This can lead to:
-
-        - Difficulty in detecting security incidents, such as unauthorized connections or data leaks.
-        - Lack of compliance with industry standards such as CIS AWS Foundations Benchmark, NIST, PCI DSS, and ISO 27001.
-        - Inability to audit network activity, which is crucial for forensic investigations.
-
-        Enabling VPC Flow Logs ensures that network traffic metadata is continuously collected, aiding in threat detection, security analytics, and compliance reporting.
+        - **Threat detection:** Active flow log delivery to CloudWatch Logs captures connection attempts, port scans, and unexpected traffic patterns that signal unauthorized access or data exfiltration.
+        - **Incident investigation:** Without a traffic record, security teams cannot reconstruct what happened after a breach or determine which resources were reached.
+        - **Compliance evidence:** Continuous network traffic logging is a prerequisite for audit controls in many security frameworks that require demonstrable monitoring of ingress and egress activity.
+        - **Anomaly baselining:** Long-term flow log data lets teams establish normal traffic patterns and alert on deviations before they escalate into incidents.
 
         **Risk mitigation**
 
-        - Enhances network visibility by capturing VPC-level traffic metadata.
-        - Improves threat detection by monitoring suspicious or unauthorized traffic.
-        - Supports compliance requirements for security monitoring and audit logging.
+        - **Network visibility:** Captures metadata for all accepted and rejected connections across every VPC, giving defenders a complete view of lateral movement and external contact.
+        - **Early warning:** REJECT-type flow log entries surface reconnaissance and brute-force attempts against private resources before attackers succeed.
+        - **Forensic record:** Retained flow logs provide a durable audit trail that supports post-incident analysis and regulatory inquiries.
       audit: |
         ### Audit via Console
 
@@ -4161,23 +4101,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon DynamoDB tables are encrypted using AWS Key Management Service (KMS) to protect sensitive data at rest. DynamoDB encryption at rest ensures that data is automatically encrypted before being written to disk and decrypted when read, preventing unauthorized access to stored information.
+        This check ensures that Amazon DynamoDB tables are encrypted using a customer-managed AWS KMS key rather than the default AWS-owned key. By default, DynamoDB encrypts tables at rest using an AWS-owned key, which provides basic protection but does not give the account owner control over key lifecycle, access policy, or audit visibility.
 
         **Why this matters**
 
-        By default, AWS encrypts DynamoDB tables using an AWS-owned key, but customer-managed keys (CMKs) provide additional security benefits such as:
-
-        - Access control via AWS Identity and Access Management (IAM) policies.
-        - Key rotation for enhanced security and compliance.
-        - Auditability with CloudTrail logging of key usage.
-
-        Encrypting DynamoDB tables using AWS KMS CMKs aligns with security best practices and compliance standards such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, ISO 27001, and NIST.
+        - **Key ownership:** Customer-managed KMS keys (CMKs) allow the account owner to define, rotate, and revoke key access independently of AWS, enabling true control over who can decrypt table data.
+        - **Access auditability:** Every API call that uses a CMK is logged to AWS CloudTrail, creating an auditable record of who accessed DynamoDB data and when.
+        - **Separation of duties:** IAM key policies can restrict decryption to specific roles or services, preventing broad access even from accounts with full DynamoDB permissions.
+        - **Regulatory alignment:** Many compliance frameworks require that encryption keys for sensitive data stores be customer-controlled and rotatable on a defined schedule.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access to sensitive data by enforcing encryption at rest.
-        - Enhances security by leveraging customer-managed KMS keys (CMKs) instead of default AWS-managed keys.
-        - Ensures compliance with industry security and regulatory requirements.
+        - **Key revocation:** If a principal is compromised, the CMK can be disabled or its policy updated to immediately deny decryption without deleting the table.
+        - **Blast radius containment:** Scoping CMK access to specific IAM roles limits the number of identities that can read plaintext table data even if another AWS service in the account is compromised.
       audit: |
         ### Audit via Console
 
@@ -4391,21 +4327,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Lambda functions are configured with function-level concurrent execution limits. Without these limits, an attacker who can trigger a Lambda function through a controlled event source such as a public API endpoint, S3 bucket, or SQS queue can cause unbounded parallel executions that exhaust the account-level concurrency pool, effectively denying service to all other Lambda functions in the account.
+        This check ensures that AWS Lambda functions are configured with a function-level reserved concurrency limit greater than zero. By default, Lambda functions share the account-wide concurrency pool with no per-function cap, meaning a single function can exhaust the entire pool and deny service to all other functions in the account.
 
         **Why this matters**
 
-        Without function-level concurrency limits:
-
-        - An attacker triggering a single function can exhaust the entire account's concurrency pool, causing a denial-of-service for all other Lambda-backed services (denial-of-wallet and service disruption).
-        - Unbounded executions from a compromised or abused event source can generate massive compute charges as a financial attack vector.
-        - Other security-critical Lambda functions such as incident response automations or security event processors can be throttled and unable to execute during an attack.
+        - **Denial-of-service prevention:** An attacker who can trigger a Lambda function through a public API endpoint, S3 event, or SQS queue can flood it with invocations, starving every other Lambda-backed service in the account.
+        - **Denial-of-wallet containment:** Unbounded parallel executions convert a cheap event-source vulnerability into a large unexpected compute bill, even before any data is accessed.
+        - **Security function availability:** Incident response automations and security event processors that are also Lambda functions must retain available concurrency during an attack to execute when they are needed most.
+        - **Workload isolation:** Reserved concurrency acts as a resource boundary between unrelated workloads, preventing a traffic spike in one service from cascading into another.
 
         **Risk mitigation**
 
-        - **Blast radius containment:** Limits the impact of a single compromised or abused function to its reserved concurrency, protecting other functions from starvation.
-        - **Denial-of-wallet prevention:** Caps the compute a single function can consume, limiting the financial damage from event-source abuse.
-        - **Workload isolation:** Ensures security-critical functions retain available concurrency even when other functions are under attack.
+        - **Blast radius cap:** A per-function concurrency limit bounds the maximum parallel executions a single abused function can consume, protecting the rest of the account from starvation.
+        - **Cost control:** Reserved concurrency limits the compute cost attributable to a single function, reducing the financial damage from event-source abuse or misconfigured triggers.
       audit: |
         ### Audit via Console
 
@@ -4571,23 +4505,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Lambda functions have resource-based policies that explicitly prohibit public access. Resource-based policies control who can invoke or access Lambda functions, and improperly configured policies may inadvertently allow unauthorized users to trigger functions or access sensitive functionality and data.
+        This check ensures that the resource-based policy attached to each AWS Lambda function contains no statements that grant invocation rights to the wildcard principal (`*`). By default, Lambda functions have no resource-based policy, but policies added for service integrations or cross-account access can inadvertently include a wildcard principal that exposes the function to any AWS identity or unauthenticated caller.
 
         **Why this matters**
 
-        Without proper access controls on Lambda functions:
-
-        - Unauthorized users may be able to invoke functions that process sensitive data or perform privileged operations.
-        - Malicious actors could potentially trigger resource-intensive functions as part of a denial-of-service attack.
-        - Public exposure of Lambda functions may violate compliance requirements such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and SOC 2, which mandate strict access controls for compute resources.
-
-        Lambda functions should follow the principle of least privilege, ensuring that only explicitly authorized identities can invoke or access the function.
+        - **Unauthorized invocation:** A wildcard principal in an Allow statement lets any AWS account or unauthenticated caller trigger the function, potentially executing privileged business logic or reading sensitive data processed by the handler.
+        - **Data exposure:** Functions that process customer records, access databases, or call downstream services can become a path to sensitive information when invocable by arbitrary callers.
+        - **Amplification risk:** Publicly invocable functions can be used as a compute amplifier in denial-of-service or cryptomining attacks at the account owner's expense.
+        - **Least-privilege enforcement:** Restricting invocation to named principals enforces the minimum-access model required by most security frameworks for compute resources.
 
         **Risk mitigation**
 
-        - Prevents unauthorized invocation of Lambda functions by restricting access to trusted entities only.
-        - Reduces the attack surface by eliminating public exposure of serverless compute resources.
-        - Ensures compliance with security frameworks that require controlled access to computing resources.
+        - **Explicit principal scoping:** Replacing wildcard principals with specific AWS account IDs, service principals, or ARNs ensures only authorized callers can invoke the function.
+        - **Reduced attack surface:** Removing public invoke permissions eliminates the most direct exploitation path for functions that handle sensitive workloads or privileged AWS API calls.
       audit: |
         ### Audit via Console
 
@@ -4752,23 +4682,20 @@ queries:
     mql: aws.rds.dbinstance.pendingMaintenanceActions == empty
     docs:
       desc: |
-        This check ensures that Amazon Relational Database Service (RDS) instances have the latest operating system patches applied and no pending OS upgrades are available. Operating system patches include critical security updates, bug fixes, and performance improvements that help maintain the security posture and stability of database instances.
+        This check ensures that Amazon RDS instances have no pending OS-level maintenance actions waiting to be applied. AWS manages the underlying operating system for RDS instances and queues security patches and updates as pending maintenance; customer accounts are responsible for scheduling when those updates are applied within their maintenance windows.
 
         **Why this matters**
 
-        Without regular application of OS patches on RDS instances:
-
-        - Known vulnerabilities in the underlying operating system may remain unaddressed, potentially allowing attackers to exploit these weaknesses.
-        - Database instances may miss important performance improvements and stability fixes that could impact application reliability.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 requirements for timely security patch management may not be satisfied.
-
-        While AWS manages the underlying infrastructure, customers are responsible for scheduling and applying OS patches to their RDS instances during defined maintenance windows. Postponing these upgrades increases the risk exposure window for known vulnerabilities.
+        - **Vulnerability exposure window:** Each day a known OS patch remains unapplied is an additional day that a known CVE can be exploited against the database host.
+        - **Managed responsibility boundary:** Although AWS owns the underlying infrastructure, AWS explicitly delegates patch scheduling to the account owner, making pending maintenance a customer accountability item.
+        - **Cascading risk:** Database hosts are high-value targets; an OS-level exploit on an unpatched RDS instance can give an attacker access to data in memory, bypass encryption, or pivot to other VPC resources.
+        - **Compliance expectations:** Patch management controls in multiple security frameworks require that critical and high-severity patches be applied within defined timeframes after availability.
 
         **Risk mitigation**
 
-        - **Security Posture:** Reduces vulnerability exposure by ensuring the latest security patches are applied.
-        - **Operational Stability:** Incorporates bug fixes and performance improvements that enhance database reliability.
-        - **Compliance Management:** Helps meet regulatory requirements for timely security patch management.
+        - **Attack surface reduction:** Applying pending OS patches closes known vulnerabilities before they can be exploited against database infrastructure.
+        - **Audit evidence:** A clean pending-maintenance state provides auditors with evidence that patch management obligations are being met on a continuous basis.
+        - **Operational stability:** OS-level updates include stability and performance fixes that reduce the risk of unexpected database host behavior in production.
       audit: |
         ### Audit via Console
 
@@ -4916,11 +4843,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        Amazon RDS utilizes the widely adopted AES-256 encryption algorithm, a standard in the industry, to safeguard the data stored within your DB instances. This encryption secures your information directly on the server infrastructure where your Amazon RDS DB instance resides. After encryption is enabled, Amazon RDS automatically manages access authentication and data decryption without requiring manual intervention, ensuring a minimal effect on database performance.
+        This check ensures that all Amazon RDS instances have storage encryption enabled, protecting data at rest with AES-256 encryption managed through AWS KMS. Encryption cannot be enabled on an existing unencrypted RDS instance; it must be set at creation time, making early detection of unencrypted instances critical.
 
         **Why this matters**
 
-        Since databases frequently contain confidential and essential data, enabling encryption is a crucial security measure. It acts as a vital layer of defense against unauthorized access or exposure of sensitive information. By activating RDS encryption, you ensure comprehensive protection, as the encryption covers the data on the instance's underlying storage, along with its automated backups, any read replicas, and all created snapshots.
+        - **Data protection scope:** RDS encryption covers the instance storage, automated backups, read replicas, and all snapshots created from the instance, ensuring that every copy of the data inherits the same protection.
+        - **Physical media exposure:** Without encryption, data written to the underlying storage media is readable by anyone with physical or low-level access to the host infrastructure.
+        - **Snapshot portability risk:** Unencrypted snapshots can be shared with or copied to any AWS account and restored without any key access requirement, making them a common vector for accidental data leakage.
+        - **Regulatory expectation:** Most data-protection frameworks treat encryption of database storage as a baseline control for any system that handles personal, financial, or health information.
+
+        **Risk mitigation**
+
+        - **Transparent protection:** AWS KMS encryption operates below the database engine layer, requiring no application changes while ensuring all writes to disk are encrypted automatically.
+        - **Key-based access control:** Attaching a customer-managed KMS key allows the account owner to audit decrypt operations, restrict which roles can read data, and revoke access by disabling the key.
       audit: |
         ### Audit via Console
 
@@ -5124,27 +5059,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon RDS database clusters have encryption in transit enforced through the appropriate cluster parameter group settings. Specifically, this verifies that the parameter `ssl` is set to "1" which mandates TLS/SSL connections for all database communications, preventing any unencrypted connections to the instances of the cluster.
+        This check ensures that the cluster parameter group associated with an Amazon RDS cluster sets the `ssl` parameter to `1`, which mandates TLS for all connections to every instance in the cluster. Without this cluster-level enforcement, individual instances or applications can establish unencrypted database connections even when TLS is available.
 
         **Why this matters**
 
-        Without proper parameter group configuration enforcing encryption in transit:
-
-        - Database administrators or applications may be able to establish unencrypted connections to the cluster, even if TLS is available.
-        - There is no uniform enforcement of secure connections across all instances in the cluster, potentially creating security inconsistencies.
-        - Compliance frameworks such as PCI DSS, HIPAA, GDPR, and SOC 2 requirements for mandatory encryption of data in transit may not be satisfied.
-
-        Using cluster parameter groups to enforce encryption provides a centralized and consistent approach to securing all instances within the cluster. Unlike instance-level or application-level settings, parameter groups ensure that secure connection requirements cannot be bypassed or misconfigured on individual instances.
+        - **Uniform enforcement:** Setting the parameter at the cluster level applies the requirement to all current and future instances in the cluster, eliminating per-instance configuration drift.
+        - **In-transit data protection:** Database queries frequently carry sensitive data such as credentials, PII, and financial records; unencrypted connections expose that data to anyone on the network path between the application and the database.
+        - **Credential interception:** Without TLS, database authentication credentials transmitted in plaintext can be captured by a network observer or man-in-the-middle attacker on the same subnet or VPC.
+        - **Compliance requirement:** Frameworks that mandate encryption of data in transit treat unencrypted database connections as a direct control failure, regardless of other compensating controls.
 
         **Risk mitigation**
 
-        - **Consistent Security Policy:** Ensures uniform encryption requirements across all instances in the cluster.
-        - **Prevent Configuration Drift:** Eliminates the risk of individual instances having different security settings.
-        - **Compliance Enforcement:** Provides an auditable mechanism to demonstrate mandatory encryption for all database connections.
-
-        **Note:**
-
-        In general, cluster parameter groups can be overridden by instance parameter groups, but there is no equivalent setting at the instance group level for `ssl`.
+        - **Centralized control:** A cluster parameter group change enforces TLS across every instance simultaneously, ensuring no instance can serve unencrypted connections even after a configuration change or instance replacement.
+        - **Connection rejection:** With `ssl=1`, the database engine refuses plaintext connection attempts at the protocol level, providing a hard technical control rather than relying on application-side TLS configuration.
       audit: |
         ### Audit via Console
 
@@ -5374,23 +5301,19 @@ queries:
       aws.rds.allPendingMaintenanceActions.where(resourceArn == rdsArn) == empty
     docs:
       desc: |
-        This check ensures that Amazon RDS database clusters, including Aurora clusters, have the latest operating system patches applied and no pending OS upgrades are available. Operating system patches include critical security updates, bug fixes, and performance improvements that help maintain the security posture and stability of database clusters.
+        This check ensures that Amazon RDS clusters, including Aurora clusters, have no pending OS-level maintenance actions waiting to be applied. AWS queues critical security patches and updates as pending maintenance for the underlying host infrastructure; scheduling and applying those updates within the maintenance window is the account owner's responsibility.
 
         **Why this matters**
 
-        Without regular application of OS patches on RDS clusters:
-
-        - Known vulnerabilities in the underlying operating system may remain unaddressed, potentially allowing attackers to exploit these weaknesses across multiple database instances.
-        - Database clusters may miss important performance improvements and stability fixes that could impact application reliability and high availability.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 requirements for timely security patch management may not be satisfied.
-
-        While AWS manages the underlying infrastructure, customers are responsible for scheduling and applying OS patches to their RDS clusters during defined maintenance windows. Postponing these upgrades increases the risk exposure window for known vulnerabilities.
+        - **Multi-instance blast radius:** An unpatched OS vulnerability in an Aurora cluster can affect the writer and all reader instances simultaneously, amplifying the risk compared to a single-instance deployment.
+        - **Known CVE exposure:** Pending OS patches address published vulnerabilities; the longer they remain unapplied, the longer attackers with knowledge of those CVEs have an actionable target.
+        - **High-value target profile:** Database clusters are among the most attractive targets in a cloud environment because they concentrate large amounts of sensitive data behind a single reachable endpoint.
+        - **Compliance patch cadence:** Security frameworks commonly require that high-severity patches be applied within a defined window; unapplied pending maintenance is direct evidence of non-compliance.
 
         **Risk mitigation**
 
-        - **Security Posture:** Reduces vulnerability exposure by ensuring the latest security patches are applied across all instances in the cluster.
-        - **Operational Stability:** Incorporates bug fixes and performance improvements that enhance database reliability and consistency.
-        - **Compliance Management:** Helps meet regulatory requirements for timely security patch management.
+        - **Reduced vulnerability window:** Applying pending maintenance actions closes known OS-level vulnerabilities across all instances in the cluster, shrinking the exploitable attack surface.
+        - **Audit readiness:** A cluster with no pending maintenance actions provides clean evidence that patch management obligations are being honored during each maintenance window cycle.
       audit: |
         ### Audit via Console
 
@@ -5564,11 +5487,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        Amazon RDS utilizes the industry-standard AES-256 encryption algorithm to safeguard the data stored within your DB clusters. This encryption secures your information directly across the cluster's underlying storage volume. Once encryption is enabled for the cluster, Amazon RDS automatically manages access authentication and data decryption transparently, designed to ensure a minimal impact on overall cluster performance.
+        This check ensures that all Amazon RDS clusters have storage encryption enabled, protecting data at rest with AES-256 encryption managed through AWS KMS. Encryption must be enabled when the cluster is created and cannot be added to an existing unencrypted cluster, making early detection essential.
 
         **Why this matters**
 
-        Database clusters often consolidate significant amounts of sensitive or critical data. Implementing encryption is therefore a highly recommended security practice to protect this data against unauthorized access or potential disclosure. By activating RDS encryption on your cluster, you ensure comprehensive data-at-rest protection, covering the data within the shared cluster storage, as well as associated components like automated backups, cluster snapshots, and any read replicas within the cluster environment.
+        - **Cluster-wide coverage:** Enabling encryption on the cluster protects the shared cluster storage volume, all automated backups, cluster snapshots, and any read replicas created within the cluster environment.
+        - **Snapshot exposure risk:** Unencrypted cluster snapshots can be restored by any AWS account that receives a copy, bypassing all network and IAM controls that protect the live cluster.
+        - **Storage media access:** Without encryption, data written to the underlying shared storage is readable at the infrastructure level without any database credentials or VPC network access.
+        - **Regulatory baseline:** Most data protection and privacy frameworks treat encryption of database cluster storage as a mandatory baseline for systems handling sensitive or regulated data.
+
+        **Risk mitigation**
+
+        - **Transparent protection:** KMS-based cluster encryption operates below the Aurora storage layer with no application changes required, ensuring all data written to shared cluster storage is encrypted automatically.
+        - **Key-level access control:** Using a customer-managed KMS key enables the account owner to audit every decrypt operation, restrict access to specific IAM roles, and revoke data access by disabling the key independently of the cluster.
       audit: |
         ### Audit via Console
 
@@ -5810,23 +5741,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Relational Database Service (RDS) clusters and cluster instances are not publicly accessible to prevent unauthorized access to sensitive databases. By default, RDS instances can be configured to allow public access, which exposes them to the internet, increasing the risk of security breaches, unauthorized data access, and potential data exfiltration.
+        This check ensures that Amazon RDS cluster instances are not configured as publicly accessible and that the VPC subnets hosting the cluster do not route traffic through an internet gateway. By default, the AWS console offers a publicly accessible option during cluster creation, and it is easy to inadvertently expose a cluster to the internet.
 
         **Why this matters**
 
-        Publicly accessible RDS clusters pose significant security risks, including:
-
-        - Unauthorized access if credentials or security configurations are weak.
-        - Brute-force attacks on database authentication.
-        - Non-compliance with security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
-
-        To mitigate these risks, RDS clusters should be deployed in private subnets and accessible only through bastion hosts, VPNs, or AWS PrivateLink instead of direct internet exposure.
+        - **Direct internet exposure:** A publicly accessible RDS cluster has a DNS endpoint resolvable from the internet, making the database authentication layer directly reachable to any attacker worldwide.
+        - **Brute-force attack surface:** Once a database endpoint is reachable from the internet, automated credential stuffing and brute-force tools can target it continuously without needing to first compromise any other resource.
+        - **Compliance boundary violation:** Most security frameworks explicitly prohibit placing production database clusters on network segments with internet gateway routes, treating such configuration as a boundary control failure.
+        - **Lateral movement risk:** A compromised publicly accessible cluster becomes a pivot point from which attackers can reach other private resources within the same VPC.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by restricting direct exposure to the internet.
-        - Enhances database security by enforcing private networking best practices.
-        - Ensures compliance with regulatory and cloud security standards.
+        - **Network perimeter enforcement:** Deploying clusters in private subnets and removing internet gateway routes ensures the database is only reachable through controlled paths such as VPN, bastion host, or AWS PrivateLink.
+        - **Reduced credential exposure:** Removing internet reachability eliminates the entire class of attacks that require only a network path to the database port, requiring attackers to first compromise an internal resource.
       audit: |
         ### Audit via Console
 
@@ -6064,23 +5991,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Relational Database Service (RDS) instances are not publicly accessible to prevent unauthorized access to sensitive databases. By default, RDS instances can be configured to allow public access, which exposes them to the internet, increasing the risk of security breaches, unauthorized data access, and potential data exfiltration.
+        This check ensures that Amazon RDS instances are not configured as publicly accessible and that the VPC subnets hosting the instance do not route traffic to an internet gateway. The AWS console exposes a publicly accessible toggle during instance creation that is easy to leave enabled, directly exposing the database to the internet.
 
         **Why this matters**
 
-        Publicly accessible RDS instances pose significant security risks, including:
-
-        - Unauthorized access if credentials or security configurations are weak.
-        - Brute-force attacks on database authentication.
-        - Non-compliance with security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
-
-        To mitigate these risks, RDS instances should be deployed in private subnets and accessible only through bastion hosts, VPNs, or AWS PrivateLink instead of direct internet exposure.
+        - **Unauthenticated reachability:** A publicly accessible RDS instance has a DNS endpoint resolvable from the public internet, placing the database authentication layer within reach of any attacker without requiring prior access to the VPC.
+        - **Credential attack exposure:** Continuously internet-exposed database ports are targeted by automated scanners that attempt default credentials, known CVE exploits, and brute-force attacks around the clock.
+        - **Defense-in-depth failure:** Private subnet deployment is a foundational network control; bypassing it by enabling public accessibility removes an entire layer of the security model before any IAM or security group rules are even evaluated.
+        - **Data exfiltration path:** A compromised publicly accessible database instance can be queried directly from attacker-controlled infrastructure, bypassing egress monitoring in the VPC.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by restricting direct exposure to the internet.
-        - Enhances database security by enforcing private networking best practices.
-        - Ensures compliance with regulatory and cloud security standards.
+        - **Network isolation:** Placing RDS instances in private subnets with no internet gateway route means access requires a foothold inside the VPC, drastically raising the cost of an attack.
+        - **Reduced attack surface:** Removing public accessibility eliminates the most direct exploitation path and ensures that database credentials are not the only barrier between an attacker and the data.
       audit: |
         ### Audit via Console
 
@@ -6263,23 +6186,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Redshift clusters are not publicly accessible to prevent unauthorized access and potential data breaches. A publicly accessible Redshift cluster can be reached from the internet, exposing it to security threats, including brute-force attacks and data exfiltration.
+        This check ensures that Amazon Redshift clusters are not publicly accessible from the internet. Redshift clusters are often provisioned with public accessibility enabled by default in some configurations, directly exposing the data warehouse endpoint to external network access.
 
         **Why this matters**
 
-        Amazon Redshift is used for data warehousing and analytics, often storing sensitive business intelligence and customer data. If a Redshift cluster is publicly accessible:
-
-        - Anyone on the internet could attempt to access it if misconfigured.
-        - Brute-force attacks could compromise database credentials.
-        - Compliance violations may occur under frameworks such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, ISO 27001, and SOC 2.
-
-        To mitigate these risks, Redshift clusters should be placed in private subnets and accessed securely using VPNs, VPC peering, AWS PrivateLink, or AWS IAM authentication instead of direct internet exposure.
+        - **Data warehouse exposure:** Redshift clusters typically store large volumes of aggregated business intelligence and customer data; a publicly reachable endpoint makes this data a direct target for credential attacks.
+        - **Broad attack surface:** The Redshift JDBC/ODBC port exposed to the internet is continuously scanned and probed by automated tooling looking for default credentials, known vulnerabilities, and misconfigured authentication.
+        - **High-value target:** Data warehouses consolidate information from many source systems; a single successful attack against a publicly accessible Redshift cluster can yield a comprehensive dump of cross-system data.
+        - **Network control bypass:** Enabling public accessibility routes around the private-subnet boundary that is intended to be the first layer of network defense for database infrastructure.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by restricting internet exposure.
-        - Enhances security by ensuring database traffic remains private.
-        - Ensures compliance with industry security standards.
+        - **Private network placement:** Deploying Redshift clusters in private subnets and disabling public accessibility ensures all connections must originate from within the VPC or through explicitly provisioned private connectivity such as VPN or PrivateLink.
+        - **Reduced credential risk:** Removing internet reachability means a leaked Redshift password cannot be directly exploited without the attacker first gaining access to the private network.
       audit: |
         ### Audit via Console
 
@@ -6447,21 +6366,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) volumes attached to EC2 instances are configured to be automatically deleted when the instance is terminated. When volumes persist after instance termination, they become orphaned resources that an attacker with EC2 permissions can discover, attach to their own instance, and mount to access any sensitive data they contain.
+        This check ensures that EBS volumes attached to EC2 instances are configured with the delete-on-termination flag set to true, so that volumes are automatically destroyed when their associated instance is terminated. By default, root volumes are created with delete-on-termination enabled, but additional data volumes default to persisting after instance termination.
 
         **Why this matters**
 
-        Orphaned EBS volumes are a significant data exposure risk:
-
-        - An attacker with `ec2:DescribeVolumes` and `ec2:AttachVolume` permissions can find unattached volumes and mount them to extract sensitive data such as credentials, database files, application secrets, or customer data.
-        - Orphaned volumes are often overlooked during security reviews because they are not associated with running instances, making them a low-visibility attack surface.
-        - In dynamic environments where instances are frequently created and terminated, orphaned volumes accumulate rapidly, expanding the window of exposure.
+        - **Orphaned volume attack surface:** An attacker with `ec2:DescribeVolumes` and `ec2:AttachVolume` permissions can discover unattached volumes after instance termination and mount them to a new instance to read all data they contain.
+        - **Low-visibility persistence:** Orphaned volumes are not associated with running instances, making them easy to overlook in security reviews and harder to detect with standard instance-focused monitoring.
+        - **Accumulation in dynamic environments:** Environments that frequently scale instances in and out produce orphaned volumes rapidly, expanding the pool of unmonitored storage that may contain credentials, database files, or application secrets.
+        - **Cost and hygiene:** Persistent volumes that accumulate after instance termination also generate ongoing storage costs for data that is no longer actively used or monitored.
 
         **Risk mitigation**
 
-        - **Data exposure prevention:** Ensures volumes containing sensitive data are destroyed with the instance, eliminating the orphaned volume attack surface.
-        - **Attack surface reduction:** Reduces the number of discoverable resources an attacker with compromised IAM credentials can exploit.
-        - **Security hygiene:** Prevents accumulation of unmonitored volumes that may contain unencrypted sensitive data.
+        - **Data destruction on termination:** Setting delete-on-termination ensures that volume contents are permanently destroyed with the instance, eliminating the orphaned-volume attack path entirely.
+        - **Attack surface reduction:** Fewer unattached volumes means fewer discoverable resources for an attacker with compromised EC2 IAM permissions to exploit for data access.
       audit: |
         ### Audit via Console
 
@@ -6621,19 +6538,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) snapshots are not configured to be publicly restorable. A public snapshot can be accessed by anyone, potentially exposing sensitive data. AWS provides fine-grained access controls for EBS snapshots, and by default, snapshots are private unless explicitly shared.
+        This check ensures that Amazon EBS snapshots owned by the account are not configured as publicly restorable. By default, EBS snapshots are private and accessible only to the owning account; however, the snapshot permissions can be changed to allow any AWS account to copy or restore the snapshot, and that setting can be applied accidentally through the console or API.
 
         **Why this matters**
 
-        Publicly accessible EBS snapshots pose a significant security risk, as they can contain sensitive data such as personally identifiable information (PII), credentials, or proprietary application data. If a snapshot is mistakenly made public, it can be accessed by unauthorized parties, leading to data breaches, regulatory compliance violations, and reputational damage.
-
-        Ensuring that snapshots remain private unless intentionally shared with specific AWS accounts mitigates the risk of data exposure while allowing controlled data sharing when necessary.
+        - **Unrestricted data access:** A snapshot made public can be copied and restored by any AWS account in any region without any credential or permission from the snapshot owner, giving arbitrary parties full access to the volume's contents.
+        - **Sensitive data exposure:** EBS snapshots often contain database files, application binaries, configuration files with secrets, and user data that was present on the volume at snapshot time.
+        - **Silent exfiltration:** Once a snapshot is public, any number of external parties can copy it without the owner's knowledge, making it impossible to fully contain a disclosure after the fact.
+        - **Accidental misconfiguration risk:** Snapshot permissions are a single API call or console checkbox away from becoming public, and the change is easy to make inadvertently during troubleshooting or cross-account sharing workflows.
 
         **Risk mitigation**
 
-        - **Data Security:** Prevents unauthorized access to potentially sensitive EBS snapshot data.
-        - **Compliance:** Helps maintain compliance with security frameworks such as GDPR, HIPAA, and SOC 2.
-        - **Operational Control:** Ensures that data is shared only with intended AWS accounts or users.
+        - **Explicit access control:** Keeping snapshots private and sharing them only with specific AWS account IDs ensures that access to backup data is as tightly controlled as access to the live volume.
+        - **Breach containment:** Private snapshots limit the blast radius of a credential compromise to accounts explicitly named in the snapshot permission list, rather than every AWS account worldwide.
       audit: |
         ### Audit via Console
 
@@ -6761,19 +6678,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) snapshots are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that snapshot contents are stored securely. AWS KMS provides centralized key management and integrates with EBS snapshots to automatically encrypt and decrypt data transparently.
+        This check ensures that Amazon EBS snapshots are encrypted at rest using AWS KMS. Snapshots inherit the encryption status of their source volume; snapshots taken from unencrypted volumes remain unencrypted unless explicitly encrypted during a copy operation, and those unencrypted snapshots persist until manually deleted.
 
         **Why this matters**
 
-        EBS snapshots inherit the encryption status of their source volumes. If a snapshot is created from an encrypted volume, the snapshot will be encrypted automatically using the same KMS key. However, snapshots from unencrypted volumes will remain unencrypted unless explicitly configured for encryption during the copy operation. Organizations should verify that all snapshots, including those shared or copied across accounts, maintain proper encryption settings.
-
-        AWS KMS encryption ensures that snapshot data is protected at rest, preventing unauthorized users or malicious actors from accessing sensitive information. This is particularly important for compliance with security frameworks such as GDPR, HIPAA, PCI DSS, and SOC 2.
+        - **Backup data exposure:** Unencrypted snapshots contain an exact copy of the volume's data at snapshot time, including database files, credentials, and application secrets, all readable by anyone who can restore the snapshot.
+        - **Cross-account sharing risk:** Unencrypted snapshots can be shared with or copied to any AWS account and restored without any key access requirement, making accidental sharing far more consequential than it would be for encrypted snapshots.
+        - **Independent attack surface:** Snapshots exist and persist independently of the running instance or volume; an attacker who compromises snapshot permissions can access backup data even if the original volume is encrypted.
+        - **Encrypted volume hygiene:** If the source volume was encrypted but the snapshot was taken before encryption was enabled, the snapshot remains unencrypted even though the current volume is not.
 
         **Risk mitigation**
 
-        - **Data Security:** Protects backup data at rest from unauthorized access.
-        - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
-        - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+        - **Key-gated restoration:** Encrypted snapshots can only be restored by identities with access to the KMS key used for encryption, adding a cryptographic access control layer on top of IAM and snapshot permission checks.
+        - **Centralized key management:** Using a customer-managed KMS key provides an audit trail of every decrypt operation against snapshot data and allows access to be revoked by disabling the key without deleting the snapshot.
       audit: |
         ### Audit via Console
 
@@ -6982,19 +6899,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) volumes are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that volume contents are stored securely. AWS KMS provides centralized key management and integrates with EBS to automatically encrypt and decrypt data transparently.
+        This check ensures that EBS volumes attached to EC2 instances are encrypted at rest using AWS KMS. AWS introduced account-level EBS encryption by default in 2019, but that setting applies only to newly created volumes in regions where it has been explicitly enabled; existing volumes created before the setting was activated, volumes created in regions where it was not enabled, and volumes created before migration remain unencrypted unless individually addressed.
 
         **Why this matters**
 
-        As of May 2019, AWS enables encryption by default for newly created EBS volumes in supported regions. However, organizations should still verify this setting, as encryption settings can be modified and older volumes created before this change may remain unencrypted. Additionally, organizations may want to use specific KMS keys rather than the default AWS-managed keys.
-
-        AWS KMS encryption ensures that volume data is protected at rest, preventing unauthorized users or malicious actors from accessing sensitive information. This is particularly important for compliance with security frameworks such as GDPR, HIPAA, PCI DSS, and SOC 2.
+        - **Storage media access:** Without volume encryption, data written to disk is readable at the storage infrastructure level without requiring any AWS credentials, database authentication, or application-layer access.
+        - **Snapshot inheritance:** Snapshots taken from unencrypted volumes remain unencrypted and can be restored or shared without any key access requirement, extending the exposure beyond the lifecycle of the original instance.
+        - **Pre-2019 volume risk:** Volumes created before the account-level default was enabled may still be running unencrypted in production, and automated scans are the only reliable way to detect them at scale.
+        - **Defense-in-depth:** Volume encryption provides a layer of protection that remains effective even if network controls, IAM policies, or application-layer authentication are bypassed or misconfigured.
 
         **Risk mitigation**
 
-        - **Data Security:** Protects data at rest from unauthorized access.
-        - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
-        - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+        - **Transparent at-rest protection:** KMS-based EBS encryption is applied below the filesystem layer, requiring no application changes while ensuring all data written to the volume is automatically encrypted and only readable by authorized identities.
+        - **Key-level access control:** Attaching a customer-managed KMS key lets the account owner audit every decrypt operation against volume data and restrict or revoke decryption access independently of the EC2 instance permissions.
       audit: |
         ### Audit via Console
 
@@ -7256,23 +7173,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic Block Store (EBS) volumes are encrypted using AWS Key Management Service (KMS) rather than the default EBS-managed encryption. While both methods encrypt data at rest, KMS encryption provides significantly stronger security controls including centralized key management, fine-grained access policies via IAM, automatic key rotation, and full audit trails through AWS CloudTrail.
+        This check ensures that Amazon EBS volumes are configured to use AWS KMS encryption rather than the default EBS-managed encryption. By default, EBS volumes that have encryption enabled use an AWS-managed key with no customer control over key policies, rotation scheduling, or access auditing; switching to a KMS key restores that control.
 
         **Why this matters**
 
-        EBS volumes support two server-side encryption types:
-
-        - **sse-ebs** (default): Uses an AWS-managed key with no customer control over key policies, rotation, or access auditing.
-        - **sse-kms**: Uses AWS KMS keys (either AWS-managed or customer-managed) that provide IAM-based access control, automatic or manual key rotation, and CloudTrail logging of all key usage.
-
-        Using KMS encryption ensures that organizations maintain full visibility and control over their encryption keys. This is critical for meeting compliance requirements under frameworks such as PCI DSS, HIPAA, SOC 2, and NIST 800-53, which mandate auditability and key lifecycle management for encrypted data.
+        - **Key control:** Customer-managed KMS keys support fine-grained IAM key policies, allowing you to restrict which principals can decrypt EBS volume data.
+        - **Audit trail:** Every use of the KMS key is recorded in CloudTrail, providing evidence of who accessed or decrypted data and when.
+        - **Key rotation:** Automatic annual rotation of KMS keys limits the blast radius if a key material is ever compromised.
+        - **Separation of duties:** Storing the key in KMS lets your security team manage encryption independently from the teams that provision EC2 resources.
 
         **Risk mitigation**
 
-        - **Key Management:** Provides centralized control over encryption key policies and lifecycle.
-        - **Access Auditing:** All key usage is logged in CloudTrail, enabling detection of unauthorized access attempts.
-        - **Key Rotation:** Supports automatic annual rotation of KMS keys to limit the blast radius of a compromised key.
-        - **Regulatory Compliance:** Meets encryption key management requirements for PCI DSS, HIPAA, SOC 2, and NIST frameworks.
+        - **Unauthorized data access:** Without a customer-managed key, any principal with S3 or EBS access can read encrypted volume data using the shared AWS-managed key.
+        - **Compliance gaps:** Many frameworks require customer control over encryption key lifecycle; default EBS encryption does not satisfy those controls.
+        - **Forensic blind spots:** Without CloudTrail key-usage events, detecting unauthorized decryption attempts becomes impossible.
       audit: |
         ### Audit via Console
 
@@ -7466,18 +7380,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic File System (EFS) is configured to encrypt file data at rest using AWS Key Management Service (KMS). Encryption helps protect sensitive data from unauthorized access by ensuring that files are stored securely. AWS KMS provides centralized key management and integrates with EFS to automatically encrypt and decrypt data transparently.
+        This check ensures that Amazon Elastic File System file systems are configured to encrypt file data at rest using AWS Key Management Service. By default, EFS does not enable encryption unless the account-level default or an explicit creation parameter requires it, meaning new file systems may store data in plaintext unless encryption is deliberately enforced.
 
         **Why this matters**
 
-        By default, EFS does not enable encryption unless explicitly configured. Without encryption, data stored in EFS volumes remains in plaintext, making it vulnerable to unauthorized access if an attacker gains access to the storage system.
-        AWS KMS encryption ensures that file data is protected at rest, preventing unauthorized users or malicious actors from accessing sensitive information. This is particularly important for compliance with security frameworks such as GDPR, HIPAA, PCI DSS, and SOC 2.
+        - **Data confidentiality:** Encryption at rest ensures that raw storage blocks are unreadable without the corresponding KMS key, protecting against unauthorized access to the underlying storage infrastructure.
+        - **Key lifecycle management:** KMS provides centralized control over key creation, rotation, and deletion, giving security teams visibility into who holds decryption authority.
+        - **Access auditing:** All KMS key operations are logged in CloudTrail, creating a verifiable record of data-access events for the file system.
+        - **Compliance coverage:** Regulated workloads storing personal health information, payment card data, or other sensitive records require encryption at rest as a baseline control.
 
         **Risk mitigation**
 
-        - **Data Security:** Protects data at rest from unauthorized access.
-        - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
-        - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+        - **Storage-layer compromise:** If an attacker gains access to the physical or logical storage layer, encryption prevents them from reading plaintext file data.
+        - **Insider threat:** Restricting KMS key access via IAM policies limits which principals can decrypt data even if they have direct EFS permissions.
       audit: |
         ### Audit via Console
 
@@ -7641,23 +7556,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon CloudWatch log groups are configured to encrypt log data at rest using AWS Key Management Service (KMS) Customer-Managed Keys (CMKs). CloudWatch Logs store critical operational and security data, and encrypting them using CMKs enhances security by providing better control over key management and access policies.
+        This check ensures that Amazon CloudWatch log groups are configured to encrypt log data at rest using a customer-managed AWS KMS key rather than the default AWS-managed encryption. By default, CloudWatch Logs applies server-side encryption using an AWS-managed key that customers have no control over, providing no ability to restrict, audit, or revoke access to log content through key policy.
 
         **Why this matters**
 
-        CloudWatch Logs often store critical system logs, security logs, and application logs, which may contain sensitive data. Without KMS CMK encryption:
-
-        - Logs are encrypted using default AWS-managed keys, which lack fine-grained access control.
-        - Compliance requirements under CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001 may not be met.
-        - Security risks increase, as logs could be exposed to unauthorized access.
-
-        Using customer-managed KMS CMKs allows organizations to control key permissions, enable key rotation, and track encryption events via AWS CloudTrail.
+        - **Log data sensitivity:** CloudWatch log groups frequently contain application traces, authentication events, and infrastructure telemetry that may include credentials, session tokens, or personally identifiable information.
+        - **Key access control:** A customer-managed KMS key lets you restrict which IAM principals and services can decrypt log content, enforcing separation of duties between log writers and log readers.
+        - **Audit visibility:** Every decrypt or re-encrypt operation on the KMS key appears in CloudTrail, giving security teams a verifiable record of who accessed log data.
+        - **Key revocation:** Revoking or disabling the customer-managed key immediately prevents further decryption of historical log data, supporting breach containment scenarios.
 
         **Risk mitigation**
 
-        - **Data Security:** Ensures sensitive log data is encrypted at rest.
-        - **Regulatory Compliance:** Helps meet security and compliance standards such as GDPR, HIPAA, PCI DSS, and SOC 2.
-        - **Access Control:** Provides better control over encryption keys, including key rotation and access permissions.
+        - **Unauthorized log access:** Without a customer-managed key, any AWS principal with CloudWatch Logs permissions can read log content using the shared AWS-managed key.
+        - **Compliance requirements:** Frameworks mandating customer control over encryption key management are not satisfied by AWS-managed key encryption alone.
       audit: |
         ### Audit via Console
 
@@ -7825,23 +7736,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Application Load Balancers (ALBs) are configured with secure Transport Layer Security (TLS) policies that enforce strong encryption protocols and cipher suites. TLS security policies define which protocols and ciphers are supported when establishing secure connections between clients and the load balancer, protecting data in transit from interception and tampering.
+        This check ensures that AWS Application Load Balancer HTTPS listeners are configured with a security policy that enforces TLS 1.2 or higher and strong cipher suites. AWS provides several named TLS security policies; older policies such as ELBSecurityPolicy-2016-08 permit TLS 1.0 and 1.1 and include weak ciphers, while modern policies restrict negotiation to TLS 1.2 or TLS 1.3 with forward-secrecy cipher suites.
 
         **Why this matters**
 
-        Without secure TLS policies on Application Load Balancers:
-
-        - Outdated or vulnerable cryptographic protocols such as TLS 1.0, TLS 1.1, or SSL 3.0 may be used, exposing communications to known security vulnerabilities.
-        - Weak cipher suites might be enabled, reducing the strength of encryption and potentially allowing attackers to decrypt intercepted traffic.
-        - Compliance requirements for data protection in transit, including PCI DSS, HIPAA, GDPR, and SOC 2, may not be satisfied.
-
-        Modern TLS security policies such as ELBSecurityPolicy-TLS-1-2-2017-01 or newer ensure that only strong encryption methods are used, protecting sensitive information transmitted between clients and your applications.
+        - **Protocol downgrade prevention:** TLS 1.0 and 1.1 are vulnerable to POODLE, BEAST, and related attacks; enforcing TLS 1.2+ eliminates those attack surfaces.
+        - **Cipher suite strength:** Modern policies exclude export-grade, RC4, and other weak ciphers that allow decryption of captured traffic by a capable attacker.
+        - **Forward secrecy:** Policies built around ECDHE key exchange ensure that compromising the server's long-term private key cannot retroactively decrypt past sessions.
+        - **Compliance alignment:** Payment card and healthcare data regulations explicitly prohibit early TLS versions for transmitting sensitive data.
 
         **Risk mitigation**
 
-        - **Data Protection:** Ensures sensitive data is properly encrypted in transit using strong protocols and ciphers.
-        - **Security Posture:** Prevents exploitation of known vulnerabilities in outdated TLS versions and weak cipher suites.
-        - **Regulatory Compliance:** Helps meet requirements for secure data transmission in various compliance frameworks.
+        - **Session interception:** Weak cipher suites enable an attacker with captured traffic to decrypt session content offline; restricting to modern ciphers eliminates that risk.
+        - **Downgrade attacks:** Advertising support for older protocol versions allows an active attacker to force negotiation to a weaker protocol; removing those versions from the policy closes that vector.
       audit: |
         ### Audit via Console
 
@@ -8037,23 +7944,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Application Load Balancers (ALBs) are configured with HTTPS listeners to encrypt traffic between clients and the load balancer. HTTPS listeners use TLS/SSL certificates to establish secure encrypted connections, protecting sensitive data transmitted over the network from eavesdropping and man-in-the-middle attacks.
+        This check ensures that AWS Application Load Balancers serve traffic exclusively over HTTPS listeners, so that all data exchanged between clients and the load balancer is encrypted in transit. By default, ALBs support both HTTP and HTTPS listeners; an operator must explicitly remove or redirect HTTP-only listeners to enforce encryption for all client traffic.
 
         **Why this matters**
 
-        Without HTTPS listeners on Application Load Balancers:
-
-        - Data transmitted between clients and applications remains unencrypted and vulnerable to interception by malicious actors.
-        - Authentication credentials, session tokens, personal information, and other sensitive data could be exposed in plaintext.
-        - Organizations may fail to meet compliance requirements such as PCI DSS, HIPAA, GDPR, and SOC 2, which mandate encryption for data in transit.
-
-        Using HTTP-only listeners poses significant security risks, especially when transmitting sensitive information. Modern security best practices require encryption for all web traffic, regardless of the sensitivity level.
+        - **Data confidentiality:** HTTPS listeners establish TLS sessions that encrypt all request and response data, preventing eavesdropping on network paths between clients and the application.
+        - **Credential protection:** Login forms, session cookies, and API tokens transmitted over plain HTTP are readable by any network observer; HTTPS prevents this exposure.
+        - **Integrity assurance:** TLS prevents man-in-the-middle modification of HTTP responses, protecting users from injected content or redirects.
+        - **User trust:** Browsers and security scanners flag non-HTTPS endpoints as insecure, directly affecting user confidence and SEO ranking.
 
         **Risk mitigation**
 
-        - **Data Confidentiality:** Encrypts communications to prevent unauthorized access to sensitive information.
-        - **Authentication Protection:** Secures user credentials and session information from being intercepted.
-        - **Trust and Compliance:** Builds user trust and satisfies regulatory requirements for protecting data in transit.
+        - **Network eavesdropping:** Plain HTTP traffic is readable on any network segment between the client and the load balancer; HTTPS eliminates that exposure at the transport layer.
+        - **Session hijacking:** Unencrypted cookies and tokens can be captured and replayed; TLS sessions prevent token theft from network-level interception.
       audit: |
         ### Audit via Console
 
@@ -8282,23 +8185,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Application Load Balancers (ALBs) are configured with access logging enabled to capture detailed information about requests sent to the load balancer. Access logs provide comprehensive data including client IP addresses, request paths, latencies, response codes, and more, which are delivered to an Amazon S3 bucket for storage and analysis.
+        This check ensures that AWS Application Load Balancers have access logging enabled so that request records are delivered to an S3 bucket for storage and analysis. Access logging is disabled by default on ALBs and must be explicitly enabled; without it, no persistent record of client requests, response codes, or latency exists outside of real-time CloudWatch metrics.
 
         **Why this matters**
 
-        Without access logging enabled on Application Load Balancers:
-
-        - Security teams lack visibility into traffic patterns and potential security incidents targeting web applications.
-        - Troubleshooting application issues becomes more difficult without historical request data.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 requirements for maintaining audit trails of system access may not be satisfied.
-
-        Access logs are critical for security monitoring, compliance auditing, operational troubleshooting, and traffic analysis. These logs help identify suspicious patterns that may indicate security threats or application issues.
+        - **Incident investigation:** Access logs record the client IP, request URI, response code, and processing time for every request, providing the evidence trail needed to reconstruct attack sequences or identify abused endpoints.
+        - **Threat detection:** Patterns such as high error rates, unusual user agents, or repeated probes against sensitive paths are only detectable from historical log data that does not exist if logging is disabled.
+        - **Forensic completeness:** After a security event, access logs often provide the only record of what an attacker requested before defensive measures were deployed.
+        - **Compliance documentation:** Audit frameworks require evidence that access to production systems is logged; load balancer access logs satisfy that requirement for HTTP-facing workloads.
 
         **Risk mitigation**
 
-        - **Security Monitoring:** Provides visibility into potential attacks, such as SQL injection attempts or cross-site scripting.
-        - **Compliance Documentation:** Helps meet regulatory requirements for maintaining audit trails of system access.
-        - **Operational Intelligence:** Allows analysis of traffic patterns, error rates, and client behaviors to improve application performance.
+        - **Blind spots during breach response:** Without access logs, security teams cannot determine which resources an attacker targeted or when an attack began, severely limiting containment and attribution.
+        - **Missing audit evidence:** Compliance audits and regulatory investigations typically require access logs as supporting evidence; their absence can result in audit failures.
       audit: |
         ### Audit via Console
 
@@ -8541,21 +8440,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Application Load Balancers (ALBs) have deletion protection enabled. An attacker with compromised IAM credentials can delete unprotected load balancers as a destructive sabotage action, immediately severing all traffic to backend applications and destroying security configurations such as WAF associations and access logging settings.
+        This check ensures that AWS Application Load Balancers have deletion protection enabled so that the load balancer cannot be accidentally or maliciously deleted without first disabling the protection flag. Deletion protection is off by default; a single authorized API call is sufficient to destroy an unprotected ALB and all of its associated listener, rule, and WAF configurations.
 
         **Why this matters**
 
-        Without deletion protection, ALBs are vulnerable to intentional destruction:
-
-        - An attacker with `elasticloadbalancing:DeleteLoadBalancer` permissions can destroy the load balancer in a single API call, causing immediate service disruption.
-        - WAF rules, authentication configurations, and access logging settings attached to the ALB are lost, removing security controls and forensic data sources.
-        - Rebuilding the ALB with identical security configurations is error-prone and time-consuming, extending the window of exposure during incident response.
+        - **Availability protection:** Deleting an ALB immediately terminates all traffic to the backend targets, causing a complete service outage that may persist for the time required to recreate the resource and its configuration.
+        - **Security configuration loss:** WAF web ACL associations, authentication actions, and access logging settings are stored on the ALB; destroying the ALB removes those security controls with it.
+        - **Accidental deletion guard:** Infrastructure automation scripts, misrouted CLI commands, or console mistakes can trigger deletion; the protection flag adds a required intermediate step that catches errors before they become outages.
+        - **Defense in depth:** Even with tightly scoped IAM policies, credential compromise scenarios benefit from resource-level safeguards that require multiple deliberate actions to overcome.
 
         **Risk mitigation**
 
-        - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), increasing detection opportunity.
-        - **Security configuration preservation:** Protects WAF associations, TLS settings, and logging configurations from being destroyed.
-        - **Defense in depth:** Complements IAM policies by adding resource-level protection against credential compromise scenarios.
+        - **Destructive sabotage:** An attacker who compromises credentials with `elasticloadbalancing:DeleteLoadBalancer` rights must also call the modify-attributes API to remove protection first, creating a two-step window for detection.
+        - **Blast radius reduction:** Requiring explicit protection removal before deletion limits how quickly an attacker or misconfigured automation can cause irreversible infrastructure damage.
       audit: |
         ### Audit via Console
 
@@ -8712,23 +8609,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elasticsearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
+        This check ensures that Amazon Elasticsearch Service domains are configured with encryption at rest enabled. By default, Elasticsearch Service domains do not encrypt stored data unless encryption is explicitly enabled at domain creation time; existing unencrypted domains cannot be converted and must be replaced to achieve compliance.
 
         **Why this matters**
 
-        By default, Elasticsearch Service does not encrypt data at rest unless explicitly enabled. Without encryption:
-
-        - Sensitive data remains in plaintext, making it vulnerable to unauthorized access.
-        - Security and compliance risks increase under regulations such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
-        - Data exposure risks exist if an Elasticsearch domain is compromised.
-
-        To mitigate these risks, Elasticsearch domains should be encrypted using AWS KMS, which provides centralized key management, access control, and audit logging.
+        - **Data confidentiality:** Elasticsearch domains often index sensitive business records, log data, or personally identifiable information; encryption at rest prevents that data from being read directly from the underlying storage if the domain or its storage is compromised.
+        - **KMS integration:** When encryption is enabled, AWS KMS manages the keys, providing centralized key policy control, CloudTrail audit logging of key usage, and optional customer-managed key support.
+        - **Storage-layer isolation:** Encryption ensures that access to raw EBS volumes backing the domain does not translate to readable data without possession of the corresponding KMS key.
+        - **Compliance baseline:** Regulated industries treating Elasticsearch as a data store for sensitive records require encryption at rest as a minimum control.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by ensuring all stored data is encrypted.
-        - Enhances compliance with industry security frameworks requiring encryption at rest.
-        - Improves security posture by integrating AWS KMS for key management.
+        - **Storage compromise:** If an attacker gains access to the underlying EBS volumes or snapshots of an Elasticsearch domain, encryption prevents plaintext data extraction without the KMS key.
+        - **Snapshot exposure:** Automated EBS snapshots of unencrypted domains retain plaintext data; enabling encryption at rest ensures snapshots are also encrypted.
       audit: |
         ### Audit via Console
 
@@ -9058,23 +8951,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Key Management Service (KMS) customer-managed keys (CMKs) have automatic key rotation enabled. Enabling key rotation ensures that cryptographic keys are periodically refreshed, reducing the risk of long-term key compromise and enhancing overall security.
+        This check ensures that AWS KMS customer-managed keys have automatic key rotation enabled so that key material is refreshed on an annual cycle. By default, AWS does not enable automatic rotation for customer-managed symmetric keys; without it, the same key material is used indefinitely, increasing the potential impact if that material is ever exposed or compromised.
 
         **Why this matters**
 
-        By default, AWS does not enable automatic rotation for CMKs, leaving encryption keys unchanged unless manually rotated. Without key rotation:
-
-        - Keys remain in use indefinitely, increasing the impact of potential key compromise.
-        - Compliance issues may arise under security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, ISO 27001, and NIST.
-        - Security best practices require periodic key changes to limit exposure.
-
-        AWS allows automatic key rotation for symmetric CMKs every 365 days, ensuring that keys remain secure over time.
+        - **Limiting key exposure window:** Rotating key material annually bounds the maximum time period over which a compromised key can be used to decrypt historical data.
+        - **Cryptographic hygiene:** Periodic key rotation follows the principle of limiting key material lifetime, reducing the value of cryptographic attacks that require large volumes of data encrypted under the same key.
+        - **Compliance requirements:** Several security frameworks explicitly require cryptographic key rotation on a defined schedule; disabling automatic rotation creates a gap that must be remediated manually.
+        - **Operational safety net:** Automatic rotation removes the dependency on manual processes that can be missed during team transitions or operational pressure.
 
         **Risk mitigation**
 
-        - Reduces key compromise risk by ensuring keys are periodically refreshed.
-        - Ensures compliance with security frameworks that mandate key rotation.
-        - Improves cryptographic security by limiting key lifespan.
+        - **Key compromise blast radius:** If key material is extracted or leaked, rotation limits the window during which an attacker can use the compromised material to decrypt data.
+        - **Audit accountability:** CloudTrail records each rotation event, providing a verifiable rotation history that satisfies auditor requests for evidence of key lifecycle management.
       audit: |
         ### Audit via Console
 
@@ -9222,23 +9111,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker notebook instances are configured to encrypt data at rest using AWS Key Management Service (KMS). Enabling KMS encryption enhances security by protecting sensitive machine learning (ML) data stored in SageMaker notebook instances from unauthorized access.
+        This check ensures that Amazon SageMaker notebook instances are configured with a KMS key to encrypt the attached EBS storage volume. By default, SageMaker notebook instances use an AWS-managed key for storage encryption; specifying a customer-managed KMS key gives the owning team control over key policy, rotation, and access auditing for the ML data stored on the instance.
 
         **Why this matters**
 
-        By default, SageMaker notebook instances may store training datasets, model artifacts, and proprietary code in Amazon EBS volumes. Without KMS encryption:
-
-        - Data is stored in plaintext, making it vulnerable to unauthorized access.
-        - Security and compliance risks increase, especially for organizations under PCI DSS, HIPAA, ISO 27001, and CIS AWS Foundations Benchmark.
-        - No centralized control over encryption keys, preventing fine-grained access control and auditing.
-
-        To mitigate these risks, SageMaker notebook instances should be encrypted using AWS KMS, allowing secure key management, key rotation, and logging of key usage.
+        - **ML data sensitivity:** Notebook instances frequently store training datasets, model artifacts, proprietary notebooks, and experiment outputs that may contain sensitive intellectual property or regulated personal data.
+        - **Key policy control:** A customer-managed KMS key allows the security team to define precisely which IAM principals and services can decrypt the notebook storage, preventing unauthorized access even by other AWS service roles.
+        - **Audit trail:** Key usage events are recorded in CloudTrail, providing a record of when the notebook storage was accessed or decrypted.
+        - **Consistent encryption posture:** Specifying a KMS key for notebook instances aligns SageMaker with the broader organizational policy of using customer-managed keys across all storage resources.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access to sensitive machine learning data.
-        - Ensures compliance with security frameworks that mandate encryption.
-        - Improves security posture by leveraging AWS KMS for centralized key management.
+        - **Storage-layer access:** If an attacker gains access to the EBS volume backing the notebook instance, a customer-managed key prevents data extraction without an explicit key policy grant.
+        - **Cross-team data leakage:** Without a customer-managed key, the default AWS-managed key is shared across all resources in the account; using a dedicated key isolates notebook data and limits lateral access.
       audit: |
         ### Audit via Console
 
@@ -9398,23 +9283,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS CloudTrail has log file validation enabled to verify the integrity of logged events. Log file validation generates a digitally signed digest file containing a hash of each log that CloudTrail delivers, allowing you to determine whether a log file was modified, deleted, or unchanged after CloudTrail delivered it.
+        This check ensures that AWS CloudTrail trails have log file validation enabled so that delivered log files are protected by a cryptographic hash digest. When log file validation is active, CloudTrail delivers a signed SHA-256 digest file for each hour's worth of log data; the digest can be used to detect whether any log file was modified, deleted, or replaced after delivery.
 
         **Why this matters**
 
-        Without log file validation enabled in CloudTrail:
-
-        - Unauthorized modifications to log files may go undetected, compromising the reliability of audit trails.
-        - Attackers could potentially alter or delete log records to cover their tracks after gaining unauthorized access.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 requirements for maintaining tamper-proof audit logs may not be satisfied.
-
-        Log file validation is crucial for maintaining the chain of custody for security events and ensuring the authenticity of CloudTrail logs during security investigations, compliance audits, and forensic analysis of security incidents.
+        - **Tamper detection:** Digitally signed digest files make it possible to determine whether an attacker or insider modified CloudTrail logs to cover their tracks after a security incident.
+        - **Chain of custody:** Validated logs carry a verifiable integrity guarantee that is accepted by many regulatory auditors and forensic investigators as evidence that the log record was not altered.
+        - **Insider threat coverage:** Even administrators with write access to the S3 bucket cannot silently alter log files without breaking the digest chain, because the digest files themselves are signed by CloudTrail.
+        - **Incident response confidence:** During breach investigations, validated logs provide high confidence that the event record accurately reflects what occurred, rather than a post-incident fabrication.
 
         **Risk mitigation**
 
-        - **Log Integrity:** Provides cryptographic assurance that logs have not been modified since they were delivered by CloudTrail.
-        - **Forensic Readiness:** Ensures reliable evidence for security incident investigations and dispute resolution.
-        - **Compliance Validation:** Helps meet regulatory requirements for tamper-evident logging mechanisms.
+        - **Log tampering:** Without validation, an attacker with S3 write access can delete or overwrite log files to remove evidence of their activity; validation makes such tampering detectable.
+        - **Audit failures:** Compliance frameworks require tamper-evident audit trails; logs without integrity validation may fail auditor scrutiny even if the underlying events were accurately recorded.
       audit: |
         ### Audit via Console
 
@@ -9631,23 +9512,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS CloudTrail trails are configured to use AWS Key Management Service (KMS) for server-side encryption (SSE). Using KMS encryption protects log data from unauthorized access and enhances the security of audit logs.
+        This check ensures that AWS CloudTrail trails are configured to encrypt log files using a KMS key before storing them in S3. By default, CloudTrail delivers logs to S3 without additional server-side encryption beyond the bucket's own settings; explicitly attaching a KMS key to the trail means logs are encrypted using that key regardless of the bucket's configuration, giving the security team direct control over who can decrypt the audit record.
 
         **Why this matters**
 
-        By default, CloudTrail logs are not encrypted using a customer-managed KMS key (CMK) unless explicitly configured. Without KMS encryption:
-
-        - CloudTrail logs may be accessed or modified if security policies are misconfigured.
-        - Sensitive log data is stored in plaintext, increasing security risks.
-        - Compliance requirements under CIS AWS Foundations Benchmark, PCI DSS, HIPAA, ISO 27001, and NIST may not be met.
-
-        Using KMS CMKs provides fine-grained access control, automatic key rotation, and detailed audit logging via AWS CloudTrail.
+        - **Log confidentiality:** CloudTrail logs contain a complete record of API activity across the account, including IAM changes, resource modifications, and authentication events; encrypting them limits read access to principals explicitly authorized by the KMS key policy.
+        - **Key policy separation:** Attaching a dedicated KMS key to the trail allows the security team to grant decrypt access independently of the S3 bucket policy, preventing infrastructure engineers who can access the bucket from reading audit logs.
+        - **CloudTrail key usage audit:** Decryption of CloudTrail logs using the KMS key is itself logged in CloudTrail, creating a meta-audit trail of who accessed the audit record.
+        - **Compliance control:** Many frameworks require that audit logs be protected with encryption under customer-controlled keys, not merely S3 default encryption.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access to audit logs by enforcing encryption.
-        - Enhances security posture by integrating AWS KMS for key management.
-        - Ensures compliance with industry security frameworks requiring encryption at rest.
+        - **Unauthorized log reading:** Without KMS encryption on the trail, any IAM principal with S3 GetObject permission on the log bucket can read the full audit record; a KMS key policy adds an additional access control layer.
+        - **Cross-account log exposure:** In multi-account CloudTrail aggregation setups, KMS encryption ensures that log data from one account cannot be decrypted by principals in another account without an explicit key grant.
       audit: |
         ### Audit via Console
 
@@ -9805,23 +9682,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups are configured to restrict incoming SSH (port 22) traffic. Allowing unrestricted SSH access (0.0.0.0/0 or ::/0) poses a significant security risk by exposing instances to unauthorized access attempts, brute-force attacks, and potential exploitation by malicious actors.
+        This check ensures that AWS security groups do not permit unrestricted inbound access on port 22, the default SSH port. By default, security groups deny all inbound traffic unless explicitly permitted; however, configurations that allow SSH from any source (0.0.0.0/0 or ::/0) are common in development environments and frequently persist into production, exposing instances directly to the internet.
 
         **Why this matters**
 
-        By default, AWS allows full control over inbound and outbound traffic through security groups. However, allowing unrestricted SSH access increases the risk of unauthorized logins, credential theft, and automated attacks. Instead, SSH access should be restricted to specific IP addresses, such as known administrative networks, bastion hosts, or VPN subnets.
-
-        **Restricting SSH access helps mitigate:**
-
-        - **Brute-force attacks:** Reduces exposure to automated SSH login attempts.
-        - **Unauthorized access:** Limits access to only trusted networks.
-        - **Compliance risks:** Aligns with best practices in security frameworks like PCI DSS, NIST, and CIS benchmarks.
+        - **Brute-force exposure:** Port 22 is among the most actively scanned ports on the internet; unrestricted access allows automated tools to continuously attempt authentication against any reachable instance.
+        - **Credential theft risk:** Successful brute-force or exploitation of SSH vulnerabilities gives an attacker an interactive shell with the privileges of the SSH user, typically a stepping stone to full instance compromise.
+        - **Lateral movement:** An SSH foothold on one instance provides access to internal VPC routes, enabling attackers to pivot to other resources that are not internet-accessible.
+        - **Audit expectations:** Network segmentation controls that restrict administrative access to specific source ranges are a baseline expectation in virtually all security frameworks.
 
         **Risk mitigation**
 
-        - **Minimize attack surface:** Reduces the number of exposed SSH endpoints.
-        - **Ensure least privilege access:** Restricts access to only authorized IP ranges.
-        - **Improve network security:** Protects EC2 instances from unauthorized access.
+        - **Attack surface reduction:** Restricting SSH access to specific IP ranges such as a corporate VPN or bastion host eliminates the vast majority of opportunistic and automated attacks that target open port 22.
+        - **Access accountability:** When SSH is only permitted from known source addresses, login attempts from unexpected sources trigger immediate alerts, improving threat detection response time.
       audit: |
         ### Audit via Console
 
@@ -9996,25 +9869,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow unrestricted incoming Virtual Network Computing (VNC) traffic, which operates on ports 5900-5903. Allowing unrestricted VNC access (0.0.0.0/0 or ::/0) exposes instances to unauthorized access attempts, brute-force attacks, and remote exploitation.
+        This check ensures that AWS security groups do not permit unrestricted inbound access on ports 5900 through 5903, the standard VNC port range. VNC provides graphical remote desktop access and operates without mandatory transport encryption in many implementations; exposing it directly to the internet enables attackers to attempt password guessing, exploit known VNC vulnerabilities, or observe screen content if authentication is bypassed.
 
         **Why this matters**
 
-        VNC is a widely used remote desktop protocol that, if exposed to the internet, can be exploited by attackers for unauthorized access, credential theft, or lateral movement within the network. Attackers frequently scan for open VNC ports, and leaving them unrestricted significantly increases the risk of compromise.
-
-        To mitigate risks, VNC access should be restricted to trusted IP addresses, such as an internal corporate network, a VPN, or a bastion host.
-
-        **Risks of unrestricted VNC access:**
-
-        - **Brute-force attacks:** Attackers can repeatedly attempt to guess VNC passwords.
-        - **Unencrypted connections:** Many VNC implementations do not encrypt traffic by default.
-        - **Unauthorized remote access:** Unrestricted access allows attackers to control the remote system.
+        - **Unencrypted protocol risk:** Many VNC server configurations do not enforce TLS, meaning session content including keystrokes and screen output may be transmitted in plaintext between client and server.
+        - **Brute-force susceptibility:** VNC's simple password authentication model is vulnerable to automated credential-guessing attacks when accessible from arbitrary source addresses.
+        - **Wide attack scanning:** Automated scanners continuously probe the internet for open VNC ports; an unrestricted security group rule ensures the instance will receive sustained unauthorized access attempts.
+        - **Remote code exposure:** Historical VNC implementations have carried exploitable vulnerabilities; limiting network reachability reduces the exploitable attack surface independent of patch status.
 
         **Risk mitigation**
 
-        - **Limit exposure:** Restrict VNC access to known IP addresses such as an office VPN or bastion host.
-        - **Use encrypted alternatives:** Consider replacing VNC with more secure alternatives like SSH tunneling or AWS Session Manager.
-        - **Enhance authentication:** Use strong passwords, multi-factor authentication (MFA), and network segmentation.
+        - **Access restriction:** Limiting VNC access to trusted source ranges such as a VPN or jump host eliminates exposure to internet-based scanning and brute-force attempts.
+        - **Secure alternative adoption:** Using AWS Systems Manager Session Manager or SSH tunneling for remote desktop access removes the need to expose VNC ports at the network layer entirely.
       audit: |
         ### Audit via Console
 
@@ -10200,23 +10067,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups are not configured to allow unrestricted inbound Remote Desktop Protocol (RDP) traffic, which operates on port 3389. Allowing unrestricted RDP access (0.0.0.0/0 or ::/0) significantly increases the risk of brute-force attacks, unauthorized remote access, and exploitation by malicious actors.
+        This check ensures that AWS security groups do not permit unrestricted inbound access on port 3389, the default Windows Remote Desktop Protocol port. RDP is a primary attack vector for Windows-based cloud infrastructure; internet-exposed port 3389 is targeted by continuous automated scanning, brute-force credential attacks, and exploitation of RDP protocol vulnerabilities such as BlueKeep.
 
         **Why this matters**
 
-        RDP is a widely used protocol for remote administration of Windows-based instances in AWS. However, exposing port 3389 to the internet without restrictions creates a high-security risk. Attackers continuously scan for open RDP ports and attempt brute-force login attacks using credential stuffing or password spraying techniques.
-
-        Instead of allowing open RDP access, organizations should:
-
-        - Restrict RDP access to trusted IP addresses such as corporate networks, VPNs, or bastion hosts.
-        - Use AWS Systems Manager Session Manager as a secure alternative to direct RDP access.
-        - Enable multi-factor authentication (MFA) and strong authentication mechanisms.
+        - **High-value target:** RDP provides interactive access to Windows instances with the privileges of the authenticated user; a successful login gives an attacker the same capabilities as a legitimate administrator.
+        - **Credential stuffing:** Large-scale breach databases give attackers ready-made username and password pairs to try against exposed RDP endpoints, making brute-force attacks highly effective.
+        - **Protocol vulnerability history:** RDP has a documented history of critical remote code execution vulnerabilities that allow unauthenticated compromise of instances reachable on port 3389.
+        - **Lateral movement gateway:** Compromising one Windows instance via RDP provides an attacker with a foothold from which to pivot laterally within the VPC and access internal resources.
 
         **Risk mitigation**
 
-        - **Prevent brute-force attacks:** Limits exposure to automated credential-guessing attacks.
-        - **Ensure least privilege access:** Only trusted IPs can establish RDP sessions.
-        - **Improve security posture:** Protects Windows servers from unauthorized access and exploits.
+        - **Attack surface elimination:** Restricting port 3389 to known administrative source ranges such as a VPN subnet or bastion host removes the instance from the pool of targets scanned by internet-facing attackers.
+        - **Secure access alternatives:** Routing RDP through AWS Systems Manager Session Manager eliminates the need to open port 3389 at the security group level, providing audited access without a network exposure.
       audit: |
         ### Audit via Console
 
@@ -10393,23 +10256,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow unrestricted access to all IPs (0.0.0.0/0 or ::/0) on any port. Allowing open access to security groups exposes AWS resources to unauthorized access, increasing the risk of security breaches, brute-force attacks, and data exfiltration.
+        This check ensures that AWS security groups do not contain inbound rules that allow all protocols and all ports from any source (0.0.0.0/0 or ::/0 with protocol -1). A catch-all allow-all-traffic inbound rule grants unrestricted access to every port on every protocol simultaneously, eliminating the selective access control that security groups are designed to provide.
 
         **Why this matters**
 
-        AWS security groups act as virtual firewalls that control inbound and outbound traffic. When a security group allows access from all IPs (0.0.0.0/0 for IPv4 or ::/0 for IPv6) on all ports, it poses significant risks:
-
-        - Unrestricted access to sensitive services such as SSH on port 22, RDP on port 3389, or databases like MySQL on port 3306.
-        - Increased exposure to brute-force attacks, credential stuffing, and other cyber threats.
-        - Compliance violations under security frameworks such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, ISO 27001, and NIST.
-
-        To mitigate these risks, security groups should be configured with the principle of least privilege, allowing access only to specific IP ranges and necessary ports.
+        - **Complete exposure:** An allow-all inbound rule makes every service running on the instance reachable from the internet, including administrative interfaces, databases, internal APIs, and any other listening process regardless of intended exposure.
+        - **No defense in depth:** Security groups are the primary network access control for EC2 resources; an unrestricted rule removes that layer entirely, leaving the instance dependent solely on host-level firewalls and application authentication.
+        - **Broad attack surface:** Every open port is a potential entry point; attackers scanning the instance can probe all services simultaneously and exploit any vulnerable or misconfigured one.
+        - **Compliance violation:** Virtually every security framework requires that network access be limited to necessary ports and protocols using the principle of least privilege; allow-all rules are explicitly prohibited by most frameworks.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by restricting inbound and outbound traffic.
-        - Reduces exposure to external attacks such as brute force or malware injection.
-        - Ensures compliance with industry best practices and cloud security standards.
+        - **Principle of least privilege:** Replacing the allow-all rule with explicit port-specific rules limits network access to only the services that legitimately require inbound connections, dramatically reducing the exploitable attack surface.
+        - **Blast radius containment:** When a service-specific rule is used instead of an unrestricted rule, compromise of one service does not automatically expose all other ports on the same instance to the attacker's network.
       audit: |
         ### Audit via Console
 
@@ -10583,24 +10442,18 @@ queries:
       # No terraform-state variant: Terraform state files do not preserve provider credentials, so the check would always trivially pass.
     docs:
       desc: |
-        This check ensures that AWS provider configurations in Terraform do not contain hard-coded access keys or secret keys. Hard-coded credentials pose a significant security risk, especially if the Terraform configuration is committed to version control systems.
+        This check ensures that Terraform AWS provider configurations do not contain hard-coded access keys or secret keys. By default, nothing prevents a developer from placing literal credentials in a provider block, but doing so puts static secrets into source files that are often committed to version control and shared widely.
 
         **Why this matters**
 
-        Hard-coded credentials in Terraform configurations can lead to:
-
-        - **Credential exposure:** If the code is committed to a public or shared repository, attackers can discover and exploit the credentials.
-        - **Unauthorized access:** Compromised credentials can provide full access to AWS resources, leading to data breaches, resource abuse, or financial loss.
-        - **Compliance violations:** Many security frameworks (CIS, SOC 2, PCI DSS, ISO 27001) prohibit storing credentials in code.
+        - **Credential leakage through version control:** Hard-coded access keys in Terraform files are exposed to everyone with read access to the repository, including any future forks or clones.
+        - **Broad blast radius on compromise:** A single leaked provider credential grants the attacker the same AWS permissions as the identity used, across every account the credential can access.
+        - **Long-lived exposure:** Unlike short-lived IAM role credentials, static access keys remain valid until explicitly rotated or revoked, giving attackers extended windows of opportunity.
 
         **Risk mitigation**
 
-        - Prevents credential leakage by enforcing secure authentication methods.
-        - Ensures compliance with security best practices for infrastructure as code.
-        - Reduces the attack surface by eliminating static credentials from codebases.
-      # NOTE (2026-03-29): CLI remediation not included because this is a Terraform-specific check
-      # about removing hard-coded credentials from provider blocks. The fix requires editing
-      # Terraform configuration files, not running AWS CLI commands.
+        - **Prefer environment-based or role-based authentication:** Using environment variables, AWS profiles, or IAM instance roles means credentials never appear in code.
+        - **Enforce least-privilege for CI pipelines:** Automation that authenticates via assumed roles limits what an attacker gains even if the pipeline configuration is exposed.
       audit: |
         ### Audit via Console
 
@@ -10726,21 +10579,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon API Gateway method settings have caching enabled and that cached data is encrypted. Caching improves performance by reducing the load on backend services, while encryption protects sensitive data stored in the cache.
+        This check ensures that Amazon API Gateway method settings have caching enabled and that cached data is encrypted at rest. By default, API Gateway caching is not enabled on stage method settings, and when enabled, cache encryption is not automatically applied, leaving response data stored in plaintext.
 
         **Why this matters**
 
-        API Gateway caching stores responses from backend integrations to reduce latency and backend load. Without encryption:
-
-        - **Data exposure:** Cached responses may contain sensitive information that could be accessed if the cache is compromised.
-        - **Compliance violations:** Security frameworks such as PCI DSS, HIPAA, and SOC 2 require encryption of data at rest.
-        - **Security risks:** Unencrypted caches are vulnerable to unauthorized access.
+        - **Sensitive data in cached responses:** API responses often contain personal information, tokens, or business-sensitive data that should not reside in unencrypted storage, even temporarily.
+        - **Defense in depth for storage compromise:** Encrypting the cache ensures that physical or logical access to the underlying cache storage does not expose readable response data.
+        - **Reduced backend exposure:** Enabling caching reduces the volume of requests reaching backend services, limiting the surface area for injection and abuse attacks on those services.
 
         **Risk mitigation**
 
-        - Protects sensitive API response data by encrypting cached content.
-        - Ensures compliance with data protection regulations.
-        - Reduces the risk of data breaches from compromised cache storage.
+        - **Encrypt cached content:** Enabling cache encryption ensures that cached API responses cannot be read by unauthorized parties if the cache layer is accessed directly.
+        - **Consistent encryption posture:** Applying encryption uniformly to all cached method settings prevents gaps where only some methods are protected.
       audit: |
         ### Audit via Console
 
@@ -10886,21 +10736,18 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon API Gateway stages have access logging enabled. Access logs capture detailed information about API requests, which is essential for monitoring, troubleshooting, and security analysis.
+        This check ensures that Amazon API Gateway stages have execution logging enabled by verifying that the logging level for method settings is set to ERROR or INFO rather than OFF. By default, execution logging is disabled on new API Gateway stages, which means API request and response details are not captured in CloudWatch Logs.
 
         **Why this matters**
 
-        Without access logging enabled:
-
-        - **Limited visibility:** Inability to track API usage patterns, errors, and performance issues.
-        - **Security blind spots:** Difficulty in detecting and investigating suspicious activities or attacks.
-        - **Compliance gaps:** Many security frameworks (CIS, SOC 2, PCI DSS) require logging of API access for audit purposes.
+        - **Detection of API abuse:** Execution logs record request parameters, integration responses, and error details, making it possible to identify unusual patterns such as automated scanning or injection attempts.
+        - **Troubleshooting and root cause analysis:** When backend integrations fail or return unexpected responses, execution logs provide the detailed trace needed to diagnose the issue quickly.
+        - **Accountability for API activity:** Logs create a record of what requests were processed, enabling post-incident review and supporting audit requirements.
 
         **Risk mitigation**
 
-        - Enables monitoring and alerting on API activity.
-        - Supports incident response and forensic investigations.
-        - Ensures compliance with audit and logging requirements.
+        - **Security event visibility:** Logging API execution surfaces unauthorized or malformed requests that would otherwise go unnoticed.
+        - **Incident response support:** Detailed execution logs reduce the time needed to reconstruct attack timelines and affected resources after a security event.
       audit: |
         ### Audit via Console
 
@@ -11014,21 +10861,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon API Gateway methods have authentication enabled. Methods without authentication (authorization set to NONE) should at minimum require an API key to prevent unauthorized access.
+        This check ensures that Amazon API Gateway methods require authentication by verifying that methods with authorization set to NONE have API key enforcement enabled. By default, API Gateway methods can be deployed without any authentication requirement, making them callable by anyone on the internet.
 
         **Why this matters**
 
-        Unauthenticated API endpoints can lead to:
-
-        - **Unauthorized access:** Anyone can invoke the API, potentially accessing sensitive data or functionality.
-        - **Abuse and misuse:** Open endpoints are vulnerable to automated attacks, scraping, and resource abuse.
-        - **Data breaches:** Exposed APIs without authentication can leak sensitive information.
+        - **Unauthorized invocation:** An unauthenticated API endpoint allows any internet client to call the method, potentially exposing sensitive business logic or data without any identity verification.
+        - **Resource abuse and cost amplification:** Open endpoints are easily targeted by automated bots that can generate large volumes of requests, increasing operational costs and degrading availability.
+        - **Data exposure through unintended callers:** Backend services behind an unauthenticated endpoint may return data that should only be accessible to known, verified callers.
+        - **Privilege escalation path:** An unauthenticated gateway method that proxies to internal AWS services can serve as an entry point for privilege escalation if the integration role is overly permissive.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access to API resources.
-        - Reduces the risk of API abuse and denial of service attacks.
-        - Ensures compliance with security best practices for API protection.
+        - **Require authentication on every non-OPTIONS method:** Enforcing AWS IAM, a Cognito user pool, a Lambda authorizer, or at minimum an API key prevents anonymous invocations.
+        - **Reduce attack surface by default:** Requiring authentication as a baseline forces explicit justification for any public endpoint, reducing the chance of accidental exposure.
       audit: |
         ### Audit via Console
 
@@ -11191,21 +11036,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon API Gateway custom domain names are configured with TLS 1.2 security policy. Older TLS versions (1.0 and 1.1) have known vulnerabilities and should not be used.
+        This check ensures that Amazon API Gateway custom domain names are configured with the TLS 1.2 security policy, preventing clients from negotiating older protocol versions. By default, API Gateway may accept connections using TLS 1.0 or TLS 1.1, which contain known cryptographic weaknesses that have been deprecated by major standards bodies.
 
         **Why this matters**
 
-        Using outdated TLS versions exposes APIs to:
-
-        - **Known vulnerabilities:** TLS 1.0 and 1.1 have security weaknesses that can be exploited by attackers.
-        - **Man-in-the-middle attacks:** Weak encryption can be broken, allowing attackers to intercept and modify traffic.
-        - **Compliance violations:** PCI DSS, HIPAA, and other standards require TLS 1.2 or higher.
+        - **Known cryptographic vulnerabilities:** TLS 1.0 and 1.1 are susceptible to attacks such as BEAST, POODLE, and downgrade attacks that can allow an attacker to decrypt traffic.
+        - **Man-in-the-middle interception:** Weak cipher suites available in older TLS versions reduce the cost for an attacker to intercept and tamper with API traffic in transit.
+        - **Client compatibility as a non-issue:** All modern browsers and HTTP clients have supported TLS 1.2 since 2013, making backward compatibility with older versions unnecessary for production APIs.
 
         **Risk mitigation**
 
-        - Protects API traffic with strong encryption.
-        - Ensures compliance with industry security standards.
-        - Prevents exploitation of known TLS vulnerabilities.
+        - **Enforce TLS 1.2 minimum:** Restricting the security policy to TLS 1.2 eliminates the negotiation of vulnerable protocol versions and cipher suites.
+        - **Protect API traffic in transit:** Strong TLS ensures that session tokens, request payloads, and response bodies cannot be read or modified by network-level attackers.
       audit: |
         ### Audit via Console
 
@@ -11350,21 +11192,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS X-Ray tracing is enabled on Amazon API Gateway REST APIs. X-Ray tracing provides request-level visibility that enables detection of API attacks including injection attempts, brute-force authentication attacks, and API enumeration by revealing abnormal request patterns, elevated error rates, and unusual downstream call chains.
+        This check ensures that AWS X-Ray active tracing is enabled on Amazon API Gateway REST API stages. By default, X-Ray tracing is disabled on API Gateway stages, meaning request-level trace data is not collected or forwarded to the X-Ray service.
 
         **Why this matters**
 
-        Without X-Ray tracing, API attacks are difficult to detect and investigate:
-
-        - **Injection attack detection:** X-Ray traces reveal abnormal downstream call patterns and error rates that indicate SQL injection, command injection, or other payload-based attacks against backend services.
-        - **Brute-force visibility:** Authentication brute-force attacks and credential stuffing produce distinctive trace patterns (high error rates on auth endpoints) that are visible in X-Ray but invisible in aggregate metrics alone.
-        - **API enumeration detection:** Attackers probing API endpoints to discover undocumented functionality generate trace patterns that reveal systematic endpoint scanning.
+        - **Injection attack detection:** X-Ray traces surface abnormal downstream call patterns and elevated error rates that indicate SQL injection, command injection, or other payload-based attacks against backend services.
+        - **Brute-force and credential-stuffing visibility:** Authentication endpoints under attack produce distinctive trace patterns with high error rates that are visible in X-Ray but invisible in aggregate CloudWatch metrics alone.
+        - **API enumeration detection:** Attackers systematically probing endpoint paths generate trace patterns revealing systematic endpoint scanning that can trigger alerts before a successful compromise.
+        - **Incident investigation depth:** When a security event occurs, per-request trace data shows exactly which backend services were called, with what parameters, and what was returned.
 
         **Risk mitigation**
 
-        - **Attack pattern detection:** Enables identification of injection, brute-force, and enumeration attacks through abnormal request trace analysis.
-        - **Incident investigation:** Provides request-level forensic data showing exactly which backend services were affected during an attack.
-        - **Anomaly baselining:** Establishes normal API call patterns so that attacker-driven deviations can trigger alerts.
+        - **Anomaly baselining:** X-Ray establishes normal API call patterns so that attacker-driven deviations in latency, error rate, or call chains can be detected and alerted on.
+        - **Reduce mean time to detect:** Request-level forensic data available immediately after an incident shortens the window between breach and containment.
       audit: |
         ### Audit via Console
 
@@ -11506,21 +11346,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 instance user data does not contain hard-coded secrets such as AWS access keys or secret keys. User data is often logged and can be accessed by anyone with permissions to describe instances, making it an insecure location for sensitive credentials.
+        This check ensures that EC2 instance user data scripts do not contain hard-coded AWS access keys or secret keys. User data is stored in plaintext and is retrievable by any principal with EC2 describe permissions, and it is frequently included in CloudWatch logs and instance metadata responses, making it an insecure location for sensitive credentials.
 
         **Why this matters**
 
-        Storing secrets in EC2 user data poses significant risks:
-
-        - **Credential exposure:** User data is visible to anyone with EC2 describe permissions and is often logged to CloudWatch.
-        - **Persistence:** Unlike environment variables, user data persists and can be retrieved at any time.
-        - **Compliance violations:** Security frameworks prohibit storing credentials in plain text.
+        - **Persistent credential exposure:** Unlike a temporary environment variable, user data persists and can be retrieved at any time via the AWS API or the EC2 instance metadata endpoint, giving attackers ongoing access to the embedded credential.
+        - **Broad retrieval surface:** Any IAM principal with `ec2:DescribeInstanceAttribute` can read user data for all instances in the account, and CloudWatch log ingestion of startup scripts may also capture the plaintext value.
+        - **Lateral movement risk:** A compromised access key found in user data provides the attacker with the same AWS identity permissions as the credential, enabling lateral movement to other services and accounts.
 
         **Risk mitigation**
 
-        - Prevents credential leakage through user data exposure.
-        - Ensures compliance with security best practices for secret management.
-        - Encourages use of secure alternatives like IAM roles, Secrets Manager, or Parameter Store.
+        - **Use IAM instance profiles instead:** Attaching an IAM role to the instance provides temporary, automatically rotated credentials without any secrets appearing in configuration.
+        - **Retrieve secrets at runtime from managed stores:** Fetching values from AWS Secrets Manager or Systems Manager Parameter Store at boot time keeps secrets out of user data and provides centralized rotation and access auditing.
       audit: |
         ### Audit via Console
 
@@ -11675,21 +11512,18 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that IAM policies do not use wildcard (*) resources except in Deny statements. Using wildcards in Allow statements grants overly permissive access, violating the principle of least privilege.
+        This check ensures that IAM policies do not grant wildcard resource access in Allow statements, enforcing the principle of least privilege. By default, AWS provides managed policies such as AdministratorAccess and PowerUserAccess that use wildcard actions and resources, and custom policies are often written with wildcards for convenience during development, where they can remain indefinitely.
 
         **Why this matters**
 
-        Wildcard permissions in IAM policies can lead to:
-
-        - **Excessive privileges:** Users or roles may have access to resources they don't need.
-        - **Blast radius expansion:** If credentials are compromised, attackers have broad access.
-        - **Compliance violations:** CIS, SOC 2, PCI DSS, and other frameworks require least privilege access.
+        - **Excessive privilege on compromise:** When credentials attached to a wildcard-permissioned policy are stolen, the attacker inherits access to every resource in scope rather than only the subset the workload legitimately needs.
+        - **Accidental destructive access:** A wildcard Allow policy may permit deletion, modification, or exfiltration of resources that the principal was never intended to touch, turning a misconfiguration into a major incident.
+        - **Privilege escalation paths:** Overly broad IAM permissions are frequently the mechanism through which an attacker with initial limited access escalates to full account control.
 
         **Risk mitigation**
 
-        - Enforces the principle of least privilege.
-        - Reduces the potential impact of credential compromise.
-        - Ensures compliance with security frameworks.
+        - **Scope actions to specific services and operations:** Replacing `*` actions with explicit service:action pairs limits what an attacker or misconfigured workload can do even if credentials are compromised.
+        - **Scope resources to specific ARNs:** Binding permissions to named resources prevents a single policy from being the gateway to every bucket, table, or secret in the account.
       audit: |
         ### Audit via Console
 
@@ -11925,21 +11759,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets have versioning enabled. Versioning preserves multiple versions of objects, providing protection against accidental deletions and enabling recovery of previous versions.
+        This check ensures that Amazon S3 buckets have versioning enabled so that multiple versions of objects are preserved. By default, S3 buckets are created with versioning disabled, meaning any overwrite or deletion permanently removes the previous content with no built-in recovery path.
 
         **Why this matters**
 
-        Without versioning:
-
-        - **Data loss:** Accidental deletions or overwrites cannot be recovered.
-        - **No audit trail:** Changes to objects cannot be tracked over time.
-        - **Ransomware vulnerability:** Encrypted files cannot be restored to pre-attack versions.
+        - **Recovery from accidental deletion or overwrite:** Versioning allows a previous object version to be restored after an accidental `PUT` or `DELETE` without requiring a separate backup process.
+        - **Ransomware resilience:** When an attacker or malicious process overwrites objects with encrypted content, versioning provides a recovery point that predates the attack.
+        - **Audit trail for object changes:** Versioning creates a historical record of all object mutations, supporting forensic review of when and how data changed.
 
         **Risk mitigation**
 
-        - Protects against accidental data loss and overwrites.
-        - Enables recovery from ransomware attacks.
-        - Supports compliance with data retention requirements.
+        - **Enable object-level recovery:** Versioning ensures that no single API call can permanently destroy data, reducing the blast radius of both accidental and malicious write operations.
+        - **Support backup and compliance objectives:** Many data protection requirements mandate the ability to recover data to a known-good state, which versioning directly enables.
       audit: |
         ### Audit via Console
 
@@ -12089,21 +11920,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets have server access logging enabled. Access logs record all requests made to the bucket, providing valuable data for security analysis, auditing, and compliance.
+        This check ensures that Amazon S3 buckets have server access logging enabled so that all requests made to the bucket are recorded. By default, S3 server access logging is disabled, leaving no record of who accessed which objects, when, or from where.
 
         **Why this matters**
 
-        Without logging:
-
-        - **No visibility:** Unable to track who accessed what data and when.
-        - **Security blind spots:** Cannot detect unauthorized access attempts.
-        - **Compliance gaps:** Many regulations require access logging for audit purposes.
+        - **Detection of unauthorized access:** Access logs reveal unexpected GET requests, listing operations, or cross-account calls that may indicate data exfiltration or reconnaissance activity.
+        - **Forensic investigation capability:** After a security incident involving S3 data, access logs provide the timeline of which objects were read, by which principals, and from which IP addresses.
+        - **Accountability for data access:** Logging creates an auditable record of data access events, supporting both internal governance and external regulatory requirements.
 
         **Risk mitigation**
 
-        - Enables detection of unauthorized access attempts.
-        - Supports forensic investigations and incident response.
-        - Ensures compliance with audit and logging requirements.
+        - **Surface abnormal access patterns:** Continuous logging enables alerting on unusual spikes in data access volume or access by unexpected principals before a full exfiltration occurs.
+        - **Support incident response:** Detailed access logs reduce the time needed to scope the impact of a breach and identify the data that was accessed.
       audit: |
         ### Audit via Console
 
@@ -12259,21 +12087,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets have default server-side encryption enabled. When enabled, all new objects are automatically encrypted using either Amazon S3-managed keys (SSE-S3) or AWS KMS keys (SSE-KMS).
+        This check ensures that Amazon S3 buckets have a default server-side encryption configuration applied so that all new objects are automatically encrypted at rest. By default, newly created S3 buckets do not enforce a default encryption rule, meaning objects can be stored in plaintext unless the uploading client explicitly requests encryption on each request.
 
         **Why this matters**
 
-        Without default encryption:
-
-        - **Data exposure:** Unencrypted data at rest is vulnerable if storage is compromised.
-        - **Compliance violations:** PCI DSS, HIPAA, and other standards require encryption at rest.
-        - **Inconsistent protection:** Objects may be uploaded without encryption.
+        - **Plaintext data at rest:** Without default encryption, objects uploaded by clients that do not specify an encryption header are stored unencrypted, creating an exposure risk if storage media is accessed outside the normal IAM access path.
+        - **Inconsistent protection across uploads:** Relying on individual clients to request encryption leads to gaps where some objects are protected and others are not, making the bucket's security posture difficult to reason about.
+        - **Defense in depth for storage-layer access:** Encryption at rest ensures that direct access to the underlying storage infrastructure does not yield readable data.
 
         **Risk mitigation**
 
-        - Protects data at rest with strong encryption.
-        - Ensures all objects are automatically encrypted.
-        - Supports compliance with data protection regulations.
+        - **Enforce encryption uniformly:** A default encryption rule guarantees that every object, regardless of how it was uploaded, is encrypted at rest without requiring changes to uploading clients.
+        - **Reduce impact of storage-layer compromise:** If storage media or a management plane path is breached, encrypted objects cannot be read without access to the corresponding encryption key.
       audit: |
         ### Audit via Console
 
@@ -12434,21 +12259,18 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets do not have public-read or public-read-write ACLs configured. Public ACLs expose bucket contents to the internet, risking unauthorized data access and breaches.
+        This check ensures that Amazon S3 bucket access control lists do not grant public read or full-control permissions to the AllUsers group. By default, S3 buckets are private, but bucket ACLs can be explicitly set to public-read or public-read-write either at creation time or through a subsequent API call, making all objects in the bucket freely accessible to anyone on the internet.
 
         **Why this matters**
 
-        Public read ACLs can lead to:
-
-        - **Data breaches:** Anyone on the internet can access bucket contents.
-        - **Sensitive data exposure:** Confidential files may be inadvertently exposed.
-        - **Compliance violations:** GDPR, PCI DSS, and HIPAA prohibit public access to sensitive data.
+        - **Unrestricted data exposure:** A public-read ACL on a bucket makes every object it contains downloadable by any internet client without authentication, which is rarely the intended configuration for data buckets.
+        - **Sensitive data at risk:** Buckets frequently contain logs, backups, configuration files, and application data that may include personally identifiable information or secrets that should never be publicly accessible.
+        - **High-confidence misconfiguration signal:** Public ACL grants on data buckets are one of the most common root causes of S3 data breach incidents, making this a high-priority control.
 
         **Risk mitigation**
 
-        - Prevents unauthorized public access to S3 data.
-        - Protects against data breaches and leaks.
-        - Ensures compliance with data protection regulations.
+        - **Remove AllUsers grants from bucket ACLs:** Setting the bucket ACL to private and blocking public access at the account or bucket level prevents accidental or malicious public exposure.
+        - **Complement with Block Public Access settings:** Enabling all four Block Public Access settings provides a defense-in-depth layer that prevents future ACL changes from re-opening public access.
       audit: |
         ### Audit via Console
 
@@ -12595,21 +12417,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets do not have static website hosting enabled. When static website hosting is enabled on an S3 bucket, it serves content over an unauthenticated HTTP endpoint, which can expose data to the public internet.
+        This check ensures that Amazon S3 buckets do not have static website hosting enabled. When static website hosting is configured on an S3 bucket, AWS creates an unauthenticated HTTP endpoint that serves the bucket's contents publicly, bypassing the bucket's IAM and ACL access controls for any object that is readable.
 
         **Why this matters**
 
-        When static website hosting is enabled:
-
-        - **Data exposure:** The bucket's contents may be accessible over the internet without authentication.
-        - **Attack surface:** The publicly accessible endpoint can be exploited for phishing, malware distribution, or data exfiltration.
-        - **Compliance violations:** Regulations such as PCI DSS, HIPAA, and GDPR require strict control over public-facing resources.
+        - **Unauthenticated HTTP exposure:** The website endpoint serves content over plain HTTP without any authentication, making the bucket's objects accessible to any internet client regardless of bucket policy settings.
+        - **Expanded attack surface:** A publicly accessible S3 website endpoint can be abused for phishing pages, malware distribution, or open redirect attacks that leverage the trusted amazonaws.com domain.
+        - **Unintended data disclosure:** Buckets not intended as public websites may have website hosting enabled by misconfiguration, silently exposing internal files, logs, or backups to the internet.
 
         **Risk mitigation**
 
-        - Prevents accidental exposure of sensitive data through public website endpoints.
-        - Reduces the attack surface by eliminating unnecessary public-facing services.
-        - Ensures compliance with data protection and access control requirements.
+        - **Disable website hosting on non-public buckets:** Removing the website configuration eliminates the unauthenticated endpoint and ensures bucket access is controlled exclusively through IAM and bucket policies.
+        - **Use purpose-built services for static content:** When public web hosting is genuinely needed, serving content through CloudFront with HTTPS enforcement and proper access controls is the safer alternative.
       audit: |
         ### Audit via Console
 
@@ -12729,23 +12548,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS CloudTrail is configured with at least one multi-region trail that captures management events across all AWS regions. A single-region trail only records API activity in the region where it was created, leaving events in other regions unmonitored and potentially allowing attackers to operate undetected in regions where CloudTrail is not active.
+        This check ensures that AWS CloudTrail has at least one multi-region trail enabled that is actively logging. By default, CloudTrail trails created through the AWS Console are single-region, recording API activity only in the region where the trail was created and leaving all other regions without an audit record.
 
         **Why this matters**
 
-        Without a multi-region trail enabled:
-
-        - API activity in regions where CloudTrail is not active goes unrecorded, creating blind spots in the audit trail.
-        - Attackers can exploit regions without active trails to perform malicious actions without detection.
-        - Compliance frameworks such as CIS AWS Foundations Benchmark (control 3.1), PCI DSS, HIPAA, and SOC 2 require comprehensive logging across all regions.
-
-        A multi-region trail ensures complete visibility into account activity regardless of which region the API call originates from, including global service events such as IAM, STS, and CloudFront.
+        - **Blind spots in single-region trails:** An attacker who creates resources or performs API calls in a region without an active trail leaves no CloudTrail record of the activity, making detection and post-incident investigation impossible.
+        - **Global service events require multi-region coverage:** IAM, STS, and CloudFront generate global events that are only captured when a trail is configured as multi-region with global service events enabled.
+        - **Delayed detection window:** Without visibility into all regions, unauthorized activity such as new IAM users, cross-region data copies, or lateral movement through lesser-used regions may go undetected until the impact is already significant.
 
         **Risk mitigation**
 
-        - **Complete audit coverage:** All API activity across every region is captured in a single trail.
-        - **Threat detection:** Enables detection of unauthorized activity in regions that are not commonly used.
-        - **Compliance:** Meets CIS AWS Foundations Benchmark 3.1 and other regulatory requirements for comprehensive logging.
+        - **Ensure complete API audit coverage:** A multi-region trail with global service events captures every management API call across the entire account, eliminating the coverage gaps that single-region trails leave.
+        - **Support threat detection and compliance:** Comprehensive logging is the foundation for detective controls such as GuardDuty, Security Hub, and custom CloudWatch alarms that alert on suspicious activity.
       audit: |
         ### Audit via Console
 
@@ -12903,24 +12717,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon CloudFront distributions are configured to require HTTPS for viewer connections, preventing content from being served over unencrypted HTTP. By default, CloudFront distributions can be configured with an "allow-all" viewer protocol policy, which permits both HTTP and HTTPS connections and exposes users to man-in-the-middle (MITM) attacks.
+        This check ensures that Amazon CloudFront distributions are configured to require HTTPS for viewer connections by setting the viewer protocol policy to redirect-to-https or https-only. By default, CloudFront distributions can be created with the allow-all viewer protocol policy, which permits both HTTP and HTTPS connections and exposes viewer traffic to interception.
 
         **Why this matters**
 
-        When CloudFront distributions allow HTTP connections:
-
-        - Data transmitted between viewers and CloudFront is unencrypted and can be intercepted by attackers.
-        - Sensitive information such as authentication tokens, session cookies, and user data can be exposed.
-        - Users are vulnerable to man-in-the-middle attacks that can modify content in transit.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 require encryption in transit for sensitive data.
-
-        Configuring the viewer protocol policy to "https-only" or "redirect-to-https" ensures that all communication between viewers and CloudFront is encrypted.
+        - **Unencrypted traffic interception:** When HTTP connections are permitted, an attacker in a position to observe network traffic can read the full content of requests and responses, including authentication tokens and session cookies.
+        - **Content tampering in transit:** Unencrypted HTTP traffic is susceptible to man-in-the-middle modification, allowing an attacker to inject malicious scripts or redirect users to attacker-controlled resources.
+        - **Session hijacking:** Cookies and authentication headers transmitted over HTTP can be captured and replayed by an attacker who observes the traffic, leading to account takeover without requiring credential compromise.
 
         **Risk mitigation**
 
-        - **Data protection:** Prevents eavesdropping on traffic between viewers and CloudFront edge locations.
-        - **MITM prevention:** Eliminates the risk of content being modified in transit by attackers.
-        - **Compliance:** Meets regulatory requirements for encryption in transit.
+        - **Enforce HTTPS at the distribution level:** Setting the viewer protocol policy to redirect-to-https or https-only ensures every viewer connection is encrypted, regardless of whether the client initially requests HTTP.
+        - **Protect all cache behaviors:** Applying HTTPS enforcement to all cache behaviors, not just the default, prevents individual content paths from becoming unencrypted exceptions.
       audit: |
         ### Audit via Console
 
@@ -13110,24 +12918,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EKS clusters have control plane logging enabled. EKS control plane logging provides audit and diagnostic logs directly from the Amazon EKS control plane to CloudWatch Logs. These logs include API server, audit, authenticator, controller manager, and scheduler components that are essential for security monitoring and troubleshooting.
+        This check ensures that Amazon EKS clusters have control plane logging enabled by verifying that at least one log type is configured as active in the cluster's logging configuration. By default, EKS control plane logging is disabled when a cluster is created, meaning API server, audit, authenticator, controller manager, and scheduler events are not forwarded to CloudWatch Logs.
 
         **Why this matters**
 
-        Without EKS control plane logging enabled:
-
-        - Unauthorized API calls and authentication attempts go undetected, making it difficult to identify security incidents.
-        - There is no audit trail for Kubernetes API activity, hindering forensic investigations.
-        - Compliance frameworks such as CIS EKS Benchmark, PCI DSS, and SOC 2 require logging of security-relevant events.
-        - Operational issues with the control plane cannot be diagnosed effectively.
-
-        At minimum, the audit log type should be enabled as it records all individual API requests for accountability. Enabling all log types (api, audit, authenticator, controllerManager, scheduler) provides comprehensive visibility.
+        - **No audit trail for Kubernetes API activity:** Without the audit log type enabled, there is no record of who called the Kubernetes API, what resources they accessed, and what changes they made, eliminating the ability to detect unauthorized access or configuration changes.
+        - **Authentication events go unrecorded:** The authenticator log type captures credential validation decisions; without it, failed and successful authentication attempts against the cluster API are invisible to security monitoring.
+        - **Control plane failures are undiagnosable:** Scheduler and controller manager logs are essential for diagnosing workload scheduling failures and controller reconciliation errors that may indicate a compromised or misconfigured cluster.
 
         **Risk mitigation**
 
-        - **Threat detection:** Enables detection of unauthorized API calls, privilege escalation attempts, and suspicious authentication activity.
-        - **Forensic capability:** Provides detailed audit trail for incident investigation and response.
-        - **Compliance:** Meets CIS EKS Benchmark and regulatory requirements for logging security events.
+        - **Enable audit logging as a minimum:** The audit log type records all individual API requests and is the most critical for security monitoring, as it surfaces privilege escalation attempts, unauthorized resource modifications, and lateral movement within the cluster.
+        - **Forward logs to CloudWatch for alerting:** Routing control plane logs to CloudWatch Logs enables metric filters and alarms that can alert on unauthorized API calls, repeated authentication failures, or anomalous resource access patterns in near real time.
       audit: |
         ### Audit via Console
 
@@ -13294,23 +13096,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon OpenSearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). Encryption at rest protects sensitive search and analytics data from unauthorized access, ensuring that stored data is automatically encrypted before being written to disk.
+        This check ensures that Amazon OpenSearch Service domains are configured to encrypt data at rest using AWS Key Management Service (KMS). By default, OpenSearch Service does not encrypt data at rest unless explicitly enabled, leaving stored indexes and snapshots in plaintext on the underlying EBS volumes.
 
         **Why this matters**
 
-        By default, OpenSearch Service does not encrypt data at rest unless explicitly enabled. Without encryption:
-
-        - Sensitive data remains in plaintext, making it vulnerable to unauthorized access.
-        - Security and compliance risks increase under regulations such as CIS AWS Foundations Benchmark, PCI DSS, HIPAA, and ISO 27001.
-        - Data exposure risks exist if an OpenSearch domain is compromised.
-
-        To mitigate these risks, OpenSearch domains should be encrypted using AWS KMS, which provides centralized key management, access control, and audit logging.
+        - **Plaintext exposure:** Without encryption, anyone with physical or logical access to the underlying storage can read index data, snapshots, and automated backups.
+        - **Breach impact:** If an OpenSearch domain is compromised, unencrypted data can be exfiltrated immediately with no cryptographic barrier.
+        - **Key auditability:** KMS-managed encryption provides centralized key rotation, access control policies, and CloudTrail audit records for every decryption event.
+        - **Defense in depth:** Encryption at rest is a foundational layer that protects data even when network and IAM controls fail.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access by ensuring all stored data is encrypted.
-        - Enhances compliance with industry security frameworks requiring encryption at rest.
-        - Improves security posture by integrating AWS KMS for key management.
+        - **Unauthorized access prevention:** Ensures that raw storage volumes cannot be read without valid KMS key permissions.
+        - **Incident containment:** Limits the value of data obtained during a storage-layer breach to encrypted ciphertext.
+        - **Key lifecycle control:** AWS KMS enables key rotation and revocation, allowing teams to respond quickly if credentials are compromised.
       audit: |
         ### Audit via Console
 
@@ -14707,21 +14506,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic Container Registry (ECR) repositories are configured with image scanning on push. When enabled, ECR automatically scans container images for known vulnerabilities as they are pushed to the repository, providing early detection of security issues in the CI/CD pipeline.
+        This check ensures that Amazon Elastic Container Registry (ECR) repositories are configured to automatically scan images for known vulnerabilities each time a new image is pushed. By default, scan-on-push is disabled and repositories must be explicitly configured to enable it.
 
         **Why this matters**
 
-        Container images often contain operating system packages and application dependencies that may have known vulnerabilities. Without automated scanning:
-
-        - Vulnerable images may be deployed to production environments undetected.
-        - Security teams lack visibility into the vulnerability posture of container images.
-        - Compliance frameworks such as CIS, PCI DSS, and SOC 2 require vulnerability management for container workloads.
+        - **Early detection:** Vulnerabilities discovered at push time can be blocked before they ever reach a running environment, reducing the window between introduction and remediation.
+        - **Consistent coverage:** Automated scanning eliminates reliance on manual or ad-hoc security reviews, ensuring every pushed image is assessed regardless of team bandwidth.
+        - **Visibility:** Security teams gain a continuous inventory of known CVEs across all container images stored in the registry.
+        - **CI/CD integration:** Findings surfaced at push time can gate deployments, preventing vulnerable images from reaching production.
 
         **Risk mitigation**
 
-        - **Early detection:** Identifies vulnerabilities before images are deployed to production.
-        - **Automated security:** Eliminates reliance on manual scanning processes.
-        - **Compliance:** Meets regulatory requirements for container image vulnerability management.
+        - **Production risk reduction:** Stops images with critical or high-severity vulnerabilities from being deployed without a deliberate decision.
+        - **Vulnerability lifecycle management:** Creates a trackable record of when a vulnerability was introduced into the registry, supporting both response and compliance workflows.
       audit: |
         ### Audit via Console
 
@@ -14869,21 +14666,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECR repositories are configured with image tag immutability. When tag immutability is enabled, it prevents image tags from being overwritten, ensuring that once an image is tagged, the tag always refers to the same image digest.
+        This check ensures that Amazon ECR repositories are configured with image tag immutability, preventing existing image tags from being overwritten by a subsequent push. By default, ECR sets tag mutability to MUTABLE, meaning any tag can be silently replaced with a different image.
 
         **Why this matters**
 
-        Without tag immutability, an attacker or misconfigured pipeline could overwrite a trusted image tag with a malicious or vulnerable image:
-
-        - Deployments referencing a specific tag such as `v1.2.3` could silently pull a different image.
-        - Supply chain attacks become possible by replacing known-good images with compromised ones.
-        - Audit trails become unreliable when tags can point to different images over time.
+        - **Deployment integrity:** When tags are mutable, a deployment referencing `v2.1.0` today may pull a different image tomorrow if the tag was overwritten, making rollbacks and audits unreliable.
+        - **Supply chain protection:** A compromised build pipeline or insider threat can replace a trusted, scanned image with a malicious one under the same tag without any visible change to deployment manifests.
+        - **Auditability:** Immutable tags ensure that the tag-to-digest mapping is permanent, providing a trustworthy record of what was deployed at any point in time.
+        - **Accidental overwrite prevention:** Immutability guards against non-malicious mistakes such as re-using a version tag during a CI/CD misconfiguration.
 
         **Risk mitigation**
 
-        - **Supply chain security:** Prevents tag overwrites that could introduce malicious code.
-        - **Deployment integrity:** Ensures tags always reference the same image content.
-        - **Auditability:** Maintains a reliable history of what was deployed.
+        - **Tamper detection:** Any attempt to overwrite a tag will fail with an error, surfacing supply chain interference attempts that would otherwise be silent.
+        - **Rollback reliability:** Teams can confidently roll back to a previous tag knowing the image content has not changed since it was first pushed.
       audit: |
         ### Audit via Console
 
@@ -15024,21 +14819,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS task definitions do not configure containers to run in privileged mode. A privileged container has elevated access to the host system, effectively gaining root-level capabilities on the underlying EC2 instance or Fargate host.
+        This check ensures that Amazon ECS task definitions do not configure containers to run in privileged mode. A privileged container receives elevated host capabilities equivalent to running as root on the underlying EC2 or Fargate host, bypassing the container isolation boundary.
 
         **Why this matters**
 
-        Running privileged containers poses severe security risks:
-
-        - A privileged container can access the host's devices, file systems, and kernel, enabling container escape attacks.
-        - An attacker who compromises a privileged container can escalate to full control of the host and potentially other containers running on it.
-        - Privileged containers bypass most Linux security mechanisms including AppArmor, SELinux, and seccomp profiles.
+        - **Container escape:** Privileged containers can access host devices, kernel namespaces, and file systems directly, providing a straightforward path for container escape attacks.
+        - **Full host compromise:** An attacker who gains code execution inside a privileged container can escalate to control of the underlying host and all other containers running on it.
+        - **Security bypass:** Privileged mode disables or weakens AppArmor, SELinux, and seccomp profiles that would otherwise constrain what a container process can do.
+        - **Blast radius amplification:** A single compromised privileged container can become a pivot point to the broader cluster or VPC network.
 
         **Risk mitigation**
 
-        - **Container isolation:** Maintains the security boundary between the container and the host system.
-        - **Blast radius reduction:** Limits the impact of a container compromise to the container itself.
-        - **Compliance:** Meets CIS Docker Benchmark and container security best practices.
+        - **Isolation enforcement:** Keeping containers unprivileged maintains the kernel-level isolation between container processes and host resources.
+        - **Least privilege:** Requiring specific Linux capabilities instead of blanket privilege ensures containers have only the permissions their workload requires.
+        - **Breach containment:** Limiting a compromised container to its own namespace and resource scope reduces the attacker's ability to move laterally.
       audit: |
         ### Audit via Console
 
@@ -15201,23 +14995,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS task definitions configure containers with read-only root filesystems. A read-only root filesystem prevents processes inside the container from writing to the container's file system, forcing the use of explicit volume mounts for any writable data.
+        This check ensures that Amazon ECS task definitions configure containers with read-only root filesystems, preventing processes inside the container from writing to the container image's file system. By default, ECS containers have a writable root filesystem, which applications rarely need for normal operation.
 
         **Why this matters**
 
-        Without a read-only root filesystem:
-
-        - An attacker who gains code execution inside a container can write malicious binaries, scripts, or configuration changes to the file system.
-        - Malware can persist within the container by modifying system files.
-        - Web shells and backdoors can be written to the container's file system for ongoing access.
-
-        Enabling read-only root filesystems is a defense-in-depth measure that significantly reduces the impact of container compromises.
+        - **Tamper prevention:** A read-only root filesystem stops an attacker who achieves code execution from modifying container binaries, configuration files, or startup scripts.
+        - **Persistence elimination:** Without the ability to write to the file system, attackers cannot plant backdoors, web shells, or cron jobs that survive container restarts.
+        - **Malware containment:** Exploits that attempt to download and execute secondary payloads are blocked if the file system is not writable.
+        - **Immutability enforcement:** Treating containers as immutable runtime units aligns with the rebuild-and-redeploy model, making the attack surface predictable.
 
         **Risk mitigation**
 
-        - **Tamper prevention:** Prevents unauthorized modification of container binaries and configuration.
-        - **Malware persistence:** Makes it harder for attackers to establish persistence within a container.
-        - **Compliance:** Aligns with CIS Docker Benchmark recommendations and container hardening best practices.
+        - **Post-exploitation hardening:** Forces any data writes through explicitly declared volume mounts, making write activity observable and auditable.
+        - **Image integrity:** Ensures the running container file system matches the built image, closing the gap between what was scanned and what is executing.
       audit: |
         ### Audit via Console
 
@@ -15391,22 +15181,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that all container definitions within Amazon ECS task definitions have a log configuration specified. Without logging, container activity goes unrecorded, making it impossible to detect security incidents, troubleshoot failures, or meet audit requirements.
+        This check ensures that all container definitions within Amazon ECS task definitions include a log configuration, directing container output to a supported logging driver such as `awslogs`. By default, ECS does not require containers to have logging configured, leaving many deployments without any record of container activity.
 
         **Why this matters**
 
-        Containers without logging configured create blind spots in your security monitoring:
-
-        - Security incidents within containers cannot be detected or investigated.
-        - No audit trail exists for container activity, hindering forensic analysis.
-        - Application errors and failures go unrecorded, making troubleshooting difficult.
-        - Compliance frameworks such as PCI DSS, HIPAA, and SOC 2 require logging of application activity.
+        - **Security incident detection:** Without log output from containers, anomalous behavior such as unexpected command execution, connection attempts, or error spikes goes undetected.
+        - **Forensic visibility:** When a container is terminated or replaced, its in-memory log buffer is lost unless forwarded to a durable destination, destroying evidence needed for post-incident investigation.
+        - **Operational insight:** Application errors, crashes, and dependency failures that affect reliability are invisible without structured log collection.
+        - **Audit trail:** Regulated workloads require a continuous record of application activity to demonstrate control effectiveness to auditors.
 
         **Risk mitigation**
 
-        - **Incident detection:** Enables real-time monitoring and alerting for security events in containers.
-        - **Forensics:** Provides detailed logs for investigating security incidents.
-        - **Compliance:** Meets regulatory requirements for logging and audit trails.
+        - **Incident response:** Log records in CloudWatch Logs or another destination allow security teams to reconstruct attacker activity within a container after the fact.
+        - **Alerting foundation:** Centralized log collection enables downstream detection rules, metric filters, and alarms that depend on container log events.
       audit: |
         ### Audit via Console
 
@@ -15595,21 +15382,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Elastic File System (EFS) file systems have automatic backups enabled through AWS Backup. Without backups, data stored in EFS is at risk of permanent loss due to accidental deletion, corruption, or ransomware attacks.
+        This check ensures that Amazon Elastic File System (EFS) file systems have automatic backups enabled through AWS Backup. By default, automatic backups are disabled on newly created EFS file systems, meaning data is unprotected against accidental deletion, corruption, or ransomware unless backups are explicitly configured.
 
         **Why this matters**
 
-        EFS file systems often store critical application data, configuration files, and shared resources. Without automatic backups:
-
-        - Data loss from accidental deletion or corruption cannot be recovered.
-        - Ransomware attacks could encrypt data with no recovery option.
-        - Compliance frameworks such as HIPAA, PCI DSS, and SOC 2 require data backup and recovery capabilities.
+        - **Data loss risk:** EFS file systems commonly store application data, configuration, and shared content that is difficult or impossible to reconstruct if lost.
+        - **Ransomware recovery:** A backup policy provides a clean recovery point that allows data to be restored to a known-good state after an encryption or deletion attack.
+        - **Accidental deletion:** Automated backups protect against user error, runaway scripts, or misconfigured cleanup jobs that delete critical files.
+        - **Business continuity:** Recovery point and time objectives can only be met if backups exist to restore from.
 
         **Risk mitigation**
 
-        - **Data recovery:** Enables restoration of data from backups in the event of data loss.
-        - **Ransomware protection:** Provides a clean recovery point if data is encrypted by ransomware.
-        - **Compliance:** Meets regulatory requirements for data protection and business continuity.
+        - **Restore capability:** AWS Backup creates point-in-time recovery points that can be used to restore an EFS file system to a previous state with a defined RPO.
+        - **Ransomware resilience:** Immutable backup copies stored in AWS Backup vaults cannot be encrypted or deleted by the same compromised credentials that attacked the primary file system.
       audit: |
         ### Audit via Console
 
@@ -15759,21 +15544,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Application Load Balancers (ALBs) are configured to drop HTTP headers that are not valid. Invalid HTTP headers can be used in HTTP request smuggling attacks, which exploit discrepancies between how front-end and back-end servers parse HTTP requests to bypass security controls.
+        This check ensures that AWS Application Load Balancers are configured to drop HTTP request headers that do not conform to the HTTP specification. By default, ALBs forward all headers to backend targets including malformed or non-standard ones, which can enable HTTP request smuggling attacks that exploit parsing differences between the load balancer and the backend.
 
         **Why this matters**
 
-        Without dropping invalid headers:
-
-        - ALBs may forward malformed HTTP headers to backend applications, enabling request smuggling attacks.
-        - Attackers can bypass WAF rules, authentication, and authorization controls.
-        - Cache poisoning attacks become possible when invalid headers are passed through to caching layers.
+        - **Request smuggling:** Invalid or ambiguous HTTP headers such as duplicate `Content-Length` or `Transfer-Encoding` values can be crafted to cause the load balancer and backend to disagree on where one request ends and the next begins, allowing cache poisoning or authentication bypass.
+        - **WAF evasion:** Malformed headers that pass through the ALB may be interpreted differently by a WAF and the origin server, allowing attackers to craft requests that bypass security rules at the WAF layer while executing malicious payloads at the origin.
+        - **Routing exploitation:** Ambiguous header fields can be used to manipulate sticky session behavior, routing decisions, and access control checks that rely on header values.
 
         **Risk mitigation**
 
-        - **Request smuggling prevention:** Eliminates a common attack vector by dropping invalid headers before they reach backend services.
-        - **Defense in depth:** Adds an additional security layer at the load balancer level.
-        - **Compliance:** Aligns with AWS Security Hub recommendations for ALB security.
+        - **Attack vector elimination:** Rejecting invalid headers at the load balancer removes a class of request smuggling techniques before they can reach backend services.
+        - **Defense in depth:** Header validation at the ALB layer supplements application-level input validation, providing a redundant control that operates independently of backend logic.
       audit: |
         ### Audit via Console
 
@@ -15938,22 +15720,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker notebook instances do not have direct internet access enabled. When direct internet access is enabled, the notebook instance can communicate directly with the internet, bypassing VPC network controls and potentially exposing sensitive data and models.
+        This check ensures that Amazon SageMaker notebook instances are configured with direct internet access disabled, requiring all external traffic to route through the VPC and its associated network controls. By default, SageMaker enables direct internet access when no VPC configuration is specified, meaning the notebook can reach the internet without passing through security groups, NAT gateways, or proxy inspection.
 
         **Why this matters**
 
-        SageMaker notebook instances often contain sensitive machine learning data, proprietary models, and access to training datasets. Direct internet access:
-
-        - Allows data exfiltration from the notebook instance to external destinations.
-        - Exposes the instance to inbound attacks from the internet.
-        - Bypasses VPC security controls, network ACLs, and security groups.
-        - Violates the principle of least privilege for network access.
+        - **Data exfiltration:** A notebook instance with direct internet access can send training data, model weights, and proprietary code to external destinations, bypassing all VPC-level egress controls.
+        - **Attack surface:** An outbound-capable notebook running in a developer's environment is a common lateral movement target, where malicious packages or notebook code can establish reverse shells or upload credentials.
+        - **Control bypass:** Direct internet access routes traffic outside the VPC perimeter, making it invisible to VPC Flow Logs, security group rules, and network ACLs configured to govern data movement.
+        - **Least privilege:** Notebook instances rarely need unrestricted internet access; specific dependencies can be served through VPC endpoints or a controlled NAT gateway.
 
         **Risk mitigation**
 
-        - **Data exfiltration prevention:** Restricts outbound network access to VPC-controlled paths.
-        - **Attack surface reduction:** Eliminates direct internet exposure of the notebook instance.
-        - **Network control:** Ensures all traffic flows through VPC endpoints and NAT gateways where it can be monitored and controlled.
+        - **Egress control:** Routing all traffic through the VPC allows security groups, NACLs, and inspection proxies to enforce which external destinations notebook instances can reach.
+        - **Audit visibility:** Traffic through the VPC is captured in Flow Logs, providing an audit record of all network connections made by the notebook.
       audit: |
         ### Audit via Console
 
@@ -16115,22 +15894,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EKS clusters with public endpoint access enabled restrict the CIDR blocks that can reach the API server. By default, when public endpoint access is enabled, the API server is accessible from any IP address (0.0.0.0/0), exposing it to the entire internet.
+        This check ensures that Amazon EKS clusters with public API server endpoint access enabled restrict the CIDR ranges allowed to reach that endpoint, rather than allowing access from any IP address. By default, when public endpoint access is enabled, the Kubernetes API server is reachable from `0.0.0.0/0`, exposing it to authentication attempts from the entire internet.
 
         **Why this matters**
 
-        An EKS API server endpoint accessible from 0.0.0.0/0:
-
-        - Allows anyone on the internet to attempt authentication against the Kubernetes API server.
-        - Increases exposure to brute-force attacks, credential stuffing, and exploitation of API server vulnerabilities.
-        - Violates the principle of least privilege for network access.
-        - While RBAC provides authentication, network-level restrictions add critical defense in depth.
+        - **Authentication attack surface:** An API server reachable from any source allows anyone on the internet to attempt authentication, enabling brute-force, credential stuffing, and exploitation of API server vulnerabilities at scale.
+        - **Zero-day exposure:** When a critical Kubernetes API server vulnerability is disclosed, unrestricted public access means the cluster is immediately reachable by automated exploit scanners before a patch can be applied.
+        - **RBAC as sole protection:** Restricting network access to known CIDR ranges adds a second control layer; RBAC alone is a single point of failure if credentials are compromised.
+        - **Reconnaissance prevention:** Limiting who can reach the API server also limits who can perform unauthenticated discovery against the server's TLS certificate, version banner, and error responses.
 
         **Risk mitigation**
 
-        - **Attack surface reduction:** Limits who can even attempt to reach the API server.
-        - **Defense in depth:** Adds network-level access control on top of Kubernetes RBAC.
-        - **Compliance:** Meets security best practices for restricting management plane access.
+        - **Network-level access control:** Allowlisting only known operator and CI/CD CIDRs ensures that even a leaked credential cannot be used from an arbitrary internet location.
+        - **Blast radius limitation:** Restricting the source CIDR to corporate or VPN IP ranges confines the pool of potential attackers to those already inside a trusted network perimeter.
       audit: |
         ### Audit via Console
 
@@ -16303,22 +16079,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EKS clusters have deletion protection enabled. An attacker with compromised IAM credentials can delete unprotected EKS clusters to destroy Kubernetes infrastructure, eliminating all running workloads, RBAC configurations, network policies, and security controls in a single API call.
+        This check ensures that Amazon EKS clusters have deletion protection enabled, requiring the protection flag to be explicitly disabled before a cluster can be deleted. By default, EKS clusters do not have deletion protection enabled, meaning any principal with `eks:DeleteCluster` permission can destroy the entire Kubernetes control plane in a single API call.
 
         **Why this matters**
 
-        Without deletion protection:
-
-        - An attacker with `eks:DeleteCluster` permissions can destroy the entire Kubernetes control plane, immediately terminating all workloads and severing service connectivity.
-        - Cluster deletion destroys RBAC policies, network policies, service meshes, and security admission controllers, removing all in-cluster security controls simultaneously.
-        - EKS cluster recovery requires rebuilding from scratch and redeploying all workloads, creating an extended outage window that an attacker can exploit for further damage.
-        - Targeted infrastructure destruction is a common post-compromise action to cover tracks or maximize business impact.
+        - **Destructive attack prevention:** A compromised IAM credential with delete rights can terminate the cluster immediately, destroying all running workloads, RBAC configurations, network policies, and security admission controllers simultaneously.
+        - **Recovery complexity:** EKS clusters are not easily recovered from deletion; rebuilding requires recreating node groups, redeploying all workloads, and restoring all Kubernetes configuration that was not separately version-controlled.
+        - **Insider threat:** Deletion protection adds a second required step (disabling protection) before destruction, creating an additional CloudTrail event that detection systems can alert on before the cluster is lost.
+        - **Accidental deletion:** Even without malicious intent, automation bugs or operator mistakes can delete production clusters; the flag provides a safety net.
 
         **Risk mitigation**
 
-        - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
-        - **Security control preservation:** Protects RBAC, network policies, and admission controllers from being destroyed in a single action.
-        - **Incident response window:** The additional step buys time for automated alerting to detect unauthorized modification attempts before the cluster is destroyed.
+        - **Detection opportunity:** The required `UpdateClusterConfig` call to disable protection generates a CloudTrail event that can trigger immediate alerting, providing a window to stop the attack before deletion completes.
+        - **Operational safeguard:** Separates the permission to manage cluster configuration from the effective ability to destroy the cluster, reducing the blast radius of overly permissive IAM policies.
       audit: |
         ### Audit via Console
 
@@ -20391,21 +20164,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon RDS snapshots are encrypted at rest. RDS snapshots contain full backups of database instances and may include sensitive data such as customer records, credentials, or financial information. Unencrypted snapshots expose this data if the snapshot is shared, copied, or the underlying storage is compromised.
+        This check ensures that Amazon RDS snapshots are encrypted at rest using AWS Key Management Service (KMS). RDS snapshots inherit the encryption status of their source database instance; snapshots created from unencrypted databases remain unencrypted and cannot be encrypted in place without creating a new encrypted copy.
 
         **Why this matters**
 
-        RDS snapshots inherit the encryption status of their source database. Snapshots from unencrypted databases remain unencrypted and cannot be encrypted in place. Unencrypted snapshots pose several risks:
-
-        - **Data exposure:** If a snapshot is shared with another account or made public, the data is accessible without any encryption protection.
-        - **Compliance violations:** Regulatory frameworks such as PCI DSS, HIPAA, and GDPR require encryption of data at rest, including backups.
-        - **Lateral movement:** An attacker with access to unencrypted snapshots can restore them to extract sensitive data.
+        - **Backup data exposure:** Database snapshots contain a complete copy of all data in the source instance, including customer records, credentials, and financial information, making them as sensitive as the live database.
+        - **Snapshot sharing risk:** Unencrypted snapshots can be shared with other AWS accounts or inadvertently made public; once shared, the data is accessible without any cryptographic protection.
+        - **Storage-layer breach:** If the underlying S3 storage that holds snapshot data is accessed outside normal API paths, unencrypted snapshots can be read directly, bypassing all IAM and RDS access controls.
+        - **Lateral movement:** An attacker with snapshot restore permissions on an unencrypted snapshot can reconstruct the database in a different account or region beyond the reach of the original environment's security controls.
 
         **Risk mitigation**
 
-        - **Data Security:** Ensures backup data is encrypted at rest using AWS KMS, protecting against unauthorized access.
-        - **Regulatory Compliance:** Meets requirements for data-at-rest encryption in security frameworks.
-        - **Centralized Key Management:** Leverages AWS KMS for key lifecycle management and access control.
+        - **Data-at-rest protection:** KMS encryption ensures that snapshot storage is unreadable without valid key authorization, protecting backup data alongside the live database.
+        - **Key-level access control:** AWS KMS key policies can restrict which principals are authorized to restore from a snapshot, providing a separate access control layer beyond IAM snapshot permissions.
       audit: |
         ### Audit via Console
 
@@ -20546,22 +20317,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Machine Images (AMIs) owned by the account are not publicly shared. Public AMIs can be launched by anyone, potentially exposing proprietary software, embedded credentials, internal configurations, or sensitive data baked into the image.
+        This check ensures that Amazon Machine Images (AMIs) owned by the account are not configured with public launch permissions. Publicly shared AMIs can be launched by any AWS account globally, potentially exposing proprietary software, embedded secrets, internal configurations, and sensitive data baked into the image during its build process.
 
         **Why this matters**
 
-        Publicly shared AMIs pose severe security risks:
-
-        - **Credential exposure:** AMIs may contain embedded SSH keys, API credentials, database passwords, or other secrets that become accessible to anyone who launches the image.
-        - **Intellectual property leakage:** Custom software, scripts, and configurations within the AMI become publicly available.
-        - **Attack surface expansion:** Attackers can analyze public AMIs for vulnerabilities, then target running instances based on those findings.
-        - **Compliance violations:** Sharing AMIs publicly may violate data protection regulations and organizational security policies.
+        - **Credential exposure:** AMIs created from running instances may contain embedded SSH keys, API tokens, database connection strings, or application secrets that become accessible to anyone who launches the image.
+        - **Intellectual property leakage:** Custom application binaries, scripts, and configurations within the AMI become available to competitors or attackers once the image is publicly visible.
+        - **Vulnerability reconnaissance:** Attackers who can launch a copy of a public AMI can analyze it offline for vulnerabilities, weak configurations, and hardcoded credentials, then target running instances based on those findings.
+        - **Compliance risk:** Inadvertent public sharing may violate data protection obligations if the AMI contains regulated data or system configurations.
 
         **Risk mitigation**
 
-        - **Access control:** Restricts AMI usage to authorized accounts only.
-        - **Data protection:** Prevents inadvertent exposure of sensitive data embedded in images.
-        - **Compliance:** Meets CIS AWS Foundations Benchmark and organizational security requirements.
+        - **Access restriction:** Removing public launch permissions ensures AMIs are used only by explicitly authorized AWS accounts.
+        - **Secret exposure prevention:** Keeping AMIs private limits the blast radius if secrets were inadvertently baked into an image, as they remain inaccessible to external parties.
       audit: |
         ### Audit via Console
 
@@ -20712,21 +20480,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS task definitions specify a non-root user for all container definitions. Running containers as root grants the process full administrative capabilities within the container, increasing the impact of a container breakout or compromise.
+        This check ensures that Amazon ECS task definitions specify a non-root user for each container definition, preventing container processes from running as UID 0. By default, most container images run as root unless a non-root user is explicitly set in the task definition or the container image's Dockerfile.
 
         **Why this matters**
 
-        Running containers as root poses significant security risks:
-
-        - **Container escape:** A root process inside a container has a much higher chance of exploiting kernel vulnerabilities to escape the container boundary and access the host system.
-        - **File system access:** A root process inside the container can read and modify all files, including mounted volumes and secrets.
-        - **Privilege escalation:** If a container is compromised, root access provides the attacker with maximum capabilities for lateral movement and data exfiltration.
+        - **Container escape risk:** Root processes inside a container are better positioned to exploit kernel vulnerabilities that cross the container boundary and gain access to the underlying host.
+        - **File system access:** A root container process can read and modify all mounted volume content, including shared EFS volumes, secrets mounted as files, and any data written by other containers in the same task.
+        - **Privilege escalation path:** If an attacker achieves remote code execution inside a root container, they begin with maximum in-container capabilities and require no further privilege escalation to access sensitive resources within the container's scope.
+        - **Defense in depth:** Running as a non-root user is a foundational hardening measure that complements read-only filesystems, dropped capabilities, and seccomp profiles.
 
         **Risk mitigation**
 
-        - **Least privilege:** Running as a non-root user limits what an attacker can do after compromising a container.
-        - **Blast radius reduction:** Minimizes the impact of a container compromise.
-        - **Compliance:** Meets CIS Docker Benchmark 4.1 and container security best practices.
+        - **Least privilege:** A non-root user limits what an attacker can do after compromising a container, requiring additional steps to access root-owned resources.
+        - **Host protection:** Non-root processes are less likely to succeed in exploiting container runtime vulnerabilities that require elevated privileges to trigger.
       audit: |
         ### Audit via Console
 
@@ -20895,21 +20661,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS task definitions configure transit encryption for EFS (Elastic File System) volumes. When EFS volumes are mounted in ECS tasks without transit encryption, data is transmitted in plaintext between the ECS task and the EFS file system, exposing it to potential interception.
+        This check ensures that Amazon ECS task definitions enable transit encryption (`transitEncryption: ENABLED`) for every EFS volume configuration. By default, the EFS mount helper does not enforce TLS, meaning data flows between the ECS task and the EFS mount target in plaintext unless encryption in transit is explicitly required in the volume configuration.
 
         **Why this matters**
 
-        Without transit encryption on EFS volumes:
-
-        - **Data interception:** Network traffic between ECS tasks and EFS can be captured and read by anyone with access to the network path.
-        - **Man-in-the-middle attacks:** An attacker on the network could intercept or modify data in transit between the container and the file system.
-        - **Compliance violations:** Many security frameworks require encryption of data in transit, especially for sensitive workloads.
+        - **Data interception:** Without TLS, any network device or host on the path between the ECS task and the EFS mount target can capture and read file system traffic in plaintext.
+        - **Man-in-the-middle attacks:** An attacker with access to the VPC network path can intercept reads and writes, injecting or altering data in transit between the container and the file system.
+        - **Shared infrastructure risk:** In multi-tenant VPC environments or where network segmentation is incomplete, plaintext NFS traffic can be captured by adjacent workloads that should not have access to the data.
+        - **Compliance gaps:** Transmitting file system data without encryption violates the in-transit encryption requirements of many security frameworks, even when the data is encrypted at rest.
 
         **Risk mitigation**
 
-        - **Data protection:** TLS encryption protects data as it travels between ECS tasks and EFS.
-        - **Regulatory compliance:** Meets encryption-in-transit requirements for PCI DSS, HIPAA, and SOC 2.
-        - **Defense in depth:** Adds a layer of protection even if network-level controls are compromised.
+        - **End-to-end encryption:** TLS between the ECS task and the EFS mount target ensures that data is protected for its entire journey across the VPC network fabric.
+        - **Independent protection layer:** Transit encryption operates regardless of what network controls exist between the task and EFS, providing protection even if VPC routing or security group configurations are later misconfigured.
       audit: |
         ### Audit via Console
 
@@ -21099,21 +20863,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon CloudWatch log groups have a defined retention period. Without explicit retention, log groups may be manually purged or left in an ambiguous state, destroying forensic evidence needed to detect attackers who persist in an environment for weeks or months before discovery. A defined retention period ensures logs survive long enough to support threat hunting and incident investigation.
+        This check ensures that Amazon CloudWatch log groups have an explicit retention period configured rather than the default setting of never expiring. Without a defined retention period, log groups accumulate logs indefinitely but offer no guarantee that logs will be retained for a minimum duration, and organizations have no systematic control over when evidence of attacker activity may be permanently lost.
 
         **Why this matters**
 
-        Undefined log retention periods create critical gaps in attack detection and forensic capability:
-
-        - **Attacker persistence detection:** Advanced attackers often maintain access for months before discovery. Without sufficient log retention, evidence of initial compromise, lateral movement, and data exfiltration is lost before investigators can analyze it.
-        - **Forensic evidence preservation:** Incident response teams need historical logs to reconstruct attack timelines, identify compromised resources, and determine the scope of a breach.
-        - **Compliance requirements:** Security frameworks such as PCI DSS, HIPAA, and SOC 2 require defined log retention periods (often 90 days to 1 year minimum) specifically to support security investigations.
+        - **Dwell time coverage:** Advanced attackers commonly maintain access for weeks or months before detection; a defined retention period ensures that logs spanning the full intrusion window are available when an investigation begins.
+        - **Forensic completeness:** Incident response teams need historical logs to reconstruct attack timelines, identify the initial access vector, track lateral movement, and determine the full scope of a breach.
+        - **Compliance requirements:** Security frameworks require organizations to define and enforce minimum log retention periods, typically ranging from 90 days to one year, specifically to support security investigations and audit reviews.
+        - **Lifecycle management:** An explicit retention policy prevents indefinite log accumulation that would otherwise inflate storage costs without improving security.
 
         **Risk mitigation**
 
-        - **Incident response capability:** Ensures logs are available for the duration needed to detect and investigate long-running compromises.
-        - **Forensic completeness:** Preserves evidence of attacker activity across the full dwell time of a breach.
-        - **Regulatory compliance:** Meets log retention requirements mandated by security frameworks.
+        - **Evidence preservation:** A defined minimum retention ensures logs survive long enough to support threat hunting and investigation of compromises that were not immediately detected.
+        - **Regulatory posture:** Demonstrating that a retention policy is enforced satisfies auditor requests for evidence of log management controls.
       audit: |
         ### Audit via Console
 
@@ -21253,22 +21015,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Redshift clusters enforce SSL/TLS for all client connections by setting the `require_ssl` parameter to `true` in the cluster parameter group. Without SSL enforcement, database connections transmit data in plaintext, exposing queries and results to network interception.
+        This check ensures that Amazon Redshift clusters are configured to require SSL/TLS for all client connections by setting the `require_ssl` parameter to `true` in the cluster parameter group. By default, Redshift does not enforce SSL, allowing clients to connect over unencrypted channels and exposing queries and results to network interception.
 
         **Why this matters**
 
-        Unencrypted Redshift connections pose significant security risks:
-
-        - **Data interception:** Queries and results are transmitted in plaintext, allowing anyone with network access to capture sensitive data including credentials and business data.
-        - **Credential theft:** Database usernames and passwords sent over unencrypted connections can be captured via network sniffing.
-        - **Man-in-the-middle attacks:** Without SSL, attackers can intercept and modify queries and responses.
-        - **Compliance violations:** PCI DSS, HIPAA, and SOC 2 require encryption of data in transit.
+        - **Data interception prevention:** Queries and results transmitted over unencrypted connections can be captured by anyone with network access, exposing sensitive business data.
+        - **Credential protection:** Database usernames and passwords sent over unencrypted connections are vulnerable to capture via network sniffing.
+        - **Man-in-the-middle defense:** SSL provides server identity verification, preventing connections to impersonated or spoofed endpoints.
+        - **Transit confidentiality:** Enforcing SSL guarantees that all data moving between clients and the cluster is encrypted end to end.
 
         **Risk mitigation**
 
-        - **Data protection:** SSL/TLS encrypts all data transmitted between clients and the Redshift cluster.
-        - **Authentication:** SSL provides server identity verification, preventing connection to impersonated endpoints.
-        - **Regulatory compliance:** Meets encryption-in-transit requirements mandated by security frameworks.
+        - **Forced encryption:** Setting `require_ssl = true` in the parameter group rejects any connection attempt that does not negotiate TLS, removing the possibility of accidental plaintext connections.
+        - **Scope control:** Applying the parameter at the cluster level ensures enforcement regardless of individual client configuration or driver behavior.
       audit: |
         ### Audit via Console
 
@@ -22998,14 +22757,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Inspector is enabled and actively scanning EC2 instances for vulnerabilities. Inspector automatically discovers and scans EC2 instances for software vulnerabilities and unintended network exposure.
+        This check ensures that Amazon Inspector is enabled and actively scanning EC2 instances for software vulnerabilities and unintended network exposure. By default, Amazon Inspector is not enabled, so EC2 instances receive no automated vulnerability assessment unless the service is explicitly activated.
 
         **Why this matters**
 
-        - **Vulnerability detection**: Inspector continuously monitors EC2 instances for known software vulnerabilities (CVEs) and provides prioritized findings.
-        - **Automated discovery**: Automatically detects new EC2 instances and begins scanning without manual configuration.
-        - **Risk prioritization**: Uses context-aware risk scoring to help teams focus on the most critical vulnerabilities first.
-        - **Compliance alignment**: Meets requirements for continuous vulnerability assessment mandated by frameworks such as PCI DSS and NIST.
+        - **Vulnerability detection:** Inspector continuously monitors EC2 instances for known CVEs in installed software packages and produces prioritized findings.
+        - **Automated discovery:** Inspector automatically detects new instances launched after activation, eliminating manual enrollment gaps.
+        - **Risk prioritization:** Context-aware scoring helps teams focus remediation effort on vulnerabilities with the highest exploitability in their specific environment.
+        - **Network exposure visibility:** Inspector also identifies unintended network paths to EC2 instances, surfacing misconfigurations beyond software vulnerabilities.
+
+        **Risk mitigation**
+
+        - **Continuous coverage:** Active scanning ensures that newly discovered CVEs trigger findings against existing instances without requiring a rescan to be initiated manually.
+        - **Timely remediation:** Early detection of vulnerabilities reduces the window of exposure between public disclosure and patch deployment.
       audit: |
         ### Audit via Console
 
@@ -23117,14 +22881,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Inspector is enabled and actively scanning ECR container images for vulnerabilities. Inspector automatically scans container images pushed to ECR for software vulnerabilities.
+        This check ensures that Amazon Inspector is enabled and actively scanning container images stored in Amazon ECR for software vulnerabilities. By default, Inspector ECR scanning is not active, leaving container images without automated vulnerability assessment before or after deployment.
 
         **Why this matters**
 
-        - **Container security**: Automatically scans container images for known vulnerabilities before they are deployed to production.
-        - **Shift-left security**: Identifies vulnerabilities in container images early in the development lifecycle.
-        - **Continuous monitoring**: Re-scans images when new CVEs are published, ensuring ongoing protection.
-        - **Supply chain security**: Helps detect vulnerabilities in base images and third-party dependencies.
+        - **Pre-deployment detection:** Scanning images in ECR identifies vulnerable package dependencies before the image is pulled and run in production.
+        - **Continuous re-scanning:** Inspector re-evaluates images when new CVEs are published, so vulnerabilities discovered after the initial push are still surfaced.
+        - **Supply chain visibility:** Vulnerabilities in base images and third-party dependencies are detected regardless of whether the application code itself introduced them.
+        - **Centralized findings:** Inspector aggregates ECR findings alongside EC2 and Lambda findings in a single console, simplifying triage.
+
+        **Risk mitigation**
+
+        - **Shift-left enforcement:** Catching vulnerabilities at the registry level prevents known-vulnerable images from reaching production clusters.
+        - **Coverage without overhead:** Inspector integrates with ECR natively, requiring no agents or changes to existing build pipelines to provide ongoing assessment.
       audit: |
         ### Audit via Console
 
@@ -23235,14 +23004,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Inspector is enabled and actively scanning Lambda functions for vulnerabilities. Inspector scans Lambda functions and their associated layers for software vulnerabilities in application package dependencies.
+        This check ensures that Amazon Inspector is enabled and actively scanning Lambda functions and their associated layers for software vulnerabilities in application package dependencies. By default, Inspector does not scan Lambda functions, leaving serverless workloads without automated vulnerability assessment.
 
         **Why this matters**
 
-        - **Serverless security**: Detects vulnerabilities in Lambda function code dependencies and layers.
-        - **Automated scanning**: Automatically scans functions when they are deployed or updated.
-        - **Code scanning**: Identifies vulnerabilities in application package dependencies used by Lambda functions.
-        - **Continuous protection**: Re-scans when new CVEs are published to catch newly discovered vulnerabilities.
+        - **Serverless coverage:** Lambda functions package dependencies that are not updated by OS-level patching, making dedicated scanning essential for detecting vulnerable libraries.
+        - **Layer assessment:** Inspector scans Lambda layers as well as the function package itself, catching shared vulnerabilities that affect multiple functions.
+        - **Automated triggering:** Inspector rescans functions when they are deployed or updated, and also when new CVEs matching existing packages are published.
+        - **Dependency risk reduction:** Third-party package vulnerabilities in serverless functions are a common attack vector; Inspector surfaces them before they can be exploited.
+
+        **Risk mitigation**
+
+        - **Continuous protection:** Re-scanning on CVE publication ensures that functions deployed months ago are still evaluated against newly disclosed vulnerabilities.
+        - **Prioritized findings:** Inspector's risk scoring surfaces the most exploitable Lambda vulnerabilities first, allowing teams to focus remediation on highest-impact issues.
       audit: |
         ### Audit via Console
 
@@ -23357,14 +23131,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Systems Manager Parameter Store parameters of type SecureString have an explicit KMS key configured for encryption. While SSM SecureString parameters are always encrypted, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
+        This check ensures that AWS Systems Manager Parameter Store parameters of type SecureString are configured with an explicit customer-managed KMS key for encryption. While SSM always encrypts SecureString parameters, using the default AWS-managed key limits visibility and control over the encryption lifecycle.
 
         **Why this matters**
 
-        - **Explicit configuration**: Specifying a KMS key ensures encryption settings are intentional rather than relying on implicit defaults.
-        - **Audit trail**: All KMS key usage is logged in CloudTrail, providing visibility into who accessed encrypted parameters.
-        - **Compliance alignment**: Many regulatory frameworks require explicit encryption key configuration for sensitive data.
-        - **Key rotation**: Explicitly configured keys support automatic rotation, improving security posture.
+        - **Explicit key ownership:** Specifying a customer-managed KMS key makes the encryption configuration intentional and auditable rather than relying on implicit AWS defaults.
+        - **Access audit trail:** KMS key usage events are written to AWS CloudTrail, providing a record of every decryption and who performed it.
+        - **Key lifecycle control:** Organizations can rotate, disable, or schedule deletion of customer-managed keys to enforce access revocation when personnel or applications change.
+        - **Separation of duties:** Customer-managed keys allow key policies to be scoped separately from IAM policies, enabling independent control over who can decrypt parameter values.
+
+        **Risk mitigation**
+
+        - **Revocable access:** Disabling or deleting the KMS key immediately prevents decryption of associated parameters, supporting incident response scenarios.
+        - **Reduced blast radius:** Using distinct keys for different parameter scopes limits the impact of a compromised key to only the parameters encrypted under that key.
       audit: |
         ### Audit via Console
 
@@ -23497,14 +23276,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Database Migration Service (DMS) replication instances are not publicly accessible. Public replication instances expose database migration traffic to the internet, increasing the risk of data interception.
+        This check ensures that AWS Database Migration Service replication instances are not publicly accessible. By default, DMS allows replication instances to be created with a public IP address, but exposing them to the internet is unnecessary and significantly expands the attack surface for a sensitive data migration workload.
 
         **Why this matters**
 
-        - **Data exposure**: DMS replication instances handle sensitive database traffic that should not traverse the public internet.
-        - **Attack surface**: Publicly accessible instances can be targeted by attackers attempting to intercept or manipulate migration data.
-        - **Network security**: Keeping replication instances private ensures all traffic stays within trusted VPC boundaries.
-        - **Compliance alignment**: Data protection regulations often require that database traffic remains within private networks.
+        - **Sensitive data exposure:** DMS replication instances transmit database contents that often include credentials, PII, and business-critical records that should never traverse public networks.
+        - **Attack surface:** Publicly reachable instances can be targeted by automated scanners, brute force attacks, and exploitation of DMS software vulnerabilities without requiring network proximity.
+        - **VPC boundary enforcement:** Keeping replication instances private ensures all migration traffic stays within trusted VPC boundaries and cannot be intercepted on the internet.
+        - **Lateral movement risk:** A compromised public DMS instance can serve as a pivot point to reach source and target database endpoints that are co-located in the same VPC.
+
+        **Risk mitigation**
+
+        - **Private placement:** Deploying replication instances in private subnets with no public IP prevents direct internet connectivity at the network layer.
+        - **Immutable setting:** Public accessibility cannot be changed on an existing instance; creating instances as private from the outset prevents accidental exposure.
       audit: |
         ### Audit via Console
 
@@ -23639,13 +23423,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Database Migration Service (DMS) replication instances have storage encryption enabled using KMS. Encrypting replication instance storage protects data at rest during the migration process.
+        This check ensures that AWS Database Migration Service replication instances have storage encryption enabled using a KMS key. By default, DMS replication instances are not encrypted at rest unless a KMS key is specified at creation time, leaving migration data stored on the instance unprotected.
 
         **Why this matters**
 
-        - **Data protection**: Encrypts the storage used by replication instances to protect sensitive data at rest.
-        - **Compliance alignment**: Regulatory requirements often mandate encryption of data at rest for database workloads.
-        - **Risk mitigation**: Prevents unauthorized access to migration data stored on replication instance volumes.
+        - **Data at rest protection:** Replication instances temporarily store source database records during the migration process; encryption prevents unauthorized access if the underlying storage is compromised.
+        - **Migration data sensitivity:** Data in transit during a migration often includes the entire contents of production databases, making at-rest protection of the replication staging area critical.
+        - **Immutable configuration:** Encryption cannot be enabled on an existing replication instance, so the decision must be made at creation time, making policy enforcement especially important.
+
+        **Risk mitigation**
+
+        - **Storage-level protection:** KMS-encrypted instance storage ensures that data written to disk during replication cannot be read without the corresponding key, even by someone with direct access to the underlying infrastructure.
+        - **Key-controlled access:** Using a customer-managed KMS key allows the encryption key to be rotated or revoked independently of the DMS instance lifecycle.
       audit: |
         ### Audit via Console
 
@@ -23772,14 +23561,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Elastic Disaster Recovery (DRS) source server replication configurations have EBS encryption enabled. Encrypting replicated EBS volumes protects disaster recovery data at rest.
+        This check ensures that AWS Elastic Disaster Recovery source server replication configurations have EBS encryption enabled, so that replicated volumes stored in the staging area are protected at rest. By default, DRS does not require EBS encryption for replicated volumes, and configuring it to `NONE` leaves disaster recovery data unprotected.
 
         **Why this matters**
 
-        - **Data protection**: Ensures replicated volumes in the staging area are encrypted, preventing unauthorized access to DR data.
-        - **Compliance alignment**: Regulatory requirements mandate encryption of data at rest, including disaster recovery copies.
-        - **Consistent encryption**: Maintains encryption parity between source and replicated volumes.
-        - **Risk mitigation**: Protects against data exposure if staging area resources are compromised.
+        - **Staging area protection:** DRS continuously replicates source server data to EBS volumes in the staging area; without encryption, this data is accessible to anyone with access to the underlying storage.
+        - **DR data sensitivity:** Replicated volumes contain complete snapshots of production workloads, including databases and application state that may hold sensitive information.
+        - **Encryption parity:** Encrypting replicated volumes ensures that disaster recovery copies carry the same protection as the source data, avoiding a situation where production data is encrypted but its DR copy is not.
+        - **Compliance consistency:** Many frameworks require encryption of data at rest across all copies, including backup and DR replicas.
+
+        **Risk mitigation**
+
+        - **Volume-level access control:** KMS-encrypted EBS volumes cannot be mounted or read without the corresponding key, protecting DR data even if an AWS account is partially compromised.
+        - **Independent key policy:** A dedicated KMS key for DRS replication allows key access to be scoped and audited separately from production workloads.
       audit: |
         ### Audit via Console
 
@@ -23899,14 +23693,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Timestream for LiveAnalytics databases have an explicit KMS key configured for encryption. While Timestream encrypts data by default, explicitly specifying a KMS key ensures the encryption configuration is intentional and auditable.
+        This check ensures that Amazon Timestream for LiveAnalytics databases are configured with an explicit customer-managed KMS key for encryption. While Timestream encrypts all data at rest by default using an AWS-managed key, explicitly specifying a customer-managed key provides greater control over the encryption lifecycle and audit trail.
 
         **Why this matters**
 
-        - **Explicit configuration**: Specifying a KMS key ensures encryption settings are intentional rather than relying on implicit defaults.
-        - **Audit trail**: KMS key usage is logged in CloudTrail, providing visibility into data access patterns.
-        - **Compliance alignment**: Explicit encryption key configuration may be required by regulatory frameworks for time-series data.
-        - **Key lifecycle management**: Organizations can rotate, disable, or revoke keys as needed.
+        - **Explicit key ownership:** Specifying a customer-managed KMS key makes the encryption configuration intentional and visible in infrastructure-as-code rather than relying on opaque AWS defaults.
+        - **Audit visibility:** All KMS key usage events are recorded in CloudTrail, giving teams a precise record of when time-series data was accessed and by whom.
+        - **Key lifecycle control:** Organizations can rotate, disable, or schedule deletion of keys to enforce access revocation, which is not possible with AWS-managed keys.
+        - **Scope isolation:** Using a dedicated key for Timestream databases limits the blast radius of a key compromise to only those databases.
+
+        **Risk mitigation**
+
+        - **Revocable access:** Disabling the customer-managed KMS key immediately prevents decryption of database data, supporting rapid response to unauthorized access incidents.
+        - **Immutable setting:** The KMS key must be specified at database creation time and cannot be changed afterward, making upfront policy enforcement the only viable control mechanism.
       audit: |
         ### Audit via Console
 
@@ -24036,14 +23835,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Timestream for InfluxDB instances and clusters are not configured with public accessibility. Publicly accessible database instances can be reached from the internet, significantly increasing the attack surface.
+        This check ensures that Amazon Timestream for InfluxDB instances and clusters are not configured with public accessibility. By default, AWS allows InfluxDB instances to be created with a public endpoint, but there is no operational requirement to expose a time-series database directly to the internet.
 
         **Why this matters**
 
-        - **Direct internet exposure**: Publicly accessible instances can be targeted by automated scanners, brute force attacks, and exploitation of known vulnerabilities.
-        - **Data exfiltration risk**: If authentication is weak or credentials are compromised, attackers can access time-series data directly from the internet.
-        - **Compliance violations**: Most security frameworks require databases to be deployed in private subnets without direct internet access.
-        - **Lateral movement**: A compromised public-facing database can serve as a pivot point for accessing other resources in the VPC.
+        - **Direct attack exposure:** Publicly accessible database instances are reachable by automated scanners, brute force tools, and exploit frameworks without any network-level barrier.
+        - **Data exfiltration risk:** If authentication is weak or credentials are compromised, an attacker can query or delete time-series data directly from the public internet.
+        - **Lateral movement:** A compromised public-facing database can serve as a pivot point for reaching other resources co-located in the same VPC.
+        - **Immutable configuration:** Public accessibility is set at instance creation time and cannot be changed after the fact, making prevention at provisioning the only reliable control.
+
+        **Risk mitigation**
+
+        - **Network isolation:** Placing InfluxDB instances in private subnets removes the network path from the public internet, enforcing access only through VPC-internal routes or VPN.
+        - **Defense in depth:** Combining private placement with security group rules and VPC endpoint controls ensures that multiple independent controls must be bypassed for an attacker to reach the database.
       audit: |
         ### Audit via Console
 
@@ -24191,14 +23995,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Timestream for InfluxDB instances and clusters have log delivery enabled to an S3 bucket. Logging provides visibility into database operations, query patterns, and potential security events.
+        This check ensures that Amazon Timestream for InfluxDB instances and clusters have log delivery configured to deliver logs to an S3 bucket. By default, InfluxDB instances do not ship logs anywhere, leaving database operations invisible to security monitoring and incident response tooling.
 
         **Why this matters**
 
-        - **Incident detection**: Without logs, suspicious queries, unauthorized access attempts, and data exfiltration go undetected.
-        - **Forensic capability**: Logs are essential for investigating security incidents, understanding the scope of a breach, and meeting regulatory notification requirements.
-        - **Compliance requirements**: Most security frameworks require audit logging for database services, including access patterns and administrative actions.
-        - **Operational visibility**: Logs help identify performance issues, misconfigurations, and unusual usage patterns that may indicate compromise.
+        - **Incident detection:** Without logs, unauthorized access attempts, suspicious query patterns, and privilege escalation events go undetected until the impact is already significant.
+        - **Forensic capability:** Stored logs are essential for reconstructing the sequence of events during a security investigation and for meeting regulatory notification timelines.
+        - **Operational visibility:** Logs surface performance degradation, configuration errors, and unusual usage patterns that can be early indicators of compromise.
+        - **Compliance evidence:** Many security frameworks require that audit logs for database services be retained and made available for review.
+
+        **Risk mitigation**
+
+        - **Durable log retention:** Delivering logs to S3 provides tamper-resistant, durable storage with configurable retention, preventing logs from being lost when an instance is modified or replaced.
+        - **Centralized monitoring:** S3-based logs can be forwarded to SIEM or log analysis tools, enabling automated alerting on anomalous database behavior.
       audit: |
         ### Audit via Console
 
@@ -24347,14 +24156,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that VPC network ACLs do not contain inbound rules that allow unrestricted access (0.0.0.0/0 or ::/0) to SSH (port 22) or RDP (port 3389). Unrestricted network ACL rules expose management ports to the entire internet.
+        This check ensures that VPC network ACLs do not contain inbound rules that allow unrestricted access from any IP address to SSH (port 22) or RDP (port 3389). Leaving these management ports open to the internet at the network ACL level removes a critical defense-in-depth layer and exposes all subnets associated with the NACL to direct remote access attempts.
 
         **Why this matters**
 
-        - **Attack surface reduction**: Restricting SSH and RDP access at the network ACL level provides defense-in-depth beyond security groups.
-        - **Brute force prevention**: Open management ports are prime targets for automated brute force attacks.
-        - **Compliance alignment**: CIS AWS Foundations Benchmark and other frameworks require restricting management port access.
-        - **Defense in depth**: Network ACLs provide a stateless firewall layer that complements security group rules.
+        - **Management port exposure:** SSH and RDP are high-value targets for automated brute force, credential stuffing, and exploitation of known protocol vulnerabilities.
+        - **Stateless enforcement:** Unlike security groups, network ACLs are stateless and apply at the subnet boundary, providing a network-layer control that operates independently of instance-level configuration.
+        - **Defense in depth:** Blocking management ports at the NACL level ensures that even if a security group is misconfigured to allow broad access, the NACL provides a backstop.
+        - **Scope of impact:** A single permissive NACL rule affects every resource in every associated subnet, amplifying the risk of a single misconfiguration.
+
+        **Risk mitigation**
+
+        - **Source restriction:** Replacing any-source rules with rules that allow only known, trusted CIDR ranges limits SSH and RDP access to authorized network locations.
+        - **Deny at the subnet boundary:** Ensuring NACL rules deny unrestricted management port access means the control is enforced before traffic even reaches individual instance security groups.
       audit: |
         ### Audit via Console
 
@@ -24522,14 +24336,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that the default network ACL in each VPC is configured to deny all inbound and outbound traffic. The default NACL is automatically associated with subnets that are not explicitly associated with a custom NACL, so a permissive default NACL can inadvertently expose resources.
+        This check ensures that the default network ACL in each VPC is configured to deny all inbound and outbound traffic by containing no explicit ALLOW rules. By default, AWS creates the default NACL with rules that allow all traffic in both directions, and any subnet not explicitly associated with a custom NACL automatically falls back to these permissive defaults.
 
         **Why this matters**
 
-        - **Principle of least privilege**: Default deny ensures that only explicitly allowed traffic can flow through the network.
-        - **Misconfiguration prevention**: New subnets without a custom NACL automatically inherit the default NACL rules.
-        - **Defense in depth**: A restrictive default NACL provides a safety net against misconfigured security groups.
-        - **Compliance alignment**: CIS AWS Foundations Benchmark recommends restricting the default NACL.
+        - **Safe fallback posture:** When a new subnet is created without an explicit NACL association, it inherits the default NACL; if that NACL allows all traffic, the subnet has no network-layer protection until a custom NACL is applied.
+        - **Misconfiguration prevention:** Developers provisioning subnets rapidly during incidents or deployments may inadvertently leave subnets exposed by not assigning a custom NACL.
+        - **Principle of least privilege:** A default-deny posture at the network layer ensures that only explicitly permitted traffic flows, reducing the risk of unintended access paths.
+        - **Defense in depth:** A restrictive default NACL provides a safety net that catches security group misconfigurations or forgotten subnet associations.
+
+        **Risk mitigation**
+
+        - **Implicit deny:** Removing all ALLOW rules from the default NACL means any subnet that falls back to it is isolated from all traffic, making exposure from a missing custom NACL immediately visible rather than silently permissive.
+        - **Custom NACL discipline:** Enforcing a restrictive default NACL creates an operational norm where teams must explicitly design and apply network access rules for every subnet, reducing ad hoc permissive configurations.
       audit: |
         ### Audit via Console
 
@@ -24648,14 +24467,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 key pairs use modern key types (ED25519 or RSA). Legacy or unsupported key types may use weaker cryptographic algorithms that are more susceptible to attacks.
+        This check ensures that EC2 key pairs are created using a supported cryptographic key type, specifically ED25519 or RSA. AWS allows importing key pairs with arbitrary public key material, and key pairs that use deprecated or non-standard algorithms provide weaker authentication guarantees for SSH access to EC2 instances.
 
         **Why this matters**
 
-        - **Cryptographic strength**: ED25519 and RSA keys provide strong cryptographic security for SSH authentication.
-        - **Modern standards**: ED25519 offers better performance and security properties than older key types.
-        - **Compliance alignment**: Security frameworks recommend the use of strong cryptographic algorithms for authentication.
-        - **SSH security**: Using modern key types reduces the risk of key compromise through cryptographic attacks.
+        - **Cryptographic strength:** ED25519 and RSA are the two key types AWS validates and supports for EC2 key pairs; other types may rely on algorithms with known weaknesses or reduced key sizes.
+        - **Algorithm currency:** ED25519 uses modern elliptic curve cryptography that is resistant to a broader range of attacks than older DSA or ECDSA variants at equivalent key sizes.
+        - **Authentication assurance:** The strength of the key pair directly determines the difficulty of forging or brute-forcing SSH authentication credentials for EC2 instances.
+
+        **Risk mitigation**
+
+        - **Weak key replacement:** Identifying and replacing key pairs that do not use a supported type removes a potential weak link in SSH access control before it is exploited.
+        - **Standardized provisioning:** Enforcing ED25519 or RSA at key creation time through infrastructure-as-code templates prevents weaker algorithms from entering the environment.
       audit: |
         ### Audit via Console
 
@@ -24785,14 +24608,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon RDS database instances have IAM database authentication enabled. IAM authentication allows managing database access through AWS IAM policies instead of relying solely on database-level passwords.
+        This check ensures that Amazon RDS database instances have IAM database authentication enabled, allowing database access to be managed through AWS IAM policies using short-lived authentication tokens. By default, RDS instances use only native database password authentication, which relies on long-lived static credentials that are harder to rotate and audit.
 
         **Why this matters**
 
-        - **Centralized access control**: IAM authentication integrates database access with AWS identity management, eliminating the need for separate database credentials.
-        - **Temporary credentials**: IAM database authentication uses short-lived authentication tokens rather than long-lived passwords.
-        - **Audit trail**: Authentication attempts are logged in CloudTrail, providing visibility into database access patterns.
-        - **Compliance alignment**: Eliminates shared database passwords and aligns with least-privilege access principles.
+        - **Centralized identity management:** IAM database authentication integrates RDS access with AWS IAM, allowing database permissions to be granted and revoked through the same identity system used for all other AWS resources.
+        - **Short-lived credentials:** Authentication tokens generated by IAM are valid for 15 minutes, eliminating the risk of long-lived static passwords being leaked and reused.
+        - **Audit trail:** IAM authentication attempts are recorded in AWS CloudTrail, providing visibility into who accessed the database and when.
+        - **Eliminated password sprawl:** Removing static database passwords reduces the number of long-lived secrets that must be rotated, stored, and managed securely.
+
+        **Risk mitigation**
+
+        - **Credential revocation:** Revoking IAM permissions immediately prevents new token generation, cutting off database access without requiring a password change and database restart.
+        - **MFA integration:** IAM policies can require MFA for token generation, adding a second factor to database authentication beyond what native password auth supports.
       audit: |
         ### Audit via Console
 
@@ -24924,14 +24752,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that EKS managed node groups have EBS volume encryption enabled by verifying that EBS encryption by default is active in all regions where EKS node groups are deployed. Node group EBS volumes inherit the account-level EBS encryption setting.
+        This check ensures that EKS managed node group EBS volumes are encrypted by verifying that EBS encryption by default is enabled in each region where node groups are deployed. By default, AWS does not enable EBS encryption by default, meaning node group volumes provisioned through auto-scaling are created unencrypted unless explicitly configured otherwise.
 
         **Why this matters**
 
-        - **Data protection**: EKS worker node EBS volumes contain container images, ephemeral storage, and potentially sensitive application data.
-        - **Consistent encryption**: Account-level EBS encryption ensures all new volumes, including those created by auto-scaling, are encrypted.
-        - **Compliance alignment**: Meets requirements for encryption of data at rest on compute resources.
-        - **Defense in depth**: Encrypting node volumes protects data even if physical storage media is compromised.
+        - **Ephemeral data protection:** Node group EBS volumes hold container images, emptyDir volumes, and ephemeral application data that may include sensitive runtime information and secrets passed through environment variables.
+        - **Auto-scaling coverage:** Account-level EBS encryption by default ensures that every volume created by the node auto-scaler is encrypted without requiring launch template changes for each new node group.
+        - **Consistent posture:** Encryption at the account level eliminates the risk that a new node group is created without encryption because a launch template was forgotten or cloned from a non-compliant template.
+        - **Physical media protection:** Encrypted EBS volumes protect data if underlying storage hardware is decommissioned or repurposed without secure erasure.
+
+        **Risk mitigation**
+
+        - **Account-wide enforcement:** Enabling EBS encryption by default at the account and region level applies the control to all future volumes, removing per-resource configuration as a failure mode.
+        - **KMS key scoping:** Specifying a default KMS key for EBS encryption ensures all node volumes use an auditable, customer-controlled key rather than the AWS-managed default.
       audit: |
         ### Audit via Console
 
@@ -25091,14 +24924,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EKS clusters are configured to use API-based IAM authentication mode (API or API_AND_CONFIG_MAP) rather than relying solely on the legacy aws-auth ConfigMap. API-based authentication provides a more robust and auditable authentication mechanism.
+        This check ensures that Amazon EKS clusters are configured to use API-based IAM authentication mode (`API` or `API_AND_CONFIG_MAP`) rather than the legacy `CONFIG_MAP`-only mode. By default, older clusters use only the `aws-auth` ConfigMap for access control, but API-based authentication provides a more auditable and robust mechanism managed through the EKS API.
 
         **Why this matters**
 
-        - **Improved security**: API-based authentication mode uses the EKS API for managing cluster access, providing better auditability through CloudTrail.
-        - **Centralized management**: Access entries can be managed through the EKS API, Terraform, or CloudFormation rather than editing a ConfigMap.
-        - **Reduced risk**: The aws-auth ConfigMap can be accidentally deleted or misconfigured, potentially locking out cluster administrators.
-        - **Compliance alignment**: API-based authentication provides better audit trails for access management.
+        - **Auditability:** API-based authentication routes all access-entry changes through the EKS API and CloudTrail, creating a complete audit trail that the ConfigMap approach lacks.
+        - **Resilience:** The `aws-auth` ConfigMap can be accidentally deleted or corrupted, potentially locking administrators out of the cluster entirely.
+        - **Declarative management:** Access entries managed through the EKS API integrate naturally with Terraform and CloudFormation, reducing the risk of configuration drift.
+        - **Reduced attack surface:** Eliminating direct ConfigMap edits removes a common vector for privilege escalation by anyone with `kubectl` write access to `kube-system`.
+
+        **Risk mitigation**
+
+        - **Accidental lockout prevention:** API-managed access entries cannot be wiped by a single `kubectl delete configmap` command.
+        - **Centralized access control:** All IAM-to-Kubernetes principal mappings are managed in one authoritative place, making unauthorized changes easier to detect.
       audit: |
         ### Audit via Console
 
@@ -25230,14 +25068,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that all EKS cluster add-ons are in an ACTIVE status. Degraded add-ons directly undermine cluster security controls: a degraded VPC CNI plugin can break network policy enforcement, enabling lateral movement between pods. A degraded kube-proxy can bypass network policies entirely, and unhealthy CoreDNS can disrupt DNS-based security controls.
+        This check ensures that all add-ons installed on an Amazon EKS cluster report an `ACTIVE` status. By default, add-ons are deployed by AWS and should remain healthy, but upgrades, configuration errors, or resource constraints can leave them in a degraded state that silently undermines cluster security controls.
 
         **Why this matters**
 
-        - **Network policy bypass:** A degraded VPC CNI plugin can fail to enforce network policies, allowing pods to communicate freely and enabling lateral movement from a compromised container to other workloads in the cluster.
-        - **kube-proxy security bypass:** A failed or degraded kube-proxy can cause network policy enforcement to stop functioning, removing pod-level network segmentation that prevents attackers from reaching sensitive services.
-        - **Security patch gaps:** Unhealthy add-ons may be running outdated versions with known vulnerabilities that attackers can exploit for container escape or privilege escalation.
-        - **DNS manipulation risk:** Degraded CoreDNS can fail to resolve security-critical endpoints such as OIDC providers or admission webhook services, bypassing authentication and admission controls.
+        - **Network policy enforcement:** A degraded VPC CNI plugin may fail to program pod-level network policies, allowing pods to communicate freely and enabling lateral movement from a compromised workload.
+        - **kube-proxy availability:** A failed kube-proxy prevents iptables rules from being updated, which can remove pod-to-pod network segmentation and expose sensitive services to unintended callers.
+        - **Security patch currency:** Unhealthy add-ons may be running outdated versions with known vulnerabilities that attackers can exploit for container escape or privilege escalation.
+        - **Admission control stability:** Degraded CoreDNS can prevent admission webhooks and OIDC providers from resolving, disabling authentication and policy enforcement for new workloads.
+
+        **Risk mitigation**
+
+        - **Early degradation detection:** Monitoring add-on status surfaces problems before they affect workload security or availability.
+        - **Patch gap elimination:** Actively managing add-on health ensures security-relevant components stay on current, patched versions.
       audit: |
         ### Audit via Console
 
@@ -25350,14 +25193,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS clusters have Container Insights enabled. Without Container Insights, attacks against containerized workloads are invisible to security monitoring because there is no container-level metrics collection to detect anomalous behavior. These attacks include cryptomining, data exfiltration via abnormal egress traffic, and unauthorized container execution.
+        This check ensures that Amazon ECS clusters have Container Insights enabled to collect container-level metrics and logs. Container Insights is disabled by default on ECS clusters, which means security events at the task and container level go undetected.
 
         **Why this matters**
 
-        - **Cryptomining detection:** Cryptomining in compromised containers produces distinctive CPU usage patterns that Container Insights can detect. Without these metrics, cryptomining can run undetected, consuming resources and indicating a broader compromise.
-        - **Data exfiltration detection:** Abnormal network egress patterns from containers such as large data transfers to unexpected destinations are only visible through Container Insights metrics, which provide task-level network monitoring.
-        - **Unauthorized container activity:** Container Insights reveals unexpected container launches, resource consumption spikes, and task-level anomalies that indicate an attacker has deployed malicious containers or compromised existing ones.
-        - **Incident response capability:** Without container-level metrics, security teams cannot determine which specific tasks or containers were involved in a breach, significantly slowing incident response and scope assessment.
+        - **Threat detection:** Cryptomining and other compute-intensive attacks produce distinctive CPU and memory usage patterns that Container Insights can surface; without it, malicious container activity is invisible to security monitoring.
+        - **Data exfiltration visibility:** Abnormal network egress from individual tasks is only visible at the container level, which requires Container Insights metrics to detect large or unexpected outbound transfers.
+        - **Incident scoping:** When a breach occurs, Container Insights records which tasks were running, their resource usage, and their timing, giving responders the evidence needed to scope the incident accurately.
+        - **Unauthorized container detection:** Unexpected task launches, resource spikes, and scheduling anomalies visible in Container Insights can indicate an attacker has deployed malicious containers or compromised existing workloads.
+
+        **Risk mitigation**
+
+        - **Reduced attacker dwell time:** Container-level visibility accelerates detection and reduces the window attackers have to persist in the environment.
+        - **Faster response:** Granular task metrics let responders pinpoint the affected containers immediately rather than searching through host-level logs.
       audit: |
         ### Audit via Console
 
@@ -25500,14 +25348,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECS clusters have a KMS key configured for encrypting Fargate ephemeral storage. Fargate tasks use ephemeral storage for scratch space, and encrypting this storage with a customer-managed KMS key provides additional data protection.
+        This check ensures that Amazon ECS clusters have a KMS customer managed key configured for encrypting Fargate ephemeral storage. By default, Fargate tasks receive ephemeral storage without customer-controlled encryption, meaning scratch data written during task execution is protected only by AWS-managed keys.
 
         **Why this matters**
 
-        - **Data protection**: Ephemeral storage may contain sensitive data processed by containers during task execution.
-        - **Enhanced control**: Customer-managed KMS keys allow organizations to manage the encryption key lifecycle.
-        - **Compliance alignment**: Encryption of all storage volumes, including ephemeral storage, is required by many regulatory frameworks.
-        - **Audit trail**: KMS key usage is logged in CloudTrail for auditing purposes.
+        - **Sensitive data at rest:** Fargate ephemeral storage may contain decrypted secrets, intermediate processing results, or customer data written to disk during task execution.
+        - **Key ownership:** AWS-managed encryption keys cannot be audited, rotated on demand, or revoked by the customer, whereas a customer managed KMS key provides full lifecycle control.
+        - **Access auditing:** All encrypt and decrypt operations against a customer managed KMS key are logged in CloudTrail, providing an audit trail that AWS-managed keys do not offer.
+        - **Breach containment:** If a KMS key is believed to be compromised, the customer can disable or schedule its deletion to prevent further decryption of stored data.
+
+        **Risk mitigation**
+
+        - **Data exposure prevention:** Encrypting ephemeral storage with a CMK ensures that even if underlying storage is accessed outside the task lifecycle, the data remains protected.
+        - **Regulatory compliance:** Many data-protection frameworks require customer-controlled encryption for all storage that may hold regulated data.
       audit: |
         ### Audit via Console
 
@@ -25648,14 +25501,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Certificate Manager (ACM) certificates use strong key algorithms. Certificates should use RSA-2048 or higher, or ECDSA key algorithms to provide adequate cryptographic strength.
+        This check ensures that AWS Certificate Manager certificates use RSA-2048 or higher, or an ECDSA key algorithm (P-256, P-384, or P-521). Certificates using RSA-1024 rely on a key size that has been considered cryptographically weak for over a decade and should be replaced with stronger algorithms.
 
         **Why this matters**
 
-        - **Cryptographic strength**: RSA keys below 2048 bits are considered weak and may be vulnerable to cryptographic attacks.
-        - **Modern standards**: ECDSA keys (P-256, P-384, P-521) offer equivalent security to much larger RSA keys with better performance.
-        - **Compliance alignment**: PCI DSS, NIST, and other frameworks require minimum key sizes for TLS certificates.
-        - **Future-proofing**: Stronger key algorithms provide better protection against advances in computing power.
+        - **Cryptographic strength:** RSA-1024 keys can be factored with state-level computing resources, making TLS connections protected by such certificates vulnerable to passive decryption.
+        - **ECDSA efficiency:** ECDSA keys at 256 bits provide security equivalent to RSA-3072 while offering significantly lower CPU overhead during TLS handshakes, benefiting both security and performance.
+        - **Browser and client rejection:** Modern browsers and TLS clients increasingly reject certificates with weak key algorithms, potentially causing service disruptions for users.
+        - **Standards alignment:** NIST, PCI DSS, and most major security frameworks have formally deprecated RSA-1024 and require minimum 2048-bit RSA or equivalent ECDSA strength.
+
+        **Risk mitigation**
+
+        - **Traffic protection:** Strong key algorithms ensure that TLS sessions cannot be decrypted retroactively even if an attacker records encrypted traffic today.
+        - **Future-proofing:** Migrating to ECDSA or RSA-2048+ now reduces the operational burden when cryptographic deprecation timelines accelerate.
       audit: |
         ### Audit via Console
 
@@ -25796,22 +25654,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Lambda functions with environment variables are configured with a KMS customer managed key (CMK) to encrypt those variables at rest. By default, Lambda encrypts environment variables with an AWS-managed key, but using a CMK provides centralized key management, audit logging, and fine-grained access control.
+        This check ensures that AWS Lambda functions that define environment variables are configured with a customer managed KMS key to encrypt those variables at rest. By default, Lambda encrypts environment variables with an AWS-managed key, which provides no customer visibility, audit logging, or access control over the encryption operation.
 
         **Why this matters**
 
-        Lambda environment variables frequently contain sensitive data such as API keys, database credentials, and service tokens. Without a customer managed KMS key:
-
-        - Environment variables are encrypted with an AWS-managed key that cannot be audited or rotated by the customer.
-        - Any principal with `lambda:GetFunctionConfiguration` permission can view decrypted environment variable values.
-        - There is no centralized key management or access control for encryption keys.
-        - Compliance frameworks such as PCI DSS, HIPAA, and CIS AWS Foundations Benchmark recommend customer managed encryption keys for sensitive data.
+        - **Secrets protection:** Lambda environment variables commonly store API keys, database credentials, and service tokens; without a customer managed key, these secrets are protected only by the AWS service boundary with no independent audit trail.
+        - **Access audit:** All encrypt and decrypt calls against a customer managed KMS key are logged in CloudTrail, allowing security teams to detect anomalous access to sensitive configuration values.
+        - **Fine-grained access control:** KMS key policies let you restrict which IAM principals can decrypt environment variables, adding a layer of control beyond the Lambda function's execution role.
+        - **Key revocation:** If credentials stored in environment variables are believed to be compromised, the associated KMS key can be disabled immediately to prevent further decryption.
 
         **Risk mitigation**
 
-        - Prevents unauthorized access to sensitive environment variable values.
-        - Enables audit logging of encryption key usage through AWS CloudTrail.
-        - Provides fine-grained access control over who can decrypt environment variables.
+        - **Credential exposure reduction:** A customer managed key ensures that even principals with `lambda:GetFunctionConfiguration` cannot read environment variable values without KMS decrypt permission.
+        - **Compliance enablement:** Binding a CMK to Lambda functions satisfies encryption-at-rest requirements that mandate customer-controlled key management for sensitive configuration data.
       audit: |
         ### Audit via Console
 
@@ -25965,22 +25820,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Lambda functions have code signing configured to verify that only trusted code packages are deployed. Code signing uses AWS Signer to validate deployment packages against a set of allowed signing profiles, preventing unauthorized or tampered code from being deployed.
+        This check ensures that AWS Lambda functions are configured with a code signing configuration that verifies deployment packages against a set of trusted AWS Signer signing profiles. By default, Lambda accepts any deployment package regardless of its origin or integrity, leaving functions open to unauthorized code deployment.
 
         **Why this matters**
 
-        Without code signing, Lambda functions can accept any deployment package regardless of its origin or integrity:
-
-        - Malicious actors with deployment permissions could deploy tampered or backdoored code.
-        - Supply chain attacks can inject unauthorized code into the deployment pipeline.
-        - There is no cryptographic verification that the deployed code matches what was built and approved.
-        - Compliance frameworks increasingly require code integrity verification as part of secure software supply chain practices.
+        - **Supply chain integrity:** Code signing provides cryptographic verification that the deployed package was built from approved source code and has not been tampered with during the CI/CD pipeline or at rest in S3.
+        - **Insider threat mitigation:** Requiring a valid signature prevents authorized deployers from pushing modified or backdoored code that bypasses normal review processes.
+        - **Deployment pipeline enforcement:** The signing policy can be set to `Enforce`, which blocks deployments with invalid or absent signatures at the Lambda service level rather than relying solely on pipeline controls.
+        - **Tamper detection:** Any modification to a deployment package after signing invalidates the signature, making post-build tampering detectable before the code executes.
 
         **Risk mitigation**
 
-        - Prevents deployment of unauthorized or tampered Lambda function code.
-        - Provides cryptographic verification of code package integrity.
-        - Establishes a chain of trust from code build to deployment.
+        - **Unauthorized code prevention:** Only packages signed by approved signing profiles can be deployed, blocking attackers who compromise deployment credentials from running arbitrary code.
+        - **Chain of trust:** Signing establishes an auditable chain from source build to running function, supporting forensic investigation if malicious code is discovered.
       audit: |
         ### Audit via Console
 
@@ -26149,22 +26001,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker notebook instances are configured to require Instance Metadata Service Version 2 (IMDSv2). IMDSv1 is vulnerable to Server-Side Request Forgery (SSRF) attacks that can expose instance credentials and metadata to attackers.
+        This check ensures that Amazon SageMaker notebook instances are configured to require Instance Metadata Service Version 2 (IMDSv2). IMDSv1 responds to unauthenticated HTTP GET requests, making it trivially exploitable through Server-Side Request Forgery vulnerabilities present in notebook code or dependencies.
 
         **Why this matters**
 
-        SageMaker notebook instances, like EC2 instances, use the Instance Metadata Service (IMDS) to access instance credentials and configuration. IMDSv1 allows simple unauthenticated HTTP GET requests, making it a known target for SSRF attacks:
-
-        - SSRF vulnerabilities in notebook code or dependencies can be exploited to steal IAM role credentials from the metadata endpoint.
-        - IMDSv1 does not require session tokens, making credential theft trivially easy for attackers.
-        - The Capital One breach in 2019 demonstrated the real-world impact of IMDSv1 exploitation.
-        - CIS AWS Foundations Benchmark and NIST recommend enforcing IMDSv2 for all compute instances.
+        - **SSRF credential theft:** IMDSv1 can be queried with a single HTTP GET, meaning any SSRF vulnerability in a notebook or its libraries can be exploited to retrieve the instance's IAM role credentials without additional effort.
+        - **Session token requirement:** IMDSv2 requires a PUT request to obtain a session token before metadata can be accessed, a step that most SSRF attack vectors cannot complete.
+        - **IAM role exposure:** Notebook instances typically have elevated IAM roles with access to S3, training data, and other ML resources; stolen credentials enable lateral movement across the AWS environment.
+        - **Defense in depth:** Enforcing IMDSv2 at the instance level protects against credential theft even when network-level controls or library-level input validation are imperfect.
 
         **Risk mitigation**
 
-        - Prevents credential theft through SSRF attacks by requiring session-based authentication.
-        - Enforces PUT-based token requests that are blocked by most SSRF attack vectors.
-        - Aligns with security best practices for instance metadata access.
+        - **SSRF attack blocking:** The PUT-based token requirement in IMDSv2 is incompatible with most SSRF attack patterns, neutralizing this class of credential-theft attack.
+        - **Blast radius reduction:** Even if a notebook is compromised, the attacker cannot easily escalate to the underlying IAM role without IMDSv1 access.
       audit: |
         ### Audit via Console
 
@@ -26307,22 +26156,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker notebook instances have root access disabled. When root access is enabled, users within the notebook instance have full administrator privileges, which violates the principle of least privilege and increases the risk of privilege escalation.
+        This check ensures that Amazon SageMaker notebook instances are configured with root access disabled. By default, SageMaker creates notebook instances with root access enabled, granting users full administrator privileges within the notebook environment and violating the principle of least privilege.
 
         **Why this matters**
 
-        SageMaker notebook instances with root access enabled pose several security risks:
-
-        - Users can install arbitrary software packages, potentially introducing vulnerabilities.
-        - Root access enables modification of system-level configurations that could weaken security controls.
-        - Container escape vulnerabilities are more impactful when the process runs as root.
-        - Compliance frameworks such as CIS, NIST, and PCI DSS require enforcing least privilege access.
+        - **Arbitrary software installation:** Root access allows notebook users to install any software package, potentially introducing malware, vulnerable libraries, or tools that facilitate privilege escalation or data exfiltration.
+        - **System configuration modification:** A root user can alter security-relevant configurations inside the notebook instance, such as disabling logging agents, modifying network settings, or tampering with credential files.
+        - **Container escape amplification:** Kernel and container escape vulnerabilities have a far greater impact when the process running inside the container is root, as successful escapes immediately yield host-level access.
+        - **Compliance enforcement:** Frameworks such as CIS, NIST 800-53, and PCI DSS require least-privilege access to all compute environments, and root access directly contradicts this requirement.
 
         **Risk mitigation**
 
-        - Enforces the principle of least privilege by restricting administrator access.
-        - Reduces the attack surface by preventing installation of unauthorized packages.
-        - Limits the impact of potential container escape or code execution vulnerabilities.
+        - **Privilege containment:** Disabling root access limits the actions a compromised or malicious notebook user can take inside the instance.
+        - **Reduced attack surface:** Without root, attackers cannot install persistence mechanisms or modify system-level controls that would survive a notebook restart.
       audit: |
         ### Audit via Console
 
@@ -26464,22 +26310,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon S3 buckets are configured to use AWS KMS customer managed keys (CMKs) for server-side encryption rather than the default AES-256 (SSE-S3) encryption. While SSE-S3 provides encryption, KMS CMKs offer additional security benefits including key rotation control, access auditing, and fine-grained permissions.
+        This check ensures that Amazon S3 buckets use AWS KMS customer managed keys for server-side encryption rather than the default SSE-S3 (AES-256) encryption. While SSE-S3 encrypts data at rest, it uses AWS-managed keys with no customer visibility into key usage, no audit trail in CloudTrail, and no ability to enforce access control at the key level.
 
         **Why this matters**
 
-        S3 buckets encrypted with AES-256 (SSE-S3) use AWS-managed keys that provide limited visibility and control:
-
-        - No audit trail for encryption key usage (KMS keys log all usage to CloudTrail).
-        - No ability to manage key rotation policies (KMS supports automatic annual rotation).
-        - No fine-grained access control over encryption keys (KMS key policies control who can encrypt/decrypt).
-        - Compliance frameworks such as PCI DSS, HIPAA, and FedRAMP often require customer managed encryption keys for sensitive data.
+        - **Audit trail:** Every encrypt and decrypt operation against a KMS CMK is recorded in CloudTrail, enabling detection of unauthorized or anomalous access to bucket data that SSE-S3 cannot provide.
+        - **Access control enforcement:** KMS key policies allow organizations to restrict which IAM principals can decrypt bucket contents, adding a cryptographic layer of access control independent of S3 bucket policies.
+        - **Key rotation control:** Customer managed KMS keys support configurable automatic rotation, allowing organizations to meet specific key lifecycle requirements that AWS-managed SSE-S3 keys do not expose.
+        - **Breach response:** A CMK can be disabled or scheduled for deletion to prevent further decryption of bucket contents if a data breach is suspected.
 
         **Risk mitigation**
 
-        - Provides centralized key management with full audit logging through CloudTrail.
-        - Enables custom key rotation policies to meet compliance requirements.
-        - Allows fine-grained access control through KMS key policies and grants.
+        - **Unauthorized decryption prevention:** Even an IAM principal with `s3:GetObject` cannot decrypt data without also having KMS `kms:Decrypt` permission on the CMK, reducing insider threat exposure.
+        - **Compliance coverage:** Customer-controlled encryption keys satisfy data-protection requirements under frameworks that mandate organizational control over encryption key management.
       audit: |
         ### Audit via Console
 
@@ -26648,22 +26491,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS CodeBuild projects are configured with a KMS customer managed key (CMK) for encrypting build artifacts. By default, CodeBuild uses an AWS-managed key for artifact encryption, but a customer managed key provides audit logging, key rotation control, and fine-grained access permissions.
+        This check ensures that AWS CodeBuild projects are configured with a customer managed KMS key for encrypting build artifacts. By default, CodeBuild uses an AWS-managed key, which provides no audit logging for key usage, no ability to customize rotation policy, and no fine-grained access control over who can decrypt build artifacts.
 
         **Why this matters**
 
-        CodeBuild artifacts may contain compiled binaries, deployment packages, test results, and other sensitive data. Without a customer managed KMS key:
-
-        - There is no audit trail for encryption key usage in CloudTrail.
-        - Key rotation cannot be customized to meet organizational or compliance requirements.
-        - Access to decrypt build artifacts cannot be controlled through KMS key policies.
-        - Compliance frameworks such as PCI DSS and HIPAA require customer managed encryption keys for sensitive data.
+        - **Build artifact sensitivity:** CodeBuild artifacts may contain compiled binaries, deployment packages, and test credentials that represent privileged access to production systems.
+        - **Audit logging:** Encrypt and decrypt operations against a customer managed KMS key are recorded in CloudTrail, creating an audit trail for every access to build artifacts that the AWS-managed key does not provide.
+        - **Access control:** KMS key policies allow organizations to restrict which principals can decrypt build artifacts, preventing unauthorized use even if an S3 bucket policy is misconfigured.
+        - **Supply chain protection:** Controlling decryption access to build artifacts reduces the risk that an attacker who gains S3 read access can extract and analyze deployment packages.
 
         **Risk mitigation**
 
-        - Provides centralized key management with full audit logging for build artifact encryption.
-        - Enables custom key rotation policies for compliance requirements.
-        - Allows fine-grained access control over who can decrypt build artifacts.
+        - **Key-level access restriction:** Binding a CMK to CodeBuild ensures that decrypting artifacts requires both S3 access and explicit KMS key permission, enforcing defense in depth.
+        - **Incident response capability:** A CMK can be disabled immediately to block further access to artifacts if a breach of the build pipeline is suspected.
       audit: |
         ### Audit via Console
 
@@ -26822,22 +26662,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Neptune DB cluster snapshots are encrypted at rest. While the existing cluster encryption check verifies that Neptune clusters themselves are encrypted, snapshots can be shared across accounts, making their encryption status independently important.
+        This check ensures that Amazon Neptune DB cluster snapshots have storage encryption enabled. Snapshots can be shared across AWS accounts or inadvertently made public, so their encryption status matters independently of the source cluster's encryption setting.
 
         **Why this matters**
 
-        Neptune DB cluster snapshots contain a complete copy of the graph database at a point in time. Unencrypted snapshots pose several risks:
-
-        - Snapshots shared with other AWS accounts expose unencrypted data to those accounts.
-        - If a snapshot is made public (accidentally or intentionally), all graph data is exposed in plaintext.
-        - Backup copies of sensitive graph data should maintain the same encryption standards as the source cluster.
-        - Compliance frameworks require encryption at rest for all copies and backups of sensitive data.
+        - **Cross-account sharing risk:** Snapshots shared with another AWS account expose their contents to that account's principals; unencrypted snapshots make this data available in plaintext without any additional access control.
+        - **Accidental public exposure:** An unencrypted snapshot that is mistakenly made public exposes the complete graph database contents to anyone with internet access.
+        - **Backup data parity:** Regulatory and compliance frameworks require that backup copies maintain the same encryption posture as the source data, which makes snapshot encryption independently verifiable.
+        - **Data exfiltration via snapshots:** Attackers with limited permissions may be able to copy a snapshot to an account they control; encryption ensures the copy is useless without the associated KMS key.
 
         **Risk mitigation**
 
-        - Ensures all snapshots maintain encryption at rest, protecting data in backup copies.
-        - Prevents accidental exposure of plaintext data when snapshots are shared.
-        - Maintains compliance with data protection requirements across all copies of data.
+        - **Data-at-rest protection:** Encrypted snapshots ensure that graph data remains protected even if the snapshot is accessed outside the intended AWS account boundary.
+        - **Compliance audit simplification:** Consistent encryption across the cluster and all its snapshots provides a clean audit result without requiring case-by-case snapshot reviews.
       audit: |
         ### Audit via Console
 
@@ -26990,22 +26827,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 instances have the source/destination check enabled. When this check is disabled, an instance can route network traffic that is not specifically destined for or originating from the instance, effectively allowing it to act as a network bridge, NAT gateway, or router.
+        This check ensures that the source/destination check is enabled on EC2 instances. By default this check is enabled; disabling it allows an instance to receive and forward network traffic not addressed to it, which is only required for instances intentionally operating as NAT gateways, VPN appliances, or network bridges.
 
         **Why this matters**
 
-        Disabling source/destination checks on EC2 instances introduces network security risks:
-
-        - An instance with this check disabled can forward traffic between subnets, potentially bypassing security group rules and network ACLs.
-        - Compromised instances with disabled source/dest checks can be used to intercept or redirect network traffic (man-in-the-middle attacks).
-        - It can mask the true source of malicious traffic by allowing an instance to send packets with spoofed source IP addresses.
-        - Source/destination checks should only be disabled on instances intentionally functioning as NAT gateways, VPN appliances, or load balancers.
+        - **Traffic interception:** An instance with the check disabled can receive packets destined for other hosts, enabling a compromised instance to act as a man-in-the-middle and inspect or modify traffic within the VPC.
+        - **Security group bypass:** Routing traffic through an instance with the check disabled can allow that traffic to bypass security group rules applied to the actual destination, circumventing network access controls.
+        - **IP spoofing enablement:** With the check disabled, an instance can send packets with a source IP address that does not belong to it, masking the origin of malicious traffic within the VPC.
+        - **Lateral movement facilitation:** A compromised instance acting as a network bridge can reach subnets and resources that would otherwise be inaccessible based on the instance's own security group rules.
 
         **Risk mitigation**
 
-        - Prevents instances from being used as unauthorized network bridges or traffic interceptors.
-        - Maintains the integrity of VPC routing by ensuring instances only process their own traffic.
-        - Reduces the risk of network-based attacks from compromised instances.
+        - **Network integrity enforcement:** Keeping the check enabled ensures each instance processes only its own traffic, preserving the routing assumptions on which VPC security group rules are built.
+        - **Compromise isolation:** If an instance is compromised, the source/destination check limits the attacker's ability to pivot to other network segments by restricting what traffic the instance can handle.
       audit: |
         ### Audit via Console
 
@@ -32805,17 +32639,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that security groups associated with Amazon WorkSpaces do not contain inbound rules allowing unrestricted access from `0.0.0.0/0` or `::/0`. Overly permissive security groups expose WorkSpaces to the entire internet, creating a direct attack path to corporate desktops.
+        This check ensures that security groups associated with Amazon WorkSpaces do not contain inbound rules that permit traffic from all IPv4 (`0.0.0.0/0`) or all IPv6 (`::/0`) sources. WorkSpaces are full Windows or Linux desktop environments with access to corporate applications, documents, and internal networks, making unrestricted inbound access a direct exposure of the corporate desktop fleet to the internet.
 
         **Why this matters**
 
-        - **Direct desktop exposure**: WorkSpaces are full desktop environments with access to corporate applications, documents, and internal networks. Unrestricted inbound access allows anyone on the internet to attempt connections.
-        - **Credential attacks**: Open inbound ports enable brute force and credential stuffing attacks against RDP, PCoIP, or WSP protocols used by WorkSpaces.
-        - **Lateral movement**: A compromised WorkSpace with broad network access can serve as a pivot point into the corporate network, reaching internal resources that are not directly internet-facing.
-        - **Data exfiltration**: Attackers who gain access to a WorkSpace can access any data or applications available to the workspace user.
-        - **Compliance requirements**: Security frameworks require network access to be restricted to the minimum necessary, and unrestricted inbound rules violate this principle.
+        - **Direct desktop exposure:** Unrestricted inbound rules allow any internet host to attempt connections to WorkSpaces desktops, enabling brute-force and credential-stuffing attacks against RDP, PCoIP, or WSP protocols.
+        - **Lateral movement risk:** A compromised WorkSpace typically has access to internal resources and corporate identity systems; an attacker who gains access can pivot freely across the internal network.
+        - **Data exfiltration surface:** WorkSpaces users often have access to sensitive documents and applications; an attacker on a compromised desktop can exfiltrate data that is not directly internet-accessible.
+        - **Protocol vulnerability exposure:** Open inbound rules leave WorkSpaces exposed to zero-day vulnerabilities in the remote desktop protocols without any network-layer filtering to reduce the attacker pool.
 
-        Restrict security group inbound rules to specific CIDR ranges such as corporate office IPs, VPN endpoints, or known management networks.
+        **Risk mitigation**
+
+        - **Attack surface reduction:** Restricting inbound rules to known CIDR ranges such as corporate office IPs or VPN endpoints eliminates opportunistic internet-sourced attacks against the desktop fleet.
+        - **Breach containment:** Network-level restrictions limit the source of connections to trusted ranges, making it significantly harder for external attackers to establish an initial foothold on a WorkSpace.
       audit: |
         ### Audit via Console
 
@@ -33797,22 +33633,18 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon Redshift clusters are configured to use the `Current` maintenance track rather than the `Trailing` track. The maintenance track determines which cluster version is applied during maintenance windows and directly affects the security posture of the cluster.
+        This check ensures that Amazon Redshift clusters are configured to use the `Current` maintenance track rather than the `Trailing` track. The `Trailing` track intentionally runs clusters on the cluster version that preceded the most recent update, meaning those clusters are always at least one patch release behind and may be missing critical security fixes.
 
         **Why this matters**
 
-        Amazon Redshift offers two maintenance tracks:
-
-        - **Current**: Applies the latest approved cluster version, including the most recent security patches, bug fixes, and feature updates.
-        - **Trailing**: Applies the cluster version that was current before the most recent update, meaning the cluster runs on an older version that may be missing critical security patches.
-
-        Clusters on the `Trailing` maintenance track are intentionally running behind on security updates. While this may provide additional testing time for application compatibility, it increases the window of exposure to known vulnerabilities that have already been patched in the `Current` track.
+        - **Security patch currency:** The `Current` track applies the latest approved Redshift version during each maintenance window, while the `Trailing` track defers those patches by one release cycle, extending the exposure window for known vulnerabilities.
+        - **Exploit window:** Attackers actively scan for unpatched database versions; clusters on the `Trailing` track are identifiably behind and may be targeted for vulnerabilities already fixed in the `Current` track.
+        - **Operational simplicity:** Running on the `Current` track avoids accumulating a backlog of deferred patches that eventually must be applied all at once, which carries greater compatibility and operational risk than incremental updates.
 
         **Risk mitigation**
 
-        - **Timely Patching:** Ensures clusters receive security patches as soon as they are available.
-        - **Reduced Vulnerability Window:** Minimizes the time clusters are exposed to known security issues.
-        - **Compliance:** Meets patch management requirements under frameworks such as NIST 800-53 (SI-2), ISO 27001, and SOC 2.
+        - **Timely patching:** Switching to the `Current` track ensures clusters receive security patches as soon as AWS certifies them for production use.
+        - **Reduced exposure window:** Eliminating the deliberate one-version lag minimizes the time window during which a known, patchable vulnerability is present in the cluster.
       audit: |
         ### Audit via Console
 
@@ -36713,23 +36545,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker models have network isolation enabled. When network isolation is enabled, the container cannot make any outbound network calls, even to other AWS services. This prevents potential data exfiltration from ML models.
+        This check ensures that Amazon SageMaker models have network isolation enabled, which prevents model containers from making any outbound network connections including calls to other AWS services. Without network isolation, model inference containers have unrestricted outbound access that could be exploited to exfiltrate training data, model artifacts, or inference inputs.
 
         **Why this matters**
 
-        Without network isolation, SageMaker model containers have outbound network access, which could be exploited to:
-
-        - Exfiltrate sensitive training data or model artifacts to external endpoints.
-        - Communicate with unauthorized services or command-and-control infrastructure.
-        - Access unintended AWS resources beyond what the execution role permits at the network level.
-
-        Enabling network isolation ensures that model containers operate in a fully sandboxed environment where no outbound network traffic is permitted.
+        - **Data exfiltration prevention:** A model container with outbound network access can send inference inputs, model weights, or processed data to external endpoints; network isolation removes this capability entirely.
+        - **Command-and-control blocking:** Compromised or maliciously crafted model containers may attempt to beacon to attacker-controlled infrastructure; network isolation prevents this at the network level regardless of the container's behavior.
+        - **Defense in depth:** Network isolation enforces a hard network boundary that operates independently of IAM policies, ensuring that even an overly permissive execution role cannot be abused for network-level data access.
+        - **Regulatory alignment:** Data privacy frameworks increasingly require that ML inference environments be isolated from external networks when processing regulated or sensitive data.
 
         **Risk mitigation**
 
-        - Prevents data exfiltration from ML model containers.
-        - Reduces the blast radius if a model container is compromised.
-        - Supports defense-in-depth by enforcing network-level restrictions alongside IAM policies.
+        - **Container compromise containment:** If a model container is exploited, network isolation prevents the attacker from using it as an outbound channel to exfiltrate data or reach external infrastructure.
+        - **Blast radius reduction:** Isolating model containers from the network limits the potential impact of supply chain attacks embedded in model artifacts or inference code.
       audit: |
         ### Audit via Console
 
@@ -36875,23 +36703,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker models are deployed within a VPC. Deploying models in a VPC allows you to control network traffic using security groups and network ACLs, and ensures that data does not traverse the public internet.
+        This check ensures that Amazon SageMaker models are deployed within a VPC. By default, SageMaker model containers communicate over the public internet unless a VPC is explicitly configured, which removes network-level control over who can reach the endpoint.
 
         **Why this matters**
 
-        Without VPC configuration, SageMaker model containers communicate over the public internet, which increases exposure to:
-
-        - Man-in-the-middle attacks during data transfer.
-        - Unauthorized network access to model endpoints.
-        - Inability to apply network-level access controls such as security groups and NACLs.
-
-        Deploying models within a VPC provides network-level isolation and enables you to restrict access to model containers using standard AWS networking controls.
+        - **Network isolation:** Deploying inside a VPC lets security groups and network ACLs restrict which resources can reach the model container.
+        - **Private connectivity:** Traffic between the model container and AWS services such as S3 or ECR stays on the AWS private network rather than traversing the internet.
+        - **Blast radius containment:** If a container is compromised, VPC boundaries limit how far an attacker can move laterally.
+        - **Compliance alignment:** Many frameworks require that production workloads handling sensitive data operate within controlled network segments.
 
         **Risk mitigation**
 
-        - Restricts network access to model containers using security groups and NACLs.
-        - Keeps data transfer within the AWS private network.
-        - Enables integration with VPC endpoints for secure access to AWS services.
+        - **Controlled ingress and egress:** Security groups attached to the VPC enforce fine-grained rules on which traffic reaches the container.
+        - **Reduced public exposure:** Removing the public-internet path eliminates a whole class of network-based attack vectors against inference endpoints.
+        - **Auditability:** VPC flow logs provide visibility into all network traffic to and from model containers.
       audit: |
         ### Audit via Console
 
@@ -37032,23 +36857,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker training jobs have network isolation enabled. When network isolation is enabled, training containers cannot make outbound network calls, preventing potential data exfiltration of training data and model artifacts.
+        This check ensures that Amazon SageMaker training jobs have network isolation enabled. When enabled, training containers cannot make any outbound network calls, so sensitive training data and model artifacts have no path to external endpoints. By default, network isolation is off, meaning training containers can reach the internet unless this flag is explicitly set.
 
         **Why this matters**
 
-        Training jobs process potentially sensitive datasets and produce valuable model artifacts. Without network isolation:
-
-        - Training data could be exfiltrated to external endpoints by compromised or malicious training code.
-        - Model artifacts and hyperparameters could be leaked.
-        - The training container could be used as a pivot point for lateral movement within the network.
-
-        Enabling network isolation ensures training containers operate in a fully sandboxed environment.
+        - **Data exfiltration prevention:** Network isolation eliminates the outbound path that malicious or compromised training code would use to send data to an attacker-controlled endpoint.
+        - **Third-party algorithm safety:** Models and scripts from third-party sources may contain embedded callbacks; isolation prevents those callbacks from succeeding.
+        - **Artifact protection:** Model weights, gradients, and hyperparameter data produced during training cannot leave the container.
+        - **Defense in depth:** Isolation complements VPC security groups and IAM by adding a container-level network control.
 
         **Risk mitigation**
 
-        - Prevents exfiltration of sensitive training data and model artifacts.
-        - Reduces risk from untrusted or third-party training algorithms.
-        - Enforces a zero-trust network posture for ML training workloads.
+        - **Zero outbound path:** No network call leaves the training container regardless of what code runs inside it.
+        - **Reduced lateral movement risk:** A compromised training environment cannot probe or pivot to other services in the VPC or on the internet.
+        - **Supply-chain defense:** Even if a poisoned dependency tries to phone home, isolation silently blocks the attempt.
       audit: |
         ### Audit via Console
 
@@ -37135,23 +36957,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker training jobs have inter-container traffic encryption enabled. When enabled, traffic between training containers in distributed training is encrypted using TLS 1.2.
+        This check ensures that Amazon SageMaker training jobs have inter-container traffic encryption enabled. Distributed training spans multiple instances that exchange gradients, model parameters, and intermediate results; by default this traffic is not encrypted in transit between containers, exposing it to anyone with access to VPC-level traffic analysis.
 
         **Why this matters**
 
-        Distributed training jobs use multiple instances that exchange data such as gradients, model parameters, and intermediate results. Without inter-container traffic encryption:
-
-        - Sensitive training data transmitted between containers could be intercepted.
-        - Model parameters and gradients could be captured, potentially enabling model reconstruction.
-        - Compliance requirements for encryption in transit may not be met.
-
-        Enabling inter-container traffic encryption ensures all communication between training instances is protected with TLS 1.2.
+        - **Data in transit protection:** Encrypting inter-container traffic with TLS 1.2 prevents interception of model parameters and training data flowing between distributed instances.
+        - **Compliance requirements:** Many frameworks mandate encryption of all sensitive data in transit, including internal cluster communications.
+        - **Model confidentiality:** Unencrypted gradient updates can reveal information about the training dataset through model inversion or membership inference.
+        - **Insider threat reduction:** Encryption ensures that even a user with VPC flow log or packet-capture access cannot reconstruct training data from traffic.
 
         **Risk mitigation**
 
-        - Protects sensitive data exchanged between distributed training instances.
-        - Ensures compliance with encryption-in-transit requirements.
-        - Prevents interception of model parameters during distributed training.
+        - **Encrypted channel:** TLS 1.2 is applied to all traffic between training containers, removing plaintext exposure on the cluster network.
+        - **Tamper detection:** Encrypted connections include integrity checks that detect in-path modification of gradients or parameters.
+        - **Auditability:** Enabling the flag is a verifiable, machine-readable signal that encryption requirements have been addressed for this job.
       audit: |
         ### Audit via Console
 
@@ -37238,23 +37057,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker training jobs are deployed within a VPC. Running training jobs in a VPC enables network-level access controls and keeps data transfer within the AWS private network.
+        This check ensures that Amazon SageMaker training jobs are deployed within a VPC. By default, training containers communicate over the public internet unless a `VpcConfig` is specified, which means data moving between the container and AWS services is routed through paths outside your control.
 
         **Why this matters**
 
-        Without VPC configuration, training containers communicate over the public internet, which:
-
-        - Increases exposure to network-based attacks during data transfer.
-        - Prevents the use of security groups and NACLs to control network access.
-        - May not meet organizational requirements for network isolation of sensitive workloads.
-
-        Deploying training jobs within a VPC ensures that all network traffic stays within your controlled network environment.
+        - **Network-level access control:** Running inside a VPC enables security groups and network ACLs to restrict which resources the training container can reach.
+        - **Private service connectivity:** Subnets paired with VPC endpoints for S3, ECR, and CloudWatch keep data on the AWS private network throughout the training job.
+        - **Regulatory compliance:** Many data-protection frameworks require sensitive workloads to operate within a defined, isolated network segment.
+        - **Reduced attack surface:** Removing the public-internet path eliminates network-based attacks during data transfer.
 
         **Risk mitigation**
 
-        - Restricts network access using security groups and NACLs.
-        - Enables private connectivity to S3, ECR, and other AWS services via VPC endpoints.
-        - Keeps training data transfer within the AWS private network.
+        - **Controlled routing:** Security groups enforce which inbound and outbound connections the training container is allowed to make.
+        - **Private data transfer:** Training datasets read from S3 and model artifacts written back stay within the private network when VPC endpoints are configured.
+        - **Blast radius containment:** A compromised training container is constrained to the VPC rather than having unrestricted internet access.
       audit: |
         ### Audit via Console
 
@@ -37341,23 +37157,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker processing jobs have network isolation enabled. Processing jobs handle data transformation, feature engineering, and model evaluation. When network isolation is enabled, containers cannot make outbound network calls.
+        This check ensures that Amazon SageMaker processing jobs have network isolation enabled. Processing jobs handle data transformation, feature engineering, and model evaluation; they often operate on raw data containing PII or other sensitive information. By default, network isolation is off, meaning a processing container can make outbound internet calls unless this setting is explicitly enabled.
 
         **Why this matters**
 
-        Processing jobs often handle raw, unprocessed data that may contain sensitive information such as PII, financial records, or healthcare data. Without network isolation:
-
-        - Sensitive data processed during feature engineering could be exfiltrated.
-        - Processing containers could be exploited to access unauthorized resources.
-        - Third-party processing code could transmit data to external endpoints.
-
-        Enabling network isolation prevents all outbound traffic from processing containers.
+        - **Sensitive data protection:** Processing jobs frequently consume unmasked datasets; network isolation prevents that data from being sent to external endpoints.
+        - **Third-party code safety:** Processing containers may include third-party libraries or custom scripts that could contain embedded data-exfiltration logic.
+        - **Least-privilege networking:** Blocking all outbound calls from the container is the strongest possible network-level control short of no connectivity at all.
+        - **Defense in depth:** Isolation operates independently of VPC security groups and IAM policies, adding an extra layer that cannot be bypassed through misconfigured rules.
 
         **Risk mitigation**
 
-        - Prevents exfiltration of sensitive data during processing.
-        - Reduces risk from third-party or untrusted processing code.
-        - Enforces defense-in-depth alongside IAM and VPC controls.
+        - **No outbound path:** Network isolation removes the ability for any code running in the container to establish external connections.
+        - **Exfiltration prevention:** Even if a malicious dependency attempts to call home, isolation silently drops the connection.
+        - **Auditability:** The isolation flag is a verifiable, policy-enforceable signal recorded in the job description API response.
       audit: |
         ### Audit via Console
 
@@ -37441,23 +37254,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker processing jobs have inter-container traffic encryption enabled. When enabled, traffic between processing containers in distributed processing is encrypted using TLS 1.2.
+        This check ensures that Amazon SageMaker processing jobs have inter-container traffic encryption enabled. Distributed processing jobs run across multiple instances that exchange intermediate data; by default this traffic is not encrypted in transit between containers, exposing it to network-level inspection.
 
         **Why this matters**
 
-        Distributed processing jobs run across multiple instances that exchange intermediate data. Without inter-container traffic encryption:
-
-        - Sensitive data transmitted between processing containers could be intercepted.
-        - Intermediate processing results containing PII or confidential data may be exposed.
-        - Compliance requirements for encryption in transit may not be met.
-
-        Enabling inter-container traffic encryption ensures all communication between processing instances is protected.
+        - **PII and PHI protection:** Processing jobs commonly handle data containing personal or health information; encrypting inter-container traffic prevents that data from being readable on the cluster network.
+        - **Compliance with encryption-in-transit requirements:** Frameworks such as HIPAA and PCI-DSS require encryption of all sensitive data in transit, including internal cluster communications.
+        - **Intermediate result confidentiality:** Partial aggregations and feature vectors produced mid-job can reveal information about the source dataset if intercepted.
+        - **Consistent security posture:** Applying the same encryption standard used for external connections to internal cluster traffic closes an often-overlooked gap.
 
         **Risk mitigation**
 
-        - Protects sensitive data exchanged between distributed processing instances.
-        - Ensures compliance with encryption-in-transit requirements.
-        - Prevents interception of intermediate processing data.
+        - **TLS protection:** TLS 1.2 encrypts all traffic flowing between processing container instances, removing the plaintext exposure.
+        - **Integrity assurance:** Encrypted channels include tamper-detection, preventing modification of intermediate results during distributed processing.
+        - **Verifiable control:** The flag is machine-readable and survives in the job description API, making it straightforward to audit at scale.
       audit: |
         ### Audit via Console
 
@@ -37540,23 +37350,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon SageMaker processing jobs are deployed within a VPC. Running processing jobs in a VPC provides network-level access controls and keeps data transfer within the AWS private network.
+        This check ensures that Amazon SageMaker processing jobs are deployed within a VPC. By default, processing containers communicate over the public internet unless a `VpcConfig` is specified in the `NetworkConfig`, meaning data read from and written to AWS services takes an internet-routed path.
 
         **Why this matters**
 
-        Without VPC configuration, processing containers communicate over the public internet, which:
-
-        - Increases exposure to network-based attacks during data transfer.
-        - Prevents the use of security groups and NACLs to restrict access.
-        - May not meet organizational requirements for network isolation of data processing workloads.
-
-        Deploying processing jobs within a VPC ensures that all network traffic stays within your controlled network environment.
+        - **Network-level access control:** Placing processing jobs inside a VPC allows security groups and network ACLs to enforce which services and endpoints the container can reach.
+        - **Private service connectivity:** VPC endpoints for S3, ECR, and CloudWatch ensure that all data movement stays on the AWS private network.
+        - **Sensitive data handling:** Processing jobs often operate on raw, unanonymized datasets; keeping traffic off the public internet reduces exposure during ingest and output.
+        - **Regulatory compliance:** Many frameworks require that workloads handling sensitive data operate within a controlled, isolated network environment.
 
         **Risk mitigation**
 
-        - Restricts network access using security groups and NACLs.
-        - Enables private connectivity to S3 and other AWS services via VPC endpoints.
-        - Keeps data transfer within the AWS private network.
+        - **Restricted egress:** Security groups define exactly which outbound connections the processing container is permitted to make.
+        - **Private data transfer:** Datasets read from S3 and results written back remain on the AWS private network when VPC endpoints are in place.
+        - **Lateral movement containment:** A compromised processing container is limited to the VPC's defined boundaries rather than having unrestricted internet access.
       audit: |
         ### Audit via Console
 
@@ -37655,25 +37462,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon SageMaker domains are configured with a KMS key for encrypting the EFS volume that stores user data. SageMaker domains use an EFS file system to store notebooks, data, and artifacts for all users in the domain.
+        This check ensures that Amazon SageMaker domains are configured with a customer-managed KMS key for encrypting the EFS volume that stores user data. By default, SageMaker creates the domain EFS file system without a customer-managed key, meaning notebook files, training scripts, datasets, and model artifacts are protected only by AWS-managed encryption with no customer control over key policies or rotation.
 
         **Why this matters**
 
-        SageMaker domains store sensitive data including notebooks, training scripts, datasets, and model artifacts in an Amazon EFS file system. Without KMS encryption:
-
-        - Sensitive ML data is stored without customer-controlled encryption.
-        - No centralized key management or auditing of encryption key usage.
-        - Compliance requirements for encryption at rest may not be met.
-        - Inability to control access to encrypted data through KMS key policies.
-
-        Configuring a KMS key for the domain ensures that all data in the EFS volume is encrypted with a customer-managed key.
+        - **Customer-controlled encryption:** A KMS key lets you define who can decrypt the EFS volume through key policies, independent of IAM permissions on the domain itself.
+        - **Key rotation:** Customer-managed keys can be set to rotate automatically, limiting the window of exposure if a key is ever compromised.
+        - **Audit trail:** Every use of the KMS key is logged in CloudTrail, providing a record of who accessed encrypted domain data and when.
+        - **Compliance requirements:** Frameworks requiring encryption at rest with customer-managed keys cannot be satisfied by AWS-managed encryption alone.
 
         **Risk mitigation**
 
-        - Protects sensitive ML data at rest with customer-managed encryption.
-        - Enables centralized key management and rotation through AWS KMS.
-        - Provides audit trail of encryption key usage via CloudTrail.
-        - Supports compliance with frameworks requiring encryption at rest.
+        - **Access revocation:** Disabling or deleting the KMS key immediately prevents decryption of domain data, enabling an emergency response that outpaces IAM-based revocation.
+        - **Scoped decryption rights:** Key policies can restrict decryption to specific roles, preventing other AWS principals in the account from reading domain storage.
+        - **Independent control plane:** Key management is separated from the SageMaker service, so a compromise of the domain does not automatically compromise the encryption keys.
       audit: |
         ### Audit via Console
 
@@ -37823,27 +37625,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check flags SageMaker training jobs whose hyperparameters look like they carry AWS credentials. Two patterns are detected:
-
-        1. **Suspicious key names**: a hyperparameter whose key is `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, or `aws_security_token` (case-insensitive), regardless of its value.
-        2. **Access key IDs in values**: any hyperparameter value containing an AWS access key ID (matches `AKIA…`, `ASIA…`, `AROA…`, and the other documented AWS key-ID prefixes).
-
-        Secret access keys and session-token *values* are not regex-detected directly because they have no distinguishing format; the suspicious-key-name rule is what catches those in practice. Hyperparameters are passed to training containers as environment variables and stored by the SageMaker service, so any credential embedded there is recoverable from CloudTrail, the training job description API, and any IAM principal with `sagemaker:DescribeTrainingJob`.
+        This check ensures that Amazon SageMaker training jobs do not embed AWS credentials in hyperparameters. Hyperparameters are passed to training containers as environment variables and stored persistently in the SageMaker service, where they are returned in plain text by the describe API to any principal with `sagemaker:DescribeTrainingJob`. The check detects two patterns: suspicious key names (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_security_token`) and values that match AWS access key ID prefixes such as `AKIA`, `ASIA`, and `AROA`.
 
         **Why this matters**
 
-        Developers often paste AWS credentials into hyperparameters as a convenience to let training code pull from S3 or write to DynamoDB without configuring an instance profile:
-
-        - Hyperparameters are returned in plain text by `DescribeTrainingJob`, which is readable by many roles that would otherwise not have access to the credentials.
-        - Training job records persist long after the job finishes, so leaked credentials remain recoverable for as long as the record is retained.
-        - If the training job is shared with a SageMaker project, experiment, or model card, the credentials leak into every downstream artifact.
-        - Hardcoded credentials bypass the IAM role scoping that `iamRole` is supposed to provide, defeating least-privilege.
+        - **Broad read access:** Any IAM principal with `sagemaker:DescribeTrainingJob` can retrieve hyperparameters, so credentials stored there are exposed to a much wider audience than intended.
+        - **Long-lived exposure:** Training job records persist after the job finishes, meaning leaked credentials remain recoverable for as long as the record is retained.
+        - **Downstream propagation:** Hyperparameters are copied into SageMaker experiments, model cards, and pipeline run metadata, spreading credentials into every downstream artifact.
+        - **Least-privilege bypass:** Embedding credentials defeats the scoped IAM role (`iamRole`) that should be the only source of AWS access for the training container.
 
         **Risk mitigation**
 
-        - Remove every AWS access key pattern from hyperparameters.
-        - Use the training job's `iamRole` (instance profile) for all AWS access.
-        - Rotate any credentials that have ever appeared in a hyperparameter. Consider them compromised.
+        - **IAM role replacement:** Training containers should obtain AWS credentials exclusively through the job's attached IAM role, eliminating any need to pass credentials as parameters.
+        - **Immediate rotation:** Any credentials that have appeared in a hyperparameter should be treated as compromised and rotated immediately.
+        - **Preventive scanning:** Applying this check in CI or pre-submission hooks catches credential leaks before the training job is created.
       audit: |
         ### Audit via Console
 
@@ -37931,24 +37726,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check verifies that hub content imported from the public SageMaker JumpStart hub and made available in a private hub carries markdown documentation. Populating the markdown field forces a human to review and record their approval of the third-party model before teams deploy it.
+        This check ensures that hub content imported from the public SageMaker JumpStart hub into a private hub carries a non-empty markdown documentation field. Requiring documentation forces a human reviewer to record their approval of the third-party model or notebook before it becomes available to all SageMaker users in the account.
 
         **Why this matters**
 
-        Public JumpStart models are unvetted third-party supply-chain artifacts:
-
-        - Model weights can be backdoored or contain hidden trojan triggers that activate on specific inputs.
-        - The base container image pulled by the model can contain vulnerable or malicious packages.
-        - Pre-trained weights may have been trained on data that violates licensing or privacy requirements.
-        - Hub content imported into a private hub is discoverable by every SageMaker user in the account, so an unvetted model gets re-used widely.
-
-        Requiring markdown documentation on every publicly-sourced piece of hub content creates an audit trail: a reviewer must describe who approved the content, what scans were run, and what restrictions apply before it becomes available in the private hub.
+        - **Supply-chain vetting:** Public JumpStart models are third-party artifacts whose weights, container images, and dependencies have not been vetted by AWS or your organization by default.
+        - **Backdoor and trojan risk:** Model weights can be poisoned with hidden triggers, and container images may include vulnerable or malicious packages that are only discovered after deployment.
+        - **Licensing and privacy:** Pre-trained weights may have been trained on data that violates licensing restrictions or privacy regulations applicable to your organization.
+        - **Wide reuse:** Content imported into a private hub is discoverable by every SageMaker user in the account, so a single unvetted model gets re-used widely before any review occurs.
 
         **Risk mitigation**
 
-        - Forces a documented approval step for every third-party model entering the private hub.
-        - Provides a discoverable record for compliance audits covering supply-chain vetting.
-        - Surfaces un-reviewed content quickly so it can be deleted or reviewed before deployment.
+        - **Documented approval gate:** Requiring a populated markdown field creates an audit trail that names the reviewer, describes what scans were run, and records any restrictions on the model's use.
+        - **Compliance evidence:** The markdown field provides discoverable, machine-verifiable evidence that supply-chain vetting was performed, satisfying frameworks that require third-party component review.
+        - **Early detection:** The check surfaces un-reviewed content immediately after import so it can be deleted or reviewed before any team deploys it.
       audit: |
         ### Audit via Console
 
@@ -38041,22 +37832,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that every SageMaker model package marked `Approved` ran the registered validation specification and has a non-empty `approvalDescription` recording the reviewer's justification. Approved packages without validation or without a reviewer note indicate an auto-approval, a rubber-stamp approval, or a reviewer skipping the process.
+        This check ensures that every SageMaker model package marked `Approved` ran its registered validation specification and carries a non-empty `approvalDescription`. An approved package without validation (`skipModelValidation == "All"`) or without a reviewer note indicates that the approval gating was bypassed, leaving an unvalidated model ready for production deployment.
 
         **Why this matters**
 
-        A model package with `approvalStatus == "Approved"` is a green light for downstream pipelines to deploy it to production endpoints. Two dangerous patterns bypass meaningful review:
-
-        - `skipModelValidation == "All"` explicitly disables the validation specification, so the model is approved without any of the tests that were supposed to run against it.
-        - An empty `approvalDescription` means no reviewer recorded what they checked, when, or why they approved. There is no accountability.
-
-        Together these produce an undocumented, unvalidated model in a system that trusts the `Approved` flag to gate deployments. An attacker (or careless insider) who can toggle `approvalStatus` can silently ship a compromised model.
+        - **Validation bypass risk:** Setting `skipModelValidation` to `All` disables the test suite that was registered precisely to catch regressions, safety violations, and metric thresholds before a model reaches production.
+        - **Accountability gap:** An empty `approvalDescription` means no reviewer recorded what they checked, creating a gap in the audit trail that compliance auditors and incident responders rely on.
+        - **Deployment trust:** Downstream pipelines and CI/CD systems treat the `Approved` flag as a green light; a model that reached `Approved` without validation is one step away from a production endpoint.
+        - **Insider and automation risk:** Anyone who can call `UpdateModelPackage` can flip the status to `Approved`; the approval description and validation run are the only durable signals that a human reviewed the transition.
 
         **Risk mitigation**
 
-        - Requires reviewer accountability via a mandatory `approvalDescription`.
-        - Ensures the registered validation specification actually ran before approval.
-        - Creates an auditable trail for compliance frameworks covering model risk management.
+        - **Validation enforcement:** Requiring that validation ran before approval ensures automated quality, fairness, and safety checks have passed for every model entering production.
+        - **Reviewer accountability:** Mandating a non-empty approval description creates a named, timestamped record that makes the approval auditable and attributable.
+        - **Audit trail completeness:** The combination of a validation record and a description satisfies compliance frameworks that require documented evidence of model risk review.
       audit: |
         ### Audit via Console
 
@@ -38164,23 +37953,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every SageMaker code repository references a Secrets Manager secret for Git credentials. A code repository without a secret reference either clones anonymously from a public Git host, which is rare for internal repositories, or relies on credentials embedded elsewhere. Neither pattern is acceptable for repositories used by notebooks, training jobs, or Studio apps.
+        This check ensures that every SageMaker code repository references a Secrets Manager secret for Git credentials. A repository without a secret reference either clones anonymously (acceptable only for fully public repositories) or relies on credentials embedded in lifecycle configs, environment variables, or Git URL query strings, none of which provide centralized management or rotation.
 
         **Why this matters**
 
-        SageMaker code repositories are cloned onto notebook instances, Studio apps, and training job containers. The Git credentials the repository uses become accessible to every workload that mounts it, so the way those credentials are stored matters:
-
-        - Embedding the credentials in a notebook startup script or lifecycle config leaks them into `sagemaker:DescribeNotebookInstanceLifecycleConfig` responses, CloudTrail, and EBS snapshots.
-        - Credentials stored outside Secrets Manager cannot be rotated centrally, so stale tokens linger after developers leave the organization.
-        - A code repository without a secret reference that clones a private Git host means the credentials are implicit in the environment, hard to audit and hard to rotate.
-
-        Requiring a Secrets Manager secret means credentials are versioned, rotatable, access-logged via CloudTrail, and scoped by KMS key policies.
+        - **Credential exposure:** Git credentials embedded in notebook lifecycle configurations appear in the `DescribeNotebookInstanceLifecycleConfig` API response, CloudTrail logs, and EBS snapshots taken of the notebook volume.
+        - **No rotation path:** Credentials stored outside Secrets Manager have no automated rotation, so stale tokens accumulate after developers leave the organization or after a potential compromise.
+        - **Audit visibility:** Secrets Manager logs every retrieval of a secret in CloudTrail, giving you a complete record of when SageMaker workloads accessed Git credentials.
+        - **Blast radius:** A single embedded token that is shared across notebooks, training jobs, and Studio apps becomes a single point of failure if it is leaked.
 
         **Risk mitigation**
 
-        - Centralizes Git credential storage in Secrets Manager.
-        - Provides an audit trail when credentials are read by SageMaker workloads.
-        - Enables rotation without modifying notebook/lifecycle/training-job code.
+        - **Centralized credential management:** Secrets Manager stores, versions, and rotates Git credentials independently of the notebooks and jobs that use them.
+        - **Access-controlled retrieval:** KMS key policies on the Secrets Manager secret restrict which IAM roles can read it, enabling fine-grained control over credential access.
+        - **Rotation without code changes:** Rotating the secret in Secrets Manager takes effect the next time SageMaker clones the repository, with no changes required to notebook or training-job definitions.
       audit: |
         ### Audit via Console
 
@@ -38303,23 +38089,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every SageMaker monitoring job definition has network isolation enabled and inter-container traffic encryption enabled in its `networkConfig`. The check covers data quality, model quality, model bias, and model explainability definitions. Monitoring jobs continuously read captured endpoint inference traffic, which typically contains the same sensitive inputs and outputs that the production endpoint handles.
+        This check ensures that every SageMaker monitoring job definition has both network isolation and inter-container traffic encryption enabled in its `networkConfig`. This covers data quality, model quality, model bias, and model explainability job definitions. Monitoring jobs continuously read captured endpoint inference traffic, which contains the same sensitive inputs and outputs that the production endpoint handles.
 
         **Why this matters**
 
-        Monitoring jobs pull captured data from S3 (often recorded via `dataCaptureConfig`) and process it against baselines. The captured data can include PII, PHI, prompts, authentication tokens sent to an endpoint, and model responses that reveal training data. Without hardened `networkConfig`:
-
-        - `enableNetworkIsolation == false` lets the monitoring container reach the internet, so a compromised or malicious monitoring image can exfiltrate everything it reads.
-        - `enableInterContainerTrafficEncryption == false` means traffic between monitoring containers in a distributed run is sent in the clear on the VPC network, recoverable by anyone with VPC flow log or packet-capture access.
-        - Missing isolation also makes the monitoring container a pivot point for lateral movement into VPCs that host customer data.
-
-        Both controls are off by default; they must be explicitly enabled when the job definition is created.
+        - **Captured data sensitivity:** Inference traffic recorded via `dataCaptureConfig` can include PII, PHI, authentication tokens, and model responses that reveal information about the training dataset.
+        - **Exfiltration via monitoring containers:** Without network isolation, a compromised or malicious monitoring image can reach external endpoints and exfiltrate everything it reads from the captured data store.
+        - **Plaintext cluster traffic:** Disabling inter-container encryption means traffic between monitoring containers in a distributed run is sent in the clear on the VPC network, readable by anyone with packet-capture access.
+        - **Default-off controls:** Both settings are disabled by default in SageMaker and must be explicitly enabled when the job definition is created, making this a common oversight.
 
         **Risk mitigation**
 
-        - Prevents monitoring containers from reaching external endpoints.
-        - Protects sensitive inference data as it is processed by monitoring workloads.
-        - Aligns monitoring posture with the production endpoint it is validating.
+        - **Outbound blocking:** Network isolation prevents monitoring containers from reaching external endpoints regardless of what code is in the monitoring image.
+        - **Encrypted inter-node traffic:** TLS on inter-container traffic ensures that captured data being processed across instances cannot be intercepted on the cluster network.
+        - **Consistent posture:** Applying the same network controls to monitoring jobs as to training and processing jobs closes a gap where production-equivalent data is handled with weaker protections.
       audit: |
         ### Audit via Console
 
@@ -38513,24 +38296,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check verifies that the default execution role attached to every SageMaker domain does not have the AWS-managed `AdministratorAccess` policy. The default execution role is inherited by every user profile, Studio app, and space in the domain that does not override it, so attaching `AdministratorAccess` grants every SageMaker user in the domain full administrative access to the AWS account.
+        This check ensures that the default execution role attached to a SageMaker domain does not have the AWS-managed `AdministratorAccess` policy. The default execution role is inherited by every user profile, Studio app, and space in the domain that does not override it, so attaching `AdministratorAccess` grants every SageMaker user in the domain full administrative access to the AWS account. AWS does not restrict this role by default, making it easy to accidentally create a domain with an overly broad role.
 
         **Why this matters**
 
-        `AdministratorAccess` grants `Action: "*"` on `Resource: "*"`, the broadest possible permission set. When the SageMaker domain's default execution role carries it:
-
-        - Every Studio notebook, JupyterLab app, and KernelGateway app runs with full AWS administrator privileges.
-        - Any user who compromises a Studio session (phishing, stolen session token, malicious dependency) has administrator access to the entire account.
-        - A malicious training job or Python package can pivot from the SageMaker VPC to any AWS service.
-        - Least-privilege boundaries normally enforced by IAM are effectively disabled.
-
-        SageMaker execution roles should grant only the specific S3 buckets, KMS keys, ECR repositories, and SageMaker actions the workload requires.
+        - **Inherited blast radius:** Every Studio notebook, JupyterLab app, and KernelGateway app in the domain runs with the role's permissions, meaning `AdministratorAccess` affects all users simultaneously.
+        - **Session compromise escalation:** A phished Studio session token or stolen browser cookie immediately yields full account administrator access, not just SageMaker access.
+        - **Dependency supply-chain risk:** A malicious Python package installed in any notebook can call AWS APIs at import time; with `AdministratorAccess`, that call can do anything in the account.
+        - **Least-privilege violation:** The `AdministratorAccess` managed policy grants `Action: "*"` on `Resource: "*"`, which defeats every IAM boundary that would otherwise limit the scope of a compromise.
 
         **Risk mitigation**
 
-        - Prevents inherited account-wide administrator access for every SageMaker user.
-        - Contains the blast radius of a compromised notebook or training job.
-        - Aligns the domain with the principle of least privilege.
+        - **Scoped execution role:** Replacing `AdministratorAccess` with `AmazonSageMakerFullAccess` or a custom policy limits the domain role to only the AWS actions legitimate SageMaker workloads require.
+        - **Per-user overrides:** Users or teams needing elevated access can be assigned dedicated execution roles via user profile settings, keeping the domain default minimal.
+        - **Audit enforcement:** Automated detection of `AdministratorAccess` on domain roles prevents it from being re-introduced silently during role updates.
       audit: |
         ### Audit via Console
 
@@ -38618,23 +38397,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check verifies that no SageMaker notebook instance has the AWS-managed `AdministratorAccess` policy attached to its IAM role. A notebook instance with `AdministratorAccess` lets anyone who runs code inside the Jupyter environment perform any AWS action in the account, including malicious code pulled in via a package installation or a Git clone.
+        This check ensures that no SageMaker notebook instance has the AWS-managed `AdministratorAccess` policy attached to its IAM role. Notebook instances frequently run untrusted or semi-trusted code, including packages installed from PyPI, conda, or Git repositories, and shared notebooks that execute automatically at open time. Any of these sources can carry malicious code that inherits the role's permissions.
 
         **Why this matters**
 
-        Notebook instances frequently run untrusted or semi-trusted code:
-
-        - Data scientists install packages from PyPI, conda, and Git repositories, any of which can be supply-chain compromised.
-        - Notebooks are shared via Git, and a malicious notebook can call `boto3` at open time.
-        - Compromised notebook sessions (phished credentials, stolen browser cookies) inherit whatever permissions the role has.
-
-        With `AdministratorAccess` attached, a single compromised notebook is equivalent to a full account takeover. Scoped roles limit the blast radius to only what the legitimate workflow needs.
+        - **Supply-chain compromise:** A poisoned PyPI or conda package installed during a session can call AWS APIs at import time; with `AdministratorAccess`, a single `pip install` can become a full account takeover.
+        - **Shared notebook risk:** Notebooks shared via Git may contain cells that call `boto3` automatically when opened, turning a routine collaboration into a privilege escalation.
+        - **Session hijacking:** Stolen browser cookies or phished credentials for a notebook session yield full account administrator access rather than just notebook-scoped permissions.
+        - **Lateral movement:** A compromised notebook with `AdministratorAccess` can create IAM users, modify security groups, and access data in any S3 bucket in the account.
 
         **Risk mitigation**
 
-        - Prevents a compromised notebook from taking over the whole AWS account.
-        - Limits supply-chain risk from malicious Python/JupyterLab packages.
-        - Supports regulatory frameworks that require demonstrable least privilege for ML workloads.
+        - **Blast radius containment:** Replacing `AdministratorAccess` with a scoped policy limits what compromised code can do to only the resources the legitimate workflow requires.
+        - **Regulatory alignment:** Scoped notebook roles are demonstrably least-privilege, satisfying ML workload controls in frameworks that require evidence of minimal permissions.
+        - **Defense in depth:** Scoped IAM permissions work alongside network controls such as VPC and security groups to limit the impact of any single compromise vector.
       audit: |
         ### Audit via Console
 
@@ -38718,23 +38494,20 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check verifies that no SageMaker training job or processing job has the AWS-managed `AdministratorAccess` policy attached to its IAM role. Training and processing containers execute algorithm code, scripts, and dependencies with the permissions of the attached role, and any of those inputs can be compromised.
+        This check ensures that no SageMaker training job or processing job has the AWS-managed `AdministratorAccess` policy attached to its IAM role. Training and processing containers execute algorithm code, scripts, and dependencies with the permissions of the attached role, and any of those inputs can be compromised through supply-chain attacks, shared bucket access, or CI pipeline manipulation.
 
         **Why this matters**
 
-        Training and processing jobs are ephemeral compute that consume third-party algorithm containers, Python packages from PyPI, Git-hosted scripts, and datasets from S3. Any of these inputs can carry malicious code:
-
-        - A poisoned pip dependency in the training environment can call `boto3` during import.
-        - An attacker who can upload a training script (via a shared bucket or CI pipeline) inherits the role's permissions when the job runs.
-        - Captured data from compromised training jobs with broad IAM can be exfiltrated to any AWS account via `sts:AssumeRole` or `s3:CopyObject` to an attacker-controlled bucket.
-
-        Scoping training and processing roles to the specific S3 buckets, KMS keys, and ECR repositories the job requires limits the blast radius of every one of these compromise vectors.
+        - **Algorithm container risk:** Third-party training containers pulled from a public registry may include code that calls AWS APIs; with `AdministratorAccess`, those calls have no guardrails.
+        - **Dependency supply chain:** A poisoned pip dependency in the training environment can execute AWS API calls during import before training code even starts.
+        - **Shared input bucket exposure:** An attacker who can upload a training script to a shared S3 bucket inherits the role's full permissions when the job runs that script.
+        - **Data exfiltration path:** A compromised training role with `AdministratorAccess` can copy data to any external S3 bucket or assume any role in the account, turning a training job into an exfiltration channel.
 
         **Risk mitigation**
 
-        - Prevents poisoned algorithm containers or scripts from pivoting to full account access.
-        - Limits the impact of upstream supply-chain compromises.
-        - Forces explicit, auditable permissions for each training and processing workload.
+        - **Minimal permissions:** Scoping each job role to the specific S3 buckets, KMS keys, ECR repositories, and CloudWatch Logs groups the job needs limits the damage from any single compromise.
+        - **Supply-chain containment:** Even if a malicious dependency attempts destructive API calls, a scoped role prevents it from acting outside the job's declared resources.
+        - **Auditable boundaries:** Explicit, documented permissions on each job role make it straightforward to verify during security reviews that no job can access resources outside its intended scope.
       audit: |
         ### Audit via Console
 
@@ -40416,11 +40189,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect unauthorized API calls within your AWS environment. Unauthorized API calls may indicate an attacker probing your environment or attempting to exploit misconfigured IAM permissions.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect unauthorized API calls across your AWS environment. By default, CloudWatch does not ship alerting for access-denied events; creating this filter and alarm surfaces patterns such as `AccessDenied` and `UnauthorizedAccess` errors in near real time.
 
-        Real-time monitoring of unauthorized API calls helps security teams identify and respond to potential breaches before significant damage occurs. Without this alarm, unauthorized access attempts may go undetected for extended periods.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring for these events to maintain continuous awareness of access control violations across all AWS services.
+        - **Early breach detection:** Repeated authorization failures are a leading indicator that an attacker is probing your environment or that a compromised credential is being used.
+        - **Reduced dwell time:** Prompt notification lets security teams investigate and revoke access before significant damage occurs.
+        - **Continuous visibility:** Metric filters turn raw CloudTrail log data into actionable signals without requiring manual log reviews.
+        - **IAM misconfiguration discovery:** Surges in access-denied calls often reveal overly restrictive or incorrectly attached IAM policies that need correction.
+
+        **Risk mitigation**
+
+        - **Attacker probing:** Alerting on authorization failures limits the window attackers have to quietly map permission boundaries before being detected.
+        - **Credential compromise:** Real-time alarms enable rapid revocation of compromised credentials before they are leveraged for privilege escalation.
+        - **Audit evidence:** A documented alarm configuration demonstrates active monitoring to auditors and incident response teams.
       audit: |
         ### Audit via Console
 
@@ -40620,11 +40402,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect AWS Management Console sign-ins that occur without multi-factor authentication (MFA). Console logins without MFA represent an elevated risk since accounts protected only by passwords are more susceptible to compromise.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect AWS Management Console sign-ins that occur without multi-factor authentication. By default, AWS does not alert when a user authenticates with only a password; this filter monitors CloudTrail for `ConsoleLogin` events where `MFAUsed` is not `Yes`.
 
-        Monitoring for MFA-less logins allows security teams to identify users who bypass MFA requirements and take corrective action. This is particularly important for privileged accounts with broad permissions across your AWS environment.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends this control to enforce MFA usage and detect policy violations in real time.
+        - **Password-only accounts are high risk:** Accounts secured only by passwords are vulnerable to phishing, credential stuffing, and brute-force attacks.
+        - **Privileged access exposure:** IAM users with broad permissions who bypass MFA are prime targets; detecting such logins quickly limits the impact window.
+        - **Policy enforcement visibility:** The alarm surfaces MFA policy violations in real time, enabling corrective action before unauthorized activity occurs.
+
+        **Risk mitigation**
+
+        - **Account takeover prevention:** Alerting on MFA-less logins lets administrators lock down accounts before an attacker can act on the access they obtained.
+        - **Compliance gap detection:** The alarm helps identify users who are not enrolled in MFA so that enrollment can be enforced before an incident occurs.
+        - **Incident scope limitation:** Quick detection of MFA-less logins reduces the time an attacker has to perform unauthorized actions within the console.
       audit: |
         ### Audit via Console
 
@@ -40824,11 +40614,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect usage of the AWS root account. The root account has unrestricted access to all resources and should be used only for tasks that specifically require root credentials, such as initial account setup.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect any use of the AWS root account. The root account holds unrestricted access to all AWS resources and services; AWS recommends using it only for initial account setup and a small set of account-management tasks that explicitly require root credentials.
 
-        Any use of root credentials in day-to-day operations is a significant security concern and may indicate that an attacker has gained access to the root account. Immediate alerting on root usage enables rapid incident response.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark strongly recommends monitoring root account activity to comply with the principle of least privilege and to detect potential account compromise.
+        - **Unlimited blast radius:** Root account activity bypasses all IAM permission boundaries, so any misuse can affect every resource in the account.
+        - **Indicator of compromise:** Because routine operations should never require the root account, any root API call is anomalous and warrants immediate investigation.
+        - **Principle of least privilege:** Monitoring root usage enforces the expectation that day-to-day operations use scoped IAM identities rather than the account's most powerful credential.
+
+        **Risk mitigation**
+
+        - **Rapid compromise detection:** A real-time alarm on root activity ensures that unauthorized use of root credentials is surfaced before widespread damage can occur.
+        - **Insider threat deterrence:** Visibility into every root action discourages misuse by administrators who have access to the root credentials.
+        - **Incident response acceleration:** Immediate notification allows security teams to disable the root access key and rotate credentials before an attacker can escalate further.
       audit: |
         ### Audit via Console
 
@@ -41029,11 +40827,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to IAM policies. IAM policy changes, such as creating, modifying, or deleting policies, can significantly alter the access control landscape of your AWS environment.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to IAM policies, including creation, modification, deletion, and attachment or detachment of managed and inline policies. By default, CloudWatch does not alert on IAM policy activity; this filter monitors CloudTrail for events such as `CreatePolicy`, `DeletePolicy`, and `AttachRolePolicy`.
 
-        Unauthorized or accidental IAM policy changes could grant excessive permissions to users or roles, potentially leading to privilege escalation or data exposure. Real-time alerting on IAM policy changes allows security teams to review and remediate unintended modifications promptly.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring IAM policy changes to maintain continuous visibility into access control modifications and prevent privilege escalation attacks.
+        - **Privilege escalation path:** IAM policy changes are one of the most common mechanisms attackers use to grant themselves or a backdoor principal broader permissions after gaining initial access.
+        - **Accidental exposure:** Developers and administrators sometimes apply overly permissive policies inadvertently; real-time alerting allows the change to be caught and corrected quickly.
+        - **Governance continuity:** Continuous monitoring of policy changes ensures that access control decisions are reviewed and that policy drift does not go unnoticed.
+        - **Change management integrity:** Unexpected policy modifications outside of a change window are a strong signal of unauthorized activity.
+
+        **Risk mitigation**
+
+        - **Rapid detection of privilege escalation:** Alerting on IAM policy changes surfaces attempts to grant elevated permissions before the attacker can leverage those permissions.
+        - **Rollback window:** Early notification gives administrators time to revert unauthorized policy changes before they are exercised.
+        - **Audit trail support:** The alarm corroborates evidence gathered during incident investigations and demonstrates active monitoring to auditors.
       audit: |
         ### Audit via Console
 
@@ -41234,11 +41041,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS CloudTrail configuration. CloudTrail is the primary audit log for AWS API activity, and any modifications to its configuration could indicate an attempt to disable or circumvent logging.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to AWS CloudTrail configuration. CloudTrail is the primary audit log for all AWS API activity; events such as `StopLogging`, `DeleteTrail`, and `UpdateTrail` can impair or eliminate audit visibility.
 
-        Attackers who gain sufficient privileges may attempt to disable CloudTrail to cover their tracks. Immediate alerting on CloudTrail configuration changes ensures that any tampering with the audit log system is detected and investigated promptly.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark requires monitoring CloudTrail configuration changes to protect the integrity of the audit logging infrastructure itself.
+        - **Log tampering is an attacker priority:** Disabling or deleting CloudTrail trails is a well-known attacker tactic to eliminate forensic evidence after gaining access.
+        - **Audit integrity dependency:** All other CloudWatch-based monitoring controls depend on CloudTrail delivering logs; if CloudTrail is stopped, the entire detection stack is blinded.
+        - **Compliance requirement:** Regulatory frameworks require continuous logging of API activity; any gap introduced by a configuration change may constitute a compliance violation.
+
+        **Risk mitigation**
+
+        - **Anti-tampering detection:** An alarm on CloudTrail configuration changes ensures that any attempt to disable logging is caught within minutes rather than days.
+        - **Rapid re-enablement:** Early notification allows administrators to restart logging and recover the delivery channel before an extended gap in audit coverage develops.
+        - **Incident confidence:** When CloudTrail configuration is monitored, security teams can be confident that log gaps are detected and do not represent unobserved attacker activity.
       audit: |
         ### Audit via Console
 
@@ -41439,11 +41254,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect failed console authentication attempts. Repeated authentication failures may indicate a brute force attack or credential stuffing attempt targeting your AWS Management Console.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect failed AWS Management Console authentication attempts. By default, CloudWatch does not alert on sign-in failures; this filter monitors CloudTrail for `ConsoleLogin` events combined with a `Failed` result.
 
-        Early detection of authentication failures enables security teams to lock down accounts under attack, investigate the source of repeated failures, and take preventative action before an attacker succeeds. Without this monitoring, account takeover attempts may go unnoticed.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring console authentication failures to detect and respond to unauthorized access attempts targeting the management console.
+        - **Brute-force and credential stuffing signals:** A spike in failed logins is one of the clearest early indicators of an active password-guessing attack against one or more accounts.
+        - **Targeted account attack detection:** A concentrated pattern of failures against a single account suggests targeted enumeration or credential-based attacks that should trigger account protection measures.
+        - **Short reaction window:** Account lockout and investigation must happen quickly; without automated alerting, authentication attacks can run undetected for extended periods.
+
+        **Risk mitigation**
+
+        - **Attack interruption:** Real-time notification enables administrators to apply additional authentication controls or lock accounts before an attacker succeeds.
+        - **Source identification:** The alarm creates an investigation trigger so that source IP addresses and account targets can be analyzed and blocked at the network level.
+        - **Account takeover prevention:** Detecting failure patterns early prevents attackers from eventually succeeding with a correct password and gaining console access.
       audit: |
         ### Audit via Console
 
@@ -41644,11 +41467,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect disabling or scheduled deletion of customer-managed KMS keys (CMKs). CMKs protect encrypted data across many AWS services, and their unauthorized deletion or disabling can render encrypted data permanently inaccessible.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect disabling or scheduled deletion of customer-managed KMS keys (CMKs). By default, CloudWatch does not alert on KMS key state changes; this filter monitors CloudTrail for `DisableKey` and `ScheduleKeyDeletion` events from `kms.amazonaws.com`.
 
-        Disabling or deleting a CMK is an irreversible or time-sensitive operation that can cause widespread service disruption and data loss. Immediate alerting on these events allows administrators to cancel scheduled key deletions within the waiting period and prevent accidental or malicious data loss.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends this control to protect encryption key availability and detect ransomware-style attacks targeting KMS keys.
+        - **Data rendered permanently inaccessible:** Deleting a CMK without a backup or recovery path makes all data encrypted under that key permanently unreadable, which is functionally equivalent to data destruction.
+        - **Ransomware-style attack vector:** Adversaries with KMS permissions can disable or schedule deletion of keys to extort organizations by denying access to their own encrypted data.
+        - **Waiting period is time-limited:** AWS enforces a minimum 7-day deletion waiting period; early detection leaves time to cancel the scheduled deletion before it becomes irreversible.
+
+        **Risk mitigation**
+
+        - **Deletion cancellation window:** Immediate alerting ensures administrators can cancel a scheduled key deletion well within the waiting period before data loss occurs.
+        - **Unauthorized action detection:** An alarm on CMK state changes surfaces misuse of KMS permissions by both external attackers and internal principals.
+        - **Encrypted workload continuity:** Proactive monitoring prevents service disruptions caused by the loss of encryption keys that protect databases, S3 objects, and other storage.
       audit: |
         ### Audit via Console
 
@@ -41849,11 +41680,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Amazon S3 bucket policies and ACLs. S3 buckets frequently contain sensitive data, and unintended changes to bucket policies or ACLs can inadvertently expose that data publicly.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to Amazon S3 bucket policies and ACLs. By default, CloudWatch does not alert on S3 permission changes; this filter monitors CloudTrail for events such as `PutBucketPolicy`, `PutBucketAcl`, and `DeleteBucketPolicy` from `s3.amazonaws.com`.
 
-        Monitoring S3 bucket policy changes enables security teams to detect misconfiguration events that could lead to data breaches. This is especially important given the high frequency of data exposure incidents caused by misconfigured S3 buckets.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring S3 bucket policy changes to prevent unauthorized data exposure and enforce data governance policies across your object storage environment.
+        - **Data exposure risk is high:** Misconfigured bucket policies are one of the most frequent causes of large-scale data breaches in AWS environments, often resulting from a single accidental policy update.
+        - **Public access can be set instantly:** A single `PutBucketPolicy` call can make a previously private bucket publicly readable; without alerting, such changes can persist for extended periods.
+        - **Governance dependency:** Organizations rely on bucket policies to enforce encryption, logging, and access control requirements; unauthorized changes undermine all dependent controls.
+
+        **Risk mitigation**
+
+        - **Immediate exposure detection:** Real-time alerting on policy changes means that accidental or malicious public exposure is caught within minutes rather than discovered during periodic audits.
+        - **Change review enablement:** Prompt notification allows security teams to review whether a policy change was authorized and revert it quickly if it was not.
+        - **Data protection continuity:** Monitoring ensures that data governance policies enforced through bucket policies are not silently removed.
       audit: |
         ### Audit via Console
 
@@ -42054,11 +41893,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS Config configuration. AWS Config provides continuous compliance monitoring and resource configuration tracking, and any modifications to its configuration could undermine your compliance posture.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to AWS Config configuration. By default, CloudWatch does not alert on Config service changes; this filter monitors CloudTrail for events such as `StopConfigurationRecorder` and `DeleteDeliveryChannel` from `config.amazonaws.com`.
 
-        Disabling AWS Config's configuration recorder or delivery channel would blind your organization to configuration changes across AWS resources, defeating a key compliance and security monitoring capability. Alerting on these events ensures that such tampering is detected immediately.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring AWS Config changes to protect the integrity of your compliance monitoring infrastructure and detect attempts to disable configuration tracking.
+        - **Compliance monitoring dependency:** AWS Config provides the foundation for continuous compliance assessment; stopping the configuration recorder or deleting the delivery channel silently breaks compliance visibility across all resource types.
+        - **Attacker anti-detection tactic:** An attacker with sufficient privileges may disable AWS Config to prevent detection of configuration changes that would otherwise trigger Config rules.
+        - **Audit coverage gap:** Changes to Config settings can create undetected gaps in compliance posture that persist until the next manual audit.
+
+        **Risk mitigation**
+
+        - **Tamper detection:** Alerting on Config changes ensures that attempts to disable compliance monitoring are surfaced immediately rather than discovered during an audit.
+        - **Rapid remediation:** Early notification allows administrators to re-enable the configuration recorder and delivery channel before a significant gap in compliance visibility develops.
+        - **Defense-in-depth protection:** Monitoring the monitoring system itself ensures that the overall security posture remains observable even when individual services are targeted.
       audit: |
         ### Audit via Console
 
@@ -42259,11 +42106,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to VPC security groups. Security groups act as virtual firewalls controlling inbound and outbound traffic to AWS resources, and unauthorized changes could expose systems to attack.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to VPC security groups. By default, CloudWatch does not alert on security group modifications; this filter monitors CloudTrail for events such as `AuthorizeSecurityGroupIngress`, `AuthorizeSecurityGroupEgress`, `RevokeSecurityGroupIngress`, `RevokeSecurityGroupEgress`, `CreateSecurityGroup`, and `DeleteSecurityGroup`.
 
-        Monitoring security group changes allows security teams to detect overly permissive rules being added, such as rules allowing unrestricted ingress from the internet. Prompt detection and remediation of such changes reduces the window of exposure.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring security group changes to maintain network security posture and detect unauthorized modifications to network access controls.
+        - **Firewall rule exposure:** A single overly permissive ingress rule opening a sensitive port to the internet can expose critical infrastructure to exploitation within minutes of being applied.
+        - **Broad resource impact:** Security group changes can affect all instances and services associated with a group simultaneously, amplifying the security impact of any single change.
+        - **Change management integrity:** Unauthorized security group modifications outside of approved change windows are a reliable indicator of unauthorized access or insider threats.
+
+        **Risk mitigation**
+
+        - **Unauthorized rule detection:** Real-time alerting on security group changes surfaces permissive rules quickly enough to revoke them before they can be exploited.
+        - **Network perimeter continuity:** Monitoring ensures that the intended network access control posture is maintained and that unreviewed changes do not linger.
+        - **Incident investigation support:** The alarm creates an investigation trigger that helps security teams determine whether a change was authorized and correlate it with other suspicious activity.
       audit: |
         ### Audit via Console
 
@@ -42464,11 +42319,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Network Access Control Lists (NACLs). NACLs provide subnet-level traffic filtering in VPCs, and unauthorized changes could weaken your network perimeter defenses.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to Network Access Control Lists (NACLs). By default, CloudWatch does not alert on NACL modifications; this filter monitors CloudTrail for events such as `CreateNetworkAcl`, `CreateNetworkAclEntry`, `DeleteNetworkAcl`, `DeleteNetworkAclEntry`, `ReplaceNetworkAclEntry`, and `ReplaceNetworkAclAssociation`.
 
-        Unlike security groups which are stateful, NACLs are stateless and operate at the subnet boundary, making them a critical layer of defense-in-depth. Changes to NACLs can affect all resources within a subnet simultaneously, amplifying the impact of misconfiguration.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring NACL changes to maintain subnet-level network security and detect unauthorized modifications to your network access control infrastructure.
+        - **Subnet-wide impact:** Unlike security groups, NACLs apply to all resources in a subnet simultaneously; a single NACL change can open or close traffic for an entire network segment.
+        - **Stateless filtering bypass risk:** Incorrectly configured NACL entries can bypass stateful security group controls, creating unintended ingress or egress paths that are not visible in security group audits alone.
+        - **Defense-in-depth layer:** NACLs serve as a second layer of network control; monitoring their changes ensures that both layers of VPC network defense remain intact.
+
+        **Risk mitigation**
+
+        - **Rapid unauthorized-change detection:** An alarm on NACL events allows administrators to review and revert unauthorized rule modifications before they are exploited.
+        - **Subnet exposure prevention:** Early detection of overly permissive entries prevents attackers from leveraging a weakened NACL to reach otherwise protected resources in the subnet.
+        - **Compliance evidence:** Monitoring NACL changes demonstrates active oversight of subnet-level network controls to auditors and compliance assessors.
       audit: |
         ### Audit via Console
 
@@ -42669,11 +42532,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to network gateways including internet gateways, customer gateways, and virtual private gateways. Network gateways control traffic flow between your VPCs and external networks, and unauthorized changes could expose internal resources.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to network gateways including internet gateways, customer gateways, and virtual private gateways. By default, CloudWatch does not alert on gateway modifications; this filter monitors CloudTrail for events such as `CreateCustomerGateway`, `DeleteCustomerGateway`, `AttachInternetGateway`, `CreateInternetGateway`, `DeleteInternetGateway`, and `DetachInternetGateway`.
 
-        Changes to network gateways can fundamentally alter the connectivity of your AWS environment, potentially opening new attack surfaces or disrupting existing secure connections. Monitoring these changes ensures that any unauthorized modifications to network topology are detected promptly.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring network gateway changes to maintain visibility into VPC connectivity changes and detect unauthorized exposure of internal resources to the internet.
+        - **Internet exposure control:** Attaching an internet gateway to a VPC or subnet that was previously private instantly creates a public-facing network path where none existed before.
+        - **VPN connectivity integrity:** Changes to customer gateways or virtual private gateways can disrupt or reroute secure site-to-site VPN connections, affecting both availability and confidentiality.
+        - **Topology change visibility:** Gateway changes are fundamental network infrastructure modifications that can have cascading effects on routing, access control, and compliance boundaries.
+
+        **Risk mitigation**
+
+        - **Unauthorized internet exposure detection:** Real-time alerting on gateway changes surfaces the attachment of internet gateways to private VPCs before attackers can exploit the new connectivity.
+        - **Network topology audit:** Prompt notification enables security teams to verify that gateway changes were authorized and consistent with network design intent.
+        - **Rapid rollback:** Early detection leaves time to detach or remove unauthorized gateways before sensitive resources in the VPC are discovered and targeted.
       audit: |
         ### Audit via Console
 
@@ -42874,11 +42745,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to VPC route tables. Route tables control the routing of traffic within and between VPCs, and unauthorized modifications could redirect traffic to malicious destinations or disrupt network connectivity.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to VPC route tables. By default, CloudWatch does not alert on routing modifications; this filter monitors CloudTrail for events such as `CreateRoute`, `CreateRouteTable`, `ReplaceRoute`, `ReplaceRouteTableAssociation`, `DeleteRouteTable`, `DeleteRoute`, and `DisassociateRouteTable`.
 
-        Route table changes can be used in attacks to intercept or redirect network traffic, enabling man-in-the-middle attacks or data exfiltration. Monitoring route table changes provides visibility into potential traffic redirection attempts in your AWS network infrastructure.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring route table changes to maintain the integrity of network routing and detect unauthorized attempts to redirect or intercept network traffic within your VPCs.
+        - **Traffic redirection risk:** Route table modifications can silently redirect traffic destined for legitimate services to attacker-controlled infrastructure, enabling man-in-the-middle or data exfiltration attacks.
+        - **Network segmentation bypass:** Adding a route between VPCs or subnets that were intentionally isolated can break network segmentation controls and widen the blast radius of a compromise.
+        - **Availability impact:** Deleting or replacing routes can disrupt connectivity for entire subnets, causing outages that may mask the underlying unauthorized change.
+
+        **Risk mitigation**
+
+        - **Traffic interception prevention:** Real-time alerting on route changes allows administrators to identify and remove unauthorized routes before sensitive traffic is misdirected.
+        - **Segmentation integrity:** Monitoring route table modifications ensures that intentional network isolation between environments is not silently circumvented.
+        - **Forensic trigger:** The alarm creates an investigation entry point that helps security teams correlate suspicious routing changes with other indicators of compromise.
       audit: |
         ### Audit via Console
 
@@ -43079,11 +42958,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to Virtual Private Clouds (VPCs). VPCs form the foundational network isolation layer in AWS, and changes to VPC configuration can have broad security implications across all resources within the VPC.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to Virtual Private Clouds (VPCs). By default, CloudWatch does not alert on VPC modifications; this filter monitors CloudTrail for events such as `CreateVpc`, `DeleteVpc`, `ModifyVpcAttribute`, `AcceptVpcPeeringConnection`, `CreateVpcPeeringConnection`, `DeleteVpcPeeringConnection`, and `RejectVpcPeeringConnection`.
 
-        Unauthorized creation, modification, or deletion of VPCs could be indicators of an attacker attempting to establish persistence or pivot within your AWS environment. Monitoring VPC changes provides visibility into fundamental network topology modifications that could affect your entire infrastructure.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring VPC changes to detect unauthorized modifications to your network isolation boundaries and maintain visibility into changes to the core network infrastructure.
+        - **Foundational isolation boundary:** VPCs define the outermost network isolation layer for AWS workloads; changes to VPC configuration can affect the security posture of every resource deployed within them.
+        - **Peering connection exposure:** Unauthorized VPC peering connections can grant another AWS account access to internal resources that are not exposed to the internet, creating a lateral movement path.
+        - **Attribute modification risk:** VPC attribute changes, such as enabling DNS hostnames or modifying tenancy, can have unintended security consequences that are difficult to detect without monitoring.
+
+        **Risk mitigation**
+
+        - **Unauthorized peering detection:** Real-time alerting on VPC changes surfaces unauthorized peering connections before they can be used to traverse into sensitive environments.
+        - **Configuration drift prevention:** Monitoring VPC attribute changes ensures that the network isolation properties of each VPC remain consistent with their designed security posture.
+        - **Incident scope determination:** VPC change alarms help incident responders quickly determine whether network infrastructure was modified as part of an attack chain.
       audit: |
         ### Audit via Console
 
@@ -43284,11 +43171,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that a CloudWatch metric filter and alarm exist to detect changes to AWS Organizations configuration. AWS Organizations allows central governance of multiple AWS accounts, and unauthorized changes to organizational structure or policies can have broad security implications across your entire AWS footprint.
+        This check ensures that a CloudWatch log metric filter and alarm are configured to detect changes to AWS Organizations configuration. By default, CloudWatch does not alert on organizational events; this filter monitors CloudTrail for activity from `organizations.amazonaws.com`, including events such as `CreateAccount`, `AttachPolicy`, `DeleteOrganization`, `DetachPolicy`, and `UpdatePolicy`.
 
-        Changes to Service Control Policies (SCPs), organizational units, or account membership in AWS Organizations can override security controls applied at the account level. Monitoring these changes is critical for organizations using AWS Organizations to enforce security guardrails across all member accounts.
+        **Why this matters**
 
-        CIS AWS Foundations Benchmark recommends monitoring AWS Organizations changes to detect unauthorized modifications to your multi-account governance structure and service control policies.
+        - **Cross-account blast radius:** Service Control Policies (SCPs) applied at the organization or organizational unit level can grant or restrict permissions across all member accounts simultaneously; unauthorized SCP changes have immediate enterprise-wide impact.
+        - **Account governance integrity:** Adding or removing accounts from organizational units changes which guardrails and policies govern those accounts, potentially removing critical security controls.
+        - **Management account criticality:** The AWS Organizations management account has unique capabilities that cannot be constrained by SCPs; any change to organizational structure from this account warrants immediate review.
+
+        **Risk mitigation**
+
+        - **SCP tampering detection:** Alerting on organizational policy changes surfaces unauthorized modifications to the security guardrails that protect all member accounts before the weakened controls can be exploited.
+        - **Account lifecycle oversight:** Real-time notification on account creation, invitation, and removal events ensures that the organizational account inventory remains accurate and controlled.
+        - **Governance continuity:** Monitoring organizational changes helps prevent attackers from using management account access to disable organization-wide security controls across the entire AWS footprint.
       audit: |
         ### Audit via Console
 
@@ -43489,23 +43384,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        Security groups should restrict outbound traffic to only necessary destinations and ports. Unrestricted egress (0.0.0.0/0 on all ports) allows compromised instances to communicate with any external host, facilitating data exfiltration or command-and-control communication.
+        This check ensures that AWS VPC security groups are configured to deny unrestricted outbound traffic to all destinations on all protocols. By default, newly created security groups in AWS include an outbound rule allowing all traffic to `0.0.0.0/0`; restricting egress to only required destinations and ports limits the damage an attacker can do with a compromised resource.
 
         **Why this matters**
 
-        Unrestricted outbound access from EC2 instances and other resources can:
-
-        - Enable compromised resources to exfiltrate sensitive data to attacker-controlled infrastructure.
-        - Allow malware or backdoors to establish command-and-control (C2) channels to arbitrary external hosts.
-        - Violate compliance requirements from frameworks such as CIS AWS Foundations Benchmark, PCI DSS, and ISO 27001 that mandate egress filtering.
-
-        Limiting outbound traffic to only required destinations and ports is a fundamental defense-in-depth control.
+        - **Data exfiltration containment:** Broad egress rules allow compromised instances to send data to any external host, enabling attackers to exfiltrate sensitive data unimpeded.
+        - **Command-and-control disruption:** Restricting outbound traffic prevents malware from establishing connections to attacker-controlled command-and-control infrastructure.
+        - **Lateral movement limitation:** Controlled egress reduces the ability of a compromised instance to scan or attack external targets, limiting the blast radius of a breach.
+        - **Defense-in-depth enforcement:** Egress filtering complements ingress controls by ensuring that even if an attacker gains execution inside the network, outbound communication is restricted.
 
         **Risk mitigation**
 
-        - Reduces the impact of compromised instances by preventing arbitrary outbound communications.
-        - Limits the blast radius of a breach by restricting lateral movement and data exfiltration paths.
-        - Supports compliance with network segmentation and egress filtering requirements.
+        - **Exfiltration prevention:** Allowing only necessary outbound connections eliminates the primary channel attackers use to remove data from a compromised environment.
+        - **Malware impact reduction:** Blocking arbitrary outbound connections prevents ransomware and other malware from communicating with external infrastructure for key exchange or instructions.
       audit: |
         ### Audit via Console
 
@@ -43668,25 +43559,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        The AWS root account has unrestricted access to all resources in the account and cannot be limited by IAM policies. Protecting it with a hardware MFA device provides a significantly stronger authentication guarantee than a software (virtual) MFA token, which can be compromised if the device or seed material is stolen.
+        This check ensures that the AWS root account is protected with a hardware MFA device rather than a software (virtual) MFA token. By default, AWS allows any MFA type including virtual authenticator apps, but a hardware device provides a substantially stronger guarantee because the TOTP seed cannot be copied or exfiltrated remotely.
 
         **Why this matters**
 
-        The root account is the most privileged identity in an AWS account. If compromised, an attacker gains complete control over all resources, billing, and account settings. Hardware MFA provides:
-
-        - A physical second factor that cannot be exfiltrated remotely, unlike virtual MFA apps or TOTP seeds stored in software.
-        - Protection against phishing attacks targeting one-time codes entered on malicious sites.
-        - Compliance with strict authentication requirements in standards such as PCI DSS, NIST SP 800-53, and ISO 27001 that differentiate hardware-based MFA.
-
-        A virtual MFA device alone is insufficient for root account protection because the TOTP seed can be backed up, copied, or stolen without the account owner's knowledge.
-
-        This check passes when MFA is active on the root account AND no virtual MFA device is associated with root, implying that a hardware MFA device is in use.
+        - **Strongest available protection:** A hardware token requires physical possession to authenticate, making remote account takeover impossible even if credentials and virtual seed material are both stolen.
+        - **Protection against phishing:** Virtual MFA codes can be captured and replayed via phishing sites; a hardware device binds the second factor to physical custody.
+        - **Root-specific risk:** The root account has unrestricted access to all resources and cannot be scoped by IAM policies, so the consequences of compromise are total account loss.
+        - **Insufficient virtual MFA:** A TOTP seed stored in software can be backed up, cloned, or exfiltrated without the account owner's knowledge, making virtual MFA alone inadequate for this identity.
 
         **Risk mitigation**
 
-        - Prevents root account takeover even if credentials are compromised through phishing or credential stuffing.
-        - Ensures the most privileged account identity requires physical possession of a hardware token to authenticate.
-        - Satisfies compliance requirements mandating hardware MFA for privileged or administrative accounts.
+        - **Remote takeover prevention:** Hardware MFA ensures that even a fully compromised credential set cannot be used to authenticate without the physical device.
+        - **Blast radius containment:** Protecting the root account reduces the risk of complete account seizure, which would expose all resources, billing, and account settings to an attacker.
       audit: |
         ### Audit via Console
 
@@ -43788,23 +43673,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        SSL/TLS certificates stored in AWS IAM that have passed their expiration date should be removed promptly. Expired certificates represent an expanded attack surface: their corresponding private keys may have been extracted, backed up, or compromised over time, and an attacker possessing these keys can impersonate the associated services. Forgotten expired certificates also indicate gaps in certificate lifecycle management that may extend to active certificates.
+        This check ensures that expired SSL/TLS certificates stored in AWS IAM are removed promptly. By default, IAM retains uploaded server certificates indefinitely after expiration; leaving them in place extends the exposure window of the associated private keys and signals gaps in certificate lifecycle management.
 
         **Why this matters**
 
-        Expired certificates stored in IAM create security risks:
-
-        - Private keys associated with long-lived or expired certificates have had extended exposure time, increasing the likelihood they have been compromised, backed up insecurely, or accessed by former employees.
-        - An attacker with a compromised private key can perform service impersonation or man-in-the-middle attacks against clients that do not perform strict certificate validation.
-        - Expired certificates that remain in IAM indicate a failure in certificate lifecycle management, suggesting that active certificates may also lack proper rotation, increasing the window for key compromise across the organization.
-
-        AWS Certificate Manager (ACM) is the recommended service for managing certificates, but some legacy integrations still use IAM-stored certificates.
+        - **Extended key exposure:** Private keys associated with long-lived or expired certificates have had more time to be compromised, backed up insecurely, or accessed by former employees.
+        - **Impersonation risk:** An attacker possessing a compromised private key can impersonate the associated service or conduct man-in-the-middle attacks against clients that do not enforce strict certificate validation.
+        - **Lifecycle management signal:** Expired certificates that remain in IAM indicate that rotation practices may be absent or inconsistent, suggesting active certificates could also be mismanaged.
+        - **Preferred alternative available:** AWS Certificate Manager (ACM) handles issuance and renewal automatically; IAM-stored certificates are a legacy integration path that warrants extra scrutiny.
 
         **Risk mitigation**
 
-        - **Attack surface reduction:** Removing expired certificates and rotating their associated keys eliminates potential impersonation vectors from compromised private keys.
-        - **Credential hygiene:** Reduces the inventory to only valid, actively managed certificates, ensuring that compromised legacy keys cannot be used for impersonation.
-        - **Lifecycle management:** Enforcing certificate cleanup drives adoption of proper rotation practices that limit key exposure time.
+        - **Attack surface reduction:** Removing expired certificates eliminates potential impersonation vectors from private keys that may have been compromised over the certificate's lifetime.
+        - **Hygiene enforcement:** Keeping only valid, actively managed certificates in IAM ensures the inventory reflects the true set of trusted keys in the environment.
       audit: |
         ### Audit via Console
 
@@ -43895,23 +43776,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        AWS recommends creating a dedicated IAM role or group with the AWSSupportAccess managed policy attached to manage interactions with AWS Support. Without a dedicated support role, operators are forced to use the root account for support interactions, expanding the blast radius of root credential compromise and eliminating forensic traceability for post-breach investigations.
+        This check ensures that at least one IAM user, role, or group has the AWSSupportAccess managed policy attached, providing a dedicated, least-privilege path for interacting with AWS Support. Without a dedicated support role, teams are forced to use the root account or overly-permissive identities for support interactions.
 
         **Why this matters**
 
-        Without a dedicated support role:
-
-        - Root account usage for support interactions increases exposure of root credentials, which provide unrestricted access to the entire AWS account and cannot be scoped with IAM policies.
-        - If the root account is compromised, there is no way to distinguish attacker-initiated support cases from legitimate ones, complicating incident response and forensic investigation.
-        - Post-breach forensics require attributing actions to specific identities. Root account actions lack granular attribution, making it impossible to determine whether support interactions during a breach were legitimate or attacker-initiated.
-
-        Assigning the AWSSupportAccess policy to a specific role, group, or user ensures that support interactions are performed with least-privilege credentials that can be audited.
+        - **Root credential protection:** Using the root account for support cases exposes the most privileged identity in the AWS account to additional risk each time a ticket is filed.
+        - **Attribution and auditability:** Actions performed under a dedicated support role are attributable to a specific IAM identity in CloudTrail, whereas root account actions lack granular attribution.
+        - **Least-privilege alignment:** The AWSSupportAccess policy grants only the permissions needed for support interactions, limiting the blast radius compared to broader administrative roles.
+        - **Incident traceability:** During a breach investigation, CloudTrail records from a named support role can be cleanly separated from attacker activity; root account records cannot.
 
         **Risk mitigation**
 
-        - **Root credential protection:** Eliminates a reason to use root credentials, reducing exposure of the most privileged account in the environment.
-        - **Forensic traceability:** Creates attributable, auditable identities for support interactions that can be distinguished from attacker activity during incident investigation.
-        - **Blast radius containment:** Ensures support access is scoped to a dedicated role with limited permissions rather than the unrestricted root account.
+        - **Blast radius containment:** Restricts support access to a role with bounded permissions rather than the unrestricted root account.
+        - **Forensic clarity:** Provides attributable, auditable identities for support interactions, making post-incident investigation more reliable.
       audit: |
         ### Audit via Console
 
@@ -44066,15 +43943,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check identifies IAM credentials (passwords and access keys) that pose a risk due to inactivity. It flags two cases: (a) credentials that have **never been used** (where `passwordLastUsed` or `accessKey1LastUsedDate` is null), indicating they may have been provisioned but never needed, and (b) credentials that have not been used within a defined threshold period. Credentials that remain active but unused increase the attack surface, as they may belong to former employees, deprecated service accounts, or forgotten automation keys that an attacker could compromise without detection.
+        This check ensures that IAM console passwords and access keys that have never been used or have not been used within the configured inactivity threshold are disabled. AWS does not automatically revoke unused credentials, so long-lived inactive credentials accumulate as dormant attack surface over time.
 
         **Why this matters**
 
-        - **Reduced attack surface:** Unused credentials that remain active are prime targets for credential stuffing, phishing, or insider threats. Disabling them limits the window of opportunity for attackers.
-        - **Compliance requirements:** CIS AWS Foundations Benchmark (1.12), NIST 800-53 (AC-2), and SOC 2 require organizations to review and disable credentials that are no longer in use.
-        - **Operational hygiene:** Stale credentials often indicate poor offboarding processes or abandoned service integrations that should be cleaned up.
+        - **Dormant account risk:** Credentials provisioned for users who have since left or for integrations that were never activated remain valid indefinitely unless explicitly disabled, creating unmonitored access paths.
+        - **Stale key exposure:** Access keys that have not rotated or been used for extended periods are more likely to have been exfiltrated from source control, configuration files, or shared storage without detection.
+        - **Detection gap:** Inactive credentials are rarely monitored in SIEM or alerting pipelines, meaning an attacker using a dormant key may operate undetected for longer than with active credentials.
+        - **Offboarding failures:** Never-used or long-idle credentials often indicate incomplete offboarding or abandoned service integrations that represent residual access the organization no longer intends to grant.
 
-        By default, credentials unused for 90 days or more are flagged. This threshold can be adjusted using the `mondooAWSSecurityCredentialInactivityThreshold` property.
+        **Risk mitigation**
+
+        - **Reduced attack surface:** Disabling unused credentials closes access paths that serve no legitimate purpose and would not be missed if revoked.
+        - **Improved detection:** A smaller set of active, monitored credentials reduces noise and improves the signal-to-noise ratio in access anomaly detection.
       audit: |
         ### Audit via Console
 
@@ -44217,23 +44098,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        AWS X-Ray provides distributed tracing for Lambda functions, enabling visibility into function execution, latency, and downstream service calls. Enabling active tracing helps security and operations teams detect anomalous behavior, unexpected latency spikes, and unauthorized invocations.
+        This check ensures that AWS Lambda functions have X-Ray active tracing enabled. By default, Lambda functions are created with tracing mode set to `PassThrough`, which does not generate trace segments; enabling active tracing is an explicit opt-in step.
 
         **Why this matters**
 
-        Without X-Ray tracing enabled on Lambda functions:
-
-        - Investigations into unexpected function behavior or security incidents lack detailed execution traces.
-        - Latency and error patterns that may indicate abuse or compromise go undetected.
-        - Compliance frameworks such as NIST SP 800-53 and SOC 2 require audit and monitoring capabilities for compute workloads.
-
-        X-Ray tracing complements CloudWatch logs by providing structured, visual traces of function invocations and their downstream dependencies.
+        - **Incident investigation:** Without execution traces, investigations into unexpected function behavior, unauthorized invocations, or security incidents lack the structured evidence needed to reconstruct what happened.
+        - **Anomaly detection:** Latency spikes, error rate increases, and unusual downstream API calls that may indicate compromise or abuse are difficult to attribute without per-invocation trace data.
+        - **Downstream visibility:** X-Ray captures calls to downstream services such as DynamoDB, S3, SNS, and external HTTP endpoints, making it possible to detect unauthorized data access patterns or exfiltration attempts.
+        - **Complementary to logs:** CloudWatch Logs capture text output, while X-Ray provides structured, timeline-based traces of function execution and service dependencies.
 
         **Risk mitigation**
 
-        - Improves incident response by providing detailed traces of function execution and service calls.
-        - Enables detection of anomalous invocation patterns or unexpected downstream API calls.
-        - Supports compliance with logging and monitoring requirements for serverless workloads.
+        - **Faster incident response:** Detailed execution traces reduce mean time to detect and contain anomalous Lambda behavior.
+        - **Evidence preservation:** Trace data supports forensic investigation by preserving a structured record of invocations and downstream calls made during a compromise window.
       audit: |
         ### Audit via Console
 
@@ -44400,23 +44277,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        Lambda resource-based policy statements that grant Allow permissions to AWS services such as S3, SNS, or EventBridge should include a Condition that specifies a source ARN. Without this condition, any resource in the granting service's account can invoke the function, creating a confused deputy vulnerability.
+        This check ensures that Lambda resource-based policy statements granting `Allow` permissions to AWS service principals include a `Condition` specifying a source ARN or source account. Without this condition, any resource within the invoking service's scope could be configured to trigger the function, creating a confused deputy vulnerability.
 
         **Why this matters**
 
-        When a Lambda permission grants invoke rights to an AWS service principal (for example, s3.amazonaws.com) without a source ARN condition:
-
-        - Any S3 bucket in any account could be configured to trigger the Lambda function if the attacker can influence cross-account trust.
-        - The confused deputy problem allows a malicious actor to use a trusted service as a proxy to invoke a Lambda function they do not have direct permission to call.
-        - Compliance requirements from NIST SP 800-53 and ISO 27001 mandate that access grants be scoped to the minimum necessary resources.
-
-        Adding a Condition with aws:SourceArn or aws:SourceAccount restricts invocations to the specific resource or account that legitimately needs access.
+        - **Confused deputy attack:** When a Lambda permission grants invoke rights to a service principal such as `s3.amazonaws.com` without a source ARN constraint, any S3 bucket under attacker control could be configured to invoke the function.
+        - **Cross-account exploitation:** An attacker with the ability to create resources in a trusted service can use that service as a proxy to invoke Lambda functions they do not have direct permission to call.
+        - **Overly broad trust:** Service principals represent entire AWS services, not specific resources; without a source ARN condition, the permission is effectively unrestricted within that service.
+        - **Defense in depth:** Source ARN conditions provide a second layer of access control that remains effective even if IAM policies are misconfigured or overly permissive.
 
         **Risk mitigation**
 
-        - Eliminates the confused deputy attack vector by binding Lambda invoke permissions to a specific source resource ARN.
-        - Ensures that only the intended AWS resource can trigger the function, even if another resource in the same service is compromised.
-        - Reduces the blast radius of misconfigured cross-service permissions.
+        - **Confused deputy prevention:** Binding invoke permissions to a specific source ARN ensures only the intended resource can trigger the function, regardless of what other principals the service principal represents.
+        - **Blast radius reduction:** Limits the impact of a compromised cross-service permission by confining the invocation scope to a known, legitimate resource.
       audit: |
         ### Audit via Console
 
@@ -44586,23 +44459,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        MFA delete adds an additional layer of protection for versioned S3 objects by requiring multi-factor authentication before permanently deleting an object version or changing the versioning state of a bucket. This prevents accidental or malicious deletion of critical data even if AWS credentials are compromised.
+        This check ensures that versioned S3 buckets have MFA delete enabled, requiring multi-factor authentication before permanently deleting an object version or disabling bucket versioning. By default, S3 buckets do not require MFA for delete operations, meaning compromised credentials alone are sufficient to destroy all object versions.
 
         **Why this matters**
 
-        Without MFA delete enabled on versioned S3 buckets:
-
-        - A compromised set of AWS credentials is sufficient to permanently delete all versions of an object, bypassing versioning protections.
-        - Ransomware or insider threats can irreversibly destroy data without requiring physical possession of an MFA device.
-        - Compliance frameworks such as NIST SP 800-53 SC-28 and SOC 2 CC6.1 require data protection controls that prevent unauthorized deletion.
-
-        MFA delete ensures that permanent data deletion requires both knowledge (credentials) and possession (MFA device), providing defense against credential-based attacks.
+        - **Credential-only deletion:** Without MFA delete, an attacker with valid AWS credentials can permanently delete all versions of every object in a versioned bucket in a single automated operation.
+        - **Ransomware targeting:** Cloud storage is a frequent ransomware target; MFA delete removes the ability to automate bulk destruction because each destructive operation requires a physical second factor.
+        - **Versioning bypass:** Versioning protects against accidental overwrites but not against deliberate deletion of all versions; MFA delete is the control that closes this gap.
+        - **Defense-in-depth for critical data:** Buckets containing audit logs, backups, or regulated data warrant the extra friction that MFA delete introduces for destructive operations.
 
         **Risk mitigation**
 
-        - Prevents permanent object deletion by requiring a second authentication factor for destructive operations.
-        - Protects against ransomware attacks that target cloud storage by deleting or encrypting versioned objects.
-        - Supports compliance with data protection requirements mandating controls against unauthorized data destruction.
+        - **Ransomware resilience:** Requiring physical MFA possession for deletion forces attackers to abandon automated destruction playbooks that rely on credential-only access.
+        - **Irreversible action gating:** Adds a deliberate, auditable second factor to the most destructive S3 operation, creating additional detection opportunities before data is permanently lost.
       audit: |
         ### Audit via Console
 
@@ -46170,23 +46039,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that Amazon ECS task definitions do not contain plaintext secrets in container environment variables. Hardcoded secrets such as passwords, API keys, and access tokens in environment variables can be exposed through the ECS console, API calls, or container introspection.
+        This check ensures that Amazon ECS task definition container environment variables do not contain plaintext secrets such as passwords, API keys, or access tokens. Embedding secrets as environment variable values exposes them to anyone with `ecs:DescribeTaskDefinition` permissions and to logging pipelines that capture environment state.
 
         **Why this matters**
 
-        Storing secrets as plaintext environment variables in ECS task definitions poses significant security risks:
-
-        - **Credential exposure:** Environment variables are visible to anyone with permissions to describe task definitions and can be logged in various places.
-        - **Rotation difficulty:** Hardcoded secrets require redeployment of task definitions to rotate, making it difficult to respond to compromises.
-        - **Blast radius:** A single compromised task definition can expose multiple secrets simultaneously.
-
-        **Scope:** This check detects common secret patterns in environment variable names such as `DB_PASSWORD`, `API_KEY`, and `AWS_SECRET_ACCESS_KEY`, as well as values matching AWS access key IDs or private key headers. Secrets stored under non-standard variable names without recognizable value patterns will not be detected.
+        - **Broad read exposure:** Task definition environment variables are readable by any IAM principal with describe permissions, by container runtime processes, and by observability tools that log environment state.
+        - **Rotation complexity:** Hardcoded secrets require creating and deploying a new task definition revision to rotate, making rapid response to a compromise operationally difficult.
+        - **Log leakage:** Container orchestration systems, debugging tools, and SIEM platforms frequently capture environment variable state, potentially persisting secret values in log storage.
+        - **Blast radius on compromise:** A single task definition with multiple plaintext secrets exposes all of them simultaneously if the definition is read by an unauthorized party.
 
         **Risk mitigation**
 
-        - Use AWS Secrets Manager or AWS Systems Manager Parameter Store to manage secrets securely.
-        - Reference secrets in task definitions using the `secrets` field with `valueFrom` instead of the `environment` field.
-        - Implement automated secret rotation through Secrets Manager.
+        - **Secrets manager integration:** Referencing secrets via the `secrets` field with `valueFrom` pointing to AWS Secrets Manager or SSM Parameter Store ensures values are injected at runtime and never stored in the task definition itself.
+        - **Rotation enablement:** Externalized secrets can be rotated in Secrets Manager and automatically picked up at the next task launch without redeployment of the task definition.
       audit: |
         ### Audit via Console
 
@@ -46335,21 +46200,19 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that the default VPC is not present in the AWS account. Default VPCs are created automatically in each AWS region with permissive network configurations that are unsuitable for production workloads.
+        This check ensures that the default VPC is not present in any AWS region. AWS automatically creates a default VPC in every region with an internet gateway, public subnets, and auto-assigned public IP addresses, configuration that is unsuitable for production workloads and not aligned with least-privilege network design.
 
         **Why this matters**
 
-        Default VPCs have several security concerns:
-
-        - **Permissive configuration:** Default VPCs include an internet gateway, public subnets, and auto-assigned public IP addresses, which can inadvertently expose resources to the internet.
-        - **Lack of segmentation:** The default network configuration does not enforce proper network segmentation or least-privilege access.
-        - **Accidental deployment:** Resources launched without specifying a VPC are placed in the default VPC, potentially bypassing security controls.
+        - **Automatic public exposure:** Instances launched into the default VPC receive public IP addresses by default, creating unintended internet-facing surfaces if a deployment targets the wrong VPC.
+        - **Missing network segmentation:** Default VPCs lack the subnet tiering, route table customization, and security group defaults that purpose-built VPCs implement, reducing the effectiveness of network-level controls.
+        - **Accidental deployment risk:** Developers and automation pipelines that omit a VPC parameter will silently land resources in the default VPC, bypassing security controls designed into production network architecture.
+        - **Lateral movement path:** Resources inadvertently placed in the default VPC may be reachable from other resources in the same flat network, reducing isolation between environments and workloads.
 
         **Risk mitigation**
 
-        - Delete default VPCs in all regions to prevent accidental use.
-        - Create custom VPCs with properly configured subnets, route tables, and security groups.
-        - Enforce VPC selection through service control policies or IAM conditions.
+        - **Accidental exposure prevention:** Removing the default VPC eliminates the fallback network that could receive resources launched without explicit VPC targeting.
+        - **Network architecture enforcement:** Ensures all workloads use purpose-built VPCs with intentional segmentation, routing, and ingress controls.
       audit: |
         ### Audit via Console
 
@@ -46455,21 +46318,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EMR clusters have local disk encryption enabled. Local disk encryption protects data stored on instance store volumes and EBS volumes attached to EMR cluster nodes using Linux Unified Key Setup (LUKS) or other encryption mechanisms.
+        This check ensures that Amazon EMR clusters have local disk encryption enabled through an EMR security configuration. By default, EMR clusters do not encrypt local disk storage; instance store volumes and EBS volumes attached to cluster nodes store data in plaintext unless encryption is explicitly configured.
 
         **Why this matters**
 
-        Without local disk encryption, sensitive data processed by EMR jobs is stored in plaintext on cluster node disks:
-
-        - **Data exposure:** Temporary data, shuffle data, and spill files written during MapReduce, Spark, or Hive jobs can contain sensitive information.
-        - **Compliance requirements:** Many regulatory frameworks require encryption of data at rest, including data on local storage volumes.
-        - **Instance store volatility:** While instance store data is lost on termination, it remains accessible during the cluster lifetime without encryption.
+        - **Sensitive intermediate data:** MapReduce, Spark, and Hive jobs frequently write temporary data, shuffle files, and spill data to local disk that may contain the sensitive records being processed.
+        - **Unencrypted EBS volumes:** Without local disk encryption, EBS volumes attached to EMR nodes store data at rest without protection, making any snapshot or cross-region copy of those volumes readable.
+        - **Instance store persistence:** Instance store volumes remain accessible to other workloads on the same physical host until the underlying hardware is decommissioned; encryption limits the exposure window.
+        - **Compliance scope:** Regulatory frameworks that require encryption of data at rest extend to local volumes on compute instances, not only managed database or object storage services.
 
         **Risk mitigation**
 
-        - **Data protection:** Ensures all data on local disks is encrypted, preventing unauthorized access to intermediate processing data.
-        - **Compliance:** Meets regulatory requirements for encryption of data at rest on compute instances.
-        - **Defense in depth:** Adds an additional layer of protection beyond network-level controls.
+        - **Data-at-rest protection:** Encrypting local disks ensures that intermediate processing data, temporary files, and spill data are unreadable without the associated KMS key.
+        - **Snapshot and copy safety:** Encrypted volumes cannot be read from snapshots or EBS copies without access to the encryption key, preventing data exfiltration through volume-level operations.
       audit: |
         ### Audit via Console
 
@@ -46660,21 +46521,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS CloudTrail multi-region trails are configured to deliver logs to Amazon CloudWatch Logs. CloudWatch integration enables real-time monitoring, alerting, and automated responses to CloudTrail events.
+        This check ensures that AWS CloudTrail multi-region trails are configured to deliver log events to Amazon CloudWatch Logs. By default, CloudTrail writes logs only to S3; CloudWatch integration must be configured explicitly to enable real-time monitoring and metric-based alerting on API activity.
 
         **Why this matters**
 
-        Without CloudWatch integration, CloudTrail logs are only available in S3, limiting monitoring capabilities:
-
-        - **Delayed detection:** Without real-time log analysis, security incidents may go undetected for extended periods.
-        - **No automated alerting:** S3-only logging requires manual or separate tooling for alert generation.
-        - **Compliance gaps:** Many security frameworks require real-time monitoring and alerting on security-relevant events.
+        - **Delayed detection without integration:** Logs stored only in S3 require periodic batch analysis or separate tooling to detect suspicious activity; CloudWatch Logs enables near-real-time event processing.
+        - **No native alerting from S3:** CloudTrail-to-S3 delivery does not produce CloudWatch metric filters or alarms; automated alerting on root account usage, policy changes, or unauthorized API calls requires CloudWatch integration.
+        - **Incident response speed:** Security incidents detected through real-time log streaming allow responders to act during or immediately after an attack rather than hours or days later during a log review cycle.
+        - **Metric filter prerequisites:** CloudWatch metric filters and alarms for controls such as root account usage, unauthorized API calls, and security group changes require CloudWatch Logs delivery to function.
 
         **Risk mitigation**
 
-        - **Real-time monitoring:** Enables immediate detection of suspicious API activity through CloudWatch metric filters and alarms.
-        - **Automated response:** CloudWatch alarms can trigger SNS notifications, Lambda functions, or other automated remediation actions.
-        - **Compliance:** Meets requirements for continuous monitoring and real-time alerting in security frameworks.
+        - **Real-time threat detection:** CloudWatch metric filters and alarms can surface suspicious API patterns within minutes of occurrence rather than in the next scheduled log review.
+        - **Automated response enablement:** CloudWatch alarms can trigger SNS notifications, Lambda functions, or Systems Manager runbooks to contain threats without manual intervention.
       audit: |
         ### Audit via Console
 
@@ -46837,21 +46696,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Redis ElastiCache clusters have automatic backup (snapshot) retention configured. Without backups, an attacker with compromised credentials can flush or destroy cache data with no recovery path, and ransomware-style attacks targeting cloud data stores rely on the absence of backups to maximize damage and leverage.
+        This check ensures that Redis ElastiCache clusters have automatic snapshot retention configured with a retention period greater than zero. By default, ElastiCache Redis clusters are created with `SnapshotRetentionLimit` set to 0, which disables automatic backups entirely.
 
         **Why this matters**
 
-        Without backup retention, ElastiCache Redis clusters have no recovery path from adversarial data destruction:
-
-        - An attacker with `elasticache:ModifyCacheCluster` or direct Redis access can flush all data, and without backups, recovery is impossible.
-        - Ransomware-style attacks increasingly target cloud-managed data stores, destroying data to pressure organizations into paying ransoms.
-        - Cache data often includes session tokens, authentication state, and application configuration that, if destroyed without backups, can cause cascading authentication failures and service outages.
+        - **No recovery without backups:** An attacker with `elasticache:ModifyCacheCluster` permissions or direct Redis access can flush all cache data, and without snapshots no recovery path exists.
+        - **Session and state destruction:** Cache clusters frequently store session tokens, authentication state, and application configuration; destruction without backups causes cascading authentication failures and service outages.
+        - **Ransomware targeting:** Managed cloud data stores including ElastiCache are targeted by ransomware-style attacks that destroy data to maximize business impact and pressure organizations into paying ransoms.
+        - **Disabled by default:** AWS ships ElastiCache with backups off, meaning clusters deployed without explicit retention configuration have zero recovery capability from the moment of creation.
 
         **Risk mitigation**
 
-        - **Ransomware resilience:** Backups ensure data can be restored after adversarial destruction, removing the attacker's leverage.
-        - **Incident recovery:** Enables restoration to a known-good state after a cache poisoning or data destruction attack.
-        - **Compliance:** Meets regulatory requirements for data backup and recovery capabilities.
+        - **Ransomware resilience:** Automatic snapshots ensure data can be restored after adversarial destruction, removing the attacker's leverage.
+        - **Recovery capability:** Retained snapshots enable restoration to a known-good cache state after a data destruction event, limiting downtime and cascading failures.
       audit: |
         ### Audit via Console
 
@@ -47002,21 +46859,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon RDS DB instances have automated backup retention configured. Without backups, an attacker who compromises database credentials can destroy or corrupt data with no recovery path, and ransomware-style attacks targeting cloud databases rely on the absence of backups to maximize damage.
+        This check ensures that Amazon RDS DB instances have automated backup retention configured with a retention period greater than zero days. By default, newly created RDS instances have backup retention enabled with a one-day window, but this can be explicitly disabled, leaving the instance without any automated recovery capability.
 
         **Why this matters**
 
-        RDS instances without backup retention have no recovery path from adversarial data destruction:
-
-        - An attacker with database-level access can DROP tables, corrupt data, or encrypt records as ransomware, and without backups the damage is permanent.
-        - Ransomware attacks increasingly target cloud-managed databases, deleting or encrypting data to pressure organizations into paying ransoms.
-        - Without point-in-time recovery, even detecting the exact moment of compromise is insufficient because there is no backup to restore from.
+        - **No recovery from destruction:** An attacker with database-level access can drop tables, corrupt data, or encrypt records, and without backups the damage cannot be reversed regardless of how quickly the attack is detected.
+        - **Ransomware leverage removed:** Automated backups eliminate the attacker's ability to use data destruction as leverage, because the organization can restore to a pre-attack state.
+        - **Incomplete protection from versioning alone:** Backups provide point-in-time recovery that covers gradual data corruption and delayed detection scenarios that a single final snapshot does not address.
+        - **Compliance mandate:** Regulatory frameworks require demonstrable backup and recovery capabilities for systems storing regulated data; a retention period of zero fails this requirement.
 
         **Risk mitigation**
 
-        - **Ransomware resilience:** Automated backups ensure data can be restored after adversarial destruction, removing the attacker's leverage.
         - **Point-in-time recovery:** Enables restoration to the moment before an attack, minimizing data loss from SQL injection, insider threats, or credential compromise.
-        - **Forensic capability:** Backup snapshots can be used to compare pre-attack and post-attack database states during incident investigation.
+        - **Forensic comparison:** Backup snapshots allow comparison of pre-attack and post-attack database states during incident investigation, supporting evidence preservation.
       audit: |
         ### Audit via Console
 
@@ -47165,21 +47020,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon RDS DB instances have Performance Insights enabled. Performance Insights provides detailed query-level and wait-event analysis that can detect active attacks against the database, including SQL injection attempts (abnormal query patterns), bulk data exfiltration (unusual read volumes), and cryptomining abuse (excessive CPU from unauthorized workloads).
+        This check ensures that Amazon RDS DB instances have Performance Insights enabled. By default, Performance Insights is disabled on RDS instances; it must be explicitly enabled, and AWS provides a free 7-day retention tier for most instance classes.
 
         **Why this matters**
 
-        Without Performance Insights, database attacks are difficult to detect:
-
-        - **SQL injection blind spots:** Abnormal query patterns from SQL injection attacks are invisible without query-level performance data, allowing attackers to extract data undetected.
-        - **Data exfiltration detection:** Bulk SELECT operations or unusual data transfer volumes that indicate exfiltration are only visible through detailed performance metrics.
-        - **Cryptomining and abuse:** Unauthorized compute-intensive workloads running against the database such as cryptomining queries appear as unexplained CPU spikes that require Performance Insights to diagnose.
+        - **SQL injection blind spots:** Abnormal query patterns generated by SQL injection attacks are invisible without query-level performance data, allowing attackers to extract data undetected through the normal database port.
+        - **Exfiltration detection:** Bulk SELECT operations and unusual data transfer volumes that signal data exfiltration are only visible through detailed per-query performance metrics rather than aggregate CloudWatch metrics.
+        - **Unauthorized workload detection:** Cryptomining queries, unauthorized batch jobs, and resource exhaustion attacks appear as unexplained CPU or wait-event spikes that Performance Insights can identify and attribute to specific queries.
+        - **Forensic evidence:** Historical performance data preserves evidence of attacker query patterns that can be used during post-incident investigation to reconstruct what was accessed or exfiltrated.
 
         **Risk mitigation**
 
-        - **Attack detection:** Enables identification of SQL injection, data exfiltration, and unauthorized workloads through abnormal query patterns and resource consumption.
-        - **Forensic analysis:** Historical performance data supports post-incident investigation by preserving evidence of attacker activity.
-        - **Anomaly baselining:** Establishes normal query patterns so that deviations from attacker activity can be identified and alerted on.
+        - **Attack detection:** Enables identification of SQL injection, data exfiltration, and unauthorized workloads through abnormal query patterns and resource consumption metrics.
+        - **Baseline establishment:** Capturing normal query patterns creates a reference for anomaly detection, allowing deviations caused by attacker activity to be identified and alerted on.
       audit: |
         ### Audit via Console
 
@@ -47333,21 +47186,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon RDS DB instances have deletion protection enabled. An attacker with compromised IAM credentials can delete unprotected database instances as a ransomware-style destructive action, causing permanent data loss if backups are insufficient or also compromised.
+        This check ensures that Amazon RDS DB instances have deletion protection enabled. By default, RDS instances are created without deletion protection, meaning any IAM principal with `rds:DeleteDBInstance` permissions can permanently destroy the instance in a single API call.
 
         **Why this matters**
 
-        Without deletion protection, RDS instances are vulnerable to intentional destruction:
-
-        - An attacker with `rds:DeleteDBInstance` permissions can permanently destroy production databases in a single API call, with the option to skip final snapshots.
-        - Ransomware-style attacks increasingly target cloud databases for destruction, leveraging compromised credentials to maximize business impact.
-        - Even with backups, the recovery window creates extended downtime that an attacker can exploit for further lateral movement or data exfiltration.
+        - **Single-call destruction:** Without deletion protection, a compromised IAM credential with delete permissions can destroy a production database instantly, with the option to skip final snapshots and leave no recovery path.
+        - **Ransomware and destructive attacks:** Ransomware-style attacks targeting cloud infrastructure use database destruction as leverage; deletion protection raises the operational cost for attackers.
+        - **Insufficient IAM alone:** IAM policies can be circumvented by privilege escalation, credential theft, or insider threats; instance-level deletion protection provides a complementary control layer.
+        - **Recovery window gap:** Even with backups, database deletion triggers downtime during restoration; deletion protection prevents the destruction event entirely rather than merely enabling recovery after the fact.
 
         **Risk mitigation**
 
-        - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
-        - **Defense in depth:** Complements IAM policies by adding instance-level protection that survives credential compromise.
-        - **Incident response window:** The additional step buys time for automated alerting to detect and respond to unauthorized modification attempts.
+        - **Two-step destruction requirement:** Deletion protection forces an attacker to first disable protection and then issue the delete call as two separate API operations, creating an additional CloudTrail event and detection opportunity before data is lost.
+        - **Defense in depth:** Adds instance-level protection that remains effective even when IAM controls are bypassed through credential compromise or privilege escalation.
       audit: |
         ### Audit via Console
 
@@ -47496,21 +47347,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon RDS DB clusters (Aurora) have deletion protection enabled. An attacker with compromised IAM credentials can delete unprotected Aurora clusters as a ransomware-style destructive action, permanently destroying all cluster data and associated read replicas in a single operation.
+        This check ensures that Amazon RDS DB clusters (Aurora) have deletion protection enabled. By default, Aurora clusters are created without deletion protection, meaning any IAM principal with `rds:DeleteDBCluster` permissions can permanently destroy the entire cluster and all associated instances in a single API call.
 
         **Why this matters**
 
-        Without deletion protection, RDS clusters are vulnerable to intentional destruction:
-
-        - An attacker with `rds:DeleteDBCluster` permissions can destroy an entire Aurora cluster and all its instances in a single API call, with the option to skip final snapshots.
-        - Cluster deletion is particularly devastating because it destroys all read replicas and failover instances simultaneously, eliminating redundancy.
-        - Ransomware-style attacks targeting cloud infrastructure use database destruction as leverage, and unprotected clusters are trivial to destroy with compromised credentials.
+        - **All-or-nothing destruction:** Aurora cluster deletion destroys the primary instance and all read replicas simultaneously, eliminating redundancy and any in-flight replication in a single operation.
+        - **Skip-snapshot option:** The delete cluster API accepts a parameter to skip the final snapshot, meaning an attacker can destroy the cluster and all recovery options in one call.
+        - **Ransomware targeting:** Aurora clusters holding critical business data are high-value targets for destructive ransomware attacks; cluster-level deletion without protection makes the attack trivially simple.
+        - **IAM controls insufficient alone:** Privilege escalation, credential theft, or insider threats can bypass IAM policies; cluster-level deletion protection provides a complementary safeguard.
 
         **Risk mitigation**
 
-        - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
-        - **Defense in depth:** Complements IAM policies by adding cluster-level protection that survives credential compromise.
-        - **Incident response window:** The additional step buys time for automated alerting to detect and respond to unauthorized modification attempts.
+        - **Two-step destruction requirement:** Deletion protection forces an attacker to first disable it via `rds:ModifyDBCluster`, generating a CloudTrail event that automated alerting can detect before the cluster is deleted.
+        - **Defense in depth:** Adds cluster-level protection that survives IAM credential compromise and complements backup-based recovery by preventing the destruction event rather than only enabling recovery after it.
       audit: |
         ### Audit via Console
 
@@ -47661,21 +47510,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon ECR repositories are configured to use AWS KMS encryption instead of the default AES-256 encryption. Customer-managed KMS encryption provides additional control over the encryption keys used to protect container images at rest.
+        This check ensures that Amazon ECR repositories are configured to use AWS KMS customer-managed key (CMK) encryption rather than the default AES-256 encryption managed by AWS. By default, ECR uses AWS-managed AES-256 encryption, which provides no control over the underlying key lifecycle, access policies, or audit trail.
 
         **Why this matters**
 
-        Using the default AES-256 encryption limits control over encryption key management:
-
-        - **Key management:** With default encryption, AWS manages the encryption keys and organizations cannot control key policies, rotation, or access.
-        - **Audit trail:** KMS encryption provides CloudTrail logging of all key usage, enabling detailed audit trails.
-        - **Access control:** KMS key policies provide fine-grained control over which principals can encrypt and decrypt images.
+        - **Key control:** Customer-managed KMS keys allow you to define key policies, enforce rotation schedules, and revoke access independently of AWS-managed defaults.
+        - **Audit visibility:** Every encryption and decryption operation against a CMK is recorded in CloudTrail, creating a detailed audit trail for container image access.
+        - **Access segmentation:** KMS key policies enable fine-grained control over which IAM principals can encrypt or decrypt images, separate from ECR repository permissions.
+        - **Credential separation:** In the event of a compromise, a CMK can be disabled or its key policy restricted without deleting the repository or its images.
 
         **Risk mitigation**
 
-        - **Enhanced control:** Organizations can manage key policies, enforce key rotation, and revoke access as needed.
-        - **Compliance:** Meets regulatory requirements that mandate customer-managed encryption keys.
-        - **Auditability:** All encryption and decryption operations are logged in CloudTrail.
+        - **Key revocation:** Disabling or scheduling deletion of the CMK immediately prevents all decryption of stored images, providing a hard stop during incident response.
+        - **Regulatory alignment:** Many data-protection regulations require customer control over encryption keys for sensitive workloads, which AWS-managed keys do not satisfy.
       audit: |
         ### Audit via Console
 
@@ -47826,21 +47673,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Neptune DB clusters have audit log export to CloudWatch Logs enabled. Without exported audit logs, attacks against the graph database are invisible to security monitoring and incident response teams. These attacks include unauthorized graph traversal to map relationships between entities, authentication brute-force attempts, and privilege abuse by over-permissioned users.
+        This check ensures that Amazon Neptune DB clusters are configured to export audit logs to Amazon CloudWatch Logs. By default, Neptune does not export audit logs, so database operations are not visible outside the cluster unless this export is explicitly enabled.
 
         **Why this matters**
 
-        Without audit log export, Neptune database attacks cannot be detected or investigated:
-
-        - **Unauthorized graph traversal:** Attackers can traverse the graph to map sensitive relationships such as organizational hierarchies, access paths, or data lineage without any record of the queries they executed.
-        - **Authentication brute force:** Failed authentication attempts against the Neptune cluster are not visible to centralized security monitoring, allowing credential attacks to proceed undetected.
-        - **Privilege abuse:** Over-permissioned users or compromised service accounts can execute unauthorized queries or administrative actions without leaving a forensic trail outside the cluster.
+        - **Attack detection:** Exported audit logs enable real-time CloudWatch alerting on failed authentication attempts, unexpected graph traversals, and unauthorized administrative commands.
+        - **Forensic reconstruction:** Centralized logs allow security teams to reconstruct attacker activity, identify compromised accounts, and determine the scope of data exposure after an incident.
+        - **Anomaly baselining:** Continuous audit log export enables baselining of normal query patterns so that bulk data extraction or privilege abuse can be detected as deviations.
+        - **Visibility gap:** Without log export, Neptune database attacks are invisible to external security monitoring and incident response tooling.
 
         **Risk mitigation**
 
-        - **Attack detection:** Enables real-time alerting on suspicious query patterns, failed authentication attempts, and unauthorized administrative actions through CloudWatch.
-        - **Forensic investigation:** Provides audit trails that allow security teams to reconstruct attacker activity, identify compromised accounts, and determine the scope of data exposure.
-        - **Anomaly detection:** Centralized logs enable baselining of normal query patterns so that unauthorized graph traversal or bulk data extraction can be identified.
+        - **Centralized monitoring:** CloudWatch Logs Insights and metric filters can alert on suspicious query patterns or repeated authentication failures without manual log review.
+        - **Retention and compliance:** Exported logs can be forwarded to long-term storage and SIEM systems, satisfying audit-trail requirements for regulated workloads.
       audit: |
         ### Audit via Console
 
@@ -47985,21 +47830,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon DocumentDB clusters have audit log export to CloudWatch Logs enabled. Exporting audit logs to CloudWatch enables centralized monitoring, analysis, and alerting on DocumentDB operations.
+        This check ensures that Amazon DocumentDB clusters are configured to export audit logs to Amazon CloudWatch Logs. By default, DocumentDB does not enable audit log export, which means database-level events such as DDL operations, authentication attempts, and data manipulation are not visible to centralized security monitoring.
 
         **Why this matters**
 
-        Without audit log export, database activity monitoring is limited:
-
-        - **Limited visibility:** Audit logs track data definition language (DDL), authentication, authorization, and data manipulation language (DML) events.
-        - **Incident response:** Centralized logs are critical for investigating security incidents and unauthorized access attempts.
-        - **Compliance:** Regulatory frameworks such as PCI DSS, HIPAA, and SOC 2 require audit logging for database services.
+        - **Unauthorized access detection:** Audit logs capture authentication failures and privilege escalation attempts that would otherwise go undetected in a silo within the cluster.
+        - **Incident investigation:** Centralized logs provide the forensic trail needed to determine what data was accessed, when, and by which principal during a security incident.
+        - **Operational anomalies:** Unusual DDL operations such as unexpected collection drops or index modifications are only visible if audit logs are exported and monitored.
 
         **Risk mitigation**
 
-        - **Monitoring:** Enables real-time monitoring of database operations through CloudWatch.
-        - **Forensics:** Provides detailed audit trails for security investigations.
-        - **Alerting:** Enables automated alerting on suspicious database activities through CloudWatch alarms.
+        - **Real-time alerting:** CloudWatch alarms and Logs Insights queries on exported audit data can trigger automated responses to suspicious database activity.
+        - **Compliance evidence:** Exported audit logs provide durable, tamper-resistant records of database operations that satisfy evidence requirements for audits and regulatory reviews.
       audit: |
         ### Audit via Console
 
@@ -48157,13 +47999,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that an AWS Config aggregator is configured to collect configuration and compliance data across all AWS accounts and regions. Without an aggregator, Config data is siloed per region, making it difficult to maintain a centralized view of resource compliance.
+        This check ensures that at least one AWS Config configuration aggregator is deployed to collect resource configuration and compliance data across accounts and regions. Without an aggregator, Config data remains siloed within each individual region, making it impossible to maintain a centralized, organization-wide compliance posture.
 
         **Why this matters**
 
-        - **Incomplete visibility:** Without aggregation, security teams must check each region individually for compliance data.
-        - **Regulatory gaps:** Many compliance frameworks require a centralized view of all infrastructure configuration across the entire organization.
-        - **Incident response delays:** During security incidents, the inability to quickly query configuration data across all regions slows investigation and remediation.
+        - **Unified visibility:** An aggregator consolidates configuration and compliance findings from all accounts and regions into a single pane, eliminating the need for manual per-region reviews.
+        - **Blind-spot elimination:** Resources provisioned in regions without dedicated Config review may never surface in compliance dashboards unless an aggregator is collecting from all sources.
+        - **Incident response speed:** During a security incident, querying a single aggregator for affected resources across the organization is significantly faster than querying each region independently.
+
+        **Risk mitigation**
+
+        - **Proactive compliance:** Continuous aggregation ensures that newly provisioned resources in any account or region are immediately evaluated against Config rules without manual intervention.
+        - **Organizational coverage:** An organization-level aggregator, backed by an IAM role, ensures even newly added accounts are automatically included in compliance reporting.
       audit: |
         ### Audit via Console
 
@@ -48309,13 +48156,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Config aggregators are configured to collect data from all AWS regions. An aggregator that only covers specific regions leaves blind spots where resource misconfigurations and compliance violations may go undetected.
+        This check ensures that AWS Config configuration aggregators are configured to collect data from all AWS regions rather than a limited subset. An aggregator scoped to specific regions leaves the remaining regions as blind spots where misconfigurations and compliance violations can go undetected.
 
         **Why this matters**
 
-        - **Incomplete compliance posture:** Resources created in regions not covered by the aggregator will not appear in compliance dashboards, creating a false sense of security.
-        - **Shadow infrastructure:** Attackers or unauthorized users may provision resources in uncovered regions to avoid detection.
-        - **Regulatory requirements:** Frameworks such as CIS AWS Foundations Benchmark require Config to aggregate data across all regions to ensure comprehensive visibility.
+        - **Shadow infrastructure:** Attackers or unauthorized users may deliberately provision resources in uncovered regions to avoid detection by region-scoped compliance tooling.
+        - **False compliance posture:** A compliance dashboard fed by a partial aggregator shows a passing score for regions that are simply not observed, creating unwarranted confidence.
+        - **Uniform coverage:** AWS services such as Lambda, EC2, and S3 can be deployed in any enabled region; only all-regions coverage ensures consistent policy enforcement.
+
+        **Risk mitigation**
+
+        - **Gap closure:** Enabling all-regions aggregation immediately brings previously unobserved regions into the compliance baseline without requiring additional per-region configuration.
+        - **Future-proof coverage:** New AWS regions enabled for the account are automatically included in an all-regions aggregator, preventing coverage gaps from regional expansion.
       audit: |
         ### Audit via Console
 
@@ -48475,14 +48327,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Amazon ECR private repository access policies do not grant public access. A repository policy that allows the `*` principal enables any AWS account or unauthenticated user to pull container images, potentially exposing proprietary code, configuration, and embedded secrets.
+        This check ensures that Amazon ECR private repository policies do not grant access to the wildcard principal (`*`), which would make the repository publicly accessible to any AWS account or unauthenticated caller. By default, ECR repositories have no resource policy and are private; a policy granting `Principal: "*"` explicitly opens the repository to the public.
 
         **Why this matters**
 
-        - **Image exposure:** Container images often contain application source code, configuration files, and embedded credentials that should not be publicly accessible.
-        - **Supply chain risk:** Publicly accessible images can be analyzed by attackers to discover vulnerabilities and develop targeted exploits.
-        - **Intellectual property:** Container images may contain proprietary business logic and trade secrets.
-        - **Compliance violations:** Many regulatory frameworks prohibit public exposure of application artifacts.
+        - **Credential exposure:** Container images frequently contain application secrets, API keys, or internal configuration that were embedded during the build process and should never be publicly accessible.
+        - **Supply chain risk:** Publicly accessible images can be pulled and analyzed by adversaries to discover vulnerabilities, reverse-engineer proprietary logic, or identify hardcoded credentials for targeted attacks.
+        - **Intellectual property:** Container images may encode proprietary business logic or trade secrets that have significant competitive or regulatory value.
+        - **Compliance violations:** Many data-protection and security frameworks require that application artifacts and their embedded configuration are restricted to authorized parties only.
+
+        **Risk mitigation**
+
+        - **Access restriction:** Replacing wildcard principals with explicit account or IAM role ARNs ensures only authorized systems can pull images, eliminating unintentional public exposure.
+        - **Defense in depth:** Removing public access from repository policies complements network controls and image scanning, ensuring artifacts are protected at the storage layer.
       audit: |
         ### Audit via Console
 
@@ -49160,13 +49017,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that all EBS volumes defined in EC2 launch configurations are encrypted. Launch configurations are a legacy Auto Scaling mechanism, but many environments still use them. Unencrypted EBS volumes in launch configurations mean every instance launched by the associated Auto Scaling group will have unencrypted root or data volumes.
+        This check ensures that all EBS volumes defined in EC2 launch configurations have encryption enabled. Launch configurations are a legacy Auto Scaling mechanism that defines the storage layout for every instance an Auto Scaling group launches; an unencrypted volume definition propagates unencrypted storage to every instance the group creates.
 
         **Why this matters**
 
-        - **Data exposure:** Unencrypted EBS volumes can be read by anyone with physical access to the underlying storage hardware or by copying the volume/snapshot to another account.
-        - **Compliance:** PCI DSS, HIPAA, SOC 2, and CIS AWS Foundations Benchmark all require encryption of data at rest.
-        - **Blast radius:** Because launch configurations are used by Auto Scaling groups, a single misconfiguration propagates to every instance the group launches.
+        - **Data-at-rest exposure:** Unencrypted EBS volumes can be read by anyone who gains physical or logical access to the underlying storage, or by detaching and reattaching a volume to a different instance.
+        - **Snapshot leakage:** Snapshots of unencrypted volumes inherit the unencrypted state, meaning any accidental public sharing of a snapshot exposes its full contents.
+        - **Blast radius amplification:** Because launch configurations drive Auto Scaling groups, a single unencrypted template propagates the risk to every instance the group launches over its lifetime.
+
+        **Risk mitigation**
+
+        - **Storage-layer protection:** Encrypting EBS volumes ensures data is protected even if storage media is physically accessed, decommissioned, or a snapshot is inadvertently shared.
+        - **Migration opportunity:** AWS recommends replacing launch configurations with launch templates, which support the same encryption settings and offer additional hardening options.
       audit: |
         ### Audit via Console
 
@@ -49342,14 +49204,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 launch configurations do not automatically assign public IP addresses to instances. Instances with public IPs are directly reachable from the internet, increasing the attack surface.
+        This check ensures that EC2 launch configurations do not set `associatePublicIpAddress` to `true`, which would automatically assign a public IP address to every instance launched by the associated Auto Scaling group. By default, whether a public IP is assigned depends on the subnet setting, but explicitly enabling it in a launch configuration overrides subnet defaults for every instance the group creates.
 
         **Why this matters**
 
-        - **Direct internet exposure:** Instances with public IPs can be scanned, probed, and attacked from anywhere on the internet.
-        - **Credential exposure:** If an instance with a public IP is compromised, the attacker has a direct path out to exfiltrate data.
-        - **Auto Scaling blast radius:** A launch configuration with `associatePublicIpAddress: true` ensures every instance launched by the group gets a public IP, multiplying the risk.
-        - **Best practice:** Instances should use NAT gateways, VPC endpoints, or load balancers for internet connectivity rather than direct public IPs.
+        - **Direct internet reachability:** Instances with public IP addresses are directly accessible from the internet, expanding the attack surface beyond what security groups alone can adequately control.
+        - **Attack surface multiplication:** A launch configuration with public IP assignment enabled causes every Auto Scaling instance to be publicly routable, so one misconfigured template affects the entire fleet.
+        - **Lateral movement risk:** A compromised internet-facing instance provides an attacker with a foothold inside the VPC that can be used for lateral movement to private resources.
+
+        **Risk mitigation**
+
+        - **Network isolation:** Routing outbound traffic through NAT gateways or VPC endpoints keeps instances private while still allowing necessary internet egress, removing the need for public IPs.
+        - **Reduced exposure window:** Instances without public IPs are not reachable from scanning and probing activity that constantly targets the public internet address space.
       audit: |
         ### Audit via Console
 
@@ -49499,15 +49365,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 launch configurations require IMDSv2 (Instance Metadata Service Version 2) by setting `httpTokens` to `required`. IMDSv1 is vulnerable to SSRF attacks that can extract instance credentials.
+        This check ensures that EC2 launch configurations require IMDSv2 by setting the `httpTokens` metadata option to `required`. IMDSv1 accepts unauthenticated HTTP GET requests to `169.254.169.254`, making it vulnerable to server-side request forgery attacks that can extract instance IAM role credentials. Because launch configurations define the metadata settings for every instance an Auto Scaling group creates, an unprotected configuration propagates the vulnerability across the entire fleet.
 
         **Why this matters**
 
-        - **SSRF vulnerability:** IMDSv1 allows unauthenticated HTTP GET requests to `169.254.169.254`. Any SSRF vulnerability in an application running on the instance can be used to steal IAM role credentials.
-        - **Auto Scaling propagation:** A launch configuration without IMDSv2 enforcement means every instance the Auto Scaling group creates will be vulnerable.
-        - **Compliance:** CIS AWS Foundations Benchmark requires IMDSv2 enforcement.
+        - **SSRF credential theft:** Any SSRF vulnerability in an application running on the instance can be used to silently retrieve IAM role credentials from the IMDSv1 endpoint without requiring any instance-level access.
+        - **Fleet-wide propagation:** A launch configuration without IMDSv2 enforcement applies the IMDSv1 vulnerability to every instance the Auto Scaling group launches, multiplying the exposure.
+        - **Session-based protection:** IMDSv2 requires a PUT-based token request before metadata can be read, a step that typical SSRF payloads cannot perform.
 
-        IMDSv2 mitigates these risks by requiring a session token obtained via an HTTP PUT request, which SSRF attacks typically cannot perform.
+        **Risk mitigation**
+
+        - **Credential protection:** Enforcing IMDSv2 eliminates the SSRF-to-credential-theft attack path, preventing an application-layer vulnerability from escalating to full IAM compromise.
+        - **Migration path:** AWS recommends replacing launch configurations with launch templates, which provide the same IMDSv2 enforcement and are the current standard for instance provisioning.
       audit: |
         ### Audit via Console
 
@@ -51253,14 +51122,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon CloudFront distributions have access logging enabled. Access logs contain detailed information about every request received by the distribution, including the requester IP, request path, response code, and edge location.
+        This check ensures that Amazon CloudFront distributions have standard access logging enabled and configured to write logs to an S3 bucket. By default, CloudFront does not enable access logging, so request-level data including client IPs, request paths, response codes, and edge locations is not retained.
 
         **Why this matters**
 
-        - **Incident investigation:** Without access logs, there is no record of who accessed your content, when, or from where. This severely hampers incident response and forensic analysis.
-        - **Abuse detection:** Access logs enable detection of unusual traffic patterns such as content scraping, credential stuffing against origin APIs, or DDoS attacks.
-        - **Compliance:** Many regulatory frameworks require logging of access to web-facing resources. CIS AWS Foundations Benchmark recommends enabling CloudFront access logging.
-        - **Cost analysis:** Logs help identify unexpected traffic sources that may be inflating CloudFront costs.
+        - **Incident investigation:** Without access logs, there is no record of who accessed distribution content, when, or from where, severely limiting the ability to reconstruct events during a security incident.
+        - **Abuse detection:** Access logs enable detection of unusual traffic patterns such as content scraping, credential stuffing against origin APIs, or high-volume DDoS precursors.
+        - **Compliance evidence:** Many regulatory frameworks require logging of access to web-facing resources, and access logs provide the durable record needed to satisfy those requirements.
+        - **Cost attribution:** Logs identify unexpected or high-volume traffic sources that may be inflating CloudFront data transfer costs due to unauthorized use.
+
+        **Risk mitigation**
+
+        - **Threat visibility:** Centralized access logs fed into a SIEM or CloudWatch allow security teams to alert on anomalous client behavior before it escalates to a significant incident.
+        - **Forensic retention:** Storing logs in S3 with appropriate lifecycle policies ensures request-level evidence is available for post-incident forensic analysis.
       audit: |
         ### Audit via Console
 
@@ -57267,14 +57141,18 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that EC2 serial console access is disabled across all regions. The EC2 serial console provides text-based access to an instance's serial port, which can be used to troubleshoot boot and network issues. However, if enabled, it can provide an additional attack vector for accessing instances.
+        This check ensures that EC2 serial console access is disabled across all AWS regions. The EC2 serial console provides text-based access to an instance's serial port and is intended for emergency troubleshooting of boot or networking failures. By default in newly created accounts the feature may be enabled, creating an additional access path that bypasses normal SSH key and network controls.
 
         **Why this matters**
 
-        - Serial console access bypasses normal network-based access controls and SSH key requirements.
-        - An attacker with IAM credentials to connect to the serial console could access instances even if network security groups block all inbound traffic.
-        - Serial console access is not needed for normal operations and should be disabled when not actively troubleshooting.
-        - CIS AWS Foundations Benchmark recommends disabling serial console access.
+        - **Access control bypass:** Serial console access does not require network connectivity or SSH keys; an IAM principal with the `ec2-instance-connect:SendSerialConsoleSSHPublicKey` permission can connect to an instance even if all inbound security group rules block traffic.
+        - **Persistent access vector:** An attacker who obtains sufficient IAM credentials can use the serial console to maintain access to instances after SSH keys are rotated or security groups are tightened.
+        - **Unnecessary attack surface:** The serial console is only needed during active troubleshooting; leaving it enabled permanently adds risk without operational benefit.
+
+        **Risk mitigation**
+
+        - **Attack surface reduction:** Disabling serial console access removes a network-independent instance access path, forcing all interactive access through audited, key-based SSH or AWS Systems Manager Session Manager.
+        - **Least-privilege enforcement:** Keeping the feature disabled by default means enabling it requires a deliberate, auditable action, providing a change record for any troubleshooting use.
       audit: |
         ### Audit via Console
 
@@ -57387,14 +57265,18 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AMI block public access is enabled across all regions. When enabled, this setting prevents AMIs from being publicly shared, protecting against accidental exposure of machine images that may contain sensitive configurations, credentials, or proprietary software.
+        This check ensures that the AMI block public access setting is enabled across all AWS regions. This account-level control prevents any Amazon Machine Image in the account from being made publicly shareable, protecting against accidental exposure of machine images that may contain sensitive configurations, credentials, or proprietary software. By default, this block may not be enabled, allowing individual AMI owners to mark images as public without an account-wide guard.
 
         **Why this matters**
 
-        - Publicly shared AMIs can expose sensitive data, credentials, or proprietary application code to anyone with an AWS account.
-        - AMIs may contain hardcoded secrets, private keys, or internal network configurations.
-        - Block public access for AMIs prevents accidental public sharing that could lead to data exposure.
-        - This is a preventive control that stops the problem at the source rather than detecting it after the fact.
+        - **Secret exposure prevention:** AMIs created from running instances often retain shell history, configuration files, private keys, or hardcoded credentials that should never be exposed outside the account.
+        - **Proprietary code protection:** Machine images may contain licensed software, compiled proprietary applications, or internal tooling that must not be distributed to arbitrary AWS accounts.
+        - **Preventive control:** Block public access acts at the API layer before a misconfigured share permission can take effect, stopping accidental public exposure at the source.
+
+        **Risk mitigation**
+
+        - **Centralized enforcement:** A single account-level block eliminates the need to audit public-sharing permissions on every individual AMI, reducing the operational burden of maintaining a private image library.
+        - **Incident containment:** Even if an automated pipeline or human error attempts to make an AMI public, the block setting rejects the operation before any external exposure can occur.
       audit: |
         ### Audit via Console
 
@@ -57509,14 +57391,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EC2 launch templates are configured to require Instance Metadata Service Version 2 (IMDSv2). IMDSv2 uses session-oriented authentication that requires a PUT request to obtain a token before metadata can be accessed, preventing SSRF attacks from extracting instance credentials.
+        This check ensures that EC2 launch templates require IMDSv2 by setting `MetadataOptions.HttpTokens` to `required`. IMDSv1 allows unauthenticated HTTP GET requests to the instance metadata endpoint at `169.254.169.254`, which means any server-side request forgery vulnerability in an application running on the instance can be used to retrieve IAM role credentials. Launch templates define the configuration for new instances, so enforcing IMDSv2 in the template ensures every instance created from it is protected.
 
         **Why this matters**
 
-        - IMDSv1 allows unauthenticated GET requests to retrieve instance metadata, including IAM role credentials.
-        - SSRF vulnerabilities in applications running on EC2 instances can be exploited to steal IAM credentials via IMDSv1.
-        - Launch templates define the configuration for new instances, so enforcing IMDSv2 in templates ensures all new instances are protected.
-        - IMDSv2 is recommended by AWS and required by CIS AWS Foundations Benchmark.
+        - **SSRF credential theft prevention:** IMDSv2 requires a PUT-based token exchange before metadata can be read, which SSRF payloads typically cannot perform, breaking the most common credential-exfiltration attack chain.
+        - **Fleet-wide protection:** Enforcing IMDSv2 in the launch template propagates the protection to every instance created from it, including those launched by Auto Scaling groups and Spot fleets.
+        - **Defense against web-layer attacks:** Web application vulnerabilities such as SSRF are frequently exploited to escalate from application compromise to full IAM account access via IMDSv1; IMDSv2 closes this path.
+
+        **Risk mitigation**
+
+        - **Credential isolation:** Preventing unauthenticated metadata access ensures that even a fully compromised web application process cannot retrieve the instance role's AWS credentials without additional exploitation steps.
+        - **Hop-limit hardening:** Combining `HttpTokens: required` with `HttpPutResponseHopLimit: 1` prevents containerized workloads from accessing the host's metadata endpoint, further limiting lateral credential access.
       audit: |
         ### Audit via Console
 
@@ -57675,14 +57561,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that S3 buckets have ownership controls set to BucketOwnerEnforced. This setting disables ACLs on the bucket, meaning all objects are owned by the bucket owner regardless of who uploaded them. This simplifies access management by ensuring that only IAM policies and bucket policies control access.
+        This check ensures that S3 buckets have Object Ownership set to `BucketOwnerEnforced`, which disables S3 ACLs and ensures the bucket owner owns all objects regardless of which account uploaded them. By default, S3 allows ACL-based access controls, meaning objects uploaded by external accounts can be owned by the uploading account and may not be accessible to the bucket owner.
 
         **Why this matters**
 
-        - S3 ACLs are a legacy access control mechanism that can grant unintended permissions alongside bucket and IAM policies.
-        - With ACLs enabled, objects uploaded by other accounts may not be accessible to the bucket owner.
-        - BucketOwnerEnforced ensures all access control is managed through IAM and bucket policies, providing a single source of truth.
-        - AWS recommends disabling ACLs for most use cases as a security best practice.
+        - **Ownership clarity:** When objects are owned by the bucket owner, access is controlled entirely through bucket policies and IAM, eliminating the dual-control complexity of ACLs alongside policies.
+        - **Accidental grant prevention:** S3 ACLs are a legacy mechanism that can silently grant permissions that conflict with or supplement bucket policies, creating unexpected access paths.
+        - **Cross-account upload safety:** Without `BucketOwnerEnforced`, objects uploaded by cross-account principals may remain inaccessible to the bucket owner, causing operational failures and data availability issues.
+
+        **Risk mitigation**
+
+        - **Single access-control plane:** Disabling ACLs forces all access decisions through IAM and bucket policies, making the effective permission set transparent and auditable from a single location.
+        - **Simplified compliance review:** Auditing access to S3 data is significantly easier when only bucket policies and IAM are in scope, reducing the risk of missed permissions during security reviews.
       audit: |
         ### Audit via Console
 
@@ -57822,14 +57712,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that CloudTrail trails have Insights enabled. CloudTrail Insights automatically analyzes management events to detect unusual API activity patterns, such as spikes in resource provisioning, bursts of IAM actions, or gaps in periodic maintenance activity.
+        This check ensures that CloudTrail trails have Insights enabled to detect anomalous API activity. CloudTrail Insights automatically analyzes management events to identify unusual call rate or error rate patterns that may indicate account compromise, runaway automation, or misconfiguration. By default, CloudTrail trails do not enable Insights, so anomaly detection requires manual log analysis or custom tooling.
 
         **Why this matters**
 
-        - CloudTrail Insights detects anomalous API call patterns that may indicate account compromise or misconfiguration.
-        - Without Insights, detecting unusual activity requires manual analysis of CloudTrail logs or custom anomaly detection.
-        - Insights generates findings for unusual write management events (ApiCallRateInsight) and API error rates (ApiErrorRateInsight).
-        - Automated anomaly detection reduces mean time to detect security incidents.
+        - **Automated anomaly detection:** Insights continuously evaluates API call patterns against a learned baseline and generates findings for statistically unusual activity, reducing the manual effort required to detect account compromise.
+        - **Error rate visibility:** The `ApiErrorRateInsight` type detects unusual spikes in API errors that may indicate automated attack tools probing service limits or misconfigured automation.
+        - **Reduced detection time:** Automated anomaly findings surfaced by Insights shorten the time between suspicious activity and investigation compared to manual log review.
+
+        **Risk mitigation**
+
+        - **Early compromise signals:** Unusual IAM provisioning spikes or resource creation bursts detected by `ApiCallRateInsight` can serve as early warning of a compromised credential being used for lateral movement or persistence.
+        - **Operational awareness:** Insights findings also identify unintentional runaway automation that can generate unexpected costs or destabilize environments, providing value beyond pure security detection.
       audit: |
         ### Audit via Console
 
@@ -57987,14 +57881,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Security Hub has at least one security standard enabled. Security standards such as AWS Foundational Security Best Practices, CIS AWS Foundations Benchmark, or PCI DSS provide automated security checks against AWS resources.
+        This check ensures that AWS Security Hub has at least one security standard enabled and actively evaluating controls. Security Hub without enabled standards acts only as an aggregation hub and performs no automated security checks; standards such as AWS Foundational Security Best Practices or CIS AWS Foundations Benchmark are required to continuously evaluate resource configurations against known security controls.
 
         **Why this matters**
 
-        - Security Hub without enabled standards provides no automated security checks, making it ineffective.
-        - Standards provide continuously evaluated security controls that detect misconfigurations as they occur.
-        - AWS Foundational Security Best Practices is the recommended baseline standard for all AWS accounts.
-        - Compliance frameworks require continuous monitoring of security controls, which standards automate.
+        - **Automated control evaluation:** Enabled standards continuously check hundreds of AWS resource configurations against known best practices without requiring custom rule authoring or manual review.
+        - **Centralized findings:** Standards generate Security Hub findings that can be routed to ticketing systems, SIEM platforms, and notification channels, accelerating remediation workflows.
+        - **Compliance mapping:** Each standard maps controls to regulatory frameworks, providing evidence of continuous monitoring that auditors and compliance programs require.
+
+        **Risk mitigation**
+
+        - **Misconfiguration detection:** Standards surface newly introduced misconfigurations as soon as resources are created or modified, enabling rapid remediation before vulnerabilities can be exploited.
+        - **Baseline establishment:** Enabling at least one standard creates an account-wide security baseline against which drift can be measured over time, making it easier to track security posture improvements.
       audit: |
         ### Audit via Console
 
@@ -58130,14 +58028,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that SNS topic access policies do not grant public access. An SNS topic with a policy that allows Principal "*" without conditions enables any AWS account or unauthenticated user to publish or subscribe to the topic.
+        This check ensures that SNS topics are configured to deny public access by blocking access policies that grant a wildcard principal without restrictive conditions. By default, SNS allows topic owners to write any policy, including one that permits anyone on the internet to publish or subscribe. Topics that omit condition keys on a `Principal: "*"` statement are fully public.
 
         **Why this matters**
 
-        - Public SNS topics can be abused to send unauthorized notifications or subscribe to receive sensitive messages.
-        - Attackers can publish messages to public topics, potentially triggering downstream Lambda functions or other integrations.
-        - Unauthorized subscribers can receive sensitive data published to the topic.
-        - SNS topic policies should follow the principle of least privilege, restricting access to specific accounts and services.
+        - **Unauthorized publishing:** Any internet client can push messages to the topic, triggering downstream Lambda functions, SQS queues, or HTTP endpoints.
+        - **Data leakage:** Unauthorized subscribers can receive every message the topic carries, including application events that contain sensitive payloads.
+        - **Abuse vector:** Public SNS topics are exploited for spam delivery, fanout amplification, and pivoting into connected services.
+        - **Blast radius:** Wildcard-principal policies are account-wide, so a single misconfigured topic can expose integrations across multiple AWS services.
+
+        **Risk mitigation**
+
+        - **Scope principals explicitly:** Replace wildcard principals with specific account ARNs, service principals, or VPC endpoint conditions.
+        - **Add source conditions:** Where cross-service publishing is required, add `aws:SourceAccount` or `aws:SourceArn` conditions to narrow the allowed callers.
+        - **Audit periodically:** Review SNS access policies on a regular cadence so newly created topics without scoped policies are caught before they are exploited.
       audit: |
         ### Audit via Console
 
@@ -58315,14 +58219,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Elastic Disaster Recovery (DRS) replication configurations use private IP addresses for data plane routing. When set to PUBLIC_IP, replication data traverses the public internet, increasing exposure to interception and eavesdropping.
+        This check ensures that AWS Elastic Disaster Recovery (DRS) source servers are configured to use private IP addresses for data plane routing rather than routing replication traffic over public IPs. By default, DRS replication configurations may use `PUBLIC_IP` routing, which sends all replication data over the public internet rather than keeping it within the AWS network backbone.
 
         **Why this matters**
 
-        - Replication data sent over public IPs traverses the public internet, even if encrypted in transit.
-        - Private IP replication keeps data within the AWS network, reducing the attack surface.
-        - Using private IP routing is required for environments with strict network isolation requirements.
-        - Compliance frameworks require data in transit to use private network paths where available.
+        - **Data exposure in transit:** Replication data routed over public IPs crosses the internet even when encrypted, increasing the attack surface compared to private network paths.
+        - **Regulatory alignment:** Many compliance frameworks require sensitive data in motion to traverse private or dedicated network paths wherever technically feasible.
+        - **Reduced interception risk:** Private IP routing keeps replication traffic within the AWS network, preventing it from being intercepted or inspected by third-party infrastructure.
+        - **Consistent network posture:** Using private routing ensures the DR environment matches the network isolation standards applied to production workloads.
+
+        **Risk mitigation**
+
+        - **Enable private routing:** Set `dataPlaneRouting` to `PRIVATE_IP` on every DRS replication configuration so replication never traverses the public internet.
+        - **Ensure private connectivity:** Confirm that AWS Direct Connect or a Site-to-Site VPN is in place between the source environment and the AWS staging area before switching to private routing.
+        - **Validate staging subnet placement:** Confirm that the staging-area subnet is in a private VPC subnet with no public IP assignment to enforce the private routing path end-to-end.
       audit: |
         ### Audit via Console
 
@@ -58450,14 +58360,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Elastic Disaster Recovery (DRS) replication configurations do not create public IP addresses for recovery instances. Recovery instances with public IPs are directly accessible from the internet, increasing the attack surface during disaster recovery scenarios.
+        This check ensures that AWS Elastic Disaster Recovery (DRS) replication configurations are set to not create public IP addresses for recovery instances. When `createPublicIP` is enabled, every recovered instance receives a public IP at launch, making it directly reachable from the internet before any hardening has been applied.
 
         **Why this matters**
 
-        - Recovery instances with public IPs are exposed to the internet, making them targets for attacks during already-stressful DR events.
-        - DR instances may not have the same hardening as production instances, making public exposure especially risky.
-        - Private-only recovery instances require VPN or Direct Connect for access, ensuring controlled access paths.
-        - During failover, security controls should remain as strict as production environments.
+        - **Immediate internet exposure:** Recovery instances launched with a public IP become internet-reachable the moment they start, often before security agents or monitoring tools have initialized.
+        - **Reduced hardening during DR:** Disaster recovery scenarios are already high-pressure; an internet-exposed recovery instance adds an attack surface at the moment when operational attention is most divided.
+        - **Access control enforcement:** Private-only recovery instances require VPN, Direct Connect, or AWS Systems Manager Session Manager for access, ensuring that only authorized administrators can reach them.
+        - **Consistency with production:** Production instances are typically private; recovery instances should replicate the same network posture to avoid introducing unexpected exposure.
+
+        **Risk mitigation**
+
+        - **Disable public IP creation:** Set `createPublicIP` to `false` in every DRS replication configuration template so recovered instances never receive a public IP at launch.
+        - **Use private access methods:** Rely on AWS Systems Manager Session Manager or a VPN-connected bastion to reach recovery instances after failover.
+        - **Review recovery launch settings:** Periodically audit DRS replication configurations and launch settings to confirm public IP creation remains disabled across all source servers.
       audit: |
         ### Audit via Console
 
@@ -58588,22 +58504,20 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     docs:
       desc: |
-        This check verifies that every Neptune instance attached to the cluster has `autoMinorVersionUpgrade` enabled. When enabled, AWS applies minor-version engine patches during the cluster's maintenance window, closing known CVEs without requiring operator action. When disabled, each instance stays on whatever engine version it was launched with until an operator manually triggers an upgrade.
+        This check ensures that every Neptune instance in a cluster is configured to receive automatic minor version upgrades. When disabled, instances remain on the engine version they were launched with until an operator manually performs an upgrade, a gap that widens over time as AWS releases new minor patches.
 
         **Why this matters**
 
-        Neptune ships minor-version patches that carry real CVE fixes. An instance that has opted out of auto-upgrade accumulates every vulnerability disclosed after its launch:
-
-        - Graph databases hold integrated data from multiple sources, so a Neptune compromise often turns into a privilege-escalation path across systems.
-        - Deferred minor-version patches are invisible in most inventory tools; the instance reports as "healthy" while running known-vulnerable code.
-        - Manual upgrade processes rarely keep up with AWS's quarterly-plus patch cadence, so the gap grows over time.
-        - Enabling auto-upgrade moves the patch application to a known maintenance window rather than an emergency operation after a new CVE ships.
+        - **Security patch coverage:** Neptune minor versions carry real CVE fixes for the engine; opting out means accumulating every vulnerability disclosed after the instance's launch.
+        - **Invisible risk:** Instances with auto-upgrade disabled appear healthy in most inventory tools while running known-vulnerable engine code.
+        - **Privilege escalation paths:** Neptune graphs integrate data from multiple sources, making a successful engine-level exploit a potential pivot point across interconnected systems.
+        - **Predictable maintenance:** Auto-upgrade applies patches within a scheduled maintenance window rather than as an emergency operation after a critical CVE is published.
 
         **Risk mitigation**
 
-        - Enable `autoMinorVersionUpgrade` on every Neptune instance.
-        - Configure a `preferredMaintenanceWindow` that matches your change-control calendar, and accept that minor patches land in that window.
-        - Pair auto-upgrade with a cluster-level deletion-protection and backup-retention policy so an unexpected patch problem is recoverable.
+        - **Enable auto minor version upgrade:** Set `autoMinorVersionUpgrade` to `true` on every Neptune cluster instance so engine patches are applied automatically.
+        - **Configure a maintenance window:** Set `preferredMaintenanceWindow` to a low-traffic period that falls within your organization's change-control calendar.
+        - **Pair with backup retention:** Ensure deletion protection and backup retention are configured so an unexpected patch regression can be recovered from without data loss.
       audit: |
         ### Audit via Console
 
@@ -58742,24 +58656,20 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     docs:
       desc: |
-        This check verifies that every DocumentDB instance in the cluster has `autoMinorVersionUpgrade` enabled. When enabled, AWS applies minor-version engine patches during the cluster's maintenance window. When disabled, each instance stays on its launched engine version until an operator manually performs an upgrade, a pattern that tends to fall behind AWS's patch cadence.
-
-        Scope note: the existing `mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade` check runs against every instance at the account level. This companion check runs per discovered DocumentDB cluster, attaching findings directly to the affected cluster so remediation owners can see which cluster is non-compliant without chasing instance IDs.
+        This check ensures that every DocumentDB instance belonging to a cluster is configured to receive automatic minor version upgrades. When disabled, instances stay on their launched engine version until manually updated, and the gap between the running version and the current patched release grows with every AWS release cycle.
 
         **Why this matters**
 
-        DocumentDB ships minor patches that include security fixes for the MongoDB-compatible engine surface:
-
-        - Engine patches regularly close RCE, authentication-bypass, and privilege-escalation CVEs.
-        - A cluster whose instances are on different engine versions is harder to operate and harder to reason about from a security posture standpoint.
-        - Auto-upgrade aligns with AWS's maintenance window, keeping patching predictable rather than reactive.
-        - Disabling auto-upgrade typically happens out of patch-risk aversion, but the alternative of staying on an EOL minor version is almost always the worse risk.
+        - **Engine-level CVE exposure:** DocumentDB minor patches include security fixes for the MongoDB-compatible engine; instances that opt out accumulate unmitigated vulnerabilities over time.
+        - **Version drift within a cluster:** When some instances upgrade and others do not, the cluster becomes harder to reason about from both an operational and a security posture standpoint.
+        - **Reactive vs. proactive patching:** Disabling auto-upgrade forces operators into reactive emergency patching when a critical CVE ships, which is a higher-risk operation than a planned maintenance-window update.
+        - **Compounding risk:** Staying on older minor versions can prevent the cluster from qualifying for feature updates that carry their own security improvements.
 
         **Risk mitigation**
 
-        - Enable `autoMinorVersionUpgrade` on every DocumentDB instance in the cluster.
-        - Validate that the cluster's `preferredMaintenanceWindow` falls inside your organization's change-control window.
-        - Pair with backup-retention and deletion-protection to recover from an unexpected patch regression.
+        - **Enable auto minor version upgrade:** Set `autoMinorVersionUpgrade` to `true` on every DocumentDB cluster instance so patches are applied on schedule.
+        - **Align the maintenance window:** Confirm that `preferredMaintenanceWindow` falls within your change-control calendar so automatic patches land at a predictable, low-impact time.
+        - **Protect against regression:** Enable cluster-level backup retention and deletion protection so an unexpected patch issue can be rolled back without data loss.
       audit: |
         ### Audit via Console
 
@@ -58899,13 +58809,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the PostgreSQL port (5432) from the internet (`0.0.0.0/0` or `::/0`). Database engines should never be exposed to the public internet; access should be limited to specific application or bastion subnets.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the PostgreSQL port (5432) from the internet. By default, newly created security groups deny all inbound traffic, but permissive rules that allow `0.0.0.0/0` or `::/0` on port 5432 are commonly introduced during development and left in place in production.
 
         **Why this matters**
 
-        - Internet-exposed PostgreSQL instances are continuously scanned for default credentials, weak passwords, and unpatched vulnerabilities such as CVE-2024-10977.
-        - A successful exploit of an exposed database results in immediate read/write access to every record, regardless of application-layer authorization.
-        - Public exposure violates baseline expectations under PCI DSS, HIPAA, NIST 800-53 SC-7, and ISO 27001 A.8.22.
+        - **Continuous credential probing:** Internet-exposed PostgreSQL endpoints are constantly scanned by automated tools looking for default credentials, weak passwords, and pre-auth vulnerabilities.
+        - **Full data access on compromise:** A successful connection grants the attacker every privilege the database user holds, with no application-layer authorization in the path.
+        - **Lateral movement:** A compromised database server is frequently used as a pivot point to reach adjacent services within the VPC.
+        - **Compliance baseline:** Publicly reachable database ports violate the network boundary requirements found in common regulatory frameworks and industry security standards.
+
+        **Risk mitigation**
+
+        - **Replace wildcard sources:** Revoke any inbound rule allowing port 5432 from `0.0.0.0/0` or `::/0` and replace it with the specific application-tier security group or a known VPN CIDR.
+        - **Apply defense-in-depth:** Pair network-level restrictions with database-level authentication, TLS enforcement, and role-based access control so a misconfigured rule alone does not result in full data exposure.
+        - **Review rules on a cadence:** Periodically audit security group inbound rules to catch permissive entries introduced during testing that were never removed.
       audit: |
         ### Audit via Console
 
@@ -59069,12 +58986,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the MySQL/MariaDB/Aurora port (3306) from `0.0.0.0/0` or `::/0`. Public exposure of relational database engines is one of the most frequently exploited cloud misconfigurations.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the MySQL/MariaDB/Aurora port (3306) from the internet. By default, new security groups deny all inbound traffic, but `0.0.0.0/0` rules on port 3306 are a common residue of development environments and cloud-setup tutorials.
 
         **Why this matters**
 
-        - Internet-reachable MySQL endpoints are constantly probed for default `root` credentials and weak passwords.
-        - Successful authentication grants the attacker every privilege the database user holds, including data exfiltration and destructive `DROP` operations.
+        - **Default credential attacks:** Internet-reachable MySQL endpoints are continuously probed by botnets testing the default `root` user and common weak passwords.
+        - **Unrestricted data manipulation:** A successful login grants the attacker every privilege the database account holds, including the ability to read, modify, or drop every table.
+        - **Lateral movement enablement:** A compromised MySQL host provides shell access on the underlying EC2 or RDS instance, enabling movement to adjacent resources within the VPC.
+        - **Compliance boundary violations:** Relational database ports reachable from the public internet fail the network isolation requirements common to regulated workloads.
+
+        **Risk mitigation**
+
+        - **Revoke wildcard rules:** Remove any inbound rule permitting port 3306 from `0.0.0.0/0` or `::/0` and replace it with a scoped source such as the application-tier security group or a specific bastion CIDR.
+        - **Use private subnets:** Place MySQL/Aurora instances in private subnets with no route to the internet gateway so the database is unreachable even if a security group rule is later misconfigured.
+        - **Audit regularly:** Review security group inbound rules on a periodic schedule to identify and remove overly permissive entries before they are discovered by external scanners.
       audit: |
         ### Audit via Console
 
@@ -59227,12 +59152,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on Microsoft SQL Server's TDS port (1433) from `0.0.0.0/0` or `::/0`. Internet-exposed SQL Server is a recurring vector for ransomware that abuses `xp_cmdshell` and weak `sa` passwords.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Microsoft SQL Server TDS port (1433) from the internet. By default, new security groups deny all inbound traffic, but `0.0.0.0/0` rules on port 1433 are frequently introduced during proof-of-concept deployments and rarely removed before promotion to production.
 
         **Why this matters**
 
-        - The `MSSQL` service is a primary target for credential-stuffing botnets.
-        - Successful logins lead to OS-level command execution via `xp_cmdshell` if it is enabled, escalating to full host compromise.
+        - **Targeted credential-stuffing:** The SQL Server service is a well-known target for credential-stuffing botnets that test the `sa` account and dictionary passwords continuously.
+        - **OS-level command execution:** A successful login to a misconfigured instance can escalate to host-level command execution via `xp_cmdshell`, turning a database compromise into full server takeover.
+        - **Data exfiltration at scale:** SQL Server stores structured business data; an attacker with unrestricted query access can bulk-export every record without triggering typical application-layer logging.
+        - **Ransomware deployment vector:** Internet-exposed SQL Server has been a documented entry point for ransomware campaigns that encrypt databases and demand payment for the decryption key.
+
+        **Risk mitigation**
+
+        - **Revoke wildcard inbound rules:** Remove any security group rule permitting TCP port 1433 from `0.0.0.0/0` or `::/0` and replace it with a scoped application-tier or VPN source.
+        - **Disable `xp_cmdshell`:** As a defense-in-depth measure, disable `xp_cmdshell` on all SQL Server instances to prevent a database login from escalating to OS-level command execution.
+        - **Use private subnets and VPN access:** Place SQL Server instances in private subnets and require VPN or Direct Connect for administrative access to eliminate internet reachability at the network layer.
       audit: |
         ### Audit via Console
 
@@ -59385,11 +59318,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Oracle Database listener port (1521) from `0.0.0.0/0` or `::/0`.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Oracle Database listener port (1521) from the internet. By default, new security groups deny all inbound traffic, but rules permitting `0.0.0.0/0` on port 1521 are sometimes added for convenience during initial configuration and left in place.
 
         **Why this matters**
 
-        Public exposure of the Oracle TNS listener has historically been used to enumerate SIDs, brute-force database credentials, and exploit listener-level vulnerabilities. Restricting the listener to internal subnets eliminates the entire class of internet-borne attacks against the database.
+        - **Listener-level enumeration:** A publicly reachable Oracle TNS listener allows attackers to enumerate database service names (SIDs) without authentication, facilitating targeted brute-force attacks.
+        - **Credential brute-force exposure:** Exposed Oracle endpoints are probed for default credentials such as `SYS`/`SYSTEM` with common passwords, a pattern that often succeeds in older or default-configured installations.
+        - **Historical listener vulnerabilities:** Oracle TNS listener exploits have a well-documented history; keeping the listener off the public internet eliminates the entire class of internet-borne attacks.
+        - **Broad data access on compromise:** Oracle databases frequently store business-critical data; a successful connection grants the attacker access to all schemas and stored procedures visible to the connecting user.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP port 1521 from `0.0.0.0/0` or `::/0` and replace it with a specific application-tier or VPN CIDR.
+        - **Place instances in private subnets:** Deploy Oracle RDS or EC2 instances into private subnets with no internet gateway route so the listener is unreachable from the public internet regardless of security group configuration.
+        - **Rotate default credentials:** Change all default Oracle account passwords and lock or drop accounts that are not needed so a public exposure does not result in an immediate compromise.
       audit: |
         ### Audit via Console
 
@@ -59539,12 +59481,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the MongoDB port (27017) from `0.0.0.0/0` or `::/0`. Internet-exposed MongoDB instances have been at the center of multiple mass ransom campaigns where attackers wipe collections and demand payment.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the MongoDB default port (27017) from the internet. MongoDB deployments have been at the center of multiple large-scale ransom campaigns in which attackers wiped collections and demanded payment, exploiting instances that were directly reachable from the internet without authentication.
 
         **Why this matters**
 
-        - Default MongoDB deployments historically lacked authentication, and exposed instances are still routinely discovered by search engines such as Shodan.
-        - Even with authentication enabled, a public endpoint accelerates credential-stuffing and exposes pre-auth CVEs to the internet.
+        - **Historical no-auth default:** Early MongoDB versions shipped with authentication disabled, and many legacy deployments remain in that state; internet-exposed instances are frequently discovered by scanners within hours of launch.
+        - **Automated wiping campaigns:** Attackers routinely use automated tools to find open MongoDB instances, dump or delete collections, and leave ransom notes demanding payment to restore the data.
+        - **Pre-authentication CVE exposure:** Even with authentication enabled, a public endpoint exposes the service to pre-auth vulnerabilities that can bypass credentials entirely.
+        - **Credential-stuffing acceleration:** A public endpoint allows unlimited brute-force attempts against MongoDB authentication with no network-level throttling.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP port 27017 from `0.0.0.0/0` or `::/0` and replace it with an application-tier security group or specific VPN CIDR.
+        - **Enable authentication:** Confirm that MongoDB is running with `--auth` and that all accounts use strong, unique passwords, so an accidental public exposure does not immediately result in unauthorized access.
+        - **Use private subnets:** Deploy MongoDB instances in private VPC subnets with no route to an internet gateway to enforce network-level isolation as a defense-in-depth layer.
       audit: |
         ### Audit via Console
 
@@ -59694,11 +59644,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Redis port (6379) from `0.0.0.0/0` or `::/0`. Open Redis servers have repeatedly been used to mine cryptocurrency, plant SSH keys via `CONFIG SET dir`, and pivot into application infrastructure.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Redis port (6379) from the internet. Redis was historically deployed without authentication, and open instances have repeatedly been used to plant SSH keys, install miners, and achieve remote code execution through the `CONFIG SET dir` technique.
 
         **Why this matters**
 
-        Redis was historically deployed without authentication. Exposed instances are routinely abused via the `CONFIG`/`DEBUG`/`MODULE LOAD` commands to gain RCE on the host running the server.
+        - **No-auth default:** Redis was designed for trusted private networks; it shipped without authentication enabled by default, meaning an exposed instance accepts every command from any connected client.
+        - **Remote code execution via CONFIG:** An unauthenticated attacker with access to a Redis instance can use `CONFIG SET dir` and `CONFIG SET dbfilename` combined with `SAVE` to write arbitrary files to the host filesystem, achieving RCE.
+        - **Cryptocurrency mining abuse:** Publicly exposed Redis instances are among the most common targets for automated cryptomining deployment scripts that establish persistence via cron.
+        - **Session and cache data exposure:** Cached data in Redis often includes session tokens, API keys, and deserialized application objects that provide further attack paths.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP port 6379 from `0.0.0.0/0` or `::/0` and replace it with a scoped application-tier security group or VPN CIDR.
+        - **Enable Redis authentication:** Configure Redis with `requirepass` or, for Redis 6+, use Access Control Lists (ACLs) so an accidental network exposure does not grant unauthenticated command access.
+        - **Use ElastiCache in-VPC mode:** Deploy Redis via ElastiCache in a private subnet with VPC subnet groups to ensure the endpoint is never assigned a public address.
       audit: |
         ### Audit via Console
 
@@ -59848,11 +59807,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Memcached port (11211) from `0.0.0.0/0` or `::/0`. Public Memcached servers have been weaponized for record-breaking UDP reflection/amplification DDoS attacks (>1 Tbps).
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Memcached port (11211) from the internet. Exposed Memcached servers have been used as amplifiers in record-setting DDoS attacks, and the cached data they hold is typically unauthenticated and readable by any connected client.
 
         **Why this matters**
 
-        Memcached's default UDP responder amplifies a 200-byte query into multi-kilobyte responses, making any exposed instance a potential DDoS amplifier. The cached data itself is also typically unauthenticated.
+        - **DDoS amplification:** Memcached's UDP protocol amplifies a small request into a much larger response, making any internet-exposed Memcached instance a potential weapon in reflection/amplification DDoS attacks against third parties.
+        - **No authentication model:** Memcached has no built-in authentication; any client that can reach the port can read, write, or flush the entire cache without credentials.
+        - **Cached data exposure:** Application caches frequently contain session data, rendered HTML fragments, and API response bodies that include personally identifiable information.
+        - **Implicit trust exploitation:** Applications that consume Memcached often trust cached values without re-validating them; an attacker who can write to the cache can inject malicious content into the application's data flow.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP or UDP port 11211 from `0.0.0.0/0` or `::/0` and replace it with a specific application-tier security group or VPN CIDR.
+        - **Disable UDP if not needed:** For application caching workloads, disable the Memcached UDP listener entirely to eliminate the amplification attack surface even if the TCP port remains internal.
+        - **Use ElastiCache in-VPC mode:** Deploy Memcached via ElastiCache in a private subnet so the endpoint is never assigned a public IP address.
       audit: |
         ### Audit via Console
 
@@ -60002,12 +59970,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Elasticsearch/OpenSearch ports (9200/9300) from `0.0.0.0/0` or `::/0`. Public clusters have been the source of repeated mass-data leaks where indices containing PII were freely accessible without authentication.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Elasticsearch and OpenSearch ports (9200 and 9300) from the internet. Publicly accessible clusters have been the source of repeated mass data leaks in which full indices containing customer records, application logs, and credentials were freely readable without any authentication.
 
         **Why this matters**
 
-        - Default Elasticsearch installs historically had no authentication; exposed clusters are continuously indexed by attackers.
-        - Compromised clusters routinely yield full-text customer records, application logs, and credentials.
+        - **No-auth historical default:** Early Elasticsearch versions shipped with no authentication, and many clusters remain in that state; exposed instances are continuously indexed by search engines and attacker tooling.
+        - **Full-text data exfiltration:** Compromised Elasticsearch clusters routinely contain PII, application logs with embedded secrets, and event data that provides a complete picture of application behavior.
+        - **Cluster API exposure:** Port 9200 exposes the full REST API, including snapshot, index deletion, and settings-change endpoints; an unauthorized client can destroy data as easily as read it.
+        - **Credential harvesting:** Application logs indexed into Elasticsearch often contain authorization headers, API keys, and session tokens that can be used to compromise other systems.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP ports 9200 or 9300 from `0.0.0.0/0` or `::/0` and replace it with a scoped application-tier security group or VPN CIDR.
+        - **Enable security features:** Configure Elasticsearch or OpenSearch with TLS and role-based access control so accidental network exposure does not immediately result in unauthenticated data access.
+        - **Use Amazon OpenSearch Service with VPC mode:** Deploy via the managed service within a VPC so the endpoint is not assigned a public endpoint by default.
       audit: |
         ### Audit via Console
 
@@ -60157,11 +60133,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Windows Remote Management ports (5985 HTTP, 5986 HTTPS) from `0.0.0.0/0` or `::/0`.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Windows Remote Management ports (5985 for HTTP, 5986 for HTTPS) from the internet. WinRM provides remote command execution on Windows hosts and is a primary target for lateral movement; exposing it to the public internet allows attackers to attempt credential brute-force and NTLM relay attacks directly against the management plane.
 
         **Why this matters**
 
-        WinRM provides remote command execution on Windows hosts and is a primary lateral-movement target. Exposing WinRM to the internet allows attackers to brute-force credentials, abuse NTLM relay, and execute commands directly on the host.
+        - **Direct command execution path:** WinRM is a full remote shell interface; a successful authentication gives the attacker interactive command access equivalent to an RDP session.
+        - **NTLM relay attacks:** Internet-facing WinRM endpoints can be abused in NTLM relay and pass-the-hash attacks to escalate from low-privilege credentials to higher-privilege accounts.
+        - **Brute-force amplification:** The management interface lacks the rate-limiting that RDP clients typically enforce, allowing faster credential enumeration from the internet.
+        - **Persistence mechanism:** Attackers who authenticate via WinRM can install services, modify registry keys, and create scheduled tasks that survive reboots.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP ports 5985 or 5986 from `0.0.0.0/0` or `::/0` and replace it with a specific management network security group or VPN CIDR.
+        - **Use AWS Systems Manager Session Manager:** Replace internet-facing WinRM with Systems Manager Session Manager, which provides audited shell access without requiring any inbound security group rules.
+        - **Require certificate-based authentication:** If WinRM must be used, configure it for HTTPS (5986) with client certificate authentication only, eliminating password-based brute-force as an attack vector.
       audit: |
         ### Audit via Console
 
@@ -60311,12 +60296,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on Docker daemon API ports (2375 plaintext, 2376 TLS) from `0.0.0.0/0` or `::/0`. The Docker daemon API is the equivalent of root on the host; any reachable client can spawn privileged containers and escape to the host filesystem.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Docker daemon API ports (2375 for plaintext, 2376 for TLS) from the internet. An accessible Docker daemon API is functionally equivalent to root on the host; any client that can reach it can spawn privileged containers, mount the host filesystem, and achieve full host compromise.
 
         **Why this matters**
 
-        - Port 2375 is unauthenticated by default. An exposed daemon allows any internet client to launch a container that mounts the host's `/` filesystem and writes to `/etc/cron.d`, instantly achieving root.
-        - Even the TLS port 2376 must not be reachable from the internet; mTLS materials should be the only access path and they should be distributed through a private network.
+        - **Unauthenticated by default on port 2375:** The plaintext Docker daemon socket has no authentication; any client that can reach port 2375 can issue any API command, including launching a container that mounts the host root filesystem.
+        - **Full host takeover via container escape:** A single API call can create a container with `--privileged --pid=host` that provides root-level access to the host operating system within seconds.
+        - **TLS does not make port 2376 safe on the internet:** Even the TLS endpoint should be restricted to private networks; mTLS materials must be distributed through private channels and the internet is not an appropriate distribution path.
+        - **Automated mass exploitation:** Scanning tools that enumerate open Docker daemon ports are actively operated, and newly exposed endpoints are typically exploited within minutes of becoming reachable.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP ports 2375 or 2376 from `0.0.0.0/0` or `::/0` immediately; these ports should never be reachable from the internet.
+        - **Disable the TCP socket:** Prefer the Unix socket (`/var/run/docker.sock`) for local access and SSH-based Docker contexts for remote administration, eliminating the TCP listener entirely.
+        - **Use AWS Systems Manager or SSH tunneling:** For remote Docker management, use Systems Manager Session Manager port forwarding or an SSH tunnel to the Unix socket rather than opening a TCP port.
       audit: |
         ### Audit via Console
 
@@ -60468,12 +60461,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the Kubernetes API server port (6443) from `0.0.0.0/0` or `::/0`. The API server is the control plane for the entire cluster and must not be reachable from the public internet.
+        This check ensures that AWS security groups are configured to block unrestricted inbound access to the Kubernetes API server port (6443) from the internet. The API server is the single control plane entry point for the entire cluster; a publicly reachable API server is continuously targeted for unauthenticated discovery, token theft, and control-plane CVE exploitation.
 
         **Why this matters**
 
-        - Public API endpoints are continuously scanned for unauthenticated discovery, weak token configurations, and known control-plane CVEs.
-        - Even when authentication is enforced, a public API server is the only piece of infrastructure that, if compromised, grants the attacker full cluster-wide privileges.
+        - **Complete cluster control on compromise:** The API server is the only interface through which an attacker needs to authenticate to gain cluster-wide privileges, including the ability to read secrets, deploy workloads, and modify RBAC policies.
+        - **Continuous internet scanning:** Automated scanners enumerate open port 6443 globally; newly exposed API servers are probed for weak or missing authentication within minutes of becoming reachable.
+        - **Pre-authentication vulnerability exposure:** Even when authentication is enforced, a public API server is exposed to pre-auth vulnerabilities in the API server itself, etcd proxy, or admission webhook chain.
+        - **Secret extraction without workload access:** The API server's secrets store can be enumerated via `kubectl get secrets --all-namespaces` by any user with the right cluster role, making it a high-value target independent of container workloads.
+
+        **Risk mitigation**
+
+        - **Revoke public inbound rules:** Remove any security group rule permitting TCP port 6443 from `0.0.0.0/0` or `::/0` and restrict access to operator networks via VPN or Direct Connect.
+        - **Use EKS private endpoint mode:** For EKS clusters, configure `endpointPrivateAccess=true` and `endpointPublicAccess=false` so the API server is only reachable within the VPC.
+        - **Restrict public endpoint CIDRs where private-only is not feasible:** If a public endpoint is operationally required, use `publicAccessCidrs` to limit access to a specific set of known operator IP ranges rather than leaving it open to the internet.
       audit: |
         ### Audit via Console
 
@@ -60625,11 +60626,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on the kubelet API ports (10250 secure, 10255 read-only) from `0.0.0.0/0` or `::/0`.
+        This check ensures that AWS security groups do not allow inbound traffic on the kubelet API ports (10250 and 10255) from `0.0.0.0/0` or `::/0`. By default these ports may be reachable over any network path, but the kubelet API exposes pod exec, log streaming, and metadata endpoints that must be restricted to trusted sources only.
 
         **Why this matters**
 
-        The kubelet API exposes pod listing, log streaming, and exec endpoints. Misconfigured kubelets that accept anonymous requests on port 10250 have been used for cryptojacking and post-exploitation reconnaissance. Port 10255 is fully unauthenticated and must never be reachable.
+        - **Unauthenticated access risk:** Port 10255 is a fully unauthenticated read-only endpoint that reveals pod metadata and environment variables to anyone who can reach it.
+        - **Remote code execution exposure:** Port 10250, when kubelets are misconfigured to accept anonymous requests, has been actively exploited for cryptojacking and lateral movement.
+        - **Authorization bypass:** The kubelet API is independent of the Kubernetes API server, so security groups are the only control that limits who can reach it directly.
+        - **Minimal blast radius from misconfiguration:** Restricting these ports to control-plane or management CIDRs means a misconfigured kubelet cannot be reached from the internet.
+
+        **Risk mitigation**
+
+        - **Reconnaissance prevention:** Closing public access blocks attackers from enumerating running pods and harvesting environment variable secrets without authentication.
+        - **Defense in depth:** Network-layer restriction supplements but does not replace kubelet authentication and authorization configuration, reducing the impact of any one control failing.
       audit: |
         ### Audit via Console
 
@@ -60779,12 +60788,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS security groups do not allow inbound traffic on etcd ports (2379 client, 2380 peer) from `0.0.0.0/0` or `::/0`. etcd holds the entire Kubernetes cluster state, including all Secrets in the cluster, so public exposure is a complete cluster compromise.
+        This check ensures that AWS security groups do not allow inbound traffic on etcd ports (2379 and 2380) from `0.0.0.0/0` or `::/0`. By default AWS security groups permit any rule that is explicitly added; a rule that opens the etcd client or peer port to the internet exposes the entire Kubernetes cluster state to unauthorized access.
 
         **Why this matters**
 
-        - Direct access to etcd bypasses every Kubernetes authorization layer.
-        - A read-only etcd connection yields every Secret in plaintext (unless encryption-at-rest is configured); a writable connection allows the attacker to insert pods, ServiceAccounts, and RBAC bindings.
+        - **Complete cluster compromise:** etcd stores every Kubernetes object including Secrets, ServiceAccount tokens, and RBAC bindings, so read access is equivalent to reading all cluster credentials.
+        - **Authorization bypass:** Direct etcd connections bypass the Kubernetes API server and all admission controllers, giving an attacker unrestricted read and write access to the data store.
+        - **Writable exposure:** A writable connection allows an attacker to insert privileged pods, create cluster-admin bindings, or corrupt workload state without leaving API-server audit logs.
+
+        **Risk mitigation**
+
+        - **Secrets protection:** Limiting etcd access to the control plane prevents credential theft even when encryption-at-rest is not configured.
+        - **Least-privilege networking:** Scoping port 2379-2380 to the control-plane security group or a VPN CIDR ensures that only intended Kubernetes components can reach the data store.
       audit: |
         ### Audit via Console
 
@@ -60934,13 +60949,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that S3 bucket policies do not contain `Allow` statements with a wildcard `Principal` (`"*"` or `{"AWS": "*"}`). A bucket policy that allows access from any principal makes objects readable or writable by anyone on the internet, regardless of whether Block Public Access is enabled at the account level.
+        This check ensures that S3 bucket policies do not contain `Allow` statements whose `Principal` is the wildcard value `"*"` or `{"AWS": "*"}`. By default a new S3 bucket has no bucket policy, but once a policy with a wildcard principal is added, that bucket becomes readable or writable by anyone on the internet regardless of Block Public Access settings at the account or bucket level.
 
         **Why this matters**
 
-        - Bucket policies are evaluated independently of Block Public Access settings; a misconfigured policy can still grant anonymous access if BPA is not enforced.
-        - Public bucket policies have been the root cause of the largest known cloud data leaks (US Voter Records, Booz Allen, Accenture, Verizon).
-        - Even buckets without PII can become a foothold: attackers can use writable public buckets to host malware, phishing pages, or pivot to other AWS services.
+        - **Independent of Block Public Access:** Bucket policies are evaluated separately from Block Public Access controls, so a wildcard principal policy can grant anonymous access even when BPA is enabled.
+        - **Proven breach vector:** Publicly accessible S3 buckets with wildcard principals have been the root cause of numerous large-scale data exposures involving sensitive records.
+        - **Write-path risk:** Even buckets without sensitive read data can be abused for hosting malware, phishing pages, or as a pivot point to other AWS services if the policy grants write permissions.
+        - **Difficult to detect at scale:** Wildcard principals are easy to add during rapid iteration and may not be caught until an automated control flags them.
+
+        **Risk mitigation**
+
+        - **Controlled access model:** Replacing wildcard principals with explicit AWS account IDs, IAM role ARNs, or service principals ensures only intended callers can access bucket contents.
+        - **Defense in depth:** Scoped bucket policies complement Block Public Access, ACL settings, and IAM policies to prevent accidental public exposure at every layer.
       audit: |
         ### Audit via Console
 
@@ -61112,11 +61133,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that an S3 bucket policy explicitly denies any request that does not use secure transport (`aws:SecureTransport: "false"`). Without an explicit deny, S3 happily accepts plain-HTTP requests, exposing object data and authorization headers in transit.
+        This check ensures that every S3 bucket policy contains an explicit `Deny` statement conditioned on `aws:SecureTransport: "false"`, blocking any request that does not use TLS. By default S3 accepts both HTTP and HTTPS connections, so without an explicit deny, clients with misconfigured TLS or legacy integrations can transmit object data and authorization headers in plaintext.
 
         **Why this matters**
 
-        S3 endpoints accept HTTP and HTTPS by default. A `Deny` statement keyed on `aws:SecureTransport` is the only mechanism that prevents accidental plain-HTTP access by clients with bad TLS configuration.
+        - **In-transit data exposure:** Plain-HTTP requests send object contents and authorization headers in cleartext, making them interceptable by anyone on the network path between the client and the S3 endpoint.
+        - **Authorization header leakage:** AWS Signature V4 credentials transmitted over HTTP can be captured and replayed within the signature validity window.
+        - **No default protection:** S3 does not enforce HTTPS by default, so the deny-on-insecure-transport statement is the only mechanism that enforces encrypted transport at the bucket level.
+
+        **Risk mitigation**
+
+        - **Mandatory encryption in transit:** A `Deny` on `aws:SecureTransport: false` ensures all requests, regardless of client configuration, must use TLS to succeed.
+        - **Compliance enforcement:** The explicit deny satisfies controls that require encryption in transit and provides auditors a policy document as evidence of the control.
       audit: |
         ### Audit via Console
 
@@ -61335,11 +61363,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that the S3 bucket has Object Ownership set to `BucketOwnerEnforced`. With this setting, ACLs are disabled and access is governed exclusively by IAM and bucket policies, removing an entire class of historical mistakes (objects uploaded with public-read ACLs).
+        This check ensures that the S3 bucket has Object Ownership set to `BucketOwnerEnforced`, which disables ACLs entirely and transfers ownership of all objects to the bucket owner. By default, new buckets created after April 2023 use `BucketOwnerEnforced`, but older buckets may still use `BucketOwnerPreferred` or `ObjectWriter`, allowing cross-account uploaders to retain object ownership and set ACLs.
 
         **Why this matters**
 
-        Cross-account uploaders have historically retained ownership of objects, leading to scenarios where the bucket owner could neither delete nor secure objects in their own bucket. `BucketOwnerEnforced` deprecates ACLs in favor of a single, IAM-driven authorization model.
+        - **Eliminates ACL-based public access:** With ACLs disabled, objects cannot be made publicly readable through per-object ACLs that bypass bucket-level controls.
+        - **Unified access model:** All access is governed exclusively by IAM and bucket policies, removing a separate authorization layer that can contradict the intended policy.
+        - **Cross-account ownership resolution:** Historically, cross-account uploaders retained ownership of objects, so the bucket owner could neither delete nor re-encrypt objects they did not own.
+        - **Simplified auditing:** A single IAM-driven authorization model is easier to audit than a combination of IAM policies, bucket policies, and per-object ACLs.
+
+        **Risk mitigation**
+
+        - **Public-read ACL prevention:** Disabling ACLs removes the mechanism by which individual objects can be marked `public-read` outside of bucket-level controls.
+        - **Consistent ownership and control:** The bucket owner always has full control over all objects, preventing scenarios where third-party-uploaded content cannot be managed or removed.
       audit: |
         ### Audit via Console
 
@@ -61471,11 +61507,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that all SNS topics are encrypted with a customer-managed KMS key (CMK), not the default `aws/sns` AWS-managed key. CMKs allow rotation, fine-grained key policies, and the ability to revoke access by disabling or deleting the key.
+        This check ensures that all Amazon SNS topics are encrypted at rest with a customer-managed KMS key (CMK) rather than the default AWS-managed `aws/sns` key. By default, SNS topics are encrypted with an AWS-managed key whose key policy cannot be modified and which cannot be rotated on demand, limiting the organization's control over message confidentiality.
 
         **Why this matters**
 
-        AWS-managed keys cannot be rotated on demand and their key policies cannot be edited. Customer-managed keys give the workload owner full control of cryptographic material, supporting BYOK and regulatory residency requirements.
+        - **Key policy control:** Customer-managed keys allow you to define precise key policies and grants that determine which principals can encrypt and decrypt SNS message bodies.
+        - **On-demand rotation:** CMKs can be rotated on a schedule or immediately after a suspected compromise, unlike AWS-managed keys which rotate on AWS's fixed schedule.
+        - **Access revocation:** Disabling or deleting a CMK immediately prevents new encrypt and decrypt operations, enabling rapid containment if a topic is compromised.
+        - **Audit trail:** Every CMK use generates a CloudTrail event, providing a per-message decryption audit trail that AWS-managed keys do not offer.
+
+        **Risk mitigation**
+
+        - **Regulatory compliance:** CMK encryption satisfies data-residency and BYOK requirements that mandate customer-held cryptographic material for sensitive messaging workloads.
+        - **Blast radius reduction:** Limiting decryption rights to the CMK's key policy means a compromised IAM principal can be removed from the key policy without rotating all application credentials.
       audit: |
         ### Audit via Console
 
@@ -61634,11 +61678,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that all SQS queues are encrypted with a customer-managed KMS key (CMK) rather than SQS-managed encryption (SSE-SQS) or the AWS-managed `aws/sqs` key.
+        This check ensures that all Amazon SQS queues are encrypted at rest with a customer-managed KMS key (CMK) rather than SSE-SQS or the AWS-managed `aws/sqs` key. By default, SQS queues use SSE-SQS or the AWS-managed key, neither of which gives the queue owner control over key rotation, key policies, or the ability to revoke decryption access.
 
         **Why this matters**
 
-        Sensitive queue payloads benefit from CMK protection because key policies can be tightly scoped, keys can be rotated on demand, and access can be revoked by disabling the CMK. SSE-SQS and `aws/sqs` keys offer no such control.
+        - **Key policy control:** Customer-managed keys let you restrict which roles and services can decrypt queue messages, reducing the blast radius if an IAM principal is compromised.
+        - **On-demand rotation:** Unlike the AWS-managed `aws/sqs` key, a CMK can be rotated immediately in response to a suspected key compromise.
+        - **Access revocation:** Disabling the CMK prevents any consumer from decrypting queued messages, enabling rapid containment of a data leak.
+        - **Decryption audit trail:** CloudTrail logs every CMK decrypt call, providing visibility into which principals are consuming queue messages.
+
+        **Risk mitigation**
+
+        - **Sensitive payload protection:** Queue messages that carry PII, credentials, or business-critical events benefit from independently revocable encryption that survives IAM policy changes.
+        - **Compliance evidence:** CMK encryption with CloudTrail logging provides the auditor-facing record that data-at-rest controls are operating on messaging infrastructure.
       audit: |
         ### Audit via Console
 
@@ -62916,13 +62968,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures every Amazon Bedrock custom model is encrypted at rest with a customer-managed KMS key (CMK). Custom models are derived from the training data you provide and the resulting model artifacts retain the sensitivity of that source data. When Bedrock encrypts a custom model with the AWS-owned default key, you cannot rotate, audit, or revoke access to the encryption key independently of the AWS account.
+        This check ensures that every Amazon Bedrock custom model is encrypted at rest with a customer-managed KMS key (CMK). By default, Bedrock encrypts custom models with an AWS-owned key that the customer cannot rotate, audit, or revoke independently, which means the organization has no mechanism to render a leaked model artifact unrecoverable.
 
         **Why this matters**
 
-        - Custom-model artifacts can leak the patterns and content of the training data through model inversion or membership inference attacks. Encrypting them with a CMK lets you delete the key to render the model unrecoverable.
-        - A CMK gives you a key policy and grants you control over which principals can decrypt the model and its training-data outputs.
-        - CloudTrail logs every CMK use, so you get a per-decryption audit trail that AWS-managed keys do not provide.
+        - **Training data sensitivity:** Custom model artifacts retain the statistical patterns of the training data used to produce them, so their unauthorized access can expose proprietary or regulated information.
+        - **Key revocation capability:** A CMK can be disabled or deleted to render model artifacts permanently inaccessible, which is not possible with AWS-owned default keys.
+        - **Granular access control:** CMK key policies and grants precisely define which principals can decrypt model artifacts and training outputs, limiting access to authorized services and users.
+        - **Decryption audit trail:** CloudTrail logs every CMK use, providing a per-operation record of who accessed model artifacts and when.
+
+        **Risk mitigation**
+
+        - **Incident containment:** If a custom model is determined to contain sensitive training data that should not have been included, the CMK can be revoked to prevent further access while remediation is planned.
+        - **Regulatory alignment:** CMK encryption satisfies BYOK requirements and compliance frameworks that mandate customer-controlled cryptographic material for AI and ML workloads handling regulated data.
       audit: |
         ### Audit via Console
 
@@ -63067,17 +63125,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every AWS WAFv2 web ACL references the AWS-managed rule groups that cover SQL injection, cross-site scripting, and known-bad inputs. AWS publishes and maintains these rule groups so customers do not have to author and update signatures themselves. The expected groups are:
-
-        - **AWSManagedRulesCommonRuleSet:** OWASP Top 10 coverage including XSS.
-        - **AWSManagedRulesSQLiRuleSet:** SQL injection patterns.
-        - **AWSManagedRulesKnownBadInputsRuleSet:** Exploit attempts against common CVEs and bad inputs.
+        This check ensures that every AWS WAFv2 web ACL references all three required AWS-managed rule groups: `AWSManagedRulesCommonRuleSet` for OWASP Top 10 including cross-site scripting, `AWSManagedRulesSQLiRuleSet` for SQL injection patterns, and `AWSManagedRulesKnownBadInputsRuleSet` for exploit attempts against common CVEs. A web ACL that lacks these rule groups relies only on custom rules, which require ongoing manual maintenance to remain current against new attack patterns.
 
         **Why this matters**
 
-        - A web ACL with custom IP allow lists or rate-limiting alone does not block injection attacks at the application layer.
-        - AWS keeps these managed rule groups current as new CVEs and exploit patterns emerge, so referencing them is more durable than maintaining hand-rolled signatures.
-        - Skipping the SQLi or XSS rule group is the single most common cause of WAF-protected applications still being compromised by injection attacks.
+        - **Maintained signature coverage:** AWS updates these managed rule groups as new CVEs and exploit patterns emerge, so referencing them is more durable than hand-rolled signatures that can drift out of date.
+        - **Injection attack coverage gap:** A web ACL with only rate-limiting or IP-based rules does not inspect request payloads and will not block SQLi or XSS attacks at the application layer.
+        - **CVE exploit blocking:** The `KnownBadInputsRuleSet` blocks exploit attempts against specific vulnerabilities such as Log4Shell and Spring4Shell within hours of their disclosure.
+        - **Baseline compliance:** Major compliance frameworks require web application firewall controls that cover injection and cross-site scripting attack classes.
+
+        **Risk mitigation**
+
+        - **Rapid threat response:** AWS-managed rule groups receive signature updates without requiring configuration changes, ensuring protection against newly disclosed vulnerabilities without manual intervention.
+        - **Defense in depth:** Managed WAF rules complement application-layer input validation, reducing the impact of any single application-side sanitization failure.
       audit: |
         ### Audit via Console
 
@@ -63352,13 +63412,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Batch job definitions do not request privileged containers. A privileged container shares the host's namespaces and capabilities, including the ability to load kernel modules and access raw devices. On EC2-backed compute environments this gives the container code root on the underlying host.
+        This check ensures that active AWS Batch job definitions do not request privileged containers. A privileged container shares the host kernel's namespaces and capabilities, including the ability to load kernel modules, access raw block devices, and manipulate host networking, giving the container code effective root on the underlying EC2 worker node.
 
         **Why this matters**
 
-        - A compromised privileged container can break out of its isolation boundary and attack other Batch jobs running on the same host.
-        - Privileged mode bypasses the user-namespace and capability dropping that Batch jobs would otherwise inherit, raising the blast radius of any code-execution flaw.
-        - Most Batch workloads do not need raw device access; the privileged flag is usually a leftover from local container debugging.
+        - **Host breakout risk:** A container running with `privileged: true` can mount the host filesystem, read other containers' memory, and escape the container isolation boundary entirely.
+        - **Lateral movement:** A compromised privileged Batch job can attack other jobs running on the same EC2 instance and access the EC2 instance metadata endpoint to steal IAM credentials.
+        - **Unnecessary escalation:** The vast majority of Batch workloads process data or run computations and have no legitimate need for raw device access or kernel-level capabilities.
+
+        **Risk mitigation**
+
+        - **Isolation boundary preservation:** Running without the privileged flag confines the container to its user namespace and capability set, so a code-execution flaw in the workload does not immediately yield host access.
+        - **Blast radius limitation:** Non-privileged containers cannot modify the host network stack or access other containers' filesystems, reducing the damage a compromised job can cause.
       audit: |
         ### Audit via Console
 
@@ -63473,13 +63538,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures AWS Batch job definitions reference container images from approved private registries rather than public ones such as Amazon ECR Public (`public.ecr.aws`) or Docker Hub (`docker.io`, `registry.hub.docker.com`). Public registries can serve images that have been retagged or compromised by a third party between scan and execution.
+        This check ensures that active AWS Batch job definitions reference container images from approved private registries rather than public sources such as Amazon ECR Public (`public.ecr.aws`), Docker Hub (`docker.io`), or unqualified image names. Public registries serve images that may be retagged, compromised, or unavailable at pull time, creating a supply-chain risk that bypasses internal scanning and signing gates.
 
         **Why this matters**
 
-        - Public images can be replaced or yanked at any time by the publisher, breaking reproducibility and opening supply-chain attacks.
-        - Images from private registries can be required to pass internal vulnerability scanning, signing, and admission policies before being usable as a Batch job source.
-        - Pulling from public registries on every job submission depends on third-party availability and rate limits that are outside your control.
+        - **Supply-chain control:** Images from private registries can be required to pass internal vulnerability scanning, signing attestation, and admission policies before being usable as Batch job sources.
+        - **Immutability and reproducibility:** Private registries under your control do not allow third parties to replace image content at a tag that is already in use, ensuring the same tag always runs the same code.
+        - **Availability independence:** Pulling from public registries on every job submission depends on third-party availability and rate limits outside your operational control.
+
+        **Risk mitigation**
+
+        - **Malicious image prevention:** Restricting images to known private registries blocks an attacker from substituting a malicious image by compromising an upstream public registry namespace.
+        - **Audit and provenance:** Images in a private ECR repository carry a push history and scan report that establishes provenance, enabling forensic investigation if a job produces unexpected behavior.
       audit: |
         ### Audit via Console
 
@@ -63607,13 +63677,18 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that the compute environments backing every enabled AWS Batch job queue land in private subnets, where instances do not receive a public IPv4 address on launch. Batch jobs typically only need outbound access through a NAT gateway or VPC endpoint, never inbound reachability from the internet.
+        This check ensures that the compute environments backing every enabled AWS Batch job queue use private subnets where EC2 instances do not receive a public IPv4 address on launch. Batch workers typically require only outbound access to pull images, call AWS APIs, and write results; they have no legitimate need for inbound reachability from the internet.
 
         **Why this matters**
 
-        - A Batch instance with a public IP exposes the AMI's services and any container ports bound to the host network directly to the internet.
-        - Public IPs widen the attack surface available to scanners that probe random IPv4 space looking for misconfigured services.
-        - Private subnets force traffic through controlled egress paths, where a NAT gateway or VPC endpoint can be audited and rate-limited.
+        - **Direct internet exposure:** An EC2 instance with a public IP exposes any services bound to host-network ports, including Docker daemon sockets and SSH, directly to internet scanners.
+        - **Expanded attack surface:** Public IPs are visible to automated scanners that continuously probe random IPv4 space, increasing the likelihood that a misconfigured service is discovered and exploited.
+        - **Uncontrolled egress bypass:** Instances in public subnets can route directly to the internet without passing through a NAT gateway or VPC endpoint, bypassing egress monitoring and filtering controls.
+
+        **Risk mitigation**
+
+        - **Controlled egress path:** Private subnets force all outbound traffic through a NAT gateway or VPC endpoint, where it can be monitored, rate-limited, and restricted to approved destinations.
+        - **Defense in depth:** Subnet placement complements security groups as a network control, so a security group misconfiguration on a private-subnet instance does not immediately result in internet-accessible services.
       audit: |
         ### Audit via Console
 
@@ -63714,13 +63789,18 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that the IAM role assumed by an AWS Batch container does not grant `Action: "*"` or `Resource: "*"` in any allow statement, and does not carry inline policies whose contents cannot be inspected by this check. Batch job code runs with the permissions of the job role, so a wildcard policy gives the workload full control over the AWS account whenever it is invoked, and an unaudited inline policy is a similar blind spot.
+        This check ensures that the IAM role assumed by an AWS Batch container job does not contain `Allow` statements with wildcard `Action` (`"*"`) or wildcard `Resource` (`"*"`), and carries no inline policies whose permissions cannot be evaluated by this check. Batch job code runs under the job role, so over-permissive policies give the workload broad access to AWS services whenever a job executes.
 
         **Why this matters**
 
-        - A Batch job that processes untrusted data and assumes a wildcard role can be pivoted by an attacker into account-wide read or write access.
-        - `iam:PassRole` combined with `Resource: "*"` lets the job role escalate to any other role in the account by passing it to a service.
-        - Inline policies are not evaluated by this check because their content is not exposed via the IAM API in a structured way; the check fails when inline policies are present so they can be reviewed and converted to managed policies.
+        - **Privilege escalation vector:** A Batch job role with `iam:PassRole` and `Resource: "*"` can pass itself or any other role to an AWS service, escalating from the Batch job to account-wide access.
+        - **Untrusted input risk:** Batch jobs often process external data; a wildcard role means any code-execution flaw in the job can pivot into full account control.
+        - **Inline policy opacity:** Inline policies are not surfaced through the managed-policy API in a structured form, making them invisible to many audit and governance tools; their presence is flagged so they can be converted to auditable managed policies.
+
+        **Risk mitigation**
+
+        - **Least-privilege enforcement:** Scoping job role permissions to the specific actions and resource ARNs the workload needs limits the blast radius of a compromised or misbehaving Batch job.
+        - **Governance pipeline compatibility:** Managed policies with explicit resource ARNs can be reviewed in change control and validated by automated permission-analysis tools before deployment.
       audit: |
         ### Audit via Console
 
@@ -63828,13 +63908,18 @@ queries:
           mondoo.com/filter-icon: aws
     docs:
       desc: |
-        This check ensures that the IAM execution role of every Step Functions state machine does not contain an allow statement with `Resource: "*"`. State machines orchestrate AWS service calls under their execution role, so a wildcard resource lets the state machine invoke `lambda:InvokeFunction`, `dynamodb:*`, and similar service actions against every resource in the account.
+        This check ensures that the IAM execution role of every AWS Step Functions state machine does not contain an `Allow` statement with `Resource: "*"`, and carries no inline policies. State machines orchestrate service calls under their execution role, and a wildcard resource means the workflow can invoke Lambda functions, write to DynamoDB tables, or publish to SNS topics across the entire account, far beyond the resources the workflow was designed to use.
 
         **Why this matters**
 
-        - A workflow that takes input from an untrusted source and passes it to a Lambda invocation parameter can become a confused-deputy primitive if the role can invoke any Lambda function.
-        - Resource wildcards prevent meaningful least-privilege auditing because they mask which downstream resources the workflow actually depends on.
-        - Inline policies are not evaluated structurally by this check; their presence fails the check so they can be reviewed and converted into managed policies that this control can audit.
+        - **Confused-deputy risk:** A workflow that accepts untrusted input and passes it to a service invocation parameter can be manipulated into calling arbitrary resources if the role permits any resource.
+        - **Least-privilege auditing:** Wildcard resources make it impossible to determine from the role policy alone which downstream services the state machine actually depends on, hindering access review.
+        - **Inline policy opacity:** Inline policies bypass the structured managed-policy API, making them invisible to permission-analysis tooling; flagging their presence prompts conversion to managed policies.
+
+        **Risk mitigation**
+
+        - **Explicit resource scoping:** Replacing `Resource: "*"` with the ARNs of the specific Lambda functions, DynamoDB tables, and other services the state machine integrates with limits the impact of a compromised or misconfigured workflow.
+        - **Change-control visibility:** Managed policies with explicit resource lists can be reviewed and approved through infrastructure-as-code change control, giving security teams visibility before a state machine is deployed or modified.
       audit: |
         ### Audit via Console
 
@@ -63958,13 +64043,18 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Private Certificate Authority (ACM PCA) instances sign issued certificates with SHA-256 or stronger digest algorithms. SHA-1 is broken for collision resistance and has been deprecated by all major browsers and TLS libraries, so a CA that signs with SHA-1 issues certificates that downstream consumers will reject or treat as untrustworthy.
+        This check ensures that every AWS Private Certificate Authority uses SHA-256 or stronger signing algorithms such as `SHA256WITHRSA`, `SHA384WITHRSA`, `SHA512WITHRSA`, `SHA256WITHECDSA`, `SHA384WITHECDSA`, or `SHA512WITHECDSA`. SHA-1 is cryptographically broken for collision resistance and has been deprecated by all major browsers, TLS libraries, and certificate authorities, so a Private CA configured with a SHA-1 algorithm issues certificates that downstream clients will reject.
 
         **Why this matters**
 
-        - SHA-1 collisions are computationally feasible and have been demonstrated against real-world signature schemes.
-        - Modern TLS clients refuse SHA-1-signed certificates outright, breaking the services that depend on them.
-        - The signing algorithm of a CA cannot be changed after the CA is created, so a SHA-1 CA must be replaced with a new SHA-256 or stronger CA.
+        - **Collision attacks:** SHA-1 collisions are computationally feasible with modern hardware, allowing an attacker who can influence two certificate requests to forge a legitimate-looking certificate.
+        - **Client rejection:** Modern TLS stacks refuse SHA-1-signed certificates outright, so services relying on a SHA-1 CA will experience TLS handshake failures with current clients.
+        - **Immutability:** The signing algorithm of a Private CA cannot be changed after creation, so a SHA-1 CA must be replaced and all issued certificates reissued before the CA can be decommissioned.
+
+        **Risk mitigation**
+
+        - **Certificate trust integrity:** SHA-256 or stronger algorithms ensure that certificates issued by the Private CA will be accepted by current and near-future TLS clients without requiring emergency reissuance.
+        - **Regulatory alignment:** Compliance frameworks such as PCI DSS and NIST SP 800-131A prohibit SHA-1 for digital signatures, so a strong signing algorithm is required for regulated workloads.
       audit: |
         ### Audit via Console
 
@@ -64113,13 +64203,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every AWS Private CA stores its private signing key in HSM-backed storage that is certified to FIPS 140-2 Level 3 or higher. The CA private key is the trust anchor for every certificate the CA issues, so its compromise lets an attacker forge certificates that downstream services will accept.
+        This check ensures that every AWS Private Certificate Authority stores its private signing key in hardware security module storage certified to FIPS 140-2 Level 3 or higher. By default, the key storage security standard of a new Private CA depends on the region and creation path; a CA whose private key is held in software-based storage has weaker tamper-resistance guarantees than one backed by a validated HSM.
 
         **Why this matters**
 
-        - FIPS 140-2 Level 3 HSMs enforce tamper-resistance and identity-based authentication for key operations, which software-only key storage cannot provide.
-        - The `keyStorageSecurityStandard` is fixed at CA creation time, so a CA created without explicit HSM storage cannot be upgraded in place.
-        - Compliance frameworks such as PCI DSS, FedRAMP, and HIPAA expect CA private keys to live in hardware-backed key stores.
+        - **Trust anchor protection:** The CA private key is the cryptographic root of trust for every certificate the CA issues; its compromise allows an attacker to forge certificates that all downstream consumers will accept as valid.
+        - **Tamper-resistance requirement:** FIPS 140-2 Level 3 HSMs enforce physical tamper-resistance and identity-based authentication for key operations, protections that software keystores cannot provide.
+        - **Immutability:** The key storage security standard is fixed at CA creation time, so a CA without explicit HSM-backed storage cannot be upgraded in place and must be replaced.
+        - **Regulatory mandate:** PCI DSS, FedRAMP High, and HIPAA security requirements expect CA private keys to be stored in hardware-backed key stores with validated tamper resistance.
+
+        **Risk mitigation**
+
+        - **Key exfiltration prevention:** An HSM-backed key cannot be exported or copied, so even if the underlying EC2 host or software layer is compromised the private key material remains protected.
+        - **Compliance evidence:** FIPS 140-2 Level 3 certification provides documented evidence for auditors that CA private key storage meets hardware-security standards required by regulated workloads.
       audit: |
         ### Audit via Console
 
@@ -64265,13 +64361,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Lightsail instances do not have firewall rules that expose remote-administration or database ports such as 22, 3389, 3306, 5432, 1433, 27017, 6379, and 9200 to `0.0.0.0/0`. Lightsail instances are often used for quick stand-ups, and the per-instance firewall is the only network control between the instance and the public internet.
+        This check ensures that Lightsail instance firewall rules do not expose remote-administration or database ports to the public internet. By default, Lightsail instances can have firewall rules that allow inbound traffic from any IP address, but leaving ports such as 22, 3389, 3306, 5432, 1433, 27017, 6379, and 9200 open to `0.0.0.0/0` gives attackers a direct path to the instance and any data store it hosts.
 
         **Why this matters**
 
-        - SSH (22) and RDP (3389) exposed to the world receive constant credential-stuffing and brute-force attacks.
-        - Database ports (MySQL 3306, PostgreSQL 5432, SQL Server 1433, MongoDB 27017, Redis 6379, Elasticsearch 9200) reveal data stores that often run with default credentials or no authentication.
-        - Lightsail does not provide VPC-level controls equivalent to security groups for non-Lightsail traffic, so the instance firewall is the last line of defense.
+        - **Brute-force exposure:** SSH (22) and RDP (3389) open to the world receive continuous credential-stuffing and brute-force traffic that standard auth mechanisms alone cannot fully absorb.
+        - **Database attack surface:** Well-known database ports such as MySQL 3306, PostgreSQL 5432, and MongoDB 27017 are enumerated by internet scanners within minutes and are frequently targeted due to default credentials or missing authentication.
+        - **Single control boundary:** Lightsail uses a per-instance firewall rather than VPC-level security groups for internet-facing traffic, making that firewall the only barrier between sensitive ports and the public internet.
+        - **Minimal legitimate need:** Remote-administration ports should never be reachable from arbitrary IPs; restrict access to known CIDR ranges or use a bastion host.
+
+        **Risk mitigation**
+
+        - **Reduce attack surface:** Removing public rules on sensitive ports eliminates the most common initial-access vectors for opportunistic attackers.
+        - **Enforce least privilege:** Scoping source CIDRs to specific management ranges ensures only authorized operators can reach administrative services.
+        - **Protect data stores:** Keeping database ports off the public internet prevents direct data exfiltration even if application-layer authentication is misconfigured.
       audit: |
         ### Audit via Console
 
@@ -64449,13 +64552,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Lightsail managed databases have `publiclyAccessible` set to `false`. A publicly accessible Lightsail database receives a public IP and can be reached from the internet, with only the database engine's authentication standing between the data and the world.
+        This check ensures that Lightsail managed databases have public accessibility disabled. By default, a Lightsail database can be created with public mode enabled, which assigns the instance a public IP and makes the database reachable from the internet on its default engine port with only database-level authentication as a barrier.
 
         **Why this matters**
 
-        - Database engines listen on well-known ports that internet scanners enumerate continuously, so a public Lightsail database is fingerprinted within minutes of being created.
-        - Authentication on the database alone is too thin a defense for production data; CVEs against the engine, weak credentials, or a single leaked password become a full data breach.
-        - A private Lightsail database can still be reached from Lightsail instances and peered VPCs through the Lightsail VPC peering feature.
+        - **Continuous scanning:** Database engines listen on well-known ports that internet scanners enumerate and fingerprint within minutes of a new instance appearing on the public internet.
+        - **Thin authentication boundary:** A single set of database credentials is the only protection between a publicly accessible database and a full data breach; a leaked or weak password immediately becomes catastrophic.
+        - **Private connectivity is sufficient:** Lightsail databases can still be reached from Lightsail instances and peered VPCs through VPC peering, so disabling public access does not break legitimate application connectivity.
+
+        **Risk mitigation**
+
+        - **Eliminate direct internet exposure:** Disabling public mode removes the public IP, forcing all connections through the Lightsail private network or a peered VPC.
+        - **Defense in depth:** Keeping the database off the public internet means an attacker must first compromise a host inside the environment before they can attempt database authentication.
+        - **Reduce CVE impact:** Engine vulnerabilities that allow unauthenticated access or privilege escalation are only exploitable if the port is reachable; private databases are not accessible even when a critical CVE is disclosed.
       audit: |
         ### Audit via Console
 
@@ -64577,13 +64686,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every non-`OPTIONS` route on an API Gateway v2 HTTP or WebSocket API has an `authorizationType` other than `NONE`. The `OPTIONS` method is excluded because browsers send pre-flight CORS requests without credentials and the API must be able to answer them anonymously.
+        This check ensures that every non-OPTIONS route on an API Gateway v2 HTTP or WebSocket API has an authorization type other than `NONE`. By default, new routes are created without an authorizer, leaving the endpoint open to any caller who can reach the API URL until an authorizer is explicitly attached.
 
         **Why this matters**
 
-        - A route with `AuthorizationType: NONE` is open to any caller on the internet who can reach the API endpoint.
-        - The default route key `$default` and catch-all route keys are easy to leave on `NONE` while testing and to forget about before going live.
-        - Authorization is enforced per-route, so adding an authorizer at the API level does not protect routes that explicitly opt out.
+        - **Open internet access:** A route with `AuthorizationType: NONE` accepts requests from any caller on the internet without requiring credentials, making the backend integration fully public.
+        - **Default oversight:** The default route key `$default` and catch-all patterns are easy to leave on `NONE` during development and forget to secure before the API goes live.
+        - **Per-route enforcement:** Authorization is applied at the route level, so an authorizer configured at the API level does not automatically protect routes that explicitly opt out.
+        - **Audit trail gap:** Unauthenticated requests cannot be attributed to a specific caller identity in CloudTrail, making incident investigation and forensics much harder.
+
+        **Risk mitigation**
+
+        - **Enforce least privilege:** Attaching a JWT, Lambda, or IAM authorizer ensures only callers who present valid credentials can invoke the route.
+        - **Block unauthorized invocation:** Requiring authorization prevents anonymous callers from triggering backend integrations that may execute privileged operations or access sensitive data.
+        - **Improve accountability:** Every authorized request carries an identity that CloudTrail can log, enabling audit trails and anomaly detection on API usage.
       audit: |
         ### Audit via Console
 
@@ -64735,13 +64851,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every API Gateway v2 custom domain is configured with the `TLS_1_2` security policy on each of its endpoint configurations. The older `TLS_1_0` policy permits TLS 1.0 and TLS 1.1 negotiation, both of which are deprecated and disallowed by modern compliance baselines.
+        This check ensures that every API Gateway v2 custom domain is configured with the `TLS_1_2` security policy on each of its endpoint configurations. By default, AWS allows custom domains to be created with the legacy `TLS_1_0` policy, which permits negotiation of TLS 1.0 and TLS 1.1, both deprecated protocols with known cryptographic weaknesses.
 
         **Why this matters**
 
-        - TLS 1.0 and TLS 1.1 have known cryptographic weaknesses including BEAST, POODLE, and weak cipher suites that no longer satisfy PCI DSS, HIPAA, and FedRAMP.
-        - The security policy is set per endpoint configuration, so a multi-region domain can have one configuration on the strong policy and another on the weak one.
-        - Enforcing `TLS_1_2` on the custom domain forces all clients to negotiate at least TLS 1.2, regardless of what the client library would default to.
+        - **Known protocol weaknesses:** TLS 1.0 and TLS 1.1 are vulnerable to attacks such as BEAST and POODLE that exploit weaknesses in older cipher suites and protocol padding.
+        - **Per-endpoint risk:** The security policy is set at the endpoint configuration level, so a multi-region domain can have one endpoint on a strong policy while another silently accepts legacy connections.
+        - **Client enforcement:** Enforcing `TLS_1_2` on the custom domain prevents any client from negotiating a weaker version regardless of the client library's default behavior.
+
+        **Risk mitigation**
+
+        - **Eliminate deprecated cipher suites:** Requiring TLS 1.2 removes support for cipher suites that can be exploited to decrypt API traffic between clients and the gateway.
+        - **Meet compliance baselines:** TLS 1.2 is the minimum version required by major compliance frameworks for protecting data in transit, which legacy policies cannot satisfy.
+        - **Protect API credentials:** API keys, OAuth tokens, and session data transmitted over deprecated TLS versions are at risk of interception; enforcing modern TLS closes this exposure.
       audit: |
         ### Audit via Console
 
@@ -64894,13 +65016,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Glue Data Catalog encryption-at-rest is set to `SSE-KMS` with an explicit KMS key identifier. The Data Catalog stores table schemas, partition metadata, and connection passwords; encrypting the catalog with a customer-managed KMS key gives you a key policy and rotation control over the metadata that describes your data lake.
+        This check ensures that AWS Glue Data Catalog encryption at rest is set to `SSE-KMS` with an explicit customer-managed KMS key identifier. By default, the Glue Data Catalog stores metadata without encryption unless explicitly configured, and even when encryption is enabled, using an AWS-owned key provides no customer visibility into key usage or access control.
 
         **Why this matters**
 
-        - The `DISABLED` mode leaves catalog metadata unencrypted at rest, exposing schema and connection details to any AWS Glue or KMS-unaware integrator that lands in the account.
-        - `SSE-KMS` with a referenced KMS key id is the only catalog encryption mode that integrates with KMS audit logs and per-key access control.
-        - The catalog also stores connection passwords, so loose catalog encryption can become a credential-leak path.
+        - **Sensitive catalog content:** The Data Catalog stores table schemas, partition metadata, and database connection passwords, making it a high-value target for attackers seeking to understand the data lake topology.
+        - **Key policy control:** Only `SSE-KMS` with a referenced customer-managed key integrates with KMS key policies and CloudTrail audit logs, allowing the data owner to control and monitor who can access catalog metadata.
+        - **Credential leak path:** Connection passwords stored in the catalog are encrypted only when catalog encryption is enabled; a disabled or AWS-owned-key configuration means those credentials are outside the customer's key management boundary.
+
+        **Risk mitigation**
+
+        - **Restrict catalog access:** A customer-managed KMS key policy can deny access to specific IAM principals independently of IAM policies, adding a second layer of access control over metadata.
+        - **Audit decryption events:** CloudTrail records every `kms:Decrypt` call against the catalog key, enabling detection of unauthorized metadata access that would be invisible with AWS-owned keys.
+        - **Centralized key governance:** A CMK can be rotated, disabled, or deleted by the account owner, providing a direct way to revoke catalog access in response to a security incident.
       audit: |
         ### Audit via Console
 
@@ -65071,13 +65199,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every Glue security configuration encrypts both job bookmarks and S3 outputs with a referenced KMS key. Glue jobs that lack a security configuration with both modes set inherit the catalog-level defaults, which may rely on AWS-owned keys without per-key access control or audit.
+        This check ensures that every AWS Glue security configuration encrypts both job bookmarks and S3 outputs with a customer-managed KMS key. Glue jobs that are not associated with a security configuration inherit catalog-level defaults and typically write S3 outputs and job bookmarks without customer-controlled encryption, leaving those artifacts outside the customer's key management boundary.
 
         **Why this matters**
 
-        - Job bookmarks record the position of incremental ETL runs and can leak data structure and processing patterns; encrypting them with `CSE-KMS` keeps them confidential at rest in the Glue metadata store.
-        - S3 outputs from a Glue job inherit the security configuration's S3 encryption mode; pairing `SSE-KMS` with an explicit key id gives you a key policy that controls who can decrypt the resulting partitions.
-        - A KmsKeyArn that is empty implies AWS managed defaults, which cannot be governed by your key administrators.
+        - **Bookmark confidentiality:** Job bookmarks record the position of incremental ETL runs and can reveal data structure and processing patterns; encrypting them with `CSE-KMS` keeps them confidential at rest in the Glue metadata store.
+        - **Output data control:** S3 outputs from a Glue job inherit the security configuration's encryption mode; pairing `SSE-KMS` with an explicit key ARN gives the data owner a key policy that controls who can decrypt the resulting partitions.
+        - **Key governance gap:** An empty or null `KmsKeyArn` in the security configuration implies AWS-managed defaults, which cannot be governed through customer key policies or rotated on the customer's schedule.
+
+        **Risk mitigation**
+
+        - **Control access to ETL outputs:** A customer-managed key policy can restrict which principals can decrypt Glue S3 outputs independently of S3 bucket policies, providing an additional access control layer.
+        - **Audit key usage:** CloudTrail records every `kms:Decrypt` and `kms:GenerateDataKey` call against both keys, producing an audit trail of who accessed which ETL output and when.
+        - **Enable incident response:** Disabling or revoking the CMK immediately blocks further access to both job bookmarks and S3 outputs, providing a fast revocation path if a Glue job or its output is compromised.
       audit: |
         ### Audit via Console
 
@@ -65279,13 +65413,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every enabled Athena workgroup encrypts query results using `SSE_KMS` or `CSE_KMS` with an explicit KMS key reference. Athena query results can contain sensitive content from the underlying data sources such as CloudTrail logs, application data, and PII; writing them to S3 without a KMS-backed key leaves the audit and access-control gap that S3 default encryption alone cannot close.
+        This check ensures that every enabled Athena workgroup encrypts query results using `SSE_KMS` or `CSE_KMS` with an explicit customer-managed KMS key reference. Athena query results are written to S3 and can contain sensitive content from underlying data sources such as CloudTrail logs, application databases, and PII; without a KMS-backed encryption configuration, audit and access-control capabilities are limited to what S3 default encryption alone can provide.
 
         **Why this matters**
 
-        - `SSE_S3` covers data-at-rest but provides no per-key audit trail, so you cannot determine who decrypted query results after the fact.
-        - `SSE_KMS` and `CSE_KMS` both produce CloudTrail events for every decryption, which is essential for incident response on sensitive query output.
-        - A workgroup whose encryption is enforced but whose `KmsKey` is empty falls back to AWS-owned keys, which sit outside customer key administration.
+        - **Audit trail for results:** `SSE_KMS` and `CSE_KMS` produce CloudTrail `kms:Decrypt` events for every access to query output, while `SSE_S3` provides no per-key visibility into who decrypted the results.
+        - **Customer key control:** A workgroup configured with `SSE_KMS` or `CSE_KMS` but no explicit key falls back to AWS-owned keys, which sit outside the customer's key administration and cannot be rotated or revoked.
+        - **Enforcement at workgroup level:** Setting `EnforceWorkGroupConfiguration` to `true` alongside a CMK prevents individual query clients from overriding the encryption setting and writing unprotected output.
+
+        **Risk mitigation**
+
+        - **Restrict result access:** A customer-managed KMS key policy can restrict which principals can decrypt Athena query output independently of S3 bucket policies, adding a second access control boundary.
+        - **Support incident response:** Disabling or revoking the CMK immediately blocks further decryption of query results, providing a fast revocation path if query output containing sensitive data is accessed improperly.
+        - **Meet regulatory requirements:** Many compliance frameworks require customer-controlled key management for data at rest, and a CMK-backed workgroup is the only Athena configuration that satisfies this requirement for query results.
       audit: |
         ### Audit via Console
 
@@ -65475,14 +65615,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that AWS Lambda function URLs require IAM authentication. A function URL configured with `AuthType: NONE` exposes the Lambda function as an anonymous HTTPS endpoint that any caller on the internet can invoke without credentials.
+        This check ensures that AWS Lambda function URLs require IAM authentication. By default, a function URL can be created with `AuthType: NONE`, which exposes the Lambda function as an anonymous HTTPS endpoint reachable by any caller on the internet without any credentials.
 
         **Why this matters**
 
-        - A function URL with `AuthType: NONE` is an anonymous code-execution endpoint reachable from the public internet.
-        - Anonymous endpoints can be abused for denial-of-service, cryptomining, or as part of a chain to reach internal resources the function can access.
-        - Unauthenticated invocation bypasses the principle of least privilege and removes audit attribution from CloudTrail.
-        - Setting `AuthType: AWS_IAM` requires callers to sign requests with SigV4 and lets resource policies and identity policies enforce who may invoke the function.
+        - **Anonymous code execution:** A function URL with `AuthType: NONE` is an unauthenticated compute endpoint that any internet client can invoke, including for denial-of-service, cryptomining, or unauthorized data access.
+        - **Blast radius amplification:** Lambda functions often carry IAM execution roles with permissions to access S3, DynamoDB, RDS, or other services; allowing anonymous invocation gives attackers indirect access to those resources.
+        - **Audit attribution loss:** Unauthenticated invocations cannot be attributed to a specific caller identity in CloudTrail, eliminating the ability to investigate or attribute suspicious function calls.
+        - **IAM enforcement:** Setting `AuthType: AWS_IAM` requires all callers to sign requests with SigV4 credentials, enabling resource-based policies and identity policies to enforce least-privilege access to the function.
+
+        **Risk mitigation**
+
+        - **Block unauthorized invocation:** IAM authentication prevents internet callers from invoking the function without valid credentials, eliminating the anonymous attack surface.
+        - **Preserve audit trails:** Authenticated invocations produce CloudTrail records with the caller's identity, supporting incident investigation and compliance reporting.
+        - **Enable fine-grained access control:** IAM authentication allows function-level resource policies to control which identities may invoke the function, which role-based conditions apply, and which actions are permitted.
       audit: |
         ### Audit via Console
 
@@ -65614,14 +65760,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that API Gateway HTTP APIs do not advertise a wildcard `Access-Control-Allow-Origin: *` while also setting `Access-Control-Allow-Credentials: true`. The CORS specification forbids this combination, and modern browsers refuse the response, but a misconfigured API still represents a clear intent that violates least privilege.
+        This check ensures that API Gateway HTTP APIs do not configure CORS with both `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true` simultaneously. The CORS specification explicitly forbids this combination because pairing a wildcard origin with credential access would allow any website to make authenticated cross-origin requests on behalf of the user, which is the exact attack CORS is designed to prevent.
 
         **Why this matters**
 
-        - Pairing `*` origins with credentials signals that the operator intends to accept authenticated cross-origin requests from any site, which is exactly the configuration browsers were designed to prevent.
-        - Some non-browser clients and older browser releases honor permissive headers anyway, allowing credential replay across origins.
-        - Even before exploitation, the misconfiguration leaks information about the API surface and the operator's threat model.
-        - Restricting `allow_origins` to the specific hostnames that may carry credentials enforces an explicit allowlist consistent with least privilege.
+        - **Credential theft vector:** A wildcard origin with credentials enabled signals intent to accept authenticated requests from any site, which some non-browser clients and older browser versions may honor, enabling credential replay attacks.
+        - **Configuration intent violation:** Even though modern browsers block this combination, the presence of this configuration in an API signals that least-privilege origin control has not been applied.
+        - **Information leakage:** A misconfigured CORS policy reveals details about the API surface and the operator's security posture that can aid attacker reconnaissance.
+
+        **Risk mitigation**
+
+        - **Enforce explicit allowlists:** Replacing `*` with a specific list of trusted origin hostnames ensures only authorized front-end applications can make credentialed cross-origin requests.
+        - **Prevent session hijacking:** Restricting allowed origins to known domains prevents malicious websites from issuing credentialed cross-origin requests that would impersonate the authenticated user.
+        - **Align with browser security model:** Removing the wildcard-credentials combination ensures the CORS policy behaves predictably across all browser implementations and security scanners.
       audit: |
         ### Audit via Console
 
@@ -65754,14 +65905,20 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every route on an API Gateway v2 WebSocket API has an `authorizationType` other than `NONE`. WebSocket routes drive long-lived, bidirectional connections, so an unauthenticated route gives any caller on the internet a persistent channel into the backend integration.
+        This check ensures that every route on an API Gateway v2 WebSocket API has an authorization type other than `NONE`. WebSocket APIs establish long-lived, bidirectional connections, and an unauthenticated route allows any internet client to open a persistent channel to the backend integration without presenting any credentials.
 
         **Why this matters**
 
-        - The `$connect` route establishes the connection, so leaving it on `NONE` means any client can open a session and start sending messages over the established connection.
-        - Once the connection is open, per-route authorization still applies, but most backends assume the connection has already been authenticated upstream.
-        - WebSocket abuse is hard to detect because there is no request/response log per message; access decisions must happen at connect time and on every route.
-        - Setting `authorization_type` to `AWS_IAM`, `JWT`, or `CUSTOM` on every route forces the caller to present credentials at connect time and on every action.
+        - **Open connection entry:** The `$connect` route controls who can open a WebSocket session; leaving it on `NONE` means any client can establish a connection and begin sending messages.
+        - **Implicit trust assumption:** Once a connection is open, most backend integrations assume the connection has already been authenticated, making the connect-time authorization decision the primary security boundary.
+        - **Limited per-message visibility:** WebSocket connections do not log individual messages the way HTTP requests are logged, so access decisions made at connect time and on each route are the primary control points.
+        - **Persistent attack surface:** A long-lived unauthenticated WebSocket connection can be used for sustained abuse including resource exhaustion, data exfiltration over an open channel, and pivoting to downstream services the backend can reach.
+
+        **Risk mitigation**
+
+        - **Authenticate at connect time:** Requiring an authorizer on the `$connect` route ensures only callers with valid credentials can open a WebSocket session.
+        - **Enforce per-action authorization:** Attaching authorizers to custom routes beyond `$connect` ensures that a connected client cannot perform actions beyond what their identity permits.
+        - **Improve audit attribution:** Authenticated routes produce CloudTrail records that associate WebSocket activity with a specific caller identity, enabling investigation of suspicious session behavior.
       audit: |
         ### Audit via Console
 
@@ -65865,14 +66022,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon EventBridge event bus resource policies do not grant `Principal: "*"` (or `AWS: "*"`) without scoping conditions such as `aws:PrincipalOrgID` or `aws:SourceAccount`. An event bus with a wildcard principal allows any AWS account to put events onto the bus, including events crafted to look like trusted sources.
+        This check ensures that Amazon EventBridge event bus resource policies do not grant a wildcard principal without scoping conditions. By default, custom event buses have no resource policy, but when cross-account access is configured, a policy that uses `Principal: "*"` or `{"AWS": "*"}` without conditions such as `aws:PrincipalOrgID` or `aws:SourceAccount` allows any AWS account in the world to put events onto the bus.
 
         **Why this matters**
 
-        - A public event bus lets an attacker inject events that drive downstream targets such as Lambda functions, Step Functions, and SQS queues.
-        - Injected events can mimic legitimate sources to trigger workflows that exfiltrate data or perform privileged operations.
-        - Cross-account access is best granted to specific account IDs, organization IDs, or AWS service principals, never to `*` without conditions.
-        - Even when a wildcard principal is technically required (cross-service integrations), it must be paired with `aws:SourceArn` or `aws:SourceAccount` conditions to constrain who can invoke it.
+        - **Untrusted event injection:** A public event bus lets any AWS principal inject events that trigger downstream targets such as Lambda functions, Step Functions, and SQS queues, enabling attackers to drive internal workflows without compromising the account directly.
+        - **Spoofed event sources:** Injected events can mimic the schema of legitimate sources to exploit trust assumptions in event-driven workflows that perform privileged operations based on event content.
+        - **Lateral movement risk:** Backend targets consuming events may carry IAM execution roles with broad permissions; an attacker who can put arbitrary events onto a bus can indirectly invoke those capabilities.
+
+        **Risk mitigation**
+
+        - **Restrict principal scope:** Replacing the wildcard principal with specific account IDs, organization IDs, or service ARNs limits which external identities can put events onto the bus.
+        - **Require condition keys:** Pairing any Allow statement with `aws:PrincipalOrgID` or `aws:SourceAccount` conditions ensures even a broad principal grant is constrained to a known organizational boundary.
+        - **Prevent unauthorized workflow invocation:** Removing public access stops attackers from using the event bus as a pivot point to trigger downstream Lambda, Step Function, or SQS targets.
       audit: |
         ### Audit via Console
 
@@ -66041,14 +66203,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Glue connections do not store credentials as plaintext in `connection_properties`. Glue connections support a `SECRET_ID` property that references an AWS Secrets Manager secret, and that is the only safe way to supply a password or token to a Glue connection.
+        This check ensures that AWS Glue connections do not store credentials as plaintext values in `connection_properties`. Glue supports a `SECRET_ID` property that references an AWS Secrets Manager secret, and that is the only secure way to supply a password or access token to a Glue connection; a plaintext `PASSWORD` key in connection properties is stored in the Glue catalog and retrievable by anyone with `glue:GetConnection` permission.
 
         **Why this matters**
 
-        - A `PASSWORD` (or `USERNAME`) value in `connection_properties` is stored in the Glue catalog in plaintext and visible to anyone with `glue:GetConnection` permission.
-        - Connection properties are exported by infrastructure-as-code tooling, so the plaintext value lands in Terraform state files and CI logs.
-        - Rotating a plaintext credential requires editing every consumer; a Secrets Manager reference rotates centrally and audits every read.
-        - Replacing the password with `SECRET_ID` keeps the secret in a system designed for credential storage, with KMS-backed encryption-at-rest and CloudTrail audit.
+        - **Catalog exposure:** A `PASSWORD` value in `connection_properties` is stored in the Glue Data Catalog in plaintext and is visible to any IAM principal that has permission to describe or get connections.
+        - **IaC sprawl:** Connection properties are serialized into Terraform state files and CI/CD pipeline logs, so a plaintext credential in a connection propagates across multiple storage locations that are difficult to fully audit and rotate.
+        - **Rotation complexity:** Plaintext credentials require every consumer to be updated when the credential is rotated; a Secrets Manager reference rotates centrally and every subsequent connection fetch retrieves the new value.
+
+        **Risk mitigation**
+
+        - **Centralize secret storage:** Storing credentials in AWS Secrets Manager with KMS-backed encryption at rest ensures the credential is protected at a level far above what the Glue catalog provides.
+        - **Audit secret access:** Secrets Manager integrates with CloudTrail to log every read of the secret value, providing an audit trail that plaintext connection properties cannot offer.
+        - **Simplify rotation:** Secrets Manager supports automatic rotation schedules, meaning the Glue connection credential can be rotated without touching the connection definition.
       audit: |
         ### Audit via Console
 
@@ -66164,14 +66331,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS Cloud9 EC2 environments use `CONNECT_SSM` as their connection type. The legacy `CONNECT_SSH` mode opens an SSH listener on the underlying instance, which requires the instance to live in a subnet reachable from the developer's network and exposes port 22 to whatever security group covers that path.
+        This check ensures that AWS Cloud9 EC2 environments use `CONNECT_SSM` as their connection type. The legacy `CONNECT_SSH` connection mode opens an inbound SSH listener on the underlying EC2 instance, which requires the instance to be in a subnet reachable from the developer's network and exposes port 22 to whatever security group and network ACL governs that path.
 
         **Why this matters**
 
-        - `CONNECT_SSM` tunnels developer sessions through AWS Systems Manager, so the instance does not need an inbound SSH port or a public IP.
-        - Removing the inbound SSH path eliminates a long-lived listener that has been used in past Cloud9 incidents.
-        - SSM Session Manager produces a CloudTrail audit trail of every developer session that SSH does not.
-        - Forcing `CONNECT_SSM` is the documented AWS guidance for Cloud9 environments that must operate in private subnets.
+        - **Eliminates inbound port:** `CONNECT_SSM` tunnels developer sessions through AWS Systems Manager, so the instance requires no inbound security group rule and no public IP address, reducing the network attack surface to zero for that path.
+        - **Removes a persistent listener:** An open SSH port is a long-lived target for brute-force and credential-stuffing attacks; SSM connectivity removes the listener entirely rather than attempting to harden it.
+        - **Produces an audit trail:** AWS Systems Manager Session Manager logs session activity to CloudTrail and optionally to S3, providing a developer session audit trail that direct SSH does not produce.
+        - **Enables private subnet placement:** `CONNECT_SSM` is the documented AWS guidance for Cloud9 environments that must operate in private subnets without internet-facing entry points.
+
+        **Risk mitigation**
+
+        - **Prevent SSH-based initial access:** Removing the inbound SSH listener eliminates one of the most common initial access vectors for opportunistic attackers targeting development environments.
+        - **Enforce VPC isolation:** Instances that use SSM connectivity do not need internet-facing routes for developer access, allowing the VPC configuration to remain fully private.
+        - **Support compliance requirements:** Many compliance frameworks require that administrative access to compute instances be logged and mediated through a privileged access management system; SSM Session Manager satisfies this requirement while SSH does not.
       audit: |
         ### Audit via Console
 
@@ -66284,14 +66457,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Elastic Beanstalk environments enable an HTTPS listener on their managed load balancer. Without an HTTPS listener, client traffic terminates at the load balancer over plain HTTP, leaving credentials and session data exposed in transit.
+        This check ensures that Elastic Beanstalk environments have an HTTPS listener enabled on their managed load balancer. By default, Elastic Beanstalk creates a load balancer with only an HTTP listener, leaving all client traffic unencrypted in transit until an operator explicitly configures a port-443 listener with an ACM certificate.
 
         **Why this matters**
 
-        - Elastic Beanstalk creates the load balancer for the user, so listener configuration is set through environment option settings rather than directly on the ELB.
-        - The relevant namespaces are `aws:elbv2:listener:443` for Application Load Balancers and `aws:elb:listener:443` for Classic Load Balancers. Enabling the listener and selecting an ACM certificate is what turns on HTTPS.
-        - A misconfigured environment with only an HTTP listener cannot satisfy PCI DSS, HIPAA, or any baseline that requires TLS for web traffic.
-        - Adding the HTTPS listener also enables clients to enforce HSTS and other browser controls that require TLS.
+        - **Plaintext credentials in transit:** Without an HTTPS listener, user credentials, session tokens, and API keys sent from the browser to the load balancer travel over HTTP and can be intercepted by anyone on the network path.
+        - **Option-setting model:** Elastic Beanstalk configures the load balancer through environment option settings under `aws:elbv2:listener:443` or `aws:elb:listener:443`; there is no in-place upgrade path, so HTTPS must be configured explicitly when the environment is created or updated.
+        - **Browser security controls blocked:** HTTPS is a prerequisite for HSTS, Secure cookies, and other browser-enforced security headers that protect users of web applications hosted on Beanstalk.
+
+        **Risk mitigation**
+
+        - **Encrypt data in transit:** Enabling the HTTPS listener ensures all traffic between clients and the load balancer is encrypted with TLS, protecting credentials and session data from network interception.
+        - **Meet transmission-security requirements:** An active HTTPS listener is the foundational control for compliance frameworks that require encrypted communication channels for web traffic.
+        - **Enable certificate pinning and HSTS:** HTTPS is required before any server-side security headers that rely on TLS can be set and enforced by browsers accessing the application.
       audit: |
         ### Audit via Console
 
@@ -66448,14 +66626,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Route 53 Resolver query logging is configured and associated with VPCs. Resolver query logs capture every DNS query that an EC2 instance, ECS task, Lambda function in a VPC, or other workload makes through the Route 53 Resolver. This is the data the security team needs to detect DNS-based exfiltration or command-and-control.
+        This check ensures that Route 53 Resolver query logging is configured and associated with VPCs. Resolver query logs capture every DNS lookup made by EC2 instances, ECS tasks, and Lambda functions within a VPC through the Route 53 Resolver, providing the visibility needed to detect DNS-based exfiltration and command-and-control activity. Without this logging, DNS traffic inside the VPC is invisible to security tooling.
 
         **Why this matters**
 
-        - DNS is one of the most common exfiltration channels because it is rarely blocked at the egress firewall.
-        - Resolver query logging is the only AWS-native way to capture queries originating inside a VPC; public hosted zone query logging only captures queries to your own zones.
-        - Detection rules for DNS tunneling, newly observed domains, and known bad indicators need this log stream as input.
-        - A configured `aws_route53_resolver_query_log_config` is only useful when paired with an `aws_route53_resolver_query_log_config_association` for every VPC that needs logging.
+        - **DNS exfiltration channel:** DNS is one of the most commonly abused exfiltration methods because outbound DNS traffic is rarely blocked at the egress firewall, making Resolver query logs essential for detecting it.
+        - **VPC-internal visibility:** Resolver query logging is the only AWS-native mechanism for capturing DNS queries originating inside a VPC; public hosted zone query logging captures only queries to zones you own, not arbitrary external lookups.
+        - **Detection dependency:** Security detection rules for DNS tunneling, newly observed domains, and threat-intelligence indicator matching require this log stream as their data source.
+
+        **Risk mitigation**
+
+        - **Detect command-and-control:** Resolver query logs enable alerting when workloads inside the VPC contact domains associated with malware or exfiltration infrastructure.
+        - **Support incident investigation:** A complete record of DNS lookups made by a compromised host is critical for reconstructing the lateral movement and exfiltration timeline during an incident.
+        - **Enable threat hunting:** Continuous DNS logging provides the baseline data required for anomaly detection, such as spotting newly observed domains or statistically unusual query volumes from a single host.
       audit: |
         ### Audit via Console
 
@@ -66572,14 +66755,19 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that DynamoDB tables with point-in-time recovery (PITR) enabled are also encrypted with a customer-managed KMS key (CMK). Continuous backups inherit the table's encryption configuration, so the only way to keep PITR snapshots under customer-controlled keys is to encrypt the source table with a CMK.
+        This check ensures that DynamoDB tables with point-in-time recovery enabled are also encrypted with a customer-managed KMS key. DynamoDB PITR creates continuous backups of the table over a rolling retention window, and those backups inherit the table's encryption configuration; using the default AWS-owned key for a table with PITR enabled means the backup data is managed outside the customer's key administration boundary.
 
         **Why this matters**
 
-        - PITR snapshots are long-lived copies of the table that span the configured retention window, so any data captured during the retention period is recoverable from those snapshots.
-        - With the default AWS-owned KMS key, AWS controls the entire key lifecycle and there is no CloudTrail visibility into key usage, so backup access cannot be audited end-to-end.
-        - A customer-managed key lets the data owner rotate, revoke, and audit access to every PITR-derived restore through KMS key policies and CloudTrail `kms:Decrypt` events.
-        - Pairing PITR with a CMK satisfies regulatory requirements that demand customer-controlled key management for backups of regulated data.
+        - **Long-lived backup exposure:** PITR snapshots retain every state of the table for the configured retention window, so a data exfiltration incident has a much larger blast radius when the backup key is outside customer control.
+        - **No decryption audit trail:** AWS-owned KMS keys do not produce CloudTrail `kms:Decrypt` events, so access to backup data by any principal cannot be audited end-to-end when the default key is used.
+        - **Regulatory key management:** Many compliance frameworks require that encrypted backups of regulated data use customer-controlled keys that can be rotated, disabled, and audited independently of the primary storage.
+
+        **Risk mitigation**
+
+        - **Enable key revocation:** A customer-managed key can be disabled or scheduled for deletion, immediately blocking further access to both the live table and all its PITR-derived restore points if a breach is detected.
+        - **Produce a decryption audit trail:** Every `kms:Decrypt` call against the CMK appears in CloudTrail, providing evidence of who accessed backup data and when, which is unavailable with AWS-owned keys.
+        - **Satisfy backup encryption requirements:** Pairing PITR with a CMK is the only DynamoDB backup configuration that satisfies compliance controls requiring customer-controlled key management for backup data.
       audit: |
         ### Audit via Console
 
@@ -66771,14 +66959,21 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that ElastiCache replication groups with automatic snapshot retention have at-rest encryption enabled and reference a KMS key. ElastiCache snapshots inherit the cluster's at-rest encryption settings, so a cluster that takes snapshots without a CMK is producing backups that are encrypted only with an AWS-owned key.
+        This check ensures that ElastiCache replication groups with automatic snapshot retention are configured with at-rest encryption enabled and a customer-managed KMS key. By default, ElastiCache snapshots inherit the cluster's encryption settings, so a cluster created without a CMK produces backups protected only by an AWS-managed key that the customer cannot rotate, revoke, or audit.
 
         **Why this matters**
 
-        - A non-zero `snapshot_retention_limit` means ElastiCache is producing and storing recoverable copies of cached data, so the snapshot itself becomes regulated data at rest.
-        - When the cluster lacks `at_rest_encryption_enabled = true`, both the cluster and its snapshots fall back to AWS-owned key material that the customer cannot rotate, revoke, or audit.
-        - A KMS key on the cluster propagates to every automated and manual snapshot, ensuring that restored data stays under the same key policy as the source cluster.
-        - Pairing snapshot retention with a customer-controlled KMS key keeps backups aligned with the data-protection controls required for the live workload.
+        - **Snapshot data scope:** A non-zero snapshot retention limit means ElastiCache is producing and storing recoverable copies of cached data, making each snapshot a regulated data-at-rest asset.
+        - **Key control:** When the cluster lacks at-rest encryption with a customer key, both the cluster and its automated snapshots fall back to AWS-owned key material that cannot be scoped with a key policy.
+        - **Propagation:** A KMS key on the cluster propagates to every automated and manual snapshot, ensuring that restored data remains under the same key policy as the source cluster.
+        - **Audit visibility:** Customer-managed keys generate CloudTrail `kms:Decrypt` events for every snapshot restore, giving operators a discrete audit trail tied to the key policy.
+        - **Data protection alignment:** Pairing snapshot retention with a customer-controlled KMS key keeps backups aligned with the data-protection controls applied to the live workload.
+
+        **Risk mitigation**
+
+        - **Unauthorized restore prevention:** A CMK with a restrictive key policy ensures that only authorized principals can decrypt and restore snapshot data, limiting exposure from account compromise.
+        - **Key revocation:** Customer-managed keys can be disabled or scheduled for deletion, providing a hard stop on any further decryption of snapshot material if a data breach is detected.
+        - **Compliance boundary:** Binding snapshots to a CMK satisfies encryption-at-rest requirements in regulated workloads and keeps the key's usage auditable through CloudTrail.
       audit: |
         ### Audit via Console
 
@@ -66933,13 +67128,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that Amazon Kinesis Video Streams are encrypted with a customer-managed KMS key (CMK). When `kms_key_id` is left unset, Kinesis Video falls back to the AWS-managed `aws/kinesisvideo` key and the customer has no ability to rotate, revoke, or audit usage of the key that protects the video fragments.
+        This check ensures that Amazon Kinesis Video Streams are configured with a customer-managed KMS key rather than the default AWS-managed `aws/kinesisvideo` key. When `kms_key_id` is omitted at stream creation, Kinesis Video falls back to the AWS-managed key and the customer has no ability to rotate, revoke, or audit usage of the key protecting the stored video fragments.
 
         **Why this matters**
 
-        - Video streams from cameras and connected devices frequently contain personal identifiable information, biometric data, or footage of regulated environments.
-        - The AWS-managed key cannot be scoped with a key policy, so any principal with `kinesisvideo:GetMedia` permissions decrypts data without producing a discrete CloudTrail `kms:Decrypt` audit trail tied to a customer key.
-        - A CMK lets the data owner enforce least privilege on decrypt operations, rotate key material on a controlled schedule, and revoke access at the key level when a device or partner is offboarded.
+        - **Sensitive data content:** Video streams from cameras and connected devices frequently contain personally identifiable information, biometric data, or footage of regulated environments requiring strong access controls.
+        - **Audit gap:** The AWS-managed key cannot be scoped with a custom key policy, so any principal with `kinesisvideo:GetMedia` permission can decrypt data without generating a discrete CloudTrail `kms:Decrypt` event tied to a customer key.
+        - **Key lifecycle control:** A customer-managed key lets the data owner enforce least privilege on decrypt operations, rotate key material on a controlled schedule, and revoke access at the key level when a device or partner is offboarded.
+        - **Regulatory alignment:** Many biometric and surveillance data regulations require operator-controlled encryption keys; the AWS-managed default does not satisfy this requirement.
+
+        **Risk mitigation**
+
+        - **Access revocation:** A customer-managed key can be disabled immediately to deny all further decryption of stored video fragments, providing a hard stop in breach scenarios.
+        - **Least-privilege enforcement:** Key policies can restrict which IAM principals and services are permitted to decrypt, limiting the blast radius of a compromised identity.
+        - **Audit trail:** Every decrypt operation against a CMK produces a CloudTrail event with the caller's identity, enabling detection of unauthorized access to video stream data.
       audit: |
         ### Audit via Console
 
@@ -67059,13 +67261,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that EMR Studio workspaces specify a customer-managed KMS key for encrypting Jupyter notebooks and other workspace artifacts stored in the backing S3 bucket. When `encryption_key_arn` is omitted, the studio falls back to AWS-managed encryption on the workspace bucket and the customer cannot bind the key lifecycle to the underlying data.
+        This check ensures that EMR Studio workspaces are configured with a customer-managed KMS key for encrypting Jupyter notebooks and other workspace artifacts stored in the backing S3 bucket. When `encryption_key_arn` is omitted, the studio falls back to AWS-managed encryption and the customer cannot bind the key lifecycle to the underlying data or produce a key-level audit trail.
 
         **Why this matters**
 
-        - EMR Studio workspaces routinely hold notebook code, query results, and small data extracts that include sensitive business or regulated data.
-        - Without a CMK on the studio, every workspace artifact is encrypted with an AWS-owned key whose policy the customer cannot author, rotate, or revoke.
-        - A customer-managed key tied to the studio makes notebook storage subject to the same audit and access-control rules as other regulated data and produces CloudTrail `kms:Decrypt` events for every workspace read.
+        - **Sensitive workspace content:** EMR Studio workspaces routinely hold notebook code, query results, and small data extracts that include sensitive business logic or regulated data belonging to the workload.
+        - **Key ownership gap:** Without a customer-managed key on the studio, every workspace artifact is encrypted with an AWS-owned key whose policy cannot be authored, rotated, or revoked by the customer.
+        - **Immutable configuration:** The encryption key is set at studio creation time and cannot be changed afterward, so any studio created without a CMK will remain under AWS-managed encryption for its entire lifetime.
+        - **Audit coverage:** A customer-managed key produces CloudTrail `kms:Decrypt` events for every workspace notebook read, enabling detection of unauthorized access to notebook content.
+
+        **Risk mitigation**
+
+        - **Controlled key revocation:** A CMK can be disabled or scheduled for deletion to deny all further decryption of studio artifacts, providing a hard stop when a studio or its data must be decommissioned.
+        - **Policy-driven access control:** Key policies can restrict which principals and services are allowed to decrypt workspace content, limiting exposure if an IAM identity or service role is compromised.
+        - **Compliance enforcement:** Binding studio storage to a CMK keeps workspace artifacts subject to the same encryption governance used for other regulated data stores in the account.
       audit: |
         ### Audit via Console
 
@@ -67216,13 +67425,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that AWS DataSync tasks reference a CloudWatch log group for transfer telemetry. DataSync task logs capture object paths, source and destination metadata, and any transfer errors. This information often reveals the structure of regulated data and must therefore be retained under the same protection controls as the data being moved.
+        This check ensures that AWS DataSync tasks are configured with a CloudWatch log group ARN so that transfer telemetry is captured and retained. DataSync task logs record object paths, source and destination metadata, and transfer errors, information that often reveals the structure of regulated data and must be retained under data-protection controls consistent with the data being moved.
 
         **Why this matters**
 
-        - A DataSync task without `cloudwatch_log_group_arn` set leaves the operator with no audit record of what data moved, when, and whether the transfer completed cleanly.
-        - Sending logs to a CloudWatch log group ensures that DataSync output lands somewhere subject to the existing CloudWatch retention and KMS encryption controls (covered by `mondoo-aws-security-cloudwatch-log-group-encrypted`).
-        - This check stays narrowly scoped to the configuration on the DataSync task; cross-resource verification of the referenced log group's KMS key is performed by the dedicated CloudWatch log-group encryption check, so the two together provide end-to-end coverage.
+        - **Audit gap:** A DataSync task without a `cloudwatch_log_group_arn` leaves the operator with no audit record of what data moved, when it moved, or whether the transfer completed without errors or corruption.
+        - **Incident investigation:** Transfer error details and object-path logs are required to reconstruct events during a security incident or data-integrity investigation; without them, forensic scope is unknown.
+        - **Chained protection:** Sending logs to a CloudWatch log group subjects DataSync output to the existing CloudWatch retention and KMS encryption controls, extending data-at-rest protection to transfer records.
+        - **Compliance traceability:** Regulated workloads require demonstrable audit trails for data movement; a missing log group makes it impossible to satisfy that requirement for DataSync-mediated transfers.
+
+        **Risk mitigation**
+
+        - **Integrity verification:** Log records enable operators to confirm that transfers completed without missing or corrupted objects, reducing the risk of silent data loss.
+        - **Anomaly detection:** Centralized CloudWatch logs feed into alarms and SIEM pipelines, allowing detection of unexpected transfer destinations, unusual volumes, or repeated failures that may indicate misconfiguration or abuse.
       audit: |
         ### Audit via Console
 
@@ -67348,14 +67563,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that CloudFront distributions that use an Amazon S3 origin attach an origin access control (OAC) to that origin. OAC is the supported successor to origin access identity (OAI) and is the only mechanism that lets CloudFront sign requests to S3 with SigV4 so that the bucket can stay fully private while still serving content through CloudFront.
+        This check ensures that CloudFront distributions using Amazon S3 origins attach an origin access control (OAC) to each such origin. OAC is the supported successor to origin access identity (OAI) and is the only mechanism that allows CloudFront to sign requests to S3 with SigV4, keeping the bucket fully private while still serving content through the distribution.
 
         **Why this matters**
 
-        - Without OAC, an S3 origin either accepts anonymous public reads (broad data exposure) or relies on a legacy OAI that does not support SSE-KMS and is no longer recommended.
-        - Attaching OAC keeps the bucket private at the resource policy level and forces every viewer request to flow through CloudFront, where WAF, logging, and TLS policies are enforced.
-        - OAC also unlocks SigV4 access to buckets that require SSE-KMS, so the access boundary and the encryption boundary stay aligned.
-        - Server-side encryption of the underlying S3 bucket is enforced by separate S3 checks; this check is scoped to the CloudFront origin binding so that misconfigurations are surfaced at the distribution rather than only at the bucket.
+        - **Bucket exposure risk:** Without OAC, an S3 origin either accepts anonymous public reads, creating broad data exposure, or relies on a legacy OAI that does not support SSE-KMS and is no longer recommended by AWS.
+        - **Enforced traffic path:** Attaching OAC keeps the bucket private at the resource policy level and forces every viewer request to flow through CloudFront, where WAF rules, access logging, and TLS policies are applied consistently.
+        - **SSE-KMS compatibility:** OAC unlocks SigV4 access to buckets that require server-side encryption with a customer-managed key, so the access boundary and encryption boundary remain aligned.
+        - **Defense-in-depth:** Restricting direct S3 access means that even if an attacker obtains a bucket URL they cannot bypass CloudFront to reach the underlying objects.
+
+        **Risk mitigation**
+
+        - **Unauthorized direct access prevention:** An S3 bucket policy that trusts only the CloudFront OAC ensures that objects cannot be retrieved by any caller that bypasses the distribution, eliminating a common data-exfiltration path.
+        - **WAF and logging enforcement:** Routing all traffic through the distribution means WAF rules and access logs apply to every request, enabling detection and blocking of malicious access patterns before they reach the S3 origin.
+        - **Scope clarity:** Surfacing the access-control misconfiguration at the distribution rather than only at the bucket allows security teams to remediate the full request path in a single fix.
       audit: |
         ### Audit via Console
 
@@ -67537,14 +67758,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every HTTPS or TLS listener on an Application or Network Load Balancer uses a security policy that requires a TLS 1.2 or higher cipher suite. Listeners that fall back to `ELBSecurityPolicy-2016-08` or any `ELBSecurityPolicy-TLS-1-0`/`ELBSecurityPolicy-TLS-1-1` policy negotiate down to deprecated TLS versions that are no longer considered safe for confidentiality or integrity.
+        This check ensures that every HTTPS or TLS listener on an Application or Network Load Balancer uses a security policy that requires TLS 1.2 or higher cipher suites. Listeners using the legacy `ELBSecurityPolicy-2016-08` or any `ELBSecurityPolicy-TLS-1-0` or `ELBSecurityPolicy-TLS-1-1` policy negotiate down to deprecated TLS versions that are no longer considered safe for confidentiality or integrity.
 
         **Why this matters**
 
-        - TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS, FedRAMP, and most government security baselines because they rely on cipher suites and integrity primitives with known weaknesses.
-        - A listener that advertises a permissive policy negotiates down to the oldest version a client supports, so a single legacy client is enough to expose the entire data path.
-        - The `ELBSecurityPolicy-TLS-1-2-*`, `ELBSecurityPolicy-TLS13-*`, and `ELBSecurityPolicy-FS-1-2-*` families pin the floor at TLS 1.2 and prefer forward-secret cipher suites, keeping recorded traffic safe even if long-lived keys leak in the future.
-        - Pinning the policy also documents the operator's intent, so subsequent changes show up in diff review instead of being silently relaxed.
+        - **Deprecated protocol risk:** TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS 4.0 and most government security baselines because they rely on cipher suites and integrity primitives with known weaknesses.
+        - **Negotiation downgrade:** A listener advertising a permissive security policy negotiates down to the oldest version a connecting client supports, so a single legacy client is enough to expose the entire data path over a weak cipher suite.
+        - **Forward secrecy:** The `ELBSecurityPolicy-TLS13-*` and `ELBSecurityPolicy-FS-1-2-*` families prefer forward-secret cipher suites, ensuring that recorded traffic remains protected even if long-lived key material leaks in the future.
+        - **Change auditability:** Pinning the policy documents the operator's intent in the resource configuration, so subsequent relaxation shows up in infrastructure change reviews.
+
+        **Risk mitigation**
+
+        - **Cipher suite control:** Enforcing a TLS 1.2-floor policy removes all cipher suites known to be exploitable via BEAST, POODLE, and similar protocol-level attacks that target TLS 1.0 and 1.1.
+        - **Compliance posture:** Eliminating deprecated TLS versions from load balancer listeners satisfies the transport-encryption requirements in PCI DSS, HIPAA, and FedRAMP without additional network controls.
+        - **Blast radius reduction:** Even if a client or internal service is compromised, a strong TLS policy ensures that captured network traffic cannot be decrypted using known cryptographic weaknesses in older protocol versions.
       audit: |
         ### Audit via Console
 
@@ -67718,14 +67945,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every SQS queue resource policy contains a statement that explicitly denies access whenever the request is not made over TLS. SQS accepts both HTTP and HTTPS by default, so without a `Deny` keyed on `aws:SecureTransport: false` a caller with a broken TLS configuration can send and receive messages in plaintext.
+        This check ensures that every SQS queue resource policy contains a statement that explicitly denies any request that is not transmitted over TLS. SQS accepts both HTTP and HTTPS by default, so without a `Deny` statement keyed on `aws:SecureTransport: false` a caller with a broken or misconfigured TLS stack can send and receive messages in plaintext.
 
         **Why this matters**
 
-        - Message bodies and SQS attributes routinely carry workload payloads, application identifiers, and references to other AWS resources; allowing plaintext access leaks all of that.
-        - The SigV4 authorization header is also sent on every request, so plaintext access exposes credentials in transit.
-        - The `aws:SecureTransport` condition key is the only resource-policy mechanism that can refuse a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
-        - Adding the `Deny` statement makes intent auditable in the queue's policy document instead of relying on every caller to opt in to TLS.
+        - **Payload exposure:** Message bodies and SQS attributes routinely carry workload payloads, application identifiers, and references to other AWS resources; allowing plaintext access leaks all of that data on the wire.
+        - **Credential exposure:** SigV4 authorization headers are included on every SQS API call, so plaintext requests also expose signing credentials in transit to any observer on the path.
+        - **Cross-account enforcement gap:** The `aws:SecureTransport` condition key is the only resource-policy mechanism capable of refusing a plaintext request; IAM identity policies cannot enforce transport security on cross-account or unauthenticated callers.
+        - **Auditable intent:** A `Deny` statement in the queue policy makes the transport requirement explicit and discoverable in the policy document rather than relying on every caller to opt in to TLS voluntarily.
+
+        **Risk mitigation**
+
+        - **Plaintext interception prevention:** The `Deny` statement blocks any HTTP-based SQS call at the service boundary, ensuring that message content and signing credentials are never transmitted in cleartext regardless of client configuration.
+        - **Consistent enforcement:** Queue-level policy enforcement applies to all callers, including third-party integrations and legacy producers, removing the dependency on client-side TLS configuration correctness.
+        - **Simplified compliance verification:** Auditors can confirm secure transport by inspecting the queue policy document directly, without needing to trace every calling application's TLS configuration.
       audit: |
         ### Audit via Console
 
@@ -67934,14 +68167,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every SNS topic resource policy contains a statement that explicitly denies access whenever the request is not made over TLS. SNS accepts HTTP for both `Publish` and management calls by default, so without a `Deny` keyed on `aws:SecureTransport: false` publishers and subscribers can carry message payloads in plaintext.
+        This check ensures that every SNS topic resource policy contains a statement that explicitly denies any request that is not made over TLS. SNS accepts HTTP for both `Publish` and management API calls by default, so without a `Deny` statement keyed on `aws:SecureTransport: false` publishers and subscribers can carry message payloads in plaintext.
 
         **Why this matters**
 
-        - Message bodies sent to SNS often contain workload events, business data, or references to other AWS resources; plaintext publish leaks all of that on the wire.
-        - SigV4 signed requests still include credential headers, so plaintext API calls expose the caller's signing material in transit.
-        - The `aws:SecureTransport` condition is the only resource-policy mechanism that refuses a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
-        - Adding the `Deny` statement also documents intent in the topic policy itself, so downstream reviewers do not need to infer encryption from network controls.
+        - **Payload exposure:** Message bodies sent to SNS often carry workload events, business data, or references to other AWS resources; a plaintext publish call leaks all of that on the network path between the caller and the SNS endpoint.
+        - **Credential exposure in transit:** SigV4-signed API calls include credential headers, so plaintext SNS API requests also expose the caller's signing material to any observer on the path.
+        - **Cross-account enforcement gap:** The `aws:SecureTransport` condition key is the only resource-policy mechanism that can refuse a plaintext API call; IAM identity policies cannot enforce transport security on cross-account or anonymous callers.
+        - **Documented intent:** A `Deny` statement in the topic policy embeds the transport requirement in the policy itself, making it auditable without needing to trace every publisher's TLS configuration.
+
+        **Risk mitigation**
+
+        - **Plaintext publish prevention:** The `Deny` statement blocks any HTTP-based SNS call at the service boundary, ensuring message content and signing credentials are never transmitted in cleartext regardless of caller configuration.
+        - **Broad caller coverage:** Topic-policy enforcement applies to all callers including third-party services, SaaS integrations, and legacy producers, removing the dependency on client-side TLS correctness.
+        - **Streamlined audit:** Auditors can confirm secure transport by reviewing the topic policy document directly, without needing to inspect the TLS configuration of every subscribing or publishing application.
       audit: |
         ### Audit via Console
 
@@ -68146,14 +68385,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that, whenever an API Gateway v2 account hosts a WebSocket API, every v2 custom domain pins the TLS floor to `TLS_1_2`. WebSocket APIs use the same custom-domain primitive as HTTP APIs, so the security policy chosen at the domain level is what governs the cipher suite negotiated for every wss:// session.
+        This check ensures that every API Gateway v2 custom domain pins its TLS floor to `TLS_1_2` when the account hosts WebSocket APIs. WebSocket APIs share the same custom-domain primitive as HTTP APIs, so the security policy chosen at the domain level governs the cipher suite negotiated for every `wss://` session established through that domain.
 
         **Why this matters**
 
-        - The default `TLS_1_0` security policy for v2 custom domains allows TLS 1.0 and TLS 1.1 negotiation, both of which are deprecated by the IETF and prohibited by PCI DSS 4.0.
-        - WebSocket sessions are long-lived, so a single weak negotiation can keep a vulnerable channel open for the lifetime of the connection.
-        - Pinning the floor to `TLS_1_2` is the only resource-level control that forces clients to negotiate modern cipher suites; downstream WAF or CloudFront policies cannot retroactively raise the protocol version.
-        - This check fires only when the account actually hosts WebSocket APIs, so the finding is scoped to the surface where WebSocket clients connect.
+        - **Deprecated default:** The default `TLS_1_0` security policy for v2 custom domains permits TLS 1.0 and TLS 1.1 negotiation, both of which are deprecated by the IETF and prohibited by PCI DSS 4.0 for cardholder data environments.
+        - **Long-lived sessions:** WebSocket connections are persistent, so a single weak negotiation can keep a vulnerable channel open for the full lifetime of the connection, amplifying the exposure window compared to short-lived HTTP requests.
+        - **Resource-level control:** Pinning the floor to `TLS_1_2` is the only resource-level control that forces connecting clients to negotiate modern cipher suites; downstream WAF or CloudFront policies cannot retroactively raise the protocol version for WebSocket traffic.
+        - **Scope accuracy:** The check applies only when the account actually hosts WebSocket APIs, so findings are scoped to the surface where WebSocket clients connect.
+
+        **Risk mitigation**
+
+        - **Cipher suite hardening:** Enforcing `TLS_1_2` removes all cipher suites with known weaknesses that are available under TLS 1.0 and 1.1, reducing the attack surface for protocol-level exploits on persistent WebSocket connections.
+        - **Compliance alignment:** Eliminating deprecated TLS versions from WebSocket endpoints satisfies transport-encryption requirements in PCI DSS 4.0 and similar standards without additional network controls.
+        - **Forward secrecy:** Modern security policies prefer ECDHE cipher suites, ensuring that captured WebSocket traffic cannot be decrypted retroactively even if the server's long-term key is later compromised.
       audit: |
         ### Audit via Console
 
@@ -68284,14 +68529,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every AWS Database Migration Service endpoint sets `ssl_mode` to a value other than `none`. DMS pulls every row of source data, including credentials, primary keys, and any encrypted-at-rest payload, and pushes it to the target endpoint over a connection it manages itself. An endpoint configured with `ssl_mode = "none"` carries that data over plaintext TCP between the replication instance and the database.
+        This check ensures that every AWS Database Migration Service endpoint sets its `ssl_mode` to a value other than `none`, requiring encrypted connections between the DMS replication instance and the source or target database. By default, a newly created DMS endpoint has `ssl_mode` set to `none`, meaning the replication instance communicates with the database over plaintext TCP.
 
         **Why this matters**
 
-        - Migration tasks move whole tables and change-data-capture streams, so the volume of data exposed by a single plaintext endpoint is much larger than for a typical application connection.
-        - DMS source endpoints also send authentication material (database username and password, or IAM auth tokens) every time the replication instance reconnects.
-        - `require` validates that the wire protocol is TLS but does not verify the server certificate; `verify-ca` and `verify-full` are stronger because they catch MITM redirection to a rogue endpoint.
-        - The control surface is the endpoint itself. The task and replication instance inherit whatever the endpoints negotiate, so this is where the floor must be set.
+        - **Data volume exposure:** Migration tasks move complete tables and change-data-capture streams, so a single plaintext endpoint exposes a far larger volume of data than a typical application connection that retrieves individual records.
+        - **Credential transmission:** DMS source endpoints send database authentication material, including usernames and passwords or IAM auth tokens, each time the replication instance reconnects to the source database.
+        - **Certificate verification strength:** Using `verify-ca` or `verify-full` additionally validates the server certificate, preventing man-in-the-middle redirection to a rogue endpoint that would still satisfy the `require` mode.
+        - **Endpoint-level configuration:** The task and replication instance inherit whatever TLS level the endpoints negotiate, making the endpoint the only effective place to set the floor for the entire migration path.
+
+        **Risk mitigation**
+
+        - **In-transit data protection:** Requiring SSL at the endpoint ensures that every row of migration data and every change event is encrypted on the wire, preventing passive interception of bulk data transfers.
+        - **Authentication material security:** Encrypting the connection protects database credentials transmitted during initial authentication and subsequent reconnects from exposure to network observers.
+        - **MITM prevention:** Choosing `verify-full` mode validates both the TLS channel and the server's identity certificate, blocking man-in-the-middle attacks that could redirect migration traffic to an unauthorized database endpoint.
       audit: |
         ### Audit via Console
 
@@ -68434,14 +68685,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every App Mesh virtual node listener is configured with a TLS block whose `mode` is either `STRICT` or `PERMISSIVE`. App Mesh defaults each listener to TLS disabled, so without an explicit `tls` block the Envoy proxy fronting the node accepts plaintext traffic from any peer that can route to it inside the mesh.
+        This check ensures that every AWS App Mesh virtual node listener is configured with a TLS block whose `mode` is set to `STRICT` or `PERMISSIVE`. App Mesh defaults each listener to TLS disabled, so without an explicit `tls` block the Envoy proxy fronting the virtual node accepts plaintext traffic from any peer that can route to it inside the mesh.
 
         **Why this matters**
 
-        - App Mesh is typically deployed inside a VPC that operators treat as trusted, which is exactly the assumption attackers exploit during lateral movement once they reach a single workload.
-        - With TLS disabled at the listener, sidecar-to-sidecar traffic is plaintext gRPC or HTTP and any compromised workload on the same subnet can read or rewrite it.
-        - `STRICT` mode refuses plaintext clients outright; `PERMISSIVE` mode accepts both TLS and plaintext during a migration window. Both are acceptable for this check, but `STRICT` is the recommended end state.
-        - The TLS block is also where the certificate source is pinned to ACM, ACM Private CA, or a file-based cert, which keeps key material discoverable for audit.
+        - **Lateral movement exposure:** App Mesh is typically deployed inside a VPC that operators treat as a trusted boundary, which is exactly the assumption attackers exploit during lateral movement once a single workload is compromised.
+        - **Plaintext sidecar traffic:** With TLS disabled at the listener, sidecar-to-sidecar traffic is plaintext gRPC or HTTP, and any compromised workload on the same subnet can read or rewrite it without detection.
+        - **Incremental migration support:** `PERMISSIVE` mode accepts both TLS and plaintext during a migration window while still enabling certificate management, allowing existing services to be migrated gradually before locking down to `STRICT`.
+        - **Certificate discoverability:** The TLS block is also where the certificate source is pinned to ACM, ACM Private CA, or a file-based certificate, keeping key material discoverable and auditable.
+
+        **Risk mitigation**
+
+        - **East-west traffic encryption:** Enforcing TLS at the virtual node listener ensures that service-to-service communication within the mesh is encrypted, containing the blast radius of a compromised sidecar or workload.
+        - **Identity binding:** When the TLS certificate comes from ACM Private CA, each virtual node's certificate is bound to a verifiable identity, enabling mutual TLS and preventing impersonation by rogue services inside the VPC.
+        - **Audit surface:** Encrypted mesh traffic combined with Envoy access logs creates an auditable record of service interactions, supporting detection of anomalous communication patterns that are invisible in a plaintext mesh.
       audit: |
         ### Audit via Console
 
@@ -68645,14 +68902,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every AWS IoT Core domain configuration pins its `tls_config.security_policy` to a current `IoTSecurityPolicy_TLS13_*` or `IoTSecurityPolicy_TLS_1_2_*` value. IoT Core accepts the legacy `IoTSecurityPolicy_TLS_1_0_*` policies by default on existing endpoints, so devices that have not been re-provisioned may still negotiate TLS 1.0 or 1.1 against the broker.
+        This check ensures that every AWS IoT Core domain configuration pins its `tls_config.security_policy` to a current `IoTSecurityPolicy_TLS13_*` or `IoTSecurityPolicy_TLS_1_2_*` value. IoT Core may fall back to the legacy `IoTSecurityPolicy_TLS_1_0_*` policies on existing endpoints, allowing devices that have not been re-provisioned to negotiate TLS 1.0 or 1.1 against the MQTT broker.
 
         **Why this matters**
 
-        - IoT fleets often run on long-lived hardware that authenticates with X.509 certificates over MQTT, so a single weak negotiation can keep millions of sessions on a deprecated TLS version.
-        - TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS and most government baselines because their cipher suites rely on broken integrity primitives.
-        - The `tls_config` block on a domain configuration is the only resource-level control that pins the cipher suite floor. Broker-side IAM and Thing policies do not see protocol version.
-        - Pinning the policy also documents intent so subsequent infrastructure-as-code changes surface in diff review instead of being silently relaxed.
+        - **Long-lived hardware exposure:** IoT fleets typically run on hardware with multi-year lifecycles that authenticates with X.509 certificates over MQTT, so a single weak negotiation policy can keep millions of device sessions on deprecated TLS versions simultaneously.
+        - **Deprecated protocol risk:** TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS and most government baselines because their cipher suites rely on broken integrity primitives.
+        - **Only resource-level control:** The `tls_config` block on a domain configuration is the only place where the cipher suite floor can be pinned at the service level; broker-side IAM and Thing policies do not inspect protocol version.
+        - **Change auditability:** Pinning the security policy documents the operator's intent so subsequent infrastructure-as-code changes that relax the TLS floor surface in diff review.
+
+        **Risk mitigation**
+
+        - **Protocol downgrade prevention:** A `TLS_1_2`-floor policy removes all cipher suites with known weaknesses available under TLS 1.0 and 1.1, protecting device telemetry and command channels from protocol-level exploits.
+        - **Fleet-wide enforcement:** Setting the policy at the domain configuration level applies the control uniformly to every device connecting through that endpoint, eliminating per-device negotiation gaps.
+        - **Compliance posture:** Enforcing modern TLS across IoT endpoints satisfies transport-encryption requirements in PCI DSS, HIPAA, and IEC 62443 without requiring firmware changes to individual devices.
       audit: |
         ### Audit via Console
 
@@ -68778,14 +69041,20 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that the Lambda function attached to each Secrets Manager secret with rotation enabled is itself configured to run inside a customer VPC. The rotation Lambda authenticates to the backing database with the secret it is rotating, so if the function has no VPC configuration it reaches the database over the public AWS network rather than over private subnets the operator controls.
+        This check ensures that the Lambda function attached to each Secrets Manager secret with rotation enabled is configured to run inside a customer VPC. The rotation Lambda authenticates to the backing database using the secret it is rotating, so without a VPC configuration the function reaches the database over the public AWS network rather than over the private subnets and security groups the operator controls.
 
         **Why this matters**
 
-        - The rotation Lambda holds both the current and the candidate credential during each rotation and must talk to the database to verify the new credential. This is exactly the moment when network isolation matters most.
-        - A rotation Lambda without `vpc_config` makes its outbound call from an AWS-managed network range, so the database's security group and network ACL cannot distinguish the legitimate caller from any other AWS workload.
-        - Putting the rotation function in the same private subnets as the database lets the database security group accept only that function's security group, which is the same boundary used for regular application traffic.
-        - This check focuses on the rotation Lambda's network configuration; the secret's encryption-at-rest and rotation cadence are enforced by separate Secrets Manager checks.
+        - **Critical timing:** The rotation Lambda holds both the current and the candidate credential during each rotation cycle and must communicate with the database to validate the new secret, making this the moment when network isolation matters most.
+        - **Security group enforcement gap:** A rotation Lambda without `vpc_config` makes its outbound call from an AWS-managed network range, so the database's security group cannot distinguish the legitimate rotation function from any other AWS workload calling the same port.
+        - **Network alignment:** Placing the rotation function in the same private subnets as the database allows the database security group to accept only traffic from the rotation function's specific security group, matching the boundary used for regular application traffic.
+        - **Blast radius containment:** A VPC-bound Lambda's egress can be further constrained with subnet routing and security groups, limiting the paths the function can take if its execution environment is compromised.
+
+        **Risk mitigation**
+
+        - **Access boundary enforcement:** Running the rotation Lambda inside the application VPC ensures it can only reach the database through private network paths governed by security groups and network ACLs, not through the public internet.
+        - **Least-privilege networking:** A dedicated security group for the rotation function, combined with a narrow database security group inbound rule, creates a named, auditable trust relationship between the rotation function and the database.
+        - **Defense against credential exposure:** Keeping credential validation traffic inside the VPC prevents the new credential from being observable on any network path outside the operator's control during the rotation window.
       audit: |
         ### Audit via Console
 
@@ -68932,14 +69201,20 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       desc: |
-        This check ensures that every CodeArtifact domain is created with an explicit `encryption_key` pointing at a customer-managed KMS key. Without that argument CodeArtifact provisions an AWS-managed key whose policy the customer cannot author, rotate, or revoke, so the package archive ends up encrypted under a boundary the operator does not control.
+        This check ensures that every CodeArtifact domain is created with an explicit `encryption_key` pointing at a customer-managed KMS key. Without this argument, CodeArtifact provisions an AWS-managed key whose policy the customer cannot author, rotate, or revoke, so the package archive is encrypted under a key boundary the operator does not control. The encryption key is fixed at domain creation time and cannot be changed afterward.
 
         **Why this matters**
 
-        - CodeArtifact domains aggregate package metadata and asset blobs from every repository in the domain, so the package store often contains internal release tags, private build hashes, and customer-specific package names.
-        - A customer-managed key lets the operator bind the domain's lifecycle to the same KMS policy and CloudTrail audit trail used for other regulated data.
-        - The encryption key is locked at domain creation time and cannot be changed later, so this is the only opportunity to enforce CMK encryption for the domain's lifetime.
-        - In-transit protection is not part of this check because CodeArtifact only exposes HTTPS endpoints; the only configurable boundary at rest is the KMS key.
+        - **Sensitive package content:** CodeArtifact domains aggregate package metadata and asset blobs from every repository they contain, which often includes internal release tags, private build hashes, and customer-specific package names that reveal build and deployment patterns.
+        - **Key lifecycle control:** A customer-managed key lets the operator bind the domain's encryption to the same KMS policy and CloudTrail audit trail used for other regulated data stores in the account.
+        - **Immutable configuration window:** The encryption key is locked at domain creation and cannot be modified later, making this the only point at which CMK encryption can be enforced for the domain's full lifetime.
+        - **Audit trail:** Every package download that triggers a decryption generates a CloudTrail `kms:Decrypt` event against the customer key, enabling detection of unexpected or unauthorized access to the domain's package store.
+
+        **Risk mitigation**
+
+        - **Key revocation capability:** A customer-managed key can be disabled or scheduled for deletion to deny all further decryption of domain package assets, providing a hard stop when a domain must be decommissioned or its data must be quarantined.
+        - **Access policy enforcement:** Key policies can restrict which IAM principals and services are permitted to decrypt domain contents, limiting the blast radius if a CI/CD role or build system is compromised.
+        - **Compliance alignment:** Binding the package store to a CMK satisfies encryption-at-rest requirements in regulated environments and enables key rotation on the operator's schedule rather than AWS's default rotation cadence.
       audit: |
         ### Audit via Console
 

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -723,6 +723,32 @@ queries:
         - **Prevents unauthorized access:** Only authorized users and services can decrypt secrets.
         - **Ensures compliance:** Meets regulatory requirements for data protection and encryption.
         - **Enhances security posture:** Reduces the risk of data breaches and unauthorized access to sensitive information.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon EKS console at https://console.aws.amazon.com/eks/.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select the cluster you want to examine.
+        4. Choose the **Configuration** tab, then choose **Secrets encryption**.
+        5. Review the **KMS key** field.
+
+        A passing cluster shows a customer-managed KMS key ARN in the **KMS key** field. A failing cluster shows no key configured or displays only the default AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all EKS clusters in the account:
+
+        ```bash
+        aws eks list-clusters --query "clusters[]"
+        ```
+
+        2. For each cluster, describe the encryption configuration:
+
+        ```bash
+        aws eks describe-cluster --name <cluster-name> --query "cluster.encryptionConfig"
+        ```
+
+        A passing cluster returns a non-empty array containing an entry with `"resources": ["secrets"]` and a `"provider"` block that includes a non-empty `keyArn`. A failing cluster returns an empty array `[]` or a provider block with no `keyArn`.
       remediation:
         - id: console
           desc: |
@@ -893,6 +919,32 @@ queries:
         - **Prevents unauthorized access:** Only resources within the VPC can communicate with the EKS control plane.
         - **Enhances security posture:** Reduces the risk of data breaches and unauthorized access to sensitive information.
         - **Improves compliance:** Aligns with security frameworks and regulations that require network isolation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon EKS console at https://console.aws.amazon.com/eks/.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select the cluster you want to examine.
+        4. Choose the **Configuration** tab, then choose **Networking**.
+        5. Review the **Cluster endpoint access** field.
+
+        A passing cluster shows **Private** endpoint access enabled and **Public** endpoint access disabled. A failing cluster shows public endpoint access enabled, or shows both public and private access enabled simultaneously.
+
+        ### Audit via CLI
+
+        1. List all EKS clusters:
+
+        ```bash
+        aws eks list-clusters --query "clusters[]"
+        ```
+
+        2. For each cluster, check the endpoint access settings:
+
+        ```bash
+        aws eks describe-cluster --name <cluster-name> --query "cluster.resourcesVpcConfig.{PrivateAccess:endpointPrivateAccess,PublicAccess:endpointPublicAccess}"
+        ```
+
+        A passing cluster returns `"PrivateAccess": true` and `"PublicAccess": false`. A failing cluster returns `"PublicAccess": true`.
       remediation:
         - id: console
           desc: |
@@ -1034,6 +1086,33 @@ queries:
         - **Prevents root key compromise:** Eliminates a major attack vector for AWS account takeovers.
         - **Ensures compliance:** Aligns with security frameworks like CIS AWS Foundations Benchmark, SOC 2, PCI DSS, and ISO 27001.
         - **Encourages least privilege:** Promotes the use of IAM users and roles for secure access control.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console as the root user or with an IAM identity that has `iam:GenerateCredentialReport` permission.
+        2. Open the IAM console at https://console.aws.amazon.com/iam/.
+        3. In the left navigation pane, choose **Credential report**.
+        4. Choose **Download credential report** to download the CSV file.
+        5. Open the CSV and find the row where the `user` column contains `<root_account>`.
+        6. Examine the `access_key_1_active` and `access_key_2_active` columns.
+
+        A passing account shows `FALSE` in both `access_key_1_active` and `access_key_2_active` for the root account row. A failing account shows `TRUE` in either column.
+
+        ### Audit via CLI
+
+        1. Generate a fresh credential report:
+
+        ```bash
+        aws iam generate-credential-report
+        ```
+
+        2. Retrieve and decode the report, then filter for the root account row:
+
+        ```bash
+        aws iam get-credential-report --query 'Content' --output text | base64 --decode | awk -F',' 'NR==1 || $1=="<root_account>"'
+        ```
+
+        A passing account shows `false` in both the `access_key_1_active` and `access_key_2_active` fields for the `<root_account>` row. A failing account shows `true` in either field.
       remediation:
         - id: console
           desc: |
@@ -1180,6 +1259,26 @@ queries:
         - **Prevents account takeovers:** Even if the root password is stolen, MFA blocks unauthorized logins.
         - **Ensures compliance:** Meets security standards such as CIS AWS Foundations Benchmark, SOC 2, ISO 27001, and PCI DSS.
         - **Strengthens account security:** Adds an extra layer of authentication beyond the password.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console.
+        2. Open the IAM console at https://console.aws.amazon.com/iam/.
+        3. In the left navigation pane, choose **Dashboard**.
+        4. Review the **Security recommendations** or **Root user** section.
+        5. Check whether **MFA** is listed as enabled for the root user.
+
+        A passing account shows MFA as active on the root user. A failing account displays a warning that root MFA is not enabled.
+
+        ### Audit via CLI
+
+        1. Check whether MFA is enabled for the root account:
+
+        ```bash
+        aws iam get-account-summary --query "SummaryMap.AccountMFAEnabled"
+        ```
+
+        A passing account returns `1`. A failing account returns `0`.
       remediation:
         - id: console
           desc: |
@@ -1377,6 +1476,31 @@ queries:
         - **Prevents brute-force attacks:** Ensures passwords are complex and difficult to guess.
         - **Reduces credential stuffing risks:** Enforces frequent password changes and prevents password reuse.
         - **Ensures compliance:** Meets security requirements for regulated industries.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **Account settings**.
+        3. Review the **Password policy** section and verify the following settings are configured:
+           - Minimum password length is at least 14 characters.
+           - Require at least one uppercase letter is enabled.
+           - Require at least one lowercase letter is enabled.
+           - Require at least one number is enabled.
+           - Require at least one non-alphanumeric character is enabled.
+           - Enable password expiration is set to 90 days or fewer.
+           - Prevent password reuse is set to 24 or more passwords.
+
+        A passing account has all of the above requirements set to compliant values. A failing account has one or more settings missing, disabled, or set to a weaker value.
+
+        ### Audit via CLI
+
+        1. Retrieve the current account password policy:
+
+        ```bash
+        aws iam get-account-password-policy
+        ```
+
+        A passing account returns a policy object where `MinimumPasswordLength` >= 14, `RequireUppercaseCharacters`, `RequireLowercaseCharacters`, `RequireNumbers`, and `RequireSymbols` are all `true`, `MaxPasswordAge` is <= 90, and `PasswordReusePrevention` is >= 24. A failing account returns values outside these thresholds or returns a `NoSuchEntityException` indicating no password policy exists.
       remediation:
         - id: console
           desc: |
@@ -1555,6 +1679,32 @@ queries:
         - Reduces the risk of long-term key exposure
         - Ensures compliance with security and regulatory standards
         - Limits the impact of potential credential leaks
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **Users**.
+        3. For each user, select the user name and choose the **Security credentials** tab.
+        4. Under **Access keys**, review the **Created** date for any active keys.
+        5. Identify any active keys where the creation date is more than 90 days ago.
+
+        A passing user has no active access keys older than 90 days. A failing user has at least one active access key that was created more than 90 days ago and has not been rotated.
+
+        ### Audit via CLI
+
+        1. List all IAM users:
+
+        ```bash
+        aws iam list-users --query "Users[*].UserName" --output text
+        ```
+
+        2. For each user, check the creation date of active access keys:
+
+        ```bash
+        aws iam list-access-keys --user-name <username> --query "AccessKeyMetadata[?Status=='Active'].{KeyId:AccessKeyId,Created:CreateDate}"
+        ```
+
+        A passing user has no active keys with a `Created` date more than 90 days in the past. A failing user has at least one active key whose `Created` date exceeds the 90-day rotation window.
       remediation:
         - id: console
           desc: |
@@ -1698,6 +1848,33 @@ queries:
         - Prevents unauthorized access due to stolen or weak passwords
         - Enhances security posture by enforcing multi-layer authentication
         - Aligns with compliance and security best practices
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **Credential report**.
+        3. Choose **Download credential report** to download the CSV file.
+        4. Open the CSV and filter for rows where `password_enabled` is `true`.
+        5. For each such row, check the `mfa_active` column.
+
+        A passing user with console access shows `true` in the `mfa_active` column. A failing user with console access shows `false` in the `mfa_active` column.
+
+        ### Audit via CLI
+
+        1. Generate and download the credential report:
+
+        ```bash
+        aws iam generate-credential-report
+        aws iam get-credential-report --query 'Content' --output text | base64 --decode
+        ```
+
+        2. Filter for console-enabled users without MFA:
+
+        ```bash
+        aws iam get-credential-report --query 'Content' --output text | base64 --decode | awk -F',' 'NR==1 || ($4=="true" && $8=="false")'
+        ```
+
+        A passing account has no rows where `password_enabled` is `true` and `mfa_active` is `false`. A failing account has one or more console-enabled users with `mfa_active` set to `false`.
       remediation:
         - id: console
           desc: |
@@ -1879,6 +2056,31 @@ queries:
         - **Privilege escalation prevention:** Removing empty groups eliminates pre-staged permission sets that an attacker could exploit with a single API call.
         - **Access review accuracy:** Ensures all groups with permissions are actively used and reviewed, closing blind spots in security audits.
         - **Attack surface reduction:** Reduces the number of permission paths an attacker can exploit after initial credential compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **User groups**.
+        3. Review the **Users** column for each group.
+        4. Identify any groups where the user count is 0.
+
+        A passing group shows at least one user in the **Users** column. A failing group shows 0 users.
+
+        ### Audit via CLI
+
+        1. List all IAM groups:
+
+        ```bash
+        aws iam list-groups --query "Groups[*].GroupName" --output text
+        ```
+
+        2. For each group, check whether any users are assigned:
+
+        ```bash
+        aws iam get-group --group-name <group-name> --query "Users[*].UserName"
+        ```
+
+        A passing group returns a non-empty list of user names. A failing group returns an empty array `[]`.
       remediation:
         - id: console
           desc: |
@@ -2043,6 +2245,31 @@ queries:
         - Reduces exposure to key compromise by minimizing unused or unnecessary credentials.
         - Simplifies access key rotation by ensuring only one key is active at any given time.
         - Enhances security posture by enforcing least privilege access for IAM users.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **Users**.
+        3. For each user, select the user name and choose the **Security credentials** tab.
+        4. Under **Access keys**, count the number of keys with **Status** set to **Active**.
+
+        A passing user has zero or one active access key. A failing user has two active access keys simultaneously.
+
+        ### Audit via CLI
+
+        1. List all IAM users:
+
+        ```bash
+        aws iam list-users --query "Users[*].UserName" --output text
+        ```
+
+        2. For each user, list active access keys and count them:
+
+        ```bash
+        aws iam list-access-keys --user-name <username> --query "AccessKeyMetadata[?Status=='Active'].AccessKeyId"
+        ```
+
+        A passing user returns an array with zero or one element. A failing user returns an array with two elements.
       remediation:
         - id: console
           desc: |
@@ -2215,6 +2442,38 @@ queries:
         - **Backdoor detection:** Eliminates inline policies as a hiding spot for attacker-planted persistent permissions.
         - **Audit visibility:** Ensures all permissions are managed through groups where they are visible to bulk access reviews and automated compliance scanning.
         - **Privilege creep prevention:** Group-based assignment makes it easier to detect and revoke excessive permissions across multiple users simultaneously.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the IAM console at https://console.aws.amazon.com/iam/.
+        2. In the left navigation pane, choose **Users**.
+        3. For each user, select the user name and choose the **Permissions** tab.
+        4. Check for any policies listed under **Permissions policies** that are not inherited from a group.
+        5. Look for inline policies (shown with an **Inline policy** badge) and directly attached managed policies.
+
+        A passing user has no inline policies and no directly attached managed policies; all permissions flow through group membership. A failing user shows one or more inline policies or directly attached managed policies.
+
+        ### Audit via CLI
+
+        1. List all IAM users:
+
+        ```bash
+        aws iam list-users --query "Users[*].UserName" --output text
+        ```
+
+        2. For each user, check for inline policies:
+
+        ```bash
+        aws iam list-user-policies --user-name <username> --query "PolicyNames"
+        ```
+
+        3. For each user, check for directly attached managed policies:
+
+        ```bash
+        aws iam list-attached-user-policies --user-name <username> --query "AttachedPolicies[*].PolicyName"
+        ```
+
+        A passing user returns empty arrays for both commands. A failing user returns one or more policy names in either command.
       remediation:
         - id: console
           desc: |
@@ -2412,6 +2671,25 @@ queries:
         - Prevents unintended access by eliminating unrestricted communication between instances.
         - Enforces least privilege by requiring explicit security group assignments.
         - Improves network security posture by reducing exposure to internal threats.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the VPC console at https://console.aws.amazon.com/vpc/.
+        2. In the left navigation pane, choose **Security groups**.
+        3. Use the filter bar to filter by **Group name** equal to `default`.
+        4. For each default security group, select it and review the **Inbound rules** and **Outbound rules** tabs.
+
+        A passing default security group shows no inbound rules and no outbound rules. A failing default security group shows one or more rules in either the inbound or outbound rules tab.
+
+        ### Audit via CLI
+
+        1. List all default security groups across all VPCs:
+
+        ```bash
+        aws ec2 describe-security-groups --filters Name=group-name,Values=default --query "SecurityGroups[*].{GroupId:GroupId,VpcId:VpcId,InboundRules:IpPermissions,OutboundRules:IpPermissionsEgress}"
+        ```
+
+        A passing security group returns empty arrays for both `InboundRules` and `OutboundRules`. A failing security group returns one or more entries in either `InboundRules` or `OutboundRules`.
       remediation:
         - id: console
           desc: |
@@ -2563,6 +2841,26 @@ queries:
         - Prevents accidental creation of unencrypted volumes by enforcing encryption automatically.
         - Ensures compliance with data protection standards that require encryption at rest.
         - Reduces the risk of data breaches by protecting data stored on AWS-managed disks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, choose **Settings** under **Account attributes**, or navigate to **EC2 Dashboard** and choose **Account attributes > EBS encryption**.
+        3. Review the **Always encrypt new EBS volumes** setting.
+
+        A passing account shows **Enabled** for default EBS encryption. A failing account shows **Disabled**.
+
+        Note: This setting is per-region. Repeat the check for each AWS region in scope.
+
+        ### Audit via CLI
+
+        1. Check whether default EBS encryption is enabled in the current region:
+
+        ```bash
+        aws ec2 get-ebs-encryption-by-default --query "EbsEncryptionByDefault"
+        ```
+
+        A passing region returns `true`. A failing region returns `false`.
       remediation:
         - id: console
           desc: |
@@ -2695,6 +2993,28 @@ queries:
         - Prevents accidental public data exposure by blocking public access to all S3 resources.
         - Enhances security posture by enforcing organization-wide security policies.
         - Ensures compliance with regulatory frameworks that require strict data access controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the S3 console at https://console.aws.amazon.com/s3/.
+        2. In the left navigation pane, choose **Block Public Access settings for this account**.
+        3. Verify that all four settings are enabled:
+           - Block public access to buckets and objects granted through new access control lists (ACLs)
+           - Block public access to buckets and objects granted through any access control lists (ACLs)
+           - Block public access to buckets and objects granted through new public bucket policies
+           - Block public and cross-account access to buckets and objects with public policies
+
+        A passing account shows all four settings enabled (checked). A failing account has one or more settings disabled.
+
+        ### Audit via CLI
+
+        1. Retrieve the account-level S3 public access block configuration:
+
+        ```bash
+        aws s3control get-public-access-block --account-id <account-id> --query "PublicAccessBlockConfiguration"
+        ```
+
+        A passing account returns an object where `BlockPublicAcls`, `IgnorePublicAcls`, `BlockPublicPolicy`, and `RestrictPublicBuckets` are all `true`. A failing account has one or more of these fields set to `false`, or the command returns a `NoSuchPublicAccessBlockConfiguration` error.
       remediation:
         - id: console
           desc: |
@@ -2852,6 +3172,36 @@ queries:
         - Prevents accidental or intentional data leaks due to misconfigured bucket policies or ACLs.
         - Strengthens security posture by enforcing explicit access control at the bucket level.
         - Ensures regulatory compliance with industry data protection standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the S3 console at https://console.aws.amazon.com/s3/.
+        2. Select a bucket from the list.
+        3. Choose the **Permissions** tab.
+        4. Under **Block public access (bucket settings)**, verify that all four settings are enabled:
+           - Block public access to buckets and objects granted through new access control lists (ACLs)
+           - Block public access to buckets and objects granted through any access control lists (ACLs)
+           - Block public access to buckets and objects granted through new public bucket policies
+           - Block public and cross-account access to buckets and objects with public policies
+        5. Repeat for each bucket in scope.
+
+        A passing bucket shows all four block public access settings enabled. A failing bucket has one or more settings disabled.
+
+        ### Audit via CLI
+
+        1. List all S3 buckets:
+
+        ```bash
+        aws s3api list-buckets --query "Buckets[*].Name" --output text
+        ```
+
+        2. For each bucket, retrieve the public access block configuration:
+
+        ```bash
+        aws s3api get-public-access-block --bucket <bucket-name> --query "PublicAccessBlockConfiguration"
+        ```
+
+        A passing bucket returns an object where `BlockPublicAcls`, `IgnorePublicAcls`, `BlockPublicPolicy`, and `RestrictPublicBuckets` are all `true`. A failing bucket has one or more fields set to `false`, or returns a `NoSuchPublicAccessBlockConfiguration` error.
       remediation:
         - id: console
           desc: |
@@ -3093,6 +3443,25 @@ queries:
         - Reduces exposure to external threats by eliminating direct public access.
         - Improves security posture by enforcing network segmentation best practices.
         - Ensures compliance with cloud security frameworks and industry standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, choose **Instances**.
+        3. Review the **Public IPv4 address** column for each running instance.
+        4. Identify any instances with a non-empty public IP address.
+
+        A passing instance shows no value (dash) in the **Public IPv4 address** column. A failing instance shows a public IP address in that column.
+
+        ### Audit via CLI
+
+        1. List all EC2 instances and their public IP addresses:
+
+        ```bash
+        aws ec2 describe-instances --query "Reservations[*].Instances[*].{InstanceId:InstanceId,PublicIp:PublicIpAddress,State:State.Name}" --output table
+        ```
+
+        A passing instance returns `null` or an empty value for `PublicIp`. A failing instance returns a non-null public IP address.
       remediation:
         - id: console
           desc: |
@@ -3254,6 +3623,28 @@ queries:
         - Prevents unauthorized metadata access by enforcing authenticated API requests.
         - Mitigates SSRF vulnerabilities that could expose instance credentials.
         - Aligns with compliance requirements for secure cloud environments.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console.
+        2. In the left navigation pane, select **Instances**.
+        3. Select an instance and open the **Details** tab.
+        4. Under **Metadata version**, verify the value.
+
+        A passing instance shows **IMDSv2 only** (or **V2 only**) under Metadata version. A failing instance shows **V1 and V2** or no explicit IMDSv2 requirement.
+
+        ### Audit via CLI
+
+        1. Run the following command to retrieve the IMDS settings for all running instances:
+
+        ```bash
+        aws ec2 describe-instances \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,HttpTokens:MetadataOptions.HttpTokens,HttpEndpoint:MetadataOptions.HttpEndpoint,State:State.Name}" \
+          --output table
+        ```
+
+        A passing instance returns `"HttpTokens": "required"` (or has `"HttpEndpoint": "disabled"`). A failing instance returns `"HttpTokens": "optional"` while `"HttpEndpoint"` is `"enabled"`.
+
       remediation:
         - id: console
           desc: |
@@ -3422,6 +3813,27 @@ queries:
         - Enabling BPA does not retroactively remove existing public access; existing Internet Gateways and public routes remain functional.
         - Service-linked resources managed by AWS such as those for ELB or NAT Gateways require explicit exemptions to continue functioning properly.
         - There may be organizational impacts requiring coordination across teams before implementation to avoid disrupting business operations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the VPC console.
+        2. In the left navigation pane, select **Settings** (under Virtual Private Cloud), then choose **Block public access settings**.
+        3. Under **Internet gateway block mode**, check the current setting.
+
+        A passing account shows a mode of **Block bidirectional** or **Block ingress** (anything other than **Off**). A failing account shows **Off**.
+
+        ### Audit via CLI
+
+        1. Run the following command to retrieve the VPC Block Public Access setting for the current region:
+
+        ```bash
+        aws ec2 describe-vpc-block-public-access-options \
+          --query "VpcBlockPublicAccessOptions.{State:State,InternetGatewayBlockMode:InternetGatewayBlockMode}" \
+          --output table
+        ```
+
+        A passing account returns an `InternetGatewayBlockMode` value of `block-bidirectional` or `block-ingress`. A failing account returns `off`.
+
       remediation:
         - id: console
           desc: |
@@ -3571,6 +3983,28 @@ queries:
         - Enhances network visibility by capturing VPC-level traffic metadata.
         - Improves threat detection by monitoring suspicious or unauthorized traffic.
         - Supports compliance requirements for security monitoring and audit logging.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the VPC console.
+        2. In the left navigation pane, select **Your VPCs**.
+        3. For each VPC, select its name and open the **Flow logs** tab.
+        4. Verify that at least one flow log exists with a status of **Active** and a traffic type of **All** or **Reject**, and that the log destination is CloudWatch Logs.
+
+        A passing VPC shows an active flow log delivering to CloudWatch Logs with traffic type ALL or REJECT. A failing VPC shows no flow logs, an inactive flow log, or a flow log that captures only ACCEPT traffic.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all flow logs and their configuration:
+
+        ```bash
+        aws ec2 describe-flow-logs \
+          --query "FlowLogs[*].{ResourceId:ResourceId,Status:FlowLogStatus,TrafficType:TrafficType,Destination:LogDestination,DestinationType:LogDestinationType,DeliverStatus:DeliverLogsStatus}" \
+          --output table
+        ```
+
+        A passing VPC has a flow log entry where `FlowLogStatus` is `ACTIVE`, `LogDestinationType` is `cloud-watch-logs`, `DeliverLogsStatus` is `SUCCESS`, and `TrafficType` is `ALL` or `REJECT`. A failing VPC has no matching entry or the entry shows `FlowLogStatus` other than `ACTIVE`.
+
       remediation:
         - id: console
           desc: |
@@ -3744,6 +4178,36 @@ queries:
         - Prevents unauthorized access to sensitive data by enforcing encryption at rest.
         - Enhances security by leveraging customer-managed KMS keys (CMKs) instead of default AWS-managed keys.
         - Ensures compliance with industry security and regulatory requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the DynamoDB console.
+        2. In the left navigation pane, select **Tables**.
+        3. Select a table and open the **Additional settings** tab (or **Table details**).
+        4. Under **Encryption**, review the **Encryption type** and **KMS key** fields.
+
+        A passing table shows an **Encryption type** of **AWS managed key** using a customer-managed KMS key, or shows a customer-managed key ARN under the KMS key field (SSEType of KMS). A failing table shows **Owned by Amazon DynamoDB** (AWS-owned key) as the encryption type.
+
+        ### Audit via CLI
+
+        1. List all DynamoDB tables and retrieve their SSE configuration:
+
+        ```bash
+        aws dynamodb list-tables --query "TableNames" --output text | tr '\t' '\n' | \
+          xargs -I{} aws dynamodb describe-table --table-name {} \
+            --query "Table.{TableName:TableName,SSEType:SSEDescription.SSEType,KMSKeyArn:SSEDescription.KMSMasterKeyArn}"
+        ```
+
+        Alternatively, check a specific table:
+
+        ```bash
+        aws dynamodb describe-table \
+          --table-name <table-name> \
+          --query "Table.SSEDescription"
+        ```
+
+        A passing table returns `"SSEType": "KMS"` with a non-empty `KMSMasterKeyArn`. A failing table returns `"SSEType": "AES256"` or an empty `SSEDescription`.
+
       remediation:
         - id: console
           desc: |
@@ -3942,6 +4406,38 @@ queries:
         - **Blast radius containment:** Limits the impact of a single compromised or abused function to its reserved concurrency, protecting other functions from starvation.
         - **Denial-of-wallet prevention:** Caps the compute a single function can consume, limiting the financial damage from event-source abuse.
         - **Workload isolation:** Ensures security-critical functions retain available concurrency even when other functions are under attack.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Lambda console.
+        2. In the left navigation pane, select **Functions**.
+        3. Select a function and open the **Configuration** tab.
+        4. Select **Concurrency** in the sub-navigation.
+        5. Check the **Reserved concurrency** value.
+
+        A passing function shows a **Reserved concurrency** value greater than zero. A failing function shows **Unreserved concurrency** (no reserved concurrency limit configured).
+
+        ### Audit via CLI
+
+        1. List all Lambda functions and check each for a reserved concurrency setting:
+
+        ```bash
+        aws lambda list-functions \
+          --query "Functions[*].FunctionName" \
+          --output text | tr '\t' '\n' | \
+          xargs -I{} aws lambda get-function-concurrency \
+            --function-name {}
+        ```
+
+        Alternatively, check a specific function:
+
+        ```bash
+        aws lambda get-function-concurrency \
+          --function-name <function-name>
+        ```
+
+        A passing function returns `{"ReservedConcurrentExecutions": <number greater than 0>}`. A failing function returns an empty response `{}` (no reserved concurrency set).
+
       remediation:
         - id: console
           desc: |
@@ -4092,6 +4588,32 @@ queries:
         - Prevents unauthorized invocation of Lambda functions by restricting access to trusted entities only.
         - Reduces the attack surface by eliminating public exposure of serverless compute resources.
         - Ensures compliance with security frameworks that require controlled access to computing resources.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Lambda console.
+        2. In the left navigation pane, select **Functions**.
+        3. Select a function and open the **Configuration** tab.
+        4. Select **Permissions** in the sub-navigation.
+        5. Under **Resource-based policy statements**, review each statement for a `Principal` of `*` or `{"AWS": "*"}`.
+
+        A passing function either has no resource-based policy or has a policy with no statements granting `Allow` to principal `*`. A failing function has one or more policy statements with `Effect: Allow` and `Principal: *` (or `AWS: *`).
+
+        ### Audit via CLI
+
+        1. Retrieve the resource-based policy for each Lambda function:
+
+        ```bash
+        aws lambda get-policy \
+          --function-name <function-name> \
+          --query "Policy" \
+          --output text | python3 -m json.tool
+        ```
+
+        Inspect each statement in the returned policy document for `"Principal": "*"` or `"Principal": {"AWS": "*"}` combined with `"Effect": "Allow"`.
+
+        A passing function has no such statement (or returns a `ResourceNotFoundException` indicating no resource-based policy exists). A failing function has at least one `Allow` statement with a wildcard principal.
+
       remediation:
         - id: console
           desc: |
@@ -4247,6 +4769,28 @@ queries:
         - **Security Posture:** Reduces vulnerability exposure by ensuring the latest security patches are applied.
         - **Operational Stability:** Incorporates bug fixes and performance improvements that enhance database reliability.
         - **Compliance Management:** Helps meet regulatory requirements for timely security patch management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS instance and open the **Maintenance & backups** tab.
+        4. Under **Pending maintenance**, check if any maintenance action is listed.
+
+        A passing instance shows **None** under Pending maintenance. A failing instance lists a pending action such as a system update or OS patch.
+
+        ### Audit via CLI
+
+        1. Run the following command to check for pending maintenance actions on all RDS instances:
+
+        ```bash
+        aws rds describe-pending-maintenance-actions \
+          --query "PendingMaintenanceActions[?ResourceIdentifier!=null].{Resource:ResourceIdentifier,Action:PendingMaintenanceActionDetails[0].Action,ApplyDate:PendingMaintenanceActionDetails[0].AutoAppliedAfterDate}" \
+          --output table
+        ```
+
+        A passing instance does not appear in the output (no pending maintenance). A failing instance appears with a pending `system-update` or similar action listed under its ARN.
+
       remediation:
         - id: console
           desc: |
@@ -4377,6 +4921,28 @@ queries:
         **Why this matters**
 
         Since databases frequently contain confidential and essential data, enabling encryption is a crucial security measure. It acts as a vital layer of defense against unauthorized access or exposure of sensitive information. By activating RDS encryption, you ensure comprehensive protection, as the encryption covers the data on the instance's underlying storage, along with its automated backups, any read replicas, and all created snapshots.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS instance and open the **Configuration** tab.
+        4. Under **Storage**, locate the **Encryption** field.
+
+        A passing instance shows **Enabled** next to Encryption. A failing instance shows **Not enabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to check the encryption status of all RDS instances:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier,StorageEncrypted:StorageEncrypted,KmsKeyId:KmsKeyId}" \
+          --output table
+        ```
+
+        A passing instance returns `"StorageEncrypted": true` with a non-empty `KmsKeyId`. A failing instance returns `"StorageEncrypted": false`.
+
       remediation:
         - id: console
           desc: |
@@ -4579,6 +5145,38 @@ queries:
         **Note:**
 
         In general, cluster parameter groups can be overridden by instance parameter groups, but there is no equivalent setting at the instance group level for `ssl`.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Parameter groups**.
+        3. Select the cluster parameter group associated with your RDS cluster.
+        4. Search for the parameter named `ssl` (for Aurora PostgreSQL) or `require_secure_transport` (for Aurora MySQL).
+        5. Check the current value.
+
+        A passing parameter group shows the `ssl` parameter set to `1` (PostgreSQL) or `require_secure_transport` set to `ON` (MySQL). A failing parameter group shows `ssl` set to `0` or `require_secure_transport` set to `OFF` (or the parameter not present).
+
+        ### Audit via CLI
+
+        1. Identify the parameter group name for the cluster:
+
+        ```bash
+        aws rds describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,ParameterGroup:DBClusterParameterGroup}" \
+          --output table
+        ```
+
+        2. Check the SSL-related parameter in that group:
+
+        ```bash
+        aws rds describe-db-cluster-parameters \
+          --db-cluster-parameter-group-name <parameter-group-name> \
+          --query "Parameters[?ParameterName=='ssl' || ParameterName=='require_secure_transport'].{Name:ParameterName,Value:ParameterValue}" \
+          --output table
+        ```
+
+        A passing parameter group returns `"ParameterValue": "1"` for `ssl` or `"ParameterValue": "ON"` for `require_secure_transport`. A failing parameter group returns `"ParameterValue": "0"` for `ssl` or `"ParameterValue": "OFF"` for `require_secure_transport`.
+
       remediation:
         - id: console
           desc: |
@@ -4793,6 +5391,28 @@ queries:
         - **Security Posture:** Reduces vulnerability exposure by ensuring the latest security patches are applied across all instances in the cluster.
         - **Operational Stability:** Incorporates bug fixes and performance improvements that enhance database reliability and consistency.
         - **Compliance Management:** Helps meet regulatory requirements for timely security patch management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS cluster (such as an Aurora cluster) and open the **Maintenance & backups** tab.
+        4. Under **Pending maintenance**, check for any listed maintenance actions.
+
+        A passing cluster shows **None** under Pending maintenance. A failing cluster lists a pending action such as a system update.
+
+        ### Audit via CLI
+
+        1. Run the following command to check for pending maintenance actions across all RDS resources, then filter for cluster ARNs:
+
+        ```bash
+        aws rds describe-pending-maintenance-actions \
+          --query "PendingMaintenanceActions[?contains(ResourceIdentifier, ':cluster:')].{Resource:ResourceIdentifier,Action:PendingMaintenanceActionDetails[0].Action,ApplyDate:PendingMaintenanceActionDetails[0].AutoAppliedAfterDate}" \
+          --output table
+        ```
+
+        A passing cluster does not appear in the output. A failing cluster appears with a pending `system-update` or similar action listed against its cluster ARN.
+
       remediation:
         - id: console
           desc: |
@@ -4949,6 +5569,28 @@ queries:
         **Why this matters**
 
         Database clusters often consolidate significant amounts of sensitive or critical data. Implementing encryption is therefore a highly recommended security practice to protect this data against unauthorized access or potential disclosure. By activating RDS encryption on your cluster, you ensure comprehensive data-at-rest protection, covering the data within the shared cluster storage, as well as associated components like automated backups, cluster snapshots, and any read replicas within the cluster environment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS cluster and open the **Configuration** tab.
+        4. Under **Storage**, locate the **Encryption** field.
+
+        A passing cluster shows **Enabled** next to Encryption. A failing cluster shows **Not enabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to check the encryption status of all RDS clusters:
+
+        ```bash
+        aws rds describe-db-clusters \
+          --query "DBClusters[*].{DBClusterIdentifier:DBClusterIdentifier,StorageEncrypted:StorageEncrypted,KmsKeyId:KmsKeyId}" \
+          --output table
+        ```
+
+        A passing cluster returns `"StorageEncrypted": true` with a non-empty `KmsKeyId`. A failing cluster returns `"StorageEncrypted": false`.
+
       remediation:
         - id: console
           desc: |
@@ -5185,6 +5827,39 @@ queries:
         - Prevents unauthorized access by restricting direct exposure to the internet.
         - Enhances database security by enforcing private networking best practices.
         - Ensures compliance with regulatory and cloud security standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS cluster and open the **Connectivity & security** tab.
+        4. Under **Security**, review the VPC, subnet group, and security groups.
+        5. Verify that the subnet group uses private subnets (no route to an internet gateway with destination `0.0.0.0/0`).
+        6. For each DB instance in the cluster, check the **Publicly accessible** field.
+
+        A passing cluster and its instances either show **Not publicly accessible** or are in subnets with no internet gateway route. A failing cluster has instances that are publicly accessible or has a security group associated with a VPC whose route table includes a `0.0.0.0/0` route via an internet gateway.
+
+        ### Audit via CLI
+
+        1. Check whether cluster instances are publicly accessible:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[?DBClusterIdentifier!=null].{InstanceId:DBInstanceIdentifier,ClusterId:DBClusterIdentifier,PubliclyAccessible:PubliclyAccessible}" \
+          --output table
+        ```
+
+        2. Verify that the VPC route tables used by the cluster's subnets do not have an internet gateway route:
+
+        ```bash
+        aws ec2 describe-route-tables \
+          --filters "Name=vpc-id,Values=<vpc-id>" \
+          --query "RouteTables[*].Routes[?GatewayId!=null && starts_with(GatewayId, 'igw-')].{DestinationCidrBlock:DestinationCidrBlock,GatewayId:GatewayId}" \
+          --output table
+        ```
+
+        A passing cluster has all instances with `PubliclyAccessible: false` and no internet gateway routes (`igw-*`) with destination `0.0.0.0/0` in its VPC route tables. A failing cluster has at least one instance with `PubliclyAccessible: true` or has an internet gateway route reachable from the cluster's security groups.
+
       remediation:
         - id: console
           desc: |
@@ -5406,6 +6081,37 @@ queries:
         - Prevents unauthorized access by restricting direct exposure to the internet.
         - Enhances database security by enforcing private networking best practices.
         - Ensures compliance with regulatory and cloud security standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the RDS console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select an RDS instance and open the **Connectivity & security** tab.
+        4. Locate the **Publicly accessible** field.
+
+        A passing instance shows **Not publicly accessible** (or the flag is set to No). A failing instance shows **Publicly accessible** set to Yes, or is in a subnet whose route table routes `0.0.0.0/0` through an internet gateway.
+
+        ### Audit via CLI
+
+        1. Run the following command to check public accessibility for all RDS instances:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier,PubliclyAccessible:PubliclyAccessible,Engine:Engine}" \
+          --output table
+        ```
+
+        2. For any instance where `PubliclyAccessible` is `true`, also verify the VPC route table does not expose it to the internet:
+
+        ```bash
+        aws ec2 describe-route-tables \
+          --filters "Name=vpc-id,Values=<vpc-id>" \
+          --query "RouteTables[*].Routes[?GatewayId!=null && starts_with(GatewayId, 'igw-') && DestinationCidrBlock=='0.0.0.0/0']" \
+          --output table
+        ```
+
+        A passing instance returns `"PubliclyAccessible": false`, or if `true`, has no internet gateway route (`igw-`) with destination `0.0.0.0/0` in its VPC. A failing instance returns `"PubliclyAccessible": true` and has an internet-facing route in its VPC.
+
       remediation:
         - id: console
           desc: |
@@ -5574,6 +6280,28 @@ queries:
         - Prevents unauthorized access by restricting internet exposure.
         - Enhances security by ensuring database traffic remains private.
         - Ensures compliance with industry security standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon Redshift console.
+        2. In the left navigation pane, select **Clusters**.
+        3. Select a cluster and open the **Properties** tab.
+        4. Under **Network and security**, locate the **Publicly accessible** field.
+
+        A passing cluster shows **No** for Publicly accessible. A failing cluster shows **Yes**.
+
+        ### Audit via CLI
+
+        1. Run the following command to check the public accessibility of all Redshift clusters:
+
+        ```bash
+        aws redshift describe-clusters \
+          --query "Clusters[*].{ClusterIdentifier:ClusterIdentifier,PubliclyAccessible:PubliclyAccessible,VpcId:VpcId}" \
+          --output table
+        ```
+
+        A passing cluster returns `"PubliclyAccessible": false`. A failing cluster returns `"PubliclyAccessible": true`.
+
       remediation:
         - id: console
           desc: |
@@ -5734,6 +6462,28 @@ queries:
         - **Data exposure prevention:** Ensures volumes containing sensitive data are destroyed with the instance, eliminating the orphaned volume attack surface.
         - **Attack surface reduction:** Reduces the number of discoverable resources an attacker with compromised IAM credentials can exploit.
         - **Security hygiene:** Prevents accumulation of unmonitored volumes that may contain unencrypted sensitive data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console.
+        2. In the left navigation pane, select **Instances**.
+        3. Select an instance and open the **Storage** tab.
+        4. Under **Block devices**, review the **Delete on termination** column for each attached volume.
+
+        A passing instance shows **Yes** in the Delete on termination column for all attached EBS volumes. A failing instance shows **No** for at least one attached volume.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all instances and their block device mappings, filtering for volumes where delete-on-termination is disabled:
+
+        ```bash
+        aws ec2 describe-instances \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,Volumes:BlockDeviceMappings[?Ebs.DeleteOnTermination==\`false\`].{Device:DeviceName,VolumeId:Ebs.VolumeId}}" \
+          --output json
+        ```
+
+        A passing instance returns an empty `Volumes` array (no volumes with `DeleteOnTermination: false`). A failing instance returns one or more entries in the `Volumes` array showing volumes configured to persist after termination.
+
       remediation:
         - id: console
           desc: |
@@ -5884,6 +6634,25 @@ queries:
         - **Data Security:** Prevents unauthorized access to potentially sensitive EBS snapshot data.
         - **Compliance:** Helps maintain compliance with security frameworks such as GDPR, HIPAA, and SOC 2.
         - **Operational Control:** Ensures that data is shared only with intended AWS accounts or users.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Elastic Block Store**, choose **Snapshots**.
+        3. In the filter bar, select **Owned by me** to show only your account's snapshots.
+        4. Examine the **Permissions** column. Any snapshot showing **Public** is accessible by all AWS accounts.
+
+        A passing snapshot shows **Private** in the Permissions column. A failing snapshot shows **Public**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all snapshots owned by your account that are publicly accessible:
+
+        ```bash
+        aws ec2 describe-snapshots --owner-ids self --query "Snapshots[?Public==\`true\`].{SnapshotId:SnapshotId,Description:Description}" --output table
+        ```
+
+        A passing account returns an empty list. A failing account returns one or more snapshot IDs with `Public` set to `true`.
       remediation:
         - id: console
           desc: |
@@ -6005,6 +6774,25 @@ queries:
         - **Data Security:** Protects backup data at rest from unauthorized access.
         - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
         - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Elastic Block Store**, choose **Snapshots**.
+        3. Select **Owned by me** from the filter bar.
+        4. Review the **Encrypted** column for each snapshot.
+
+        A passing snapshot shows **Encrypted** set to **Yes**. A failing snapshot shows **No** in the Encrypted column.
+
+        ### Audit via CLI
+
+        1. List all snapshots owned by the account and check their encryption status:
+
+        ```bash
+        aws ec2 describe-snapshots --owner-ids self --query "Snapshots[*].{SnapshotId:SnapshotId,Encrypted:Encrypted}" --output table
+        ```
+
+        A passing snapshot shows `Encrypted: true`. A failing snapshot shows `Encrypted: false`.
       remediation:
         - id: console
           desc: |
@@ -6207,6 +6995,24 @@ queries:
         - **Data Security:** Protects data at rest from unauthorized access.
         - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
         - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Elastic Block Store**, choose **Volumes**.
+        3. Review the **Encrypted** column for each volume that is in the **in-use** state.
+
+        A passing volume shows **Yes** in the Encrypted column. A failing volume shows **No**.
+
+        ### Audit via CLI
+
+        1. List all EBS volumes and their encryption status:
+
+        ```bash
+        aws ec2 describe-volumes --query "Volumes[?State=='in-use'].{VolumeId:VolumeId,Encrypted:Encrypted,State:State}" --output table
+        ```
+
+        A passing volume shows `Encrypted: true`. A failing volume shows `Encrypted: false`.
       remediation:
         - id: console
           desc: |
@@ -6467,6 +7273,25 @@ queries:
         - **Access Auditing:** All key usage is logged in CloudTrail, enabling detection of unauthorized access attempts.
         - **Key Rotation:** Supports automatic annual rotation of KMS keys to limit the blast radius of a compromised key.
         - **Regulatory Compliance:** Meets encryption key management requirements for PCI DSS, HIPAA, SOC 2, and NIST frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Elastic Block Store**, choose **Volumes**.
+        3. Select a volume and view the **Details** tab.
+        4. Check the **KMS key ID** field. Volumes using KMS encryption show a KMS key ARN. Volumes using default AWS-managed EBS encryption (sse-ebs) show no KMS key or the default AWS-managed EBS key with no customer control.
+
+        A passing volume shows a customer-managed or AWS KMS key ARN in the KMS key ID field. A failing volume shows an empty KMS key ID or the default sse-ebs encryption.
+
+        ### Audit via CLI
+
+        1. List all in-use EBS volumes and their KMS key assignments:
+
+        ```bash
+        aws ec2 describe-volumes --query "Volumes[?State=='in-use'].{VolumeId:VolumeId,Encrypted:Encrypted,KmsKeyId:KmsKeyId,SseType:SseType}" --output table
+        ```
+
+        A passing volume shows a non-empty `KmsKeyId` and `SseType` of `sse-kms`. A failing volume shows an empty `KmsKeyId` or `SseType` of `sse-ebs`.
       remediation:
         - id: console
           desc: |
@@ -6653,6 +7478,25 @@ queries:
         - **Data Security:** Protects data at rest from unauthorized access.
         - **Regulatory Compliance:** Helps meet compliance requirements for data protection and privacy.
         - **Centralized Key Management:** Uses AWS KMS for key lifecycle management, auditing, and fine-grained access control.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EFS console at https://console.aws.amazon.com/efs/.
+        2. Choose **File systems** in the left navigation pane.
+        3. Select a file system and open the **General** tab.
+        4. Check the **Encrypted** field and the **KMS key** field. Encryption must be enabled and a KMS key must be assigned.
+
+        A passing file system shows **Encrypted: Yes** and a KMS key ARN. A failing file system shows **Encrypted: No** or shows encryption enabled with no KMS key.
+
+        ### Audit via CLI
+
+        1. List all EFS file systems with their encryption status and KMS key configuration:
+
+        ```bash
+        aws efs describe-file-systems --query "FileSystems[*].{FileSystemId:FileSystemId,Encrypted:Encrypted,KmsKeyId:KmsKeyId}" --output table
+        ```
+
+        A passing file system shows `Encrypted: true` and a non-empty `KmsKeyId`. A failing file system shows `Encrypted: false` or an empty `KmsKeyId`.
       remediation:
         - id: console
           desc: |
@@ -6814,6 +7658,31 @@ queries:
         - **Data Security:** Ensures sensitive log data is encrypted at rest.
         - **Regulatory Compliance:** Helps meet security and compliance standards such as GDPR, HIPAA, PCI DSS, and SOC 2.
         - **Access Control:** Provides better control over encryption keys, including key rotation and access permissions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the CloudWatch console at https://console.aws.amazon.com/cloudwatch/.
+        2. In the left navigation pane, choose **Log groups**.
+        3. Select a log group and review the **Details** pane.
+        4. Check the **KMS key ID** field. The key must be present and must belong to a customer-managed key (not an AWS-managed key).
+
+        A passing log group shows a customer-managed KMS key ARN in the KMS key ID field. A failing log group shows no KMS key ID or an AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all CloudWatch log groups and their associated KMS keys:
+
+        ```bash
+        aws logs describe-log-groups --query "logGroups[*].{LogGroupName:logGroupName,KmsKeyId:kmsKeyId}" --output table
+        ```
+
+        2. For each log group that has a KMS key, verify the key is customer-managed:
+
+        ```bash
+        aws kms describe-key --key-id <kms-key-id> --query "KeyMetadata.{KeyManager:KeyManager,KeyId:KeyId}"
+        ```
+
+        A passing log group shows a non-empty `KmsKeyId` whose key has `KeyManager: CUSTOMER`. A failing log group shows an empty `KmsKeyId` or a key with `KeyManager: AWS`.
       remediation:
         - id: console
           desc: |
@@ -6973,6 +7842,26 @@ queries:
         - **Data Protection:** Ensures sensitive data is properly encrypted in transit using strong protocols and ciphers.
         - **Security Posture:** Prevents exploitation of known vulnerabilities in outdated TLS versions and weak cipher suites.
         - **Regulatory Compliance:** Helps meet requirements for secure data transmission in various compliance frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Load Balancing**, choose **Load Balancers**.
+        3. Select an Application Load Balancer and open the **Listeners** tab.
+        4. For each HTTPS listener, check the **Security policy** column.
+        5. Confirm the policy is one of the approved secure policies: `ELBSecurityPolicy-TLS13-1-2-2021-06`, `ELBSecurityPolicy-TLS13-1-3-2021-06`, `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`, or `ELBSecurityPolicy-FS-1-2-Res-2020-10`.
+
+        A passing listener shows one of the approved TLS policy names. A failing listener shows a deprecated or less-secure policy name such as `ELBSecurityPolicy-2016-08` or `ELBSecurityPolicy-TLS-1-1-2017-01`.
+
+        ### Audit via CLI
+
+        1. List all load balancers and retrieve their listener configurations to check TLS policies:
+
+        ```bash
+        aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text | tr '\t' '\n' | xargs -I {} aws elbv2 describe-listeners --load-balancer-arn {} --query "Listeners[*].{LoadBalancerArn:LoadBalancerArn,ListenerArn:ListenerArn,Protocol:Protocol,SslPolicy:SslPolicy}" --output table
+        ```
+
+        A passing HTTPS listener shows `SslPolicy` set to one of the approved policy names. A failing listener shows an unapproved or legacy policy name.
       remediation:
         - id: console
           desc: |
@@ -7165,6 +8054,25 @@ queries:
         - **Data Confidentiality:** Encrypts communications to prevent unauthorized access to sensitive information.
         - **Authentication Protection:** Secures user credentials and session information from being intercepted.
         - **Trust and Compliance:** Builds user trust and satisfies regulatory requirements for protecting data in transit.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Load Balancing**, choose **Load Balancers**.
+        3. Select an Application Load Balancer and open the **Listeners** tab.
+        4. Review the **Protocol** column for each listener. Confirm that all listeners use **HTTPS**, or that any **HTTP** listeners are configured with a redirect action to HTTPS.
+
+        A passing load balancer shows all listeners using the HTTPS protocol (or HTTP with a redirect to HTTPS). A failing load balancer shows one or more HTTP listeners that forward traffic directly without redirecting to HTTPS.
+
+        ### Audit via CLI
+
+        1. Retrieve listeners for all load balancers and check their protocols:
+
+        ```bash
+        aws elbv2 describe-load-balancers --query "LoadBalancers[*].LoadBalancerArn" --output text | tr '\t' '\n' | xargs -I {} aws elbv2 describe-listeners --load-balancer-arn {} --query "Listeners[*].{Protocol:Protocol,Port:Port,DefaultActions:DefaultActions}" --output json
+        ```
+
+        A passing load balancer returns only listeners with `Protocol: HTTPS` or HTTP listeners whose `DefaultActions` include a redirect to HTTPS. A failing load balancer returns an HTTP listener with a `forward` action and no HTTPS redirect.
       remediation:
         - id: console
           desc: |
@@ -7391,6 +8299,25 @@ queries:
         - **Security Monitoring:** Provides visibility into potential attacks, such as SQL injection attempts or cross-site scripting.
         - **Compliance Documentation:** Helps meet regulatory requirements for maintaining audit trails of system access.
         - **Operational Intelligence:** Allows analysis of traffic patterns, error rates, and client behaviors to improve application performance.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Load Balancing**, choose **Load Balancers**.
+        3. Select an Application Load Balancer and open the **Attributes** tab.
+        4. Under **Monitoring**, check the **Access logs** setting. Confirm that **Access logs** is set to **Enabled** and that an S3 bucket is specified.
+
+        A passing load balancer shows **Access logs: Enabled** with an S3 bucket destination. A failing load balancer shows **Access logs: Disabled**.
+
+        ### Audit via CLI
+
+        1. Retrieve the attributes for a load balancer and check the access log settings:
+
+        ```bash
+        aws elbv2 describe-load-balancer-attributes --load-balancer-arn <load-balancer-arn> --query "Attributes[?Key=='access_logs.s3.enabled' || Key=='access_logs.s3.bucket']" --output table
+        ```
+
+        A passing load balancer returns `Key: access_logs.s3.enabled` with `Value: true` and a non-empty `access_logs.s3.bucket`. A failing load balancer returns `Value: false` for `access_logs.s3.enabled`.
       remediation:
         - id: console
           desc: |
@@ -7629,6 +8556,25 @@ queries:
         - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), increasing detection opportunity.
         - **Security configuration preservation:** Protects WAF associations, TLS settings, and logging configurations from being destroyed.
         - **Defense in depth:** Complements IAM policies by adding resource-level protection against credential compromise scenarios.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the EC2 console at https://console.aws.amazon.com/ec2/.
+        2. In the left navigation pane, under **Load Balancing**, choose **Load Balancers**.
+        3. Select an Application Load Balancer and open the **Attributes** tab.
+        4. Under **Configuration**, check the **Deletion protection** setting.
+
+        A passing load balancer shows **Deletion protection: Enabled**. A failing load balancer shows **Deletion protection: Disabled**.
+
+        ### Audit via CLI
+
+        1. Retrieve load balancer attributes and check the deletion protection setting:
+
+        ```bash
+        aws elbv2 describe-load-balancer-attributes --load-balancer-arn <load-balancer-arn> --query "Attributes[?Key=='deletion_protection.enabled']" --output table
+        ```
+
+        A passing load balancer returns `Key: deletion_protection.enabled` with `Value: true`. A failing load balancer returns `Value: false`.
       remediation:
         - id: console
           desc: |
@@ -7783,6 +8729,25 @@ queries:
         - Prevents unauthorized access by ensuring all stored data is encrypted.
         - Enhances compliance with industry security frameworks requiring encryption at rest.
         - Improves security posture by integrating AWS KMS for key management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon OpenSearch Service (formerly Elasticsearch Service) console at https://console.aws.amazon.com/aos/.
+        2. In the left navigation pane, choose **Domains**.
+        3. Select a domain and open the **Security** tab.
+        4. Under **Encryption**, check the **Encryption at rest** field.
+
+        A passing domain shows **Encryption at rest: Enabled**. A failing domain shows **Encryption at rest: Disabled**.
+
+        ### Audit via CLI
+
+        1. Check the encryption-at-rest configuration for a specific Elasticsearch domain:
+
+        ```bash
+        aws es describe-elasticsearch-domain --domain-name <domain-name> --query "DomainStatus.EncryptionAtRestOptions"
+        ```
+
+        A passing domain returns `{"Enabled": true, "KmsKeyId": "..."}`. A failing domain returns `{"Enabled": false}`.
       remediation:
         - id: console
           desc: |
@@ -7943,6 +8908,25 @@ queries:
         - **Internal traffic protection:** Encrypts all communication between nodes within the Elasticsearch cluster.
         - **Defense in depth:** Adds an encryption layer beyond VPC-level network isolation.
         - **Compliance:** Meets regulatory requirements for comprehensive encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon OpenSearch Service (formerly Elasticsearch Service) console at https://console.aws.amazon.com/aos/.
+        2. In the left navigation pane, choose **Domains**.
+        3. Select a domain and open the **Security** tab.
+        4. Under **Encryption**, check the **Node-to-node encryption** field.
+
+        A passing domain shows **Node-to-node encryption: Enabled**. A failing domain shows **Node-to-node encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. Check the node-to-node encryption configuration for a specific Elasticsearch domain:
+
+        ```bash
+        aws es describe-elasticsearch-domain --domain-name <domain-name> --query "DomainStatus.NodeToNodeEncryptionOptions"
+        ```
+
+        A passing domain returns `{"Enabled": true}`. A failing domain returns `{"Enabled": false}`.
       remediation:
         - id: console
           desc: |
@@ -8091,6 +9075,31 @@ queries:
         - Reduces key compromise risk by ensuring keys are periodically refreshed.
         - Ensures compliance with security frameworks that mandate key rotation.
         - Improves cryptographic security by limiting key lifespan.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the AWS Key Management Service console at https://console.aws.amazon.com/kms/.
+        2. In the left navigation pane, choose **Customer managed keys**.
+        3. Select a key and open the **Key rotation** tab.
+        4. Check whether **Automatic key rotation** is enabled.
+
+        A passing key shows **Automatic key rotation: Enabled**. A failing key shows **Automatic key rotation: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all customer-managed KMS keys:
+
+        ```bash
+        aws kms list-keys --query "Keys[*].KeyId" --output text
+        ```
+
+        2. For each key, check whether automatic rotation is enabled:
+
+        ```bash
+        aws kms get-key-rotation-status --key-id <key-id> --query "KeyRotationEnabled"
+        ```
+
+        A passing key returns `true`. A failing key returns `false`. Note: this command applies only to symmetric customer-managed keys; it returns an error for AWS-managed keys or asymmetric keys, which can be filtered by checking `KeyMetadata.KeyManager == "CUSTOMER"` and `KeyMetadata.KeySpec == "SYMMETRIC_DEFAULT"` via `aws kms describe-key`.
       remediation:
         - id: console
           desc: |
@@ -8230,6 +9239,25 @@ queries:
         - Prevents unauthorized access to sensitive machine learning data.
         - Ensures compliance with security frameworks that mandate encryption.
         - Improves security posture by leveraging AWS KMS for centralized key management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon SageMaker console at https://console.aws.amazon.com/sagemaker/.
+        2. In the left navigation pane, under **Notebook**, choose **Notebook instances**.
+        3. Select a notebook instance and review its configuration.
+        4. Under **Permissions and encryption**, check the **Encryption key** field.
+
+        A passing notebook instance shows a KMS key ARN in the Encryption key field. A failing notebook instance shows no encryption key configured.
+
+        ### Audit via CLI
+
+        1. List all SageMaker notebook instances and their KMS key configuration:
+
+        ```bash
+        aws sagemaker list-notebook-instances --query "NotebookInstances[*].{Name:NotebookInstanceName,KmsKeyId:KmsKeyId}" --output table
+        ```
+
+        A passing notebook instance shows a non-empty `KmsKeyId`. A failing notebook instance shows an empty or null `KmsKeyId`.
       remediation:
         - id: console
           desc: |
@@ -8387,6 +9415,25 @@ queries:
         - **Log Integrity:** Provides cryptographic assurance that logs have not been modified since they were delivered by CloudTrail.
         - **Forensic Readiness:** Ensures reliable evidence for security incident investigations and dispute resolution.
         - **Compliance Validation:** Helps meet regulatory requirements for tamper-evident logging mechanisms.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the CloudTrail console at https://console.aws.amazon.com/cloudtrail/.
+        2. In the left navigation pane, choose **Trails**.
+        3. Select a trail and review its configuration.
+        4. Under **General details**, check the **Log file validation** field.
+
+        A passing trail shows **Log file validation: Enabled**. A failing trail shows **Log file validation: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all CloudTrail trails and check whether log file validation is enabled:
+
+        ```bash
+        aws cloudtrail describe-trails --query "trailList[*].{Name:Name,LogFileValidationEnabled:LogFileValidationEnabled,HomeRegion:HomeRegion}" --output table
+        ```
+
+        A passing trail shows `LogFileValidationEnabled: true`. A failing trail shows `LogFileValidationEnabled: false`.
       remediation:
         - id: console
           desc: |
@@ -8601,6 +9648,25 @@ queries:
         - Prevents unauthorized access to audit logs by enforcing encryption.
         - Enhances security posture by integrating AWS KMS for key management.
         - Ensures compliance with industry security frameworks requiring encryption at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the CloudTrail service.
+        2. Select **Trails** in the left navigation panel.
+        3. Click each trail name to open its details.
+        4. In the **Storage location** section, review the **Log file SSE-KMS encryption** field.
+
+        A passing trail shows a KMS key ARN in the **AWS KMS key** field. A failing trail shows **Disabled** or no KMS key configured.
+
+        ### Audit via CLI
+
+        1. List all trails and check for KMS encryption:
+
+        ```bash
+        aws cloudtrail describe-trails --query "trailList[*].{TrailName:Name, KmsKeyId:KmsKeyId}"
+        ```
+
+        A passing trail returns a non-empty `KmsKeyId` value such as `arn:aws:kms:us-east-1:123456789012:key/...`. A failing trail returns `null` or an empty string for `KmsKeyId`.
       remediation:
         - id: console
           desc: |
@@ -8756,6 +9822,25 @@ queries:
         - **Minimize attack surface:** Reduces the number of exposed SSH endpoints.
         - **Ensure least privilege access:** Restricts access to only authorized IP ranges.
         - **Improve network security:** Protects EC2 instances from unauthorized access.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the EC2 service.
+        2. Select **Security Groups** in the left navigation panel under **Network & Security**.
+        3. For each security group, select the group and review the **Inbound rules** tab.
+        4. Look for any rule where the **Type** is **SSH** (port 22) or the port range includes 22, and the **Source** is **0.0.0.0/0** or **::/0**.
+
+        A passing security group has no inbound rule on port 22 with source `0.0.0.0/0` or `::/0`. A failing security group has an inbound SSH rule allowing unrestricted access from any IP address.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound SSH access:
+
+        ```bash
+        aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?FromPort<=\`22\` && ToPort>=\`22\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId, GroupName:GroupName}"
+        ```
+
+        A passing result returns an empty list `[]`. A failing result returns one or more security group IDs that have unrestricted SSH access.
       remediation:
         - id: console
           desc: |
@@ -8930,6 +10015,25 @@ queries:
         - **Limit exposure:** Restrict VNC access to known IP addresses such as an office VPN or bastion host.
         - **Use encrypted alternatives:** Consider replacing VNC with more secure alternatives like SSH tunneling or AWS Session Manager.
         - **Enhance authentication:** Use strong passwords, multi-factor authentication (MFA), and network segmentation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the EC2 service.
+        2. Select **Security Groups** in the left navigation panel under **Network & Security**.
+        3. For each security group, select the group and review the **Inbound rules** tab.
+        4. Look for any rule where the port range covers 5900-5903 (VNC) and the **Source** is **0.0.0.0/0** or **::/0**.
+
+        A passing security group has no inbound VNC rule (ports 5900-5903) with source `0.0.0.0/0` or `::/0`. A failing security group has an inbound rule allowing unrestricted VNC access.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound VNC access on ports 5900-5903:
+
+        ```bash
+        aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?FromPort<=\`5900\` && ToPort>=\`5903\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId, GroupName:GroupName}"
+        ```
+
+        A passing result returns an empty list `[]`. A failing result returns one or more security group IDs that have unrestricted VNC access.
       remediation:
         - id: console
           desc: |
@@ -9113,6 +10217,25 @@ queries:
         - **Prevent brute-force attacks:** Limits exposure to automated credential-guessing attacks.
         - **Ensure least privilege access:** Only trusted IPs can establish RDP sessions.
         - **Improve security posture:** Protects Windows servers from unauthorized access and exploits.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the EC2 service.
+        2. Select **Security Groups** in the left navigation panel under **Network & Security**.
+        3. For each security group, select the group and review the **Inbound rules** tab.
+        4. Look for any rule where the **Type** is **RDP** (port 3389) and the **Source** is **0.0.0.0/0** or **::/0**.
+
+        A passing security group has no inbound rule on port 3389 with source `0.0.0.0/0` or `::/0`. A failing security group has an inbound RDP rule allowing unrestricted access from any IP address.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound RDP access:
+
+        ```bash
+        aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?FromPort<=\`3389\` && ToPort>=\`3389\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId, GroupName:GroupName}"
+        ```
+
+        A passing result returns an empty list `[]`. A failing result returns one or more security group IDs that have unrestricted RDP access.
       remediation:
         - id: console
           desc: |
@@ -9287,6 +10410,25 @@ queries:
         - Prevents unauthorized access by restricting inbound and outbound traffic.
         - Reduces exposure to external attacks such as brute force or malware injection.
         - Ensures compliance with industry best practices and cloud security standards.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the EC2 service.
+        2. Select **Security Groups** in the left navigation panel under **Network & Security**.
+        3. For each security group, select the group and review the **Inbound rules** tab.
+        4. Look for any rule where the **Protocol** is **All traffic** (protocol `-1`, covering all ports) and the **Source** is **0.0.0.0/0** or **::/0**.
+
+        A passing security group has no catch-all inbound rule (all traffic, all ports) with source `0.0.0.0/0` or `::/0`. A failing security group has an inbound rule that allows all traffic from any IP address.
+
+        ### Audit via CLI
+
+        1. Retrieve inbound rules for all security groups and inspect for open all-traffic rules:
+
+        ```bash
+        aws ec2 describe-security-groups --query "SecurityGroups[?IpPermissions[?IpProtocol=='-1' && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId, GroupName:GroupName}"
+        ```
+
+        A passing result returns an empty list `[]`. A failing result returns one or more security group IDs that allow all inbound traffic from any source.
       remediation:
         - id: console
           desc: |
@@ -9459,6 +10601,26 @@ queries:
       # NOTE (2026-03-29): CLI remediation not included because this is a Terraform-specific check
       # about removing hard-coded credentials from provider blocks. The fix requires editing
       # Terraform configuration files, not running AWS CLI commands.
+      audit: |
+        ### Audit via Console
+
+        This check applies to Terraform configuration files stored in version control, not to live AWS resources. Console-based verification is not applicable.
+
+        1. Review your source code repository for Terraform `provider "aws"` blocks.
+        2. Confirm that no `access_key` or `secret_key` attribute contains a literal credential value (e.g., a string matching the `AKIA...` pattern for access keys).
+        3. Verify that authentication is handled via environment variables, IAM instance roles, AWS profiles, or an `assume_role` block.
+
+        A passing provider block contains no `access_key` or `secret_key` literals. A failing provider block contains a hard-coded credential string in either attribute.
+
+        ### Audit via CLI
+
+        1. Search Terraform HCL files in your repository for hard-coded AWS access key patterns:
+
+        ```bash
+        grep -rE '(access_key|secret_key)\s*=\s*"(AKIA|ABIA|ACCA|ASIA)[A-Z0-9]{16}' .
+        ```
+
+        A passing repository returns no matches. A failing repository returns one or more file paths containing hard-coded credential values.
       remediation:
         - id: console
           desc: |
@@ -9579,6 +10741,32 @@ queries:
         - Protects sensitive API response data by encrypting cached content.
         - Ensures compliance with data protection regulations.
         - Reduces the risk of data breaches from compromised cache storage.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the API Gateway service.
+        2. Select the REST API to inspect.
+        3. Choose the stage to review and click the **Stages** entry in the left panel.
+        4. Select the stage name and navigate to the **Method Settings** tab (or the stage editor).
+        5. For each method, verify that **Enable Method Cache** is checked and **Encrypt cache data** is enabled.
+
+        A passing stage shows **Encrypt cache data** as enabled for all cached methods. A failing stage shows caching disabled or cache encryption not enabled.
+
+        ### Audit via CLI
+
+        1. List all REST APIs, then check each stage's method settings for cache encryption:
+
+        ```bash
+        aws apigateway get-rest-apis --query "items[*].{ApiId:id, Name:name}"
+        ```
+
+        2. For each API ID and stage name, retrieve method settings:
+
+        ```bash
+        aws apigateway get-stage --rest-api-id <rest-api-id> --stage-name <stage-name> --query "methodSettings"
+        ```
+
+        A passing stage returns method settings where `cachingEnabled` is `true` and `cacheDataEncrypted` is `true` for all methods. A failing stage returns `cacheDataEncrypted: false` or `cachingEnabled: false`.
       remediation:
         - id: console
           desc: |
@@ -9713,6 +10901,32 @@ queries:
         - Enables monitoring and alerting on API activity.
         - Supports incident response and forensic investigations.
         - Ensures compliance with audit and logging requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the API Gateway service.
+        2. Select the REST API to inspect.
+        3. Choose **Stages** in the left navigation panel and select the stage.
+        4. Click the **Logs/Tracing** tab.
+        5. Verify that the **CloudWatch Logs** logging level is set to **ERROR** or **INFO**, not **OFF**.
+
+        A passing stage shows a logging level of **ERROR** or **INFO** under CloudWatch Logs. A failing stage shows **OFF** or no logging level configured.
+
+        ### Audit via CLI
+
+        1. List all REST APIs, then check each stage for execution logging:
+
+        ```bash
+        aws apigateway get-rest-apis --query "items[*].{ApiId:id, Name:name}"
+        ```
+
+        2. For each API ID and stage name, check the method-level logging settings:
+
+        ```bash
+        aws apigateway get-stage --rest-api-id <rest-api-id> --stage-name <stage-name> --query "methodSettings.'*/*'.loggingLevel"
+        ```
+
+        A passing stage returns `"INFO"` or `"ERROR"`. A failing stage returns `"OFF"`, `null`, or an empty value.
       remediation:
         - id: console
           desc: |
@@ -9815,6 +11029,38 @@ queries:
         - Prevents unauthorized access to API resources.
         - Reduces the risk of API abuse and denial of service attacks.
         - Ensures compliance with security best practices for API protection.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the API Gateway service.
+        2. Select the REST API to inspect.
+        3. For each resource, select each method (GET, POST, etc.) and click **Method Request**.
+        4. Check the **Authorization** setting. If it is **NONE**, verify that **API Key Required** is set to **true**.
+        5. Repeat for all non-OPTIONS methods.
+
+        A passing method shows an **Authorization** value other than NONE (such as AWS_IAM, COGNITO_USER_POOLS, or CUSTOM), or if NONE then **API Key Required** is enabled. A failing method shows **Authorization: NONE** with **API Key Required** disabled.
+
+        ### Audit via CLI
+
+        1. List all REST APIs:
+
+        ```bash
+        aws apigateway get-rest-apis --query "items[*].{ApiId:id, Name:name}"
+        ```
+
+        2. For each API, list resources and check method authorization:
+
+        ```bash
+        aws apigateway get-resources --rest-api-id <rest-api-id> --query "items[*].{ResourceId:id, Path:path, Methods:resourceMethods}"
+        ```
+
+        3. For each resource and method, retrieve the method details:
+
+        ```bash
+        aws apigateway get-method --rest-api-id <rest-api-id> --resource-id <resource-id> --http-method <http-method> --query "{AuthorizationType:authorizationType, ApiKeyRequired:apiKeyRequired}"
+        ```
+
+        A passing method returns `authorizationType` other than `NONE`, or `apiKeyRequired: true` when `authorizationType` is `NONE`. A failing method returns `authorizationType: NONE` and `apiKeyRequired: false`.
       remediation:
         - id: console
           desc: |
@@ -9960,6 +11206,25 @@ queries:
         - Protects API traffic with strong encryption.
         - Ensures compliance with industry security standards.
         - Prevents exploitation of known TLS vulnerabilities.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the API Gateway service.
+        2. Select **Custom Domain Names** in the left navigation panel.
+        3. Click each custom domain name.
+        4. Review the **Security policy** field in the domain name details.
+
+        A passing custom domain name shows **TLS 1.2** as the security policy. A failing custom domain name shows **TLS 1.0** or **TLS 1.1**.
+
+        ### Audit via CLI
+
+        1. List all API Gateway custom domain names and their security policies:
+
+        ```bash
+        aws apigateway get-domain-names --query "items[*].{DomainName:domainName, SecurityPolicy:securityPolicy}"
+        ```
+
+        A passing custom domain returns `"securityPolicy": "TLS_1_2"`. A failing custom domain returns `"securityPolicy": "TLS_1_0"` or any value other than `TLS_1_2`.
       remediation:
         - id: console
           desc: |
@@ -10100,6 +11365,32 @@ queries:
         - **Attack pattern detection:** Enables identification of injection, brute-force, and enumeration attacks through abnormal request trace analysis.
         - **Incident investigation:** Provides request-level forensic data showing exactly which backend services were affected during an attack.
         - **Anomaly baselining:** Establishes normal API call patterns so that attacker-driven deviations can trigger alerts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the API Gateway service.
+        2. Select the REST API to inspect.
+        3. Choose **Stages** in the left navigation panel and select the stage.
+        4. Click the **Logs/Tracing** tab.
+        5. Verify that **X-Ray Tracing** is enabled.
+
+        A passing stage shows **X-Ray Tracing** as **Enabled**. A failing stage shows **X-Ray Tracing** as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all REST APIs:
+
+        ```bash
+        aws apigateway get-rest-apis --query "items[*].{ApiId:id, Name:name}"
+        ```
+
+        2. For each API ID and stage, check whether X-Ray tracing is enabled:
+
+        ```bash
+        aws apigateway get-stage --rest-api-id <rest-api-id> --stage-name <stage-name> --query "tracingEnabled"
+        ```
+
+        A passing stage returns `true`. A failing stage returns `false`.
       remediation:
         - id: console
           desc: |
@@ -10230,6 +11521,31 @@ queries:
         - Prevents credential leakage through user data exposure.
         - Ensures compliance with security best practices for secret management.
         - Encourages use of secure alternatives like IAM roles, Secrets Manager, or Parameter Store.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the EC2 service.
+        2. Select **Instances** in the left navigation panel.
+        3. Select an instance, click the **Actions** menu, choose **Instance Settings**, and then **View/Change User Data**.
+        4. Review the user data script for any hard-coded AWS access keys (strings matching `AKIA...` or `ASIA...`) or secret key patterns.
+
+        A passing instance contains no user data or user data that does not include any credential strings. A failing instance shows a user data script with a literal AWS access key or secret key embedded in the content.
+
+        ### Audit via CLI
+
+        1. Retrieve user data for each instance and inspect it for credential patterns:
+
+        ```bash
+        aws ec2 describe-instances --query "Reservations[*].Instances[*].InstanceId" --output text
+        ```
+
+        2. For each instance ID, retrieve and decode the user data:
+
+        ```bash
+        aws ec2 describe-instance-attribute --instance-id <instance-id> --attribute userData --query "UserData.Value" --output text | base64 --decode
+        ```
+
+        A passing instance returns empty user data or user data containing no credential strings matching `(AKIA|ABIA|ACCA|ASIA)[A-Z0-9]{16}`. A failing instance returns user data containing a hard-coded AWS access key or secret key.
       remediation:
         - id: console
           desc: |
@@ -10374,6 +11690,33 @@ queries:
         - Enforces the principle of least privilege.
         - Reduces the potential impact of credential compromise.
         - Ensures compliance with security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the IAM service.
+        2. Select **Policies** in the left navigation panel.
+        3. For each customer-managed policy, click the policy name and select the **JSON** tab to review the policy document.
+        4. Check each `Allow` statement: if the `Resource` field contains `"*"` or the `Action` field contains `"*"`, the policy uses wildcards in an Allow statement.
+        5. Wildcard usage in `Deny` statements is acceptable.
+
+        A passing policy has no `Allow` statement with both a wildcard `Action` (`"*"`) and a wildcard `Resource` (`"*"`). A failing policy has one or more `Allow` statements granting wildcard permissions.
+
+        ### Audit via CLI
+
+        1. List all customer-managed, attachable IAM policies:
+
+        ```bash
+        aws iam list-policies --scope Local --only-attached --query "Policies[*].{PolicyArn:Arn, PolicyName:PolicyName}"
+        ```
+
+        2. For each policy ARN, retrieve the default policy version document:
+
+        ```bash
+        aws iam get-policy --policy-arn <policy-arn> --query "Policy.DefaultVersionId"
+        aws iam get-policy-version --policy-arn <policy-arn> --version-id <version-id> --query "PolicyVersion.Document"
+        ```
+
+        A passing policy document contains no `Allow` statement with `"Resource": "*"` and `"Action": "*"` simultaneously. A failing policy document contains one or more such overly permissive `Allow` statements.
       remediation:
         - id: console
           desc: |
@@ -10597,6 +11940,31 @@ queries:
         - Protects against accidental data loss and overwrites.
         - Enables recovery from ransomware attacks.
         - Supports compliance with data retention requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the S3 service.
+        2. Click on the bucket name to open its details.
+        3. Select the **Properties** tab.
+        4. Scroll to the **Bucket Versioning** section and review the status.
+
+        A passing bucket shows **Bucket Versioning: Enabled**. A failing bucket shows **Bucket Versioning: Suspended** or **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all S3 buckets:
+
+        ```bash
+        aws s3api list-buckets --query "Buckets[*].Name" --output text
+        ```
+
+        2. For each bucket, check the versioning status:
+
+        ```bash
+        aws s3api get-bucket-versioning --bucket <bucket-name> --query "Status"
+        ```
+
+        A passing bucket returns `"Enabled"`. A failing bucket returns `"Suspended"`, `null`, or an empty string.
       remediation:
         - id: console
           desc: |
@@ -10736,6 +12104,31 @@ queries:
         - Enables detection of unauthorized access attempts.
         - Supports forensic investigations and incident response.
         - Ensures compliance with audit and logging requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the S3 service.
+        2. Click on the bucket name to open its details.
+        3. Select the **Properties** tab.
+        4. Scroll to the **Server access logging** section and review the status.
+
+        A passing bucket shows **Server access logging: Enabled** with a target bucket configured. A failing bucket shows **Server access logging: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all S3 buckets:
+
+        ```bash
+        aws s3api list-buckets --query "Buckets[*].Name" --output text
+        ```
+
+        2. For each bucket, retrieve the logging configuration:
+
+        ```bash
+        aws s3api get-bucket-logging --bucket <bucket-name> --query "LoggingEnabled.TargetBucket"
+        ```
+
+        A passing bucket returns a non-empty target bucket name. A failing bucket returns `null` or an empty value indicating logging is not configured.
       remediation:
         - id: console
           desc: |
@@ -10881,6 +12274,28 @@ queries:
         - Protects data at rest with strong encryption.
         - Ensures all objects are automatically encrypted.
         - Supports compliance with data protection regulations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the S3 service.
+        2. Select a bucket from the list.
+        3. Open the **Properties** tab.
+        4. Scroll to **Default encryption** and review the **Encryption type** field.
+
+        A passing bucket shows an encryption type of **SSE-S3** or **SSE-KMS** under Default encryption. A failing bucket shows **Disabled** or no encryption rule configured.
+
+        ### Audit via CLI
+
+        1. List all S3 buckets, then check the default encryption configuration for each one:
+
+        ```bash
+        aws s3api get-bucket-encryption \
+          --bucket <bucket-name> \
+          --query "ServerSideEncryptionConfiguration.Rules"
+        ```
+
+        A passing bucket returns a rules array containing an `ApplyServerSideEncryptionByDefault` entry with an `SSEAlgorithm` of `aws:kms` or `AES256`. A failing bucket returns an error (`ServerSideEncryptionConfigurationNotFoundError`) or returns an empty rules list.
+
       remediation:
         - id: console
           desc: |
@@ -11034,6 +12449,28 @@ queries:
         - Prevents unauthorized public access to S3 data.
         - Protects against data breaches and leaks.
         - Ensures compliance with data protection regulations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the S3 service.
+        2. Select the bucket you want to inspect.
+        3. Open the **Permissions** tab.
+        4. Scroll to **Access control list (ACL)** and review the listed grants.
+
+        A passing bucket has no grants for **Everyone (public access)** with **Read** or **Full control** permissions. A failing bucket shows **Everyone (public access)** listed with **Read objects** or **Full control** permissions enabled.
+
+        ### Audit via CLI
+
+        1. Retrieve the ACL for a bucket and check for public read or full-control grants:
+
+        ```bash
+        aws s3api get-bucket-acl \
+          --bucket <bucket-name> \
+          --query "Grants[?Grantee.URI=='http://acs.amazonaws.com/groups/global/AllUsers']"
+        ```
+
+        A passing bucket returns an empty list `[]`. A failing bucket returns one or more grants with `Permission` set to `READ` or `FULL_CONTROL`.
+
       remediation:
         - id: console
           desc: |
@@ -11173,6 +12610,27 @@ queries:
         - Prevents accidental exposure of sensitive data through public website endpoints.
         - Reduces the attack surface by eliminating unnecessary public-facing services.
         - Ensures compliance with data protection and access control requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the S3 service.
+        2. Select the bucket you want to inspect.
+        3. Open the **Properties** tab.
+        4. Scroll to **Static website hosting** and read the status.
+
+        A passing bucket shows **Static website hosting: Disabled**. A failing bucket shows **Static website hosting: Enabled** along with a bucket website endpoint URL.
+
+        ### Audit via CLI
+
+        1. Check whether a bucket has a website configuration:
+
+        ```bash
+        aws s3api get-bucket-website \
+          --bucket <bucket-name>
+        ```
+
+        A passing bucket returns an error: `NoSuchWebsiteConfiguration`. A failing bucket returns a JSON object containing `IndexDocument` or `ErrorDocument` keys, indicating website hosting is active.
+
       remediation:
         - id: console
           desc: |
@@ -11288,6 +12746,35 @@ queries:
         - **Complete audit coverage:** All API activity across every region is captured in a single trail.
         - **Threat detection:** Enables detection of unauthorized activity in regions that are not commonly used.
         - **Compliance:** Meets CIS AWS Foundations Benchmark 3.1 and other regulatory requirements for comprehensive logging.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the CloudTrail service.
+        2. In the left navigation pane, select **Trails**.
+        3. Review the **Multi-region trail** column for each trail.
+        4. Select a trail and confirm that **Multi-region trail** is set to **Yes** and that **Logging** status shows **Enabled**.
+
+        A passing trail shows **Multi-region trail: Yes** and **Logging: Enabled**. A failing account has no trail with both properties set, or all existing trails show **Multi-region trail: No**.
+
+        ### Audit via CLI
+
+        1. List all trails and check for a multi-region trail that is actively logging:
+
+        ```bash
+        aws cloudtrail describe-trails \
+          --query "trailList[*].{Name:Name,IsMultiRegion:IsMultiRegionTrail,HomeRegion:HomeRegion}"
+        ```
+
+        2. For each trail returned with `IsMultiRegion: true`, confirm it is logging:
+
+        ```bash
+        aws cloudtrail get-trail-status \
+          --name <trail-name> \
+          --query "{IsLogging:IsLogging}"
+        ```
+
+        A passing account has at least one trail with `IsMultiRegionTrail: true` and `IsLogging: true`. A failing account has no such trail, or every trail shows `IsMultiRegionTrail: false` or `IsLogging: false`.
+
       remediation:
         - id: console
           desc: |
@@ -11434,6 +12921,27 @@ queries:
         - **Data protection:** Prevents eavesdropping on traffic between viewers and CloudFront edge locations.
         - **MITM prevention:** Eliminates the risk of content being modified in transit by attackers.
         - **Compliance:** Meets regulatory requirements for encryption in transit.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the CloudFront service.
+        2. Select a distribution from the list.
+        3. Open the **Behaviors** tab.
+        4. Review the **Viewer protocol policy** column for each cache behavior.
+
+        A passing distribution shows **Redirect HTTP to HTTPS** or **HTTPS only** for every cache behavior. A failing distribution shows **HTTP and HTTPS** (allow-all) for any behavior.
+
+        ### Audit via CLI
+
+        1. List all CloudFront distributions, then check the viewer protocol policy for each one:
+
+        ```bash
+        aws cloudfront list-distributions \
+          --query "DistributionList.Items[*].{Id:Id,ViewerProtocolPolicy:DefaultCacheBehavior.ViewerProtocolPolicy}"
+        ```
+
+        A passing distribution returns `redirect-to-https` or `https-only` in the `ViewerProtocolPolicy` field. A failing distribution returns `allow-all`.
+
       remediation:
         - id: console
           desc: |
@@ -11620,6 +13128,28 @@ queries:
         - **Threat detection:** Enables detection of unauthorized API calls, privilege escalation attempts, and suspicious authentication activity.
         - **Forensic capability:** Provides detailed audit trail for incident investigation and response.
         - **Compliance:** Meets CIS EKS Benchmark and regulatory requirements for logging security events.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon EKS service.
+        2. Select **Clusters** in the left navigation pane and choose a cluster.
+        3. Open the **Observability** tab.
+        4. Review the **Control plane logging** section to see which log types are enabled.
+
+        A passing cluster has at least one log type (and ideally all five: API server, Audit, Authenticator, Controller manager, Scheduler) shown as **Enabled**. A failing cluster shows all log types as **Disabled**.
+
+        ### Audit via CLI
+
+        1. Check the control plane logging configuration for an EKS cluster:
+
+        ```bash
+        aws eks describe-cluster \
+          --name <cluster-name> \
+          --query "cluster.logging.clusterLogging"
+        ```
+
+        A passing cluster returns at least one entry with `"enabled": true` in the `clusterLogging` array. A failing cluster returns an empty array, null, or an array where every entry has `"enabled": false`.
+
       remediation:
         - id: console
           desc: |
@@ -11781,6 +13311,28 @@ queries:
         - Prevents unauthorized access by ensuring all stored data is encrypted.
         - Enhances compliance with industry security frameworks requiring encryption at rest.
         - Improves security posture by integrating AWS KMS for key management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** in the left navigation pane and choose a domain.
+        3. Open the **Security** tab.
+        4. Review the **Encryption at rest** field.
+
+        A passing domain shows **Encryption at rest: Enabled**. A failing domain shows **Encryption at rest: Disabled**.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption-at-rest settings for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.EncryptionAtRestOptions"
+        ```
+
+        A passing domain returns `{"Enabled": true, ...}`. A failing domain returns `{"Enabled": false}` or does not include the `EncryptionAtRestOptions` key.
+
       remediation:
         - id: console
           desc: |
@@ -11942,6 +13494,28 @@ queries:
         - **Data protection:** Encrypts all communication between clients and the OpenSearch cluster.
         - **Credential security:** Prevents exposure of authentication tokens and API keys in transit.
         - **Compliance:** Aligns with AWS Security Hub, CIS, and regulatory requirements for encryption in transit.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Security** tab.
+        4. Review the **Domain endpoint options** section for the **Require HTTPS** setting.
+
+        A passing domain shows **Require HTTPS: Enabled**. A failing domain shows **Require HTTPS: Disabled**.
+
+        ### Audit via CLI
+
+        1. Check whether HTTPS is enforced for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.DomainEndpointOptions.EnforceHTTPS"
+        ```
+
+        A passing domain returns `true`. A failing domain returns `false` or does not include the `EnforceHTTPS` key.
+
       remediation:
         - id: console
           desc: |
@@ -12087,6 +13661,28 @@ queries:
         - **Internal traffic protection:** Encrypts all communication between nodes within the OpenSearch cluster.
         - **Defense in depth:** Adds an encryption layer beyond VPC-level network isolation.
         - **Compliance:** Meets AWS Security Hub and regulatory requirements for comprehensive encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Security** tab.
+        4. Review the **Node-to-node encryption** field.
+
+        A passing domain shows **Node-to-node encryption: Enabled**. A failing domain shows **Node-to-node encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. Check whether node-to-node encryption is enabled for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.NodeToNodeEncryptionOptions.Enabled"
+        ```
+
+        A passing domain returns `true`. A failing domain returns `false` or does not include the `NodeToNodeEncryptionOptions` key.
+
       remediation:
         - id: console
           desc: |
@@ -12232,6 +13828,28 @@ queries:
         - **Protocol security:** Eliminates use of deprecated TLS versions with known vulnerabilities.
         - **Cipher strength:** TLS 1.2+ policies enforce the use of strong cipher suites.
         - **Compliance:** Meets PCI DSS, HIPAA, and other regulatory requirements for encryption protocols.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Security** tab.
+        4. Review the **Domain endpoint options** section for the **TLS security policy** setting.
+
+        A passing domain shows a TLS security policy of **Policy-Min-TLS-1-2-2019-07** or a newer equivalent. A failing domain shows **Policy-Min-TLS-1-0-2019-07** or any policy that permits TLS 1.0 or 1.1.
+
+        ### Audit via CLI
+
+        1. Check the TLS security policy configured for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.DomainEndpointOptions.TLSSecurityPolicy"
+        ```
+
+        A passing domain returns a policy name matching `Policy-Min-TLS-1-2-*` (for example, `Policy-Min-TLS-1-2-2019-07`). A failing domain returns `Policy-Min-TLS-1-0-2019-07` or a value that does not enforce TLS 1.2 as the minimum.
+
       remediation:
         - id: console
           desc: |
@@ -12379,6 +13997,28 @@ queries:
         - **Least privilege:** Enables restricting users to specific indices, documents, and fields.
         - **Data isolation:** Prevents unauthorized access to sensitive data within shared domains.
         - **Audit capability:** Provides detailed logging of who accessed what data and when.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Security** tab.
+        4. Review the **Fine-grained access control** section.
+
+        A passing domain shows **Fine-grained access control: Enabled**. A failing domain shows **Fine-grained access control: Disabled**.
+
+        ### Audit via CLI
+
+        1. Check whether fine-grained access control (advanced security options) is enabled for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.AdvancedSecurityOptions.Enabled"
+        ```
+
+        A passing domain returns `true`. A failing domain returns `false` or does not include the `AdvancedSecurityOptions` key.
+
       remediation:
         - id: console
           desc: |
@@ -12549,6 +14189,28 @@ queries:
         - **Threat detection:** Enables detection of unauthorized access attempts and anomalous query patterns.
         - **Forensic readiness:** Provides detailed audit trail for incident investigation and response.
         - **Compliance:** Meets regulatory requirements for access logging and monitoring.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Logs** tab.
+        4. Review the log types listed and check whether **Audit logs** shows a CloudWatch log group destination and a status of **Enabled**.
+
+        A passing domain shows **Audit logs: Enabled** with a CloudWatch log group configured. A failing domain shows **Audit logs: Disabled** or no audit log entry.
+
+        ### Audit via CLI
+
+        1. Check the log publishing options for an OpenSearch domain and look for the AUDIT_LOGS key:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.LogPublishingOptions.AUDIT_LOGS"
+        ```
+
+        A passing domain returns an object with `"Enabled": true` and a `CloudWatchLogsLogGroupArn` value. A failing domain returns `null`, an empty response, or an object with `"Enabled": false`.
+
       remediation:
         - id: console
           desc: |
@@ -12708,6 +14370,28 @@ queries:
         - **Network isolation:** Restricts access to the domain to resources within the VPC or connected networks.
         - **Defense in depth:** Enables use of security groups and NACLs as additional access control mechanisms.
         - **Reduced attack surface:** Eliminates direct internet exposure of the OpenSearch endpoint.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Network** tab (or review the **General information** section).
+        4. Check the **Network access** field to determine whether the domain is configured for **VPC access** or **Public access**.
+
+        A passing domain shows **Network access: VPC** with subnet IDs and security group IDs listed. A failing domain shows **Network access: Public**.
+
+        ### Audit via CLI
+
+        1. Check the VPC configuration for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.VPCOptions"
+        ```
+
+        A passing domain returns an object containing `SubnetIds` and `SecurityGroupIds`. A failing domain returns `null` or an empty object, indicating the domain is using a public endpoint.
+
       remediation:
         - id: console
           desc: |
@@ -12865,6 +14549,28 @@ queries:
         - **Authentication enforcement:** Ensures all requests to the domain must be authenticated.
         - **Data protection:** Prevents unauthorized users from accessing indexed data.
         - **Access control integrity:** Ensures fine-grained access control policies are applied to all requests.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon OpenSearch Service.
+        2. Select **Domains** and choose a domain.
+        3. Open the **Security** tab.
+        4. Under **Fine-grained access control**, check the **Anonymous auth** setting.
+
+        A passing domain shows **Anonymous auth: Disabled**. A failing domain shows **Anonymous auth: Enabled**.
+
+        ### Audit via CLI
+
+        1. Check whether anonymous authentication is enabled for an OpenSearch domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.AdvancedSecurityOptions.AnonymousAuthEnabled"
+        ```
+
+        A passing domain returns `false` or `null` (anonymous auth not enabled). A failing domain returns `true`.
+
       remediation:
         - id: console
           desc: |
@@ -13016,6 +14722,26 @@ queries:
         - **Early detection:** Identifies vulnerabilities before images are deployed to production.
         - **Automated security:** Eliminates reliance on manual scanning processes.
         - **Compliance:** Meets regulatory requirements for container image vulnerability management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon ECR service.
+        2. Select **Repositories** in the left navigation pane.
+        3. Review the **Scan on push** column in the repository list, or select a repository and open its **Settings** tab.
+
+        A passing repository shows **Scan on push: Enabled**. A failing repository shows **Scan on push: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all private ECR repositories and their scan-on-push settings:
+
+        ```bash
+        aws ecr describe-repositories \
+          --query "repositories[*].{Name:repositoryName,ScanOnPush:imageScanningConfiguration.scanOnPush}"
+        ```
+
+        A passing repository returns `"ScanOnPush": true`. A failing repository returns `"ScanOnPush": false` or omits the field.
+
       remediation:
         - id: console
           desc: |
@@ -13158,6 +14884,27 @@ queries:
         - **Supply chain security:** Prevents tag overwrites that could introduce malicious code.
         - **Deployment integrity:** Ensures tags always reference the same image content.
         - **Auditability:** Maintains a reliable history of what was deployed.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ECR**.
+        2. In the left navigation pane, select **Repositories** (under the appropriate registry: Private or Public).
+        3. For each repository, select the repository name, then choose **Edit**.
+        4. Locate the **Tag immutability** setting.
+
+        A passing repository shows **Enabled** for Tag immutability. A failing repository shows **Disabled** or no value set.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all private repositories and their tag mutability setting:
+
+        ```bash
+        aws ecr describe-repositories \
+          --query "repositories[*].{Name:repositoryName,TagImmutability:imageTagMutability}"
+        ```
+
+        A passing repository returns `"TagImmutability": "IMMUTABLE"`. A failing repository returns `"TagImmutability": "MUTABLE"`.
+
       remediation:
         - id: console
           desc: |
@@ -13292,6 +15039,31 @@ queries:
         - **Container isolation:** Maintains the security boundary between the container and the host system.
         - **Blast radius reduction:** Limits the impact of a container compromise to the container itself.
         - **Compliance:** Meets CIS Docker Benchmark and container security best practices.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ECS**.
+        2. In the left navigation pane, select **Task definitions**.
+        3. For each active task definition, select the task definition name, then open the latest revision.
+        4. For each container listed under **Container definitions**, select the container name and review the **Linux parameters** section.
+        5. Check whether the **Privileged** setting is enabled.
+
+        A passing task definition shows **Privileged** as unchecked or `false` for all containers. A failing task definition shows **Privileged** as checked or `true` for one or more containers.
+
+        ### Audit via CLI
+
+        1. Retrieve the list of active task definitions and check the privileged setting for each container:
+
+        ```bash
+        aws ecs list-task-definitions --status ACTIVE \
+          --query "taskDefinitionArns" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws ecs describe-task-definition --task-definition {} \
+          --query "taskDefinition.{Family:family,Containers:containerDefinitions[*].{Name:name,Privileged:privileged}}"
+        ```
+
+        A passing task definition returns `"Privileged": false` or `null` for all containers. A failing task definition returns `"Privileged": true` for one or more containers.
+
       remediation:
         - id: console
           desc: |
@@ -13446,6 +15218,31 @@ queries:
         - **Tamper prevention:** Prevents unauthorized modification of container binaries and configuration.
         - **Malware persistence:** Makes it harder for attackers to establish persistence within a container.
         - **Compliance:** Aligns with CIS Docker Benchmark recommendations and container hardening best practices.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ECS**.
+        2. In the left navigation pane, select **Task definitions**.
+        3. For each active task definition, select the task definition name, then open the latest revision.
+        4. For each container listed under **Container definitions**, select the container name and review the **Storage and logging** section.
+        5. Check whether **Read only root file system** is enabled.
+
+        A passing task definition shows **Read only root file system** as enabled for all containers. A failing task definition shows the setting as disabled or absent for one or more containers.
+
+        ### Audit via CLI
+
+        1. Retrieve active task definitions and check the `readonlyRootFilesystem` field for each container:
+
+        ```bash
+        aws ecs list-task-definitions --status ACTIVE \
+          --query "taskDefinitionArns" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws ecs describe-task-definition --task-definition {} \
+          --query "taskDefinition.{Family:family,Containers:containerDefinitions[*].{Name:name,ReadOnly:readonlyRootFilesystem}}"
+        ```
+
+        A passing task definition returns `"ReadOnly": true` for all containers. A failing task definition returns `"ReadOnly": false` or `null` for one or more containers.
+
       remediation:
         - id: console
           desc: |
@@ -13610,6 +15407,31 @@ queries:
         - **Incident detection:** Enables real-time monitoring and alerting for security events in containers.
         - **Forensics:** Provides detailed logs for investigating security incidents.
         - **Compliance:** Meets regulatory requirements for logging and audit trails.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ECS**.
+        2. In the left navigation pane, select **Task definitions**.
+        3. For each active task definition, select the task definition name, then open the latest revision.
+        4. For each container listed under **Container definitions**, select the container name and review the **Storage and logging** section.
+        5. Verify that a **Log configuration** (for example, `awslogs`) is specified with a log group, region, and stream prefix.
+
+        A passing task definition shows a log configuration defined for every container. A failing task definition has one or more containers with no log configuration set.
+
+        ### Audit via CLI
+
+        1. Retrieve active task definitions and inspect the `logConfiguration` field for each container:
+
+        ```bash
+        aws ecs list-task-definitions --status ACTIVE \
+          --query "taskDefinitionArns" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws ecs describe-task-definition --task-definition {} \
+          --query "taskDefinition.{Family:family,Containers:containerDefinitions[*].{Name:name,LogConfig:logConfiguration}}"
+        ```
+
+        A passing task definition returns a non-null `LogConfig` block for every container. A failing task definition returns `"LogConfig": null` for one or more containers.
+
       remediation:
         - id: console
           desc: |
@@ -13788,6 +15610,29 @@ queries:
         - **Data recovery:** Enables restoration of data from backups in the event of data loss.
         - **Ransomware protection:** Provides a clean recovery point if data is encrypted by ransomware.
         - **Compliance:** Meets regulatory requirements for data protection and business continuity.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EFS**.
+        2. In the left navigation pane, select **File systems**.
+        3. For each file system, select the file system ID, then view the **General** section on the details page.
+        4. Locate the **Automatic backups** row.
+
+        A passing file system shows **Automatic backups** as **Enabled**. A failing file system shows **Automatic backups** as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all EFS file systems, then query the backup policy for each:
+
+        ```bash
+        aws efs describe-file-systems \
+          --query "FileSystems[*].FileSystemId" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws efs describe-backup-policy --file-system-id {}
+        ```
+
+        A passing file system returns `"Status": "ENABLED"` in the `BackupPolicy` object. A failing file system returns `"Status": "DISABLED"`.
+
       remediation:
         - id: console
           desc: |
@@ -13929,6 +15774,32 @@ queries:
         - **Request smuggling prevention:** Eliminates a common attack vector by dropping invalid headers before they reach backend services.
         - **Defense in depth:** Adds an additional security layer at the load balancer level.
         - **Compliance:** Aligns with AWS Security Hub recommendations for ALB security.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **EC2**.
+        2. In the left navigation pane, under **Load Balancing**, select **Load Balancers**.
+        3. Filter to **Application** load balancers.
+        4. For each ALB, select the load balancer name and choose the **Attributes** tab.
+        5. Locate the **Drop invalid header fields** attribute.
+
+        A passing load balancer shows **Drop invalid header fields** as **On** or `true`. A failing load balancer shows the attribute as **Off** or `false`.
+
+        ### Audit via CLI
+
+        1. List all Application Load Balancers, then check the `routing.http.drop_invalid_header_fields.enabled` attribute for each:
+
+        ```bash
+        aws elbv2 describe-load-balancers \
+          --query "LoadBalancers[?Type=='application'].LoadBalancerArn" \
+          --output text | tr '\t' '\n' | \
+          xargs -I {} aws elbv2 describe-load-balancer-attributes \
+          --load-balancer-arn {} \
+          --query "Attributes[?Key=='routing.http.drop_invalid_header_fields.enabled']"
+        ```
+
+        A passing load balancer returns `"Value": "true"`. A failing load balancer returns `"Value": "false"`.
+
       remediation:
         - id: console
           desc: |
@@ -14083,6 +15954,31 @@ queries:
         - **Data exfiltration prevention:** Restricts outbound network access to VPC-controlled paths.
         - **Attack surface reduction:** Eliminates direct internet exposure of the notebook instance.
         - **Network control:** Ensures all traffic flows through VPC endpoints and NAT gateways where it can be monitored and controlled.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Notebook**, select **Notebook instances**.
+        3. For each notebook instance, select the instance name to open the details page.
+        4. Under the **Network** section, locate **Direct internet access**.
+
+        A passing notebook instance shows **Direct internet access** as **Disabled**. A failing notebook instance shows **Direct internet access** as **Enabled**.
+
+        ### Audit via CLI
+
+        1. List all SageMaker notebook instances and check the `DirectInternetAccess` field for each:
+
+        ```bash
+        aws sagemaker list-notebook-instances \
+          --query "NotebookInstances[*].NotebookInstanceName" \
+          --output text | tr '\t' '\n' | \
+          xargs -I {} aws sagemaker describe-notebook-instance \
+          --notebook-instance-name {} \
+          --query "{Name:NotebookInstanceName,DirectInternetAccess:DirectInternetAccess}"
+        ```
+
+        A passing notebook instance returns `"DirectInternetAccess": "Disabled"`. A failing notebook instance returns `"DirectInternetAccess": "Enabled"`.
+
       remediation:
         - id: console
           desc: |
@@ -14235,6 +16131,30 @@ queries:
         - **Attack surface reduction:** Limits who can even attempt to reach the API server.
         - **Defense in depth:** Adds network-level access control on top of Kubernetes RBAC.
         - **Compliance:** Meets security best practices for restricting management plane access.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EKS**.
+        2. In the left navigation pane, select **Clusters**.
+        3. For each cluster, select the cluster name, then choose the **Networking** tab.
+        4. Under **Cluster endpoint access**, locate the **Public access CIDR** list.
+        5. Verify that `0.0.0.0/0` is not present in the list.
+
+        A passing cluster shows public access CIDRs that do not include `0.0.0.0/0`. A failing cluster shows `0.0.0.0/0` in the public access CIDR list.
+
+        ### Audit via CLI
+
+        1. List all EKS clusters, then check the `publicAccessCidrs` setting for each:
+
+        ```bash
+        aws eks list-clusters --query "clusters" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws eks describe-cluster --name {} \
+          --query "cluster.{Name:name,PublicAccessCidrs:resourcesVpcConfig.publicAccessCidrs}"
+        ```
+
+        A passing cluster returns a `PublicAccessCidrs` list that does not contain `"0.0.0.0/0"`. A failing cluster returns `["0.0.0.0/0"]` or includes `"0.0.0.0/0"` in the list.
+
       remediation:
         - id: console
           desc: |
@@ -14399,6 +16319,29 @@ queries:
         - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
         - **Security control preservation:** Protects RBAC, network policies, and admission controllers from being destroyed in a single action.
         - **Incident response window:** The additional step buys time for automated alerting to detect unauthorized modification attempts before the cluster is destroyed.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EKS**.
+        2. In the left navigation pane, select **Clusters**.
+        3. For each cluster, select the cluster name and review the cluster overview page.
+        4. Locate the **Deletion protection** setting.
+
+        A passing cluster shows **Deletion protection** as **Enabled**. A failing cluster shows **Deletion protection** as **Disabled** or not set.
+
+        ### Audit via CLI
+
+        1. List all EKS clusters and check the `deletionProtection` field for each:
+
+        ```bash
+        aws eks list-clusters --query "clusters" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws eks describe-cluster --name {} \
+          --query "cluster.{Name:name,DeletionProtection:deletionProtection}"
+        ```
+
+        A passing cluster returns `"DeletionProtection": true`. A failing cluster returns `"DeletionProtection": false` or `null`.
+
       remediation:
         - id: console
           desc: |
@@ -14544,6 +16487,29 @@ queries:
         - **Build isolation:** Maintains the security boundary between the build container and the underlying host infrastructure.
         - **Blast radius reduction:** Limits the impact of a compromised build to the container itself, preventing lateral movement.
         - **Compliance:** Aligns with CIS AWS Foundations Benchmark and container security best practices that recommend running containers without elevated privileges.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS CodeBuild**.
+        2. In the left navigation pane, select **Build projects**.
+        3. For each project, select the project name, then choose **Edit** > **Environment**.
+        4. Under **Additional configuration**, check whether **Enable this flag if you want to build Docker images or want your builds to get elevated privileges** is selected.
+
+        A passing project shows the privileged mode checkbox as **unchecked**. A failing project shows the checkbox as **checked**.
+
+        ### Audit via CLI
+
+        1. List all CodeBuild projects, then check the `privilegedMode` setting for each:
+
+        ```bash
+        aws codebuild list-projects --query "projects" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws codebuild batch-get-projects --names {} \
+          --query "projects[*].{Name:name,PrivilegedMode:environment.privilegedMode}"
+        ```
+
+        A passing project returns `"PrivilegedMode": false` or `null`. A failing project returns `"PrivilegedMode": true`.
+
       remediation:
         - id: console
           desc: |
@@ -14705,6 +16671,30 @@ queries:
         - **Least privilege access:** Leverages IAM policies to control which builds and users can access specific credentials.
         - **Audit trail:** Provides CloudTrail logging for credential access, enabling detection of unauthorized retrieval.
         - **Compliance:** Meets security framework requirements (CIS, PCI DSS, SOC 2) that mandate secure credential handling.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS CodeBuild**.
+        2. In the left navigation pane, select **Build projects**.
+        3. For each project, select the project name, then choose **Edit** > **Environment**.
+        4. Under **Image pull credentials**, verify that **Custom credentials** reference a Secrets Manager ARN rather than a plaintext value.
+        5. Under **Additional configuration**, review **Environment variables** and confirm that any variable containing a sensitive name (such as PASSWORD, SECRET, KEY, TOKEN, or CREDENTIAL) uses type **Secrets Manager** or **Parameter Store** rather than **Plaintext**.
+
+        A passing project has no environment variables with sensitive names stored as PLAINTEXT and uses CODEBUILD or SERVICE_ROLE for image pull credentials. A failing project has sensitive credentials stored as PLAINTEXT environment variables or uses PLAINTEXT image pull credentials.
+
+        ### Audit via CLI
+
+        1. Retrieve project environment details and check for plaintext credentials:
+
+        ```bash
+        aws codebuild list-projects --query "projects" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws codebuild batch-get-projects --names {} \
+          --query "projects[*].{Name:name,ImagePullCredType:environment.imagePullCredentialsType,PlaintextVars:environment.environmentVariables[?type=='PLAINTEXT']}"
+        ```
+
+        A passing project returns `"ImagePullCredType"` of `"CODEBUILD"` or `"SERVICE_ROLE"` and has no `PlaintextVars` entries whose names match sensitive patterns. A failing project returns `"PLAINTEXT"` image pull credentials or has plaintext environment variables with names matching PASSWORD, SECRET, KEY, TOKEN, or CREDENTIAL.
+
       remediation:
         - id: console
           desc: |
@@ -14941,6 +16931,27 @@ queries:
         - **Data protection:** Ensures all graph data, backups, and snapshots are encrypted using AWS KMS, preventing unauthorized access to stored data.
         - **Compliance:** Meets regulatory requirements for encryption of data at rest in managed database services.
         - **Key management:** Leverages AWS KMS for centralized key management, access control policies, and automatic key rotation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Neptune**.
+        2. In the left navigation pane, select **Databases**.
+        3. For each DB cluster, select the cluster identifier to open the details page.
+        4. Under the **Configuration** tab, locate the **Encryption** row.
+
+        A passing cluster shows **Encryption** as **Enabled**. A failing cluster shows **Encryption** as **Not enabled**.
+
+        ### Audit via CLI
+
+        1. List all Neptune DB clusters and check the `StorageEncrypted` field:
+
+        ```bash
+        aws neptune describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,Encrypted:StorageEncrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        A passing cluster returns `"Encrypted": true`. A failing cluster returns `"Encrypted": false`.
+
       remediation:
         - id: console
           desc: |
@@ -15100,6 +17111,29 @@ queries:
         - **Threat detection:** Continuously monitors for malicious activity including reconnaissance, instance compromise, and account compromise.
         - **Automated analysis:** Uses machine learning to reduce false positives and prioritize findings.
         - **Compliance:** Meets regulatory requirements for continuous security monitoring.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon GuardDuty**.
+        2. Check the service status shown on the GuardDuty overview page.
+        3. Verify that **GuardDuty** is active in the current region.
+        4. Repeat the check for each AWS region in use.
+
+        A passing account shows GuardDuty as **Enabled** with an active detector. A failing account shows the GuardDuty welcome screen prompting activation, or shows the detector as disabled.
+
+        ### Audit via CLI
+
+        1. List all GuardDuty detectors in the current region, then verify each is enabled:
+
+        ```bash
+        aws guardduty list-detectors --query "DetectorIds" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws guardduty get-detector --detector-id {} \
+          --query "{DetectorId:DetectorId,Status:Status}"
+        ```
+
+        A passing account returns at least one detector with `"Status": "ENABLED"`. A failing account returns an empty `DetectorIds` list or returns `"Status": "DISABLED"`.
+
       remediation:
         - id: console
           desc: |
@@ -15231,6 +17265,29 @@ queries:
 
         - **Rapid response:** Ensures security findings are available for review within 15 minutes.
         - **Incident containment:** Reduces the time between threat detection and response.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon GuardDuty**.
+        2. In the left navigation pane, select **Settings**.
+        3. Under **Findings export options**, locate the **Updated findings** publishing frequency.
+        4. Verify the frequency is set to **15 minutes**.
+
+        A passing detector shows a findings publishing frequency of **15 minutes**. A failing detector shows **1 hour** or **6 hours**.
+
+        ### Audit via CLI
+
+        1. List all GuardDuty detectors and check the `FindingPublishingFrequency` for each:
+
+        ```bash
+        aws guardduty list-detectors --query "DetectorIds" --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws guardduty get-detector --detector-id {} \
+          --query "{DetectorId:DetectorId,FindingPublishingFrequency:FindingPublishingFrequency}"
+        ```
+
+        A passing detector returns `"FindingPublishingFrequency": "FIFTEEN_MINUTES"`. A failing detector returns `"ONE_HOUR"` or `"SIX_HOURS"`.
+
       remediation:
         - id: console
           desc: |
@@ -15352,6 +17409,26 @@ queries:
         - **Centralized visibility:** Aggregates findings from multiple security services into a single dashboard.
         - **Automated compliance:** Continuously evaluates your environment against industry standards.
         - **Prioritization:** Normalizes findings using the AWS Security Finding Format (ASFF).
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS Security Hub**.
+        2. Review the Security Hub overview page.
+        3. Verify that Security Hub is active and the security summary is visible.
+        4. Repeat the check for each AWS region in use.
+
+        A passing account shows Security Hub as enabled with a security summary dashboard. A failing account shows the Security Hub welcome page with an option to enable the service.
+
+        ### Audit via CLI
+
+        1. Check whether Security Hub is enabled by describing the hub resource in the current region:
+
+        ```bash
+        aws securityhub describe-hub --query "HubArn"
+        ```
+
+        A passing account returns a `HubArn` value. A failing account returns an error indicating Security Hub is not subscribed or enabled in the region.
+
       remediation:
         - id: console
           desc: |
@@ -15450,6 +17527,28 @@ queries:
         - **Audit trail:** Maintains a complete history of resource configuration changes.
         - **Compliance monitoring:** Enables evaluation of resources against desired configurations.
         - **Incident investigation:** Provides historical data for forensic analysis.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the AWS Config service.
+        2. In the left navigation pane, select **Settings**.
+        3. Verify that a configuration recorder is listed and that its status shows **On** (recording).
+        4. Repeat this check in each AWS Region where resources are deployed.
+
+        A passing account shows at least one configuration recorder with recording status **On**. A failing account shows no recorder, or a recorder whose recording status is **Off**.
+
+        ### Audit via CLI
+
+        1. Run the following command for each region to retrieve recorder status:
+
+        ```bash
+        aws configservice describe-configuration-recorder-status \
+          --query 'ConfigurationRecordersStatus[*].{Name:name,Recording:recording}' \
+          --output table
+        ```
+
+        A passing account returns at least one recorder with `Recording` set to `true`. A failing account returns an empty list or a recorder with `Recording` set to `false`.
+
       remediation:
         - id: console
           desc: |
@@ -15569,6 +17668,29 @@ queries:
 
         - **Complete visibility:** Ensures all resource types are monitored for configuration changes.
         - **Global coverage:** Includes IAM and other global resources in the recording scope.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the AWS Config service.
+        2. In the left navigation pane, select **Settings**.
+        3. Under **Recording method**, verify that **Record all current and future resource types** is selected.
+        4. Verify that **Include globally recorded resource types** is checked.
+        5. Repeat this check in each AWS Region.
+
+        A passing account shows the recorder configured to record all supported resource types, including global resources. A failing account shows a recorder limited to specific resource types or missing the global resource types option.
+
+        ### Audit via CLI
+
+        1. Run the following command to inspect the recorder's recording group configuration:
+
+        ```bash
+        aws configservice describe-configuration-recorders \
+          --query 'ConfigurationRecorders[*].{Name:name,AllSupported:recordingGroup.allSupported,GlobalResources:recordingGroup.includeGlobalResourceTypes}' \
+          --output table
+        ```
+
+        A passing account returns `AllSupported: true` and `GlobalResources: true` for every recorder. A failing account returns `AllSupported: false` or `GlobalResources: false`.
+
       remediation:
         - id: console
           desc: |
@@ -15710,6 +17832,29 @@ queries:
         - **Credential hygiene:** Automatically replaces secrets on a defined schedule.
         - **Breach containment:** Limits the window of exposure for compromised credentials.
         - **Compliance:** Meets regulatory requirements for credential lifecycle management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the AWS Secrets Manager service.
+        2. In the left navigation pane, select **Secrets**.
+        3. Select a secret to inspect.
+        4. Under **Rotation configuration**, verify that **Automatic rotation** is enabled and a rotation schedule is set.
+        5. Repeat for each secret in the account.
+
+        A passing secret shows **Automatic rotation** as **Enabled** with a rotation schedule. A failing secret shows **Automatic rotation** as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all secrets and check their rotation status:
+
+        ```bash
+        aws secretsmanager list-secrets \
+          --query 'SecretList[*].{Name:Name,RotationEnabled:RotationEnabled}' \
+          --output table
+        ```
+
+        A passing secret returns `RotationEnabled: true`. A failing secret returns `RotationEnabled: false` or a `null` value.
+
       remediation:
         - id: console
           desc: |
@@ -15833,6 +17978,30 @@ queries:
         - **Access management:** Fine-grained access control through KMS key policies.
         - **Auditability:** All encryption operations are logged in CloudTrail.
         - **Crypto shredding:** Usage of a customer-managed key makes crypto shredding possible. Crypto shredding is a secure data destruction technique where the encryption key is deleted, making all data encrypted with that key permanently and irreversibly unrecoverable. This is required for compliance with data retention and deletion regulations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the AWS Secrets Manager service.
+        2. In the left navigation pane, select **Secrets**.
+        3. Select a secret to inspect.
+        4. In the **Overview** section, locate the **Encryption key** field.
+        5. Verify that it references a customer-managed KMS key (not the default `aws/secretsmanager` key).
+        6. Repeat for each secret in the account.
+
+        A passing secret shows a customer-managed KMS key ARN in the **Encryption key** field. A failing secret shows `aws/secretsmanager` or an empty value.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption key configured for each secret:
+
+        ```bash
+        aws secretsmanager list-secrets \
+          --query 'SecretList[*].{Name:Name,KmsKeyId:KmsKeyId}' \
+          --output table
+        ```
+
+        A passing secret returns a customer-managed key ARN (for example, `arn:aws:kms:...`) in the `KmsKeyId` field. A failing secret returns `null` or `aws/secretsmanager`.
+
       remediation:
         - id: console
           desc: |
@@ -15957,6 +18126,28 @@ queries:
         - **Access monitoring:** Continuously monitors resource policies for external access.
         - **Policy validation:** Validates IAM policies against security best practices.
         - **Compliance:** Meets CIS and Security Hub requirements for access analysis.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the IAM service.
+        2. In the left navigation pane, under **Access reports**, select **Access Analyzer**.
+        3. Verify that at least one analyzer is listed with a status of **Active**.
+        4. Repeat this check in each AWS Region.
+
+        A passing account shows at least one Access Analyzer with status **Active**. A failing account shows no analyzers, or all analyzers in a non-active state.
+
+        ### Audit via CLI
+
+        1. List all Access Analyzers in the current region and check their status:
+
+        ```bash
+        aws accessanalyzer list-analyzers \
+          --query 'analyzers[*].{Name:name,Status:status}' \
+          --output table
+        ```
+
+        A passing account returns at least one analyzer with `Status: ACTIVE`. A failing account returns an empty list or only analyzers with a status other than `ACTIVE`.
+
       remediation:
         - id: console
           desc: |
@@ -16071,6 +18262,30 @@ queries:
         - **Data protection:** Encrypts messages at rest using KMS keys.
         - **Access control:** KMS key policies provide additional access control over who can publish and subscribe.
         - **Compliance:** Meets regulatory requirements for data-at-rest encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon SNS service.
+        2. In the left navigation pane, select **Topics**.
+        3. Select a topic to inspect.
+        4. In the **Details** section, locate the **Encryption** field.
+        5. Verify that encryption is enabled and a KMS key is listed.
+        6. Repeat for each topic in the account.
+
+        A passing topic shows a KMS key ARN under **Encryption**. A failing topic shows encryption as **Disabled** or no KMS key.
+
+        ### Audit via CLI
+
+        1. List all SNS topic ARNs and retrieve their encryption attribute:
+
+        ```bash
+        aws sns get-topic-attributes \
+          --topic-arn <topic-arn> \
+          --query 'Attributes.KmsMasterKeyId'
+        ```
+
+        A passing topic returns a non-empty KMS key ID or ARN. A failing topic returns `null` or an empty string.
+
       remediation:
         - id: console
           desc: |
@@ -16198,6 +18413,30 @@ queries:
 
         - **Message integrity:** SHA-256 provides stronger cryptographic guarantees for message verification.
         - **Security posture:** Eliminates reliance on the deprecated SHA-1 algorithm.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon SNS service.
+        2. In the left navigation pane, select **Topics**.
+        3. Select a topic to inspect.
+        4. In the **Details** section, locate the **Signature version** field.
+        5. Verify that the value is **2**.
+        6. Repeat for each topic in the account.
+
+        A passing topic shows **Signature version: 2**. A failing topic shows **Signature version: 1** or no value.
+
+        ### Audit via CLI
+
+        1. Retrieve the signature version attribute for each topic:
+
+        ```bash
+        aws sns get-topic-attributes \
+          --topic-arn <topic-arn> \
+          --query 'Attributes.SignatureVersion'
+        ```
+
+        A passing topic returns `"2"`. A failing topic returns `"1"` or no value.
+
       remediation:
         - id: console
           desc: |
@@ -16323,6 +18562,30 @@ queries:
 
         - **Data protection:** Encrypts messages at rest in the queue.
         - **Compliance:** Meets PCI DSS, HIPAA, and SOC 2 requirements for data-at-rest encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon SQS service.
+        2. Select a queue to inspect.
+        3. Choose the **Details** tab and locate the **Encryption** section.
+        4. Verify that **Server-side encryption** shows either **SSE-SQS** or **SSE-KMS** as enabled.
+        5. Repeat for each queue in the account.
+
+        A passing queue shows SSE-SQS or SSE-KMS enabled under the Encryption section. A failing queue shows encryption as **Disabled**.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption attributes for each queue:
+
+        ```bash
+        aws sqs get-queue-attributes \
+          --queue-url <queue-url> \
+          --attribute-names SqsManagedSseEnabled KmsMasterKeyId \
+          --query 'Attributes'
+        ```
+
+        A passing queue returns `SqsManagedSseEnabled: "true"` or a non-empty `KmsMasterKeyId`. A failing queue returns `SqsManagedSseEnabled: "false"` and an empty or absent `KmsMasterKeyId`.
+
       remediation:
         - id: console
           desc: |
@@ -16449,6 +18712,30 @@ queries:
         - **Security event preservation:** Failed messages are retained in the DLQ for investigation, ensuring security-relevant events are not silently lost.
         - **Attack detection:** DLQ message accumulation serves as an alert signal that messages are being rejected, potentially indicating injection of malicious payloads.
         - **Forensic evidence:** Retained failed messages provide evidence for investigating whether processing failures were caused by attacker activity.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon SQS service.
+        2. Select a queue to inspect.
+        3. Choose the **Details** tab and locate the **Dead-letter queue** section.
+        4. Verify that a dead-letter queue is configured with a target queue ARN and a maximum receives value.
+        5. Repeat for each queue in the account.
+
+        A passing queue shows a configured dead-letter queue target ARN. A failing queue shows no dead-letter queue configured.
+
+        ### Audit via CLI
+
+        1. Retrieve the redrive policy for each queue:
+
+        ```bash
+        aws sqs get-queue-attributes \
+          --queue-url <queue-url> \
+          --attribute-names RedrivePolicy \
+          --query 'Attributes.RedrivePolicy'
+        ```
+
+        A passing queue returns a JSON string containing `deadLetterTargetArn` and `maxReceiveCount`. A failing queue returns `null` or an empty value.
+
       remediation:
         - id: console
           desc: |
@@ -16588,6 +18875,30 @@ queries:
 
         - **Data protection:** Encrypts all data stored on disk in ElastiCache nodes.
         - **Compliance:** Meets PCI DSS, HIPAA, and SOC 2 requirements for data-at-rest encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon ElastiCache service.
+        2. In the left navigation pane, select **Redis caches** (or **Clusters** for Memcached).
+        3. Select a cluster to inspect.
+        4. In the cluster details, locate the **Encryption** section.
+        5. Verify that **Encryption at rest** shows **Enabled**.
+        6. Repeat for each cluster in the account.
+
+        A passing cluster shows **Encryption at rest: Enabled**. A failing cluster shows **Encryption at rest: Disabled** or no value.
+
+        ### Audit via CLI
+
+        1. List replication groups and check the at-rest encryption setting:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query 'ReplicationGroups[*].{Id:ReplicationGroupId,AtRestEncryption:AtRestEncryptionEnabled}' \
+          --output table
+        ```
+
+        A passing cluster returns `AtRestEncryption: true`. A failing cluster returns `AtRestEncryption: false` or `None`.
+
       remediation:
         - id: console
           desc: |
@@ -16721,6 +19032,30 @@ queries:
 
         - **Data protection:** Encrypts all communication between clients and ElastiCache nodes using TLS.
         - **MITM prevention:** Prevents eavesdropping on cache traffic.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon ElastiCache service.
+        2. In the left navigation pane, select **Redis caches**.
+        3. Select a cluster to inspect.
+        4. In the cluster details, locate the **Encryption** section.
+        5. Verify that **Encryption in transit** shows **Enabled**.
+        6. Repeat for each cluster in the account.
+
+        A passing cluster shows **Encryption in transit: Enabled**. A failing cluster shows **Encryption in transit: Disabled** or no value.
+
+        ### Audit via CLI
+
+        1. List replication groups and check the in-transit encryption setting:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query 'ReplicationGroups[*].{Id:ReplicationGroupId,TransitEncryption:TransitEncryptionEnabled}' \
+          --output table
+        ```
+
+        A passing cluster returns `TransitEncryption: true`. A failing cluster returns `TransitEncryption: false` or `None`.
+
       remediation:
         - id: console
           desc: |
@@ -16853,6 +19188,30 @@ queries:
 
         - **Access control:** Requires clients to authenticate before executing commands.
         - **Unauthorized access prevention:** Prevents data access from compromised network segments.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon ElastiCache service.
+        2. In the left navigation pane, select **Redis caches**.
+        3. Select a cluster to inspect.
+        4. In the cluster details, locate the **Security** section.
+        5. Verify that **Auth token** shows **Enabled** or that a token is configured.
+        6. Repeat for each Redis cluster in the account.
+
+        A passing cluster shows an AUTH token as enabled. A failing cluster shows no AUTH token configured.
+
+        ### Audit via CLI
+
+        1. List replication groups and check the authentication token setting:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query 'ReplicationGroups[*].{Id:ReplicationGroupId,AuthTokenEnabled:AuthTokenEnabled}' \
+          --output table
+        ```
+
+        A passing cluster returns `AuthTokenEnabled: true`. A failing cluster returns `AuthTokenEnabled: false` or `None`.
+
       remediation:
         - id: console
           desc: |
@@ -16988,6 +19347,30 @@ queries:
 
         - **Data protection:** Encrypts all recovery points stored in the backup vault.
         - **Compliance:** Meets requirements for backup data encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the AWS Backup service.
+        2. In the left navigation pane, select **Backup vaults**.
+        3. Select a vault to inspect.
+        4. In the vault details, locate the **Encryption key** field.
+        5. Verify that a KMS key ARN is listed.
+        6. Repeat for each vault in the account.
+
+        A passing vault shows a KMS key ARN in the **Encryption key** field. A failing vault shows no encryption key or displays the default AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all backup vaults and check their encryption key:
+
+        ```bash
+        aws backup list-backup-vaults \
+          --query 'BackupVaultList[*].{Name:BackupVaultName,EncryptionKey:EncryptionKeyArn}' \
+          --output table
+        ```
+
+        A passing vault returns a non-empty `EncryptionKey` ARN. A failing vault returns `null` or an empty value.
+
       remediation:
         - id: console
           desc: |
@@ -17110,6 +19493,30 @@ queries:
 
         - **Data protection:** Encrypts all data stored on FSx file systems.
         - **Compliance:** Meets requirements for data-at-rest encryption across file storage services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon FSx service.
+        2. In the left navigation pane, select **File systems**.
+        3. Select a file system to inspect.
+        4. In the file system details, locate the **Encryption** section.
+        5. Verify that **Encryption at rest** shows **Encrypted** and a KMS key ARN is listed.
+        6. Repeat for each file system in the account.
+
+        A passing file system shows **Encrypted** with a KMS key ARN. A failing file system shows **Not encrypted** or no encryption key.
+
+        ### Audit via CLI
+
+        1. List all FSx file systems and check their encryption settings:
+
+        ```bash
+        aws fsx describe-file-systems \
+          --query 'FileSystems[*].{Id:FileSystemId,Type:FileSystemType,Encrypted:KmsKeyId}' \
+          --output table
+        ```
+
+        A passing file system returns a non-empty `Encrypted` (KMS key ID) value. A failing file system returns `null` or no key.
+
       remediation:
         - id: console
           desc: |
@@ -17240,6 +19647,30 @@ queries:
 
         - **Data protection:** Encrypts all data blocks and system metadata in the Redshift cluster using AES-256.
         - **Compliance:** Meets regulatory requirements for data-at-rest encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the Amazon Redshift service.
+        2. In the left navigation pane, select **Clusters**.
+        3. Select a cluster to inspect.
+        4. In the cluster details, choose the **Properties** tab and locate the **Database configurations** section.
+        5. Verify that **Encryption** shows **Enabled** and a KMS key is listed.
+        6. Repeat for each cluster in the account.
+
+        A passing cluster shows **Encryption: Enabled** with a KMS key. A failing cluster shows **Encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all Redshift clusters and check their encryption status:
+
+        ```bash
+        aws redshift describe-clusters \
+          --query 'Clusters[*].{Identifier:ClusterIdentifier,Encrypted:Encrypted,KmsKeyId:KmsKeyId}' \
+          --output table
+        ```
+
+        A passing cluster returns `Encrypted: true`. A failing cluster returns `Encrypted: false`.
+
       remediation:
         - id: console
           desc: |
@@ -17369,6 +19800,28 @@ queries:
         - **Audit trail:** Provides a record of all database activity for forensic analysis.
         - **Threat detection:** Enables detection of suspicious query patterns and unauthorized access.
         - **Compliance:** Meets regulatory requirements for database activity logging.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon Redshift console.
+        2. In the left navigation, choose Clusters and select the cluster to review.
+        3. Choose the Properties tab.
+        4. Under Database configurations, locate the Audit logging row.
+
+        A passing cluster shows audit logging as Enabled with an S3 bucket destination. A failing cluster shows audit logging as Disabled.
+
+        ### Audit via CLI
+
+        1. Retrieve the logging status for a specific cluster:
+
+        ```bash
+        aws redshift describe-logging-status \
+          --cluster-identifier <cluster-id> \
+          --query '{LoggingEnabled:LoggingEnabled,BucketName:BucketName}'
+        ```
+
+        A passing cluster returns `"LoggingEnabled": true` with a non-empty `BucketName`. A failing cluster returns `"LoggingEnabled": false`.
+
       remediation:
         - id: console
           desc: |
@@ -17506,6 +19959,28 @@ queries:
         - **Data interception prevention:** Forces all COPY and UNLOAD traffic through the VPC, eliminating internet-routed data exposure.
         - **Exfiltration detection:** VPC flow logs capture all data transfer traffic, enabling detection of unauthorized UNLOAD operations to external destinations.
         - **Network policy enforcement:** Security groups and NACLs can restrict which destinations Redshift can transfer data to, limiting an attacker's ability to exfiltrate data to attacker-controlled storage.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon Redshift console.
+        2. In the left navigation, choose Clusters and select the cluster to review.
+        3. Choose the Properties tab.
+        4. Under Network and security, locate the Enhanced VPC routing row.
+
+        A passing cluster shows Enhanced VPC routing as Enabled. A failing cluster shows it as Disabled.
+
+        ### Audit via CLI
+
+        1. Describe the cluster and check the `EnhancedVpcRouting` attribute:
+
+        ```bash
+        aws redshift describe-clusters \
+          --cluster-identifier <cluster-id> \
+          --query 'Clusters[*].{ClusterIdentifier:ClusterIdentifier,EnhancedVpcRouting:EnhancedVpcRouting}'
+        ```
+
+        A passing cluster returns `"EnhancedVpcRouting": true`. A failing cluster returns `"EnhancedVpcRouting": false`.
+
       remediation:
         - id: console
           desc: |
@@ -17632,6 +20107,28 @@ queries:
 
         - **Protocol security:** Eliminates known vulnerabilities in older TLS versions.
         - **Compliance:** Meets PCI DSS, HIPAA, and industry requirements for modern encryption protocols.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon CloudFront console.
+        2. Choose Distributions and select the distribution to review.
+        3. Choose the General tab.
+        4. Under Settings, locate the Minimum SSL/TLS version field.
+
+        A passing distribution shows a minimum TLS version of TLSv1.2_2021 or TLSv1.2_2019. A failing distribution shows TLSv1, TLSv1.1, or TLSv1_2016.
+
+        ### Audit via CLI
+
+        1. Retrieve the viewer certificate configuration for the distribution:
+
+        ```bash
+        aws cloudfront get-distribution \
+          --id <distribution-id> \
+          --query 'Distribution.DistributionConfig.ViewerCertificate.{MinimumProtocolVersion:MinimumProtocolVersion,SSLSupportMethod:SSLSupportMethod}'
+        ```
+
+        A passing distribution returns `"MinimumProtocolVersion"` containing `TLSv1.2`. A failing distribution returns `TLSv1`, `TLSv1.1`, or `TLSv1_2016`.
+
       remediation:
         - id: console
           desc: |
@@ -17765,6 +20262,28 @@ queries:
         - **Attack prevention:** Filters malicious web traffic at the edge before it reaches your infrastructure.
         - **DDoS protection:** Rate-limiting rules help mitigate application-layer DDoS attacks.
         - **Compliance:** Meets requirements for web application firewall protection.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon CloudFront console.
+        2. Choose Distributions and select the distribution to review.
+        3. Choose the General tab.
+        4. Under Settings, locate the AWS WAF web ACL field.
+
+        A passing distribution shows a web ACL ARN in the AWS WAF web ACL field. A failing distribution shows None or an empty value.
+
+        ### Audit via CLI
+
+        1. Retrieve the web ACL ID for the distribution:
+
+        ```bash
+        aws cloudfront get-distribution \
+          --id <distribution-id> \
+          --query 'Distribution.DistributionConfig.WebACLId'
+        ```
+
+        A passing distribution returns a non-empty string containing a web ACL ARN or ID. A failing distribution returns an empty string or `null`.
+
       remediation:
         - id: console
           desc: |
@@ -17887,6 +20406,27 @@ queries:
         - **Data Security:** Ensures backup data is encrypted at rest using AWS KMS, protecting against unauthorized access.
         - **Regulatory Compliance:** Meets requirements for data-at-rest encryption in security frameworks.
         - **Centralized Key Management:** Leverages AWS KMS for key lifecycle management and access control.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon RDS console.
+        2. In the left navigation, choose Snapshots.
+        3. Select Manual or Automated from the filter tabs.
+        4. For each snapshot, review the Encryption column.
+
+        A passing snapshot shows a KMS key ARN in the Encryption column. A failing snapshot shows Not encrypted.
+
+        ### Audit via CLI
+
+        1. List all RDS snapshots and filter for unencrypted ones:
+
+        ```bash
+        aws rds describe-db-snapshots \
+          --query "DBSnapshots[?Encrypted==\`false\`].{SnapshotId:DBSnapshotIdentifier,Status:Status,Encrypted:Encrypted}"
+        ```
+
+        A passing environment returns an empty list. A failing environment returns one or more snapshots where `"Encrypted": false`.
+
       remediation:
         - id: console
           desc: |
@@ -18022,6 +20562,29 @@ queries:
         - **Access control:** Restricts AMI usage to authorized accounts only.
         - **Data protection:** Prevents inadvertent exposure of sensitive data embedded in images.
         - **Compliance:** Meets CIS AWS Foundations Benchmark and organizational security requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon EC2 console.
+        2. In the left navigation, under Images, choose AMIs.
+        3. Set the filter to Owned by me.
+        4. Select each AMI and choose the Permissions tab.
+        5. Check whether the AMI permission is set to Public.
+
+        A passing AMI shows Private under AMI permissions with no public launch permission group. A failing AMI shows Public.
+
+        ### Audit via CLI
+
+        1. List all AMIs owned by the account that have public launch permissions:
+
+        ```bash
+        aws ec2 describe-images \
+          --owners self \
+          --query "Images[?Public==\`true\`].{ImageId:ImageId,Name:Name,Public:Public}"
+        ```
+
+        A passing account returns an empty list. A failing account returns one or more AMIs where `"Public": true`.
+
       remediation:
         - id: console
           desc: |
@@ -18164,6 +20727,29 @@ queries:
         - **Least privilege:** Running as a non-root user limits what an attacker can do after compromising a container.
         - **Blast radius reduction:** Minimizes the impact of a container compromise.
         - **Compliance:** Meets CIS Docker Benchmark 4.1 and container security best practices.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon ECS console.
+        2. In the left navigation, choose Task definitions.
+        3. Select a task definition and choose the latest active revision.
+        4. Under Container definitions, select a container and expand the configuration.
+        5. Locate the User field under Container configuration.
+
+        A passing container definition shows a non-root user such as `1000` or a named non-root user in the User field. A failing container definition shows root, 0, or an empty User field.
+
+        ### Audit via CLI
+
+        1. List active task definition ARNs and inspect the user field for each container definition:
+
+        ```bash
+        aws ecs describe-task-definition \
+          --task-definition <task-definition-name> \
+          --query 'taskDefinition.containerDefinitions[*].{Name:name,User:user}'
+        ```
+
+        A passing task definition returns a non-empty, non-root value for every container's `user` field. A failing task definition returns an empty, `root`, or `0` user for at least one container.
+
       remediation:
         - id: console
           desc: |
@@ -18324,6 +20910,29 @@ queries:
         - **Data protection:** TLS encryption protects data as it travels between ECS tasks and EFS.
         - **Regulatory compliance:** Meets encryption-in-transit requirements for PCI DSS, HIPAA, and SOC 2.
         - **Defense in depth:** Adds a layer of protection even if network-level controls are compromised.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon ECS console.
+        2. In the left navigation, choose Task definitions.
+        3. Select a task definition and choose the latest active revision.
+        4. Choose the Volumes tab.
+        5. For each EFS volume, review the Transit encryption setting.
+
+        A passing task definition shows ENABLED for Transit encryption on every EFS volume. A failing task definition shows DISABLED or no transit encryption setting on at least one EFS volume.
+
+        ### Audit via CLI
+
+        1. Describe a task definition and check transit encryption on EFS volume configurations:
+
+        ```bash
+        aws ecs describe-task-definition \
+          --task-definition <task-definition-name> \
+          --query 'taskDefinition.volumes[?efsVolumeConfiguration!=`null`].{Name:name,TransitEncryption:efsVolumeConfiguration.transitEncryption}'
+        ```
+
+        A passing task definition returns `"TransitEncryption": "ENABLED"` for every EFS volume. A failing task definition returns `"TransitEncryption": "DISABLED"` for at least one EFS volume.
+
       remediation:
         - id: console
           desc: |
@@ -18505,6 +21114,26 @@ queries:
         - **Incident response capability:** Ensures logs are available for the duration needed to detect and investigate long-running compromises.
         - **Forensic completeness:** Preserves evidence of attacker activity across the full dwell time of a breach.
         - **Regulatory compliance:** Meets log retention requirements mandated by security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon CloudWatch console.
+        2. In the left navigation, choose Logs, then Log groups.
+        3. Review the Retention column for each log group.
+
+        A passing log group shows a defined retention period such as 90 days or 1 year in the Retention column. A failing log group shows Never expire in the Retention column.
+
+        ### Audit via CLI
+
+        1. List all log groups and filter for those without a defined retention period:
+
+        ```bash
+        aws logs describe-log-groups \
+          --query 'logGroups[?!retentionInDays].{LogGroupName:logGroupName,RetentionInDays:retentionInDays}'
+        ```
+
+        A passing environment returns an empty list. A failing environment returns one or more log groups where `retentionInDays` is not set.
+
       remediation:
         - id: console
           desc: |
@@ -18640,6 +21269,28 @@ queries:
         - **Data protection:** SSL/TLS encrypts all data transmitted between clients and the Redshift cluster.
         - **Authentication:** SSL provides server identity verification, preventing connection to impersonated endpoints.
         - **Regulatory compliance:** Meets encryption-in-transit requirements mandated by security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon Redshift console.
+        2. In the left navigation, choose Configurations, then Workload management.
+        3. Select the parameter group associated with the cluster to review.
+        4. Locate the `require_ssl` parameter and check its value.
+
+        A passing parameter group shows `require_ssl` set to `true`. A failing parameter group shows `require_ssl` set to `false` or the default value.
+
+        ### Audit via CLI
+
+        1. Retrieve the `require_ssl` parameter from the cluster's parameter group:
+
+        ```bash
+        aws redshift describe-cluster-parameters \
+          --parameter-group-name <parameter-group-name> \
+          --query "Parameters[?ParameterName=='require_ssl'].{Name:ParameterName,Value:ParameterValue,Source:Source}"
+        ```
+
+        A passing parameter group returns `"ParameterValue": "true"`. A failing parameter group returns `"ParameterValue": "false"` or the default.
+
       remediation:
         - id: console
           desc: |
@@ -18810,6 +21461,27 @@ queries:
         - **Reduced attack surface:** Prevents accidental public exposure of instances that should remain private.
         - **Defense in depth:** Works alongside security groups and NACLs to enforce network isolation.
         - **Intentional access:** Forces teams to explicitly assign public IPs or use NAT gateways/load balancers for internet access.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the VPC console.
+        2. In the left navigation, choose Subnets.
+        3. Select a subnet and choose the Details tab.
+        4. Locate the Auto-assign public IPv4 address field.
+
+        A passing subnet shows No for Auto-assign public IPv4 address. A failing subnet shows Yes.
+
+        ### Audit via CLI
+
+        1. List all subnets and check the `MapPublicIpOnLaunch` attribute:
+
+        ```bash
+        aws ec2 describe-subnets \
+          --query 'Subnets[*].{SubnetId:SubnetId,VpcId:VpcId,MapPublicIpOnLaunch:MapPublicIpOnLaunch}'
+        ```
+
+        A passing subnet returns `"MapPublicIpOnLaunch": false`. A failing subnet returns `"MapPublicIpOnLaunch": true`.
+
       remediation:
         - id: console
           desc: |
@@ -18954,6 +21626,27 @@ queries:
         - **SSRF protection:** Limits the ability of containerized workloads to reach the instance metadata service through network hops.
         - **Credential isolation:** Prevents containers from inheriting the EC2 instance IAM role credentials via the metadata service.
         - **Defense in depth:** Complements IMDSv2 enforcement by reducing the attack surface even when token-based authentication is required.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon EC2 console.
+        2. In the left navigation, choose Instances.
+        3. Select an instance and choose the Details tab.
+        4. Under Metadata options, locate the Metadata response hop limit field.
+
+        A passing instance shows a Metadata response hop limit of 1. A failing instance shows a value greater than 1.
+
+        ### Audit via CLI
+
+        1. Describe instances and retrieve their IMDS hop limit settings:
+
+        ```bash
+        aws ec2 describe-instances \
+          --query 'Reservations[*].Instances[*].{InstanceId:InstanceId,HttpEndpoint:MetadataOptions.HttpEndpoint,HopLimit:MetadataOptions.HttpPutResponseHopLimit}'
+        ```
+
+        A passing instance returns `"HopLimit": 1` when `"HttpEndpoint": "enabled"`. A failing instance returns a `HopLimit` value greater than 1.
+
       remediation:
         - id: console
           desc: |
@@ -19107,6 +21800,31 @@ queries:
         - **Comprehensive threat coverage:** Ensures all AWS services are monitored for threats, eliminating blind spots.
         - **Early detection:** Enables detection of service-specific attack patterns that core GuardDuty monitoring cannot identify.
         - **Compliance:** Meets security monitoring requirements across all AWS services in use.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon GuardDuty console.
+        2. In the left navigation, choose Settings.
+        3. Under Protection plans, review the status of each protection feature: S3 Protection, EKS Protection, Malware Protection, RDS Protection, Lambda Protection, and Runtime Monitoring.
+
+        A passing configuration shows all protection features as Enabled. A failing configuration shows one or more features as Disabled.
+
+        ### Audit via CLI
+
+        1. List all GuardDuty detector IDs in the account, then retrieve the feature status for each:
+
+        ```bash
+        aws guardduty list-detectors --query 'DetectorIds'
+        ```
+
+        ```bash
+        aws guardduty get-detector \
+          --detector-id <detector-id> \
+          --query 'Features[*].{Name:Name,Status:Status}'
+        ```
+
+        A passing detector returns `"Status": "ENABLED"` for all features including S3_DATA_EVENTS, EKS_AUDIT_LOGS, EBS_MALWARE_PROTECTION, RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS, and RUNTIME_MONITORING. A failing detector returns `"Status": "DISABLED"` for at least one feature.
+
       remediation:
         - id: console
           desc: |
@@ -19306,6 +22024,29 @@ queries:
         - **Centralized access control:** Manages database access through IAM policies alongside other AWS resource permissions.
         - **Auditability:** All authentication attempts are logged in CloudTrail.
         - **No static credentials:** Eliminates the need to store or rotate database passwords.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the Amazon Neptune console.
+        2. In the left navigation, choose Databases.
+        3. Select the Neptune DB cluster to review.
+        4. Choose the Configuration tab.
+        5. Locate the IAM DB authentication field.
+
+        A passing cluster shows IAM DB authentication as Enabled. A failing cluster shows it as Disabled.
+
+        ### Audit via CLI
+
+        1. Describe the Neptune cluster and check the IAM authentication attribute:
+
+        ```bash
+        aws neptune describe-db-clusters \
+          --db-cluster-identifier <cluster-id> \
+          --query 'DBClusters[*].{ClusterId:DBClusterIdentifier,IAMAuthEnabled:IAMDatabaseAuthenticationEnabled}'
+        ```
+
+        A passing cluster returns `"IAMAuthEnabled": true`. A failing cluster returns `"IAMAuthEnabled": false`.
+
       remediation:
         - id: console
           desc: |
@@ -19443,6 +22184,29 @@ queries:
 
         - Some AWS services such as EBS, RDS, and S3 create grants with `CreateGrant` as part of their normal operation when using customer-managed CMKs. Review flagged grants to determine if they are service-linked before removing them.
         - Removing `CreateGrant` from service-linked grants may break encryption workflows for those services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the AWS KMS console.
+        2. In the left navigation, choose Customer managed keys.
+        3. Select a key and choose the Key policy tab.
+        4. Scroll to the Grants section and review the operations listed for each grant.
+        5. Identify any grant that includes `CreateGrant` in its operations.
+
+        A passing key has no grants with `CreateGrant` in the operations list, or any such grants are confirmed to be service-linked. A failing key has one or more user-created grants that include the `CreateGrant` operation.
+
+        ### Audit via CLI
+
+        1. List all grants for a KMS key and filter for those that include the `CreateGrant` operation:
+
+        ```bash
+        aws kms list-grants \
+          --key-id <key-id> \
+          --query "Grants[?contains(Operations, 'CreateGrant')].{GrantId:GrantId,Grantee:GranteePrincipal,Operations:Operations}"
+        ```
+
+        A passing key returns an empty list or only grants issued by AWS services on behalf of service-linked roles. A failing key returns one or more grants where the `Operations` list includes `CreateGrant` for a user-managed principal.
+
       remediation:
         - id: console
           desc: |
@@ -19567,6 +22331,33 @@ queries:
         - **Prevent unauthorized access:** Ensure only specific, named principals have access to KMS key operations.
         - **Enforce least privilege:** Grant permissions only to the principals that require them.
         - **Improve auditability:** Named principals make it straightforward to trace who has access to each key.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS KMS**.
+        2. Select **Customer managed keys** from the left panel.
+        3. For each key, open the key detail page and select the **Key policy** tab.
+        4. Scroll to the **Grants** section and review each listed grant.
+        5. Check the **Grantee principal** column for any entry showing `*`.
+
+        A passing key shows no grants with a wildcard (`*`) grantee principal. A failing key shows one or more grants where the grantee principal is `*`.
+
+        ### Audit via CLI
+
+        1. List all customer-managed KMS key IDs:
+
+        ```bash
+        aws kms list-keys --query 'Keys[*].KeyId' --output text
+        ```
+
+        2. For each key, check for grants with a wildcard grantee principal:
+
+        ```bash
+        aws kms list-grants --key-id <key-id> \
+          --query "Grants[?GranteePrincipal=='*'].{GrantId:GrantId,Grantee:GranteePrincipal,Operations:Operations}"
+        ```
+
+        A passing key returns an empty list `[]`. A failing key returns one or more grant objects with `"Grantee": "*"`.
       remediation:
         - id: console
           desc: |
@@ -19700,6 +22491,31 @@ queries:
 
         - Some organizations have regulatory requirements such as BYOK mandates that require externally generated key material. In those cases, `EXTERNAL` origin is intentional and this check can be excluded for those keys.
         - `AWS_CLOUDHSM` origin may be required for specific compliance scenarios that mandate single-tenant HSM hardware. Evaluate flagged keys against your compliance requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS KMS**.
+        2. Select **Customer managed keys** from the left panel.
+        3. For each key, open the key detail page and review the **Key material origin** field under **Cryptographic configuration**.
+
+        A passing key shows **Key material origin: KMS**. A failing key shows **Key material origin: EXTERNAL** or **AWS_CLOUDHSM**.
+
+        ### Audit via CLI
+
+        1. List all customer-managed KMS keys and check their origin:
+
+        ```bash
+        aws kms list-keys --query 'Keys[*].KeyId' --output text
+        ```
+
+        2. Describe each key to inspect the origin:
+
+        ```bash
+        aws kms describe-key --key-id <key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Origin:Origin,KeyManager:KeyManager}"
+        ```
+
+        A passing key returns `"Origin": "AWS_KMS"`. A failing key returns `"Origin": "EXTERNAL"` or `"Origin": "AWS_CLOUDHSM"`.
       remediation:
         - id: console
           desc: |
@@ -19851,6 +22667,32 @@ queries:
         - **Supply chain protection:** Ensures source code integrity by verifying the repository's TLS certificate during fetches.
         - **MITM prevention:** Prevents attackers from injecting malicious code during source retrieval.
         - **Build integrity:** Guarantees that the code being built matches what is stored in the source repository.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS CodeBuild**.
+        2. Select **Build projects** from the left panel.
+        3. For each project, open the project and select **Edit** then **Source**.
+        4. Review the **Insecure SSL** setting under the source configuration.
+
+        A passing project shows **Insecure SSL** unchecked or set to **No**. A failing project shows **Insecure SSL** checked or set to **Yes**.
+
+        ### Audit via CLI
+
+        1. List all CodeBuild projects:
+
+        ```bash
+        aws codebuild list-projects --query 'projects' --output text
+        ```
+
+        2. Check the SSL verification setting for each project:
+
+        ```bash
+        aws codebuild batch-get-projects --names <project-name> \
+          --query "projects[*].{Name:name,InsecureSsl:source.insecureSsl}"
+        ```
+
+        A passing project returns `"InsecureSsl": false` or `null`. A failing project returns `"InsecureSsl": true`.
       remediation:
         - id: console
           desc: |
@@ -20003,6 +22845,26 @@ queries:
         - **Key control:** Organizations maintain full control over the encryption key lifecycle, including creation, rotation, and deletion.
         - **Access auditing:** All key usage is logged in CloudTrail, enabling security monitoring and compliance reporting.
         - **Compliance:** Meets regulatory requirements for customer-managed encryption of data at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ElastiCache**.
+        2. Select **Serverless caches** from the left panel.
+        3. For each serverless cache, open the cache details and review the **Encryption at rest** section.
+        4. Check whether a **Customer managed key** (CMK) ARN is listed under the KMS key.
+
+        A passing serverless cache shows a customer-managed KMS key ARN under encryption settings. A failing serverless cache shows no KMS key or shows only the AWS-managed default key.
+
+        ### Audit via CLI
+
+        1. List all serverless caches and check their KMS key configuration:
+
+        ```bash
+        aws elasticache describe-serverless-caches \
+          --query "ServerlessCaches[*].{Name:ServerlessCacheName,KmsKeyId:KmsKeyId}"
+        ```
+
+        A passing cache returns a non-empty `KmsKeyId` value. A failing cache returns `"KmsKeyId": null` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -20144,6 +23006,27 @@ queries:
         - **Automated discovery**: Automatically detects new EC2 instances and begins scanning without manual configuration.
         - **Risk prioritization**: Uses context-aware risk scoring to help teams focus on the most critical vulnerabilities first.
         - **Compliance alignment**: Meets requirements for continuous vulnerability assessment mandated by frameworks such as PCI DSS and NIST.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Inspector**.
+        2. Select **Account management** from the left panel.
+        3. Review the **Scan types** column for the current account.
+        4. Verify that **Amazon EC2** scanning shows a status of **Active**.
+
+        A passing account shows **Amazon EC2** scan type listed as **Active**. A failing account shows **Amazon EC2** scanning as **Disabled** or not present.
+
+        ### Audit via CLI
+
+        1. Check the current Amazon Inspector enablement status for EC2:
+
+        ```bash
+        aws inspector2 batch-get-account-status \
+          --account-ids <account-id> \
+          --query "accounts[*].{AccountId:accountId,EC2Status:resourceState.ec2.status}"
+        ```
+
+        A passing account returns `"EC2Status": "ENABLED"`. A failing account returns `"EC2Status": "DISABLED"` or the resource type is absent.
       remediation:
         - id: console
           desc: |
@@ -20242,6 +23125,27 @@ queries:
         - **Shift-left security**: Identifies vulnerabilities in container images early in the development lifecycle.
         - **Continuous monitoring**: Re-scans images when new CVEs are published, ensuring ongoing protection.
         - **Supply chain security**: Helps detect vulnerabilities in base images and third-party dependencies.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Inspector**.
+        2. Select **Account management** from the left panel.
+        3. Review the **Scan types** column for the current account.
+        4. Verify that **Amazon ECR** scanning shows a status of **Active**.
+
+        A passing account shows **Amazon ECR** scan type listed as **Active**. A failing account shows **Amazon ECR** scanning as **Disabled** or not present.
+
+        ### Audit via CLI
+
+        1. Check the current Amazon Inspector enablement status for ECR:
+
+        ```bash
+        aws inspector2 batch-get-account-status \
+          --account-ids <account-id> \
+          --query "accounts[*].{AccountId:accountId,ECRStatus:resourceState.ecr.status}"
+        ```
+
+        A passing account returns `"ECRStatus": "ENABLED"`. A failing account returns `"ECRStatus": "DISABLED"` or the resource type is absent.
       remediation:
         - id: console
           desc: |
@@ -20339,6 +23243,27 @@ queries:
         - **Automated scanning**: Automatically scans functions when they are deployed or updated.
         - **Code scanning**: Identifies vulnerabilities in application package dependencies used by Lambda functions.
         - **Continuous protection**: Re-scans when new CVEs are published to catch newly discovered vulnerabilities.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Inspector**.
+        2. Select **Account management** from the left panel.
+        3. Review the **Scan types** column for the current account.
+        4. Verify that **AWS Lambda** scanning shows a status of **Active**.
+
+        A passing account shows **AWS Lambda** scan type listed as **Active**. A failing account shows **AWS Lambda** scanning as **Disabled** or not present.
+
+        ### Audit via CLI
+
+        1. Check the current Amazon Inspector enablement status for Lambda:
+
+        ```bash
+        aws inspector2 batch-get-account-status \
+          --account-ids <account-id> \
+          --query "accounts[*].{AccountId:accountId,LambdaStatus:resourceState.lambda.status}"
+        ```
+
+        A passing account returns `"LambdaStatus": "ENABLED"`. A failing account returns `"LambdaStatus": "DISABLED"` or the resource type is absent.
       remediation:
         - id: console
           desc: |
@@ -20440,6 +23365,27 @@ queries:
         - **Audit trail**: All KMS key usage is logged in CloudTrail, providing visibility into who accessed encrypted parameters.
         - **Compliance alignment**: Many regulatory frameworks require explicit encryption key configuration for sensitive data.
         - **Key rotation**: Explicitly configured keys support automatic rotation, improving security posture.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS Systems Manager**.
+        2. Select **Parameter Store** from the left panel.
+        3. Filter parameters by type **SecureString**.
+        4. For each SecureString parameter, open the parameter details and review the **KMS Key ID** field.
+
+        A passing SecureString parameter shows an explicit KMS key ARN or alias in the **KMS Key ID** field. A failing SecureString parameter shows the default AWS-managed key `alias/aws/ssm` or no key specified.
+
+        ### Audit via CLI
+
+        1. List all SecureString parameters and check their KMS key configuration:
+
+        ```bash
+        aws ssm describe-parameters \
+          --filters "Key=Type,Values=SecureString" \
+          --query "Parameters[*].{Name:Name,Type:Type,KeyId:KeyId}"
+        ```
+
+        A passing parameter returns a customer-managed KMS key ARN in the `KeyId` field. A failing parameter returns `"KeyId": "alias/aws/ssm"` or an empty value.
       remediation:
         - id: console
           desc: |
@@ -20559,6 +23505,26 @@ queries:
         - **Attack surface**: Publicly accessible instances can be targeted by attackers attempting to intercept or manipulate migration data.
         - **Network security**: Keeping replication instances private ensures all traffic stays within trusted VPC boundaries.
         - **Compliance alignment**: Data protection regulations often require that database traffic remains within private networks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS Database Migration Service (DMS)**.
+        2. Select **Replication instances** from the left panel.
+        3. For each replication instance, open the instance details.
+        4. Review the **Publicly accessible** field under **Instance configuration**.
+
+        A passing replication instance shows **Publicly accessible: No**. A failing replication instance shows **Publicly accessible: Yes**.
+
+        ### Audit via CLI
+
+        1. List all DMS replication instances and check their public accessibility setting:
+
+        ```bash
+        aws dms describe-replication-instances \
+          --query "ReplicationInstances[*].{Id:ReplicationInstanceIdentifier,Public:PubliclyAccessible,Status:ReplicationInstanceStatus}"
+        ```
+
+        A passing instance returns `"Public": false`. A failing instance returns `"Public": true`.
       remediation:
         - id: console
           desc: |
@@ -20680,6 +23646,26 @@ queries:
         - **Data protection**: Encrypts the storage used by replication instances to protect sensitive data at rest.
         - **Compliance alignment**: Regulatory requirements often mandate encryption of data at rest for database workloads.
         - **Risk mitigation**: Prevents unauthorized access to migration data stored on replication instance volumes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS Database Migration Service (DMS)**.
+        2. Select **Replication instances** from the left panel.
+        3. For each replication instance, open the instance details.
+        4. Review the **KMS key** field under **Instance configuration**.
+
+        A passing replication instance shows a KMS key ARN in the **KMS key** field. A failing replication instance shows no KMS key or the default AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all DMS replication instances and check their KMS key configuration:
+
+        ```bash
+        aws dms describe-replication-instances \
+          --query "ReplicationInstances[*].{Id:ReplicationInstanceIdentifier,KmsKey:KmsKeyId,Status:ReplicationInstanceStatus}"
+        ```
+
+        A passing instance returns a non-empty `KmsKey` value. A failing instance returns `"KmsKey": null` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -20794,6 +23780,35 @@ queries:
         - **Compliance alignment**: Regulatory requirements mandate encryption of data at rest, including disaster recovery copies.
         - **Consistent encryption**: Maintains encryption parity between source and replicated volumes.
         - **Risk mitigation**: Protects against data exposure if staging area resources are compromised.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **AWS Elastic Disaster Recovery**.
+        2. Select **Source servers** from the left panel.
+        3. For each source server, open the server details and select **Replication settings**.
+        4. Review the **EBS encryption** setting.
+
+        A passing source server shows **EBS encryption** set to **Default** or **Custom** with a KMS key. A failing source server shows **EBS encryption** set to **None**.
+
+        ### Audit via CLI
+
+        1. List all DRS source servers:
+
+        ```bash
+        aws drs describe-source-servers \
+          --filters actionRequired=NONE \
+          --query "items[*].{SourceServerId:sourceServerID,Arn:arn}"
+        ```
+
+        2. Check the replication configuration for each source server:
+
+        ```bash
+        aws drs get-replication-configuration \
+          --source-server-id <source-server-id> \
+          --query "{EbsEncryption:ebsEncryption,EbsEncryptionKeyArn:ebsEncryptionKeyArn}"
+        ```
+
+        A passing source server returns `"EbsEncryption": "DEFAULT"` or `"CUSTOM"`. A failing source server returns `"EbsEncryption": "NONE"` or an empty value.
       remediation:
         - id: console
           desc: |
@@ -20892,6 +23907,26 @@ queries:
         - **Audit trail**: KMS key usage is logged in CloudTrail, providing visibility into data access patterns.
         - **Compliance alignment**: Explicit encryption key configuration may be required by regulatory frameworks for time-series data.
         - **Key lifecycle management**: Organizations can rotate, disable, or revoke keys as needed.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Timestream**.
+        2. Select **Databases** under **LiveAnalytics** in the left panel.
+        3. For each database, open the database details.
+        4. Review the **KMS key** field under **Encryption configuration**.
+
+        A passing database shows a customer-managed KMS key ARN in the **KMS key** field. A failing database shows no KMS key or only the AWS-managed default key.
+
+        ### Audit via CLI
+
+        1. List all Timestream databases and check their KMS key configuration:
+
+        ```bash
+        aws timestream-write list-databases \
+          --query "Databases[*].{DatabaseName:DatabaseName,KmsKeyId:KmsKeyId,Arn:Arn}"
+        ```
+
+        A passing database returns a non-empty `KmsKeyId` value. A failing database returns `"KmsKeyId": null` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -21009,6 +24044,26 @@ queries:
         - **Data exfiltration risk**: If authentication is weak or credentials are compromised, attackers can access time-series data directly from the internet.
         - **Compliance violations**: Most security frameworks require databases to be deployed in private subnets without direct internet access.
         - **Lateral movement**: A compromised public-facing database can serve as a pivot point for accessing other resources in the VPC.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Timestream**.
+        2. Select **InfluxDB instances** or **InfluxDB clusters** from the left panel.
+        3. For each instance or cluster, open the details page.
+        4. Review the **Publicly accessible** field under **Connectivity**.
+
+        A passing InfluxDB instance shows **Publicly accessible: No**. A failing InfluxDB instance shows **Publicly accessible: Yes**.
+
+        ### Audit via CLI
+
+        1. List all Timestream InfluxDB instances and check their public accessibility:
+
+        ```bash
+        aws timestream-influxdb list-db-instances \
+          --query "items[*].{Name:name,PubliclyAccessible:publiclyAccessible,Status:status}"
+        ```
+
+        A passing instance returns `"PubliclyAccessible": false`. A failing instance returns `"PubliclyAccessible": true`.
       remediation:
         - id: console
           desc: |
@@ -21144,6 +24199,26 @@ queries:
         - **Forensic capability**: Logs are essential for investigating security incidents, understanding the scope of a breach, and meeting regulatory notification requirements.
         - **Compliance requirements**: Most security frameworks require audit logging for database services, including access patterns and administrative actions.
         - **Operational visibility**: Logs help identify performance issues, misconfigurations, and unusual usage patterns that may indicate compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Timestream**.
+        2. Select **InfluxDB instances** or **InfluxDB clusters** from the left panel.
+        3. For each instance or cluster, open the details page.
+        4. Review the **Log delivery** section and check whether an S3 bucket destination is configured and enabled.
+
+        A passing InfluxDB instance shows log delivery configured with a target S3 bucket and **Enabled: Yes**. A failing InfluxDB instance shows log delivery disabled or no S3 configuration.
+
+        ### Audit via CLI
+
+        1. List all Timestream InfluxDB instances and check their log delivery configuration:
+
+        ```bash
+        aws timestream-influxdb list-db-instances \
+          --query "items[*].{Name:name,LogDelivery:logDeliveryConfiguration}"
+        ```
+
+        A passing instance returns a `LogDelivery` object with `"enabled": true` and a non-empty `bucketName`. A failing instance returns `null` or a configuration where `"enabled": false`.
       remediation:
         - id: console
           desc: |
@@ -21280,6 +24355,33 @@ queries:
         - **Brute force prevention**: Open management ports are prime targets for automated brute force attacks.
         - **Compliance alignment**: CIS AWS Foundations Benchmark and other frameworks require restricting management port access.
         - **Defense in depth**: Network ACLs provide a stateless firewall layer that complements security group rules.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. Select **Network ACLs** from the left panel.
+        3. For each network ACL, select the ACL and open the **Inbound rules** tab.
+        4. Look for any **ALLOW** rules where the source is `0.0.0.0/0` or `::/0` and the port range includes port 22 (SSH) or port 3389 (RDP).
+
+        A passing network ACL has no inbound ALLOW rules permitting port 22 or 3389 from `0.0.0.0/0` or `::/0`. A failing network ACL has one or more such unrestricted ALLOW rules.
+
+        ### Audit via CLI
+
+        1. List all network ACLs and their inbound rules:
+
+        ```bash
+        aws ec2 describe-network-acls \
+          --query "NetworkAcls[*].{AclId:NetworkAclId,Entries:Entries[?Egress==\`false\` && RuleAction=='allow']}"
+        ```
+
+        2. Filter for rules that open SSH or RDP to the internet:
+
+        ```bash
+        aws ec2 describe-network-acls \
+          --query "NetworkAcls[?Entries[?Egress==\`false\` && RuleAction=='allow' && (CidrBlock=='0.0.0.0/0' || Ipv6CidrBlock=='::/0')]].{AclId:NetworkAclId,Entries:Entries}"
+        ```
+
+        A passing account returns no network ACLs with inbound ALLOW rules from `0.0.0.0/0` or `::/0` covering port 22 or 3389. A failing account returns one or more ACLs with such entries.
       remediation:
         - id: console
           desc: |
@@ -21428,6 +24530,28 @@ queries:
         - **Misconfiguration prevention**: New subnets without a custom NACL automatically inherit the default NACL rules.
         - **Defense in depth**: A restrictive default NACL provides a safety net against misconfigured security groups.
         - **Compliance alignment**: CIS AWS Foundations Benchmark recommends restricting the default NACL.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **VPC** console.
+        2. In the left navigation pane, choose **Network ACLs**.
+        3. Review the **Default** column. Select each NACL that shows **Yes**.
+        4. Choose the **Inbound rules** tab. Review all rules other than the implicit deny-all (rule number 32767).
+        5. Choose the **Outbound rules** tab. Review all rules other than the implicit deny-all (rule number 32767).
+
+        A passing default NACL has no rules with action **Allow** in either direction. A failing default NACL shows one or more **Allow** rules on the Inbound rules or Outbound rules tab.
+
+        ### Audit via CLI
+
+        1. List all network ACLs and filter for the default ones:
+
+        ```bash
+        aws ec2 describe-network-acls \
+          --filters Name=default,Values=true \
+          --query 'NetworkAcls[*].{AclId:NetworkAclId,VpcId:VpcId,Entries:Entries}'
+        ```
+
+        A passing default NACL returns an `Entries` array that contains only entries with `RuleAction` equal to `deny` (the implicit deny-all entries have rule numbers 32767 and 32768). A failing default NACL shows at least one entry with `"RuleAction": "allow"`.
       remediation:
         - id: console
           desc: |
@@ -21532,6 +24656,26 @@ queries:
         - **Modern standards**: ED25519 offers better performance and security properties than older key types.
         - **Compliance alignment**: Security frameworks recommend the use of strong cryptographic algorithms for authentication.
         - **SSH security**: Using modern key types reduces the risk of key compromise through cryptographic attacks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Network & Security**, choose **Key Pairs**.
+        3. Review the **Type** column for each key pair.
+
+        A passing key pair shows **ed25519** or **rsa** in the Type column. A failing key pair shows any other value or a blank entry in the Type column.
+
+        ### Audit via CLI
+
+        1. List all EC2 key pairs with their types:
+
+        ```bash
+        aws ec2 describe-key-pairs \
+          --query 'KeyPairs[*].{KeyName:KeyName,KeyType:KeyType}' \
+          --output table
+        ```
+
+        A passing key pair returns `KeyType` as `ed25519` or `rsa`. A failing key pair returns a `KeyType` value other than `ed25519` or `rsa`.
       remediation:
         - id: console
           desc: |
@@ -21649,6 +24793,28 @@ queries:
         - **Temporary credentials**: IAM database authentication uses short-lived authentication tokens rather than long-lived passwords.
         - **Audit trail**: Authentication attempts are logged in CloudTrail, providing visibility into database access patterns.
         - **Compliance alignment**: Eliminates shared database passwords and aligns with least-privilege access principles.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Databases**.
+        3. Select a DB instance.
+        4. Choose the **Configuration** tab.
+        5. Under **Security**, review the **IAM DB authentication** field.
+
+        A passing DB instance shows **Enabled** next to IAM DB authentication. A failing DB instance shows **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances and check the IAM authentication setting:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query 'DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier,IAMDatabaseAuthenticationEnabled:IAMDatabaseAuthenticationEnabled}' \
+          --output table
+        ```
+
+        A passing DB instance returns `IAMDatabaseAuthenticationEnabled` as `true`. A failing DB instance returns `false`.
       remediation:
         - id: console
           desc: |
@@ -21766,6 +24932,27 @@ queries:
         - **Consistent encryption**: Account-level EBS encryption ensures all new volumes, including those created by auto-scaling, are encrypted.
         - **Compliance alignment**: Meets requirements for encryption of data at rest on compute resources.
         - **Defense in depth**: Encrypting node volumes protects data even if physical storage media is compromised.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Account attributes**, choose **EBS encryption**.
+        3. Verify that **Always encrypt new EBS volumes** is enabled for each region where EKS clusters are deployed.
+        4. To check individual node group volumes, open the **EKS** console, select a cluster, go to the **Compute** tab, select a node group, and review the **Launch template** to confirm EBS volumes have encryption enabled.
+
+        A passing configuration shows **Enabled** for EBS encryption by default. A failing configuration shows **Disabled** or shows a launch template with `Encrypted: false` for the root volume.
+
+        ### Audit via CLI
+
+        1. Check EBS encryption by default status in each relevant region:
+
+        ```bash
+        aws ec2 get-ebs-encryption-by-default \
+          --region <region> \
+          --query 'EbsEncryptionByDefault'
+        ```
+
+        A passing region returns `true`. A failing region returns `false`.
       remediation:
         - id: console
           desc: |
@@ -21912,6 +25099,28 @@ queries:
         - **Centralized management**: Access entries can be managed through the EKS API, Terraform, or CloudFormation rather than editing a ConfigMap.
         - **Reduced risk**: The aws-auth ConfigMap can be accidentally deleted or misconfigured, potentially locking out cluster administrators.
         - **Compliance alignment**: API-based authentication provides better audit trails for access management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EKS** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster.
+        4. Choose the **Access** tab.
+        5. Review the **Authentication mode** field.
+
+        A passing cluster shows **EKS API** or **EKS API and ConfigMap** as the authentication mode. A failing cluster shows **ConfigMap** only.
+
+        ### Audit via CLI
+
+        1. Describe the EKS cluster access configuration:
+
+        ```bash
+        aws eks describe-cluster \
+          --name <cluster-name> \
+          --query 'cluster.accessConfig.authenticationMode'
+        ```
+
+        A passing cluster returns `"API"` or `"API_AND_CONFIG_MAP"`. A failing cluster returns `"CONFIG_MAP"`.
       remediation:
         - id: console
           desc: |
@@ -22029,6 +25238,32 @@ queries:
         - **kube-proxy security bypass:** A failed or degraded kube-proxy can cause network policy enforcement to stop functioning, removing pod-level network segmentation that prevents attackers from reaching sensitive services.
         - **Security patch gaps:** Unhealthy add-ons may be running outdated versions with known vulnerabilities that attackers can exploit for container escape or privilege escalation.
         - **DNS manipulation risk:** Degraded CoreDNS can fail to resolve security-critical endpoints such as OIDC providers or admission webhook services, bypassing authentication and admission controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EKS** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster.
+        4. Choose the **Add-ons** tab.
+        5. Review the **Status** column for each listed add-on.
+
+        A passing add-on shows **Active** in the Status column. A failing add-on shows any other status such as **Degraded**, **Create failed**, or **Update failed**.
+
+        ### Audit via CLI
+
+        1. List all add-ons for a cluster and check their statuses:
+
+        ```bash
+        aws eks list-addons \
+          --cluster-name <cluster-name> \
+          --query 'addons' \
+          --output text | xargs -I{} aws eks describe-addon \
+            --cluster-name <cluster-name> \
+            --addon-name {} \
+            --query 'addon.{Name:addonName,Status:status}'
+        ```
+
+        A passing add-on returns `"Status": "ACTIVE"`. A failing add-on returns any other status value.
       remediation:
         - id: console
           desc: |
@@ -22123,6 +25358,29 @@ queries:
         - **Data exfiltration detection:** Abnormal network egress patterns from containers such as large data transfers to unexpected destinations are only visible through Container Insights metrics, which provide task-level network monitoring.
         - **Unauthorized container activity:** Container Insights reveals unexpected container launches, resource consumption spikes, and task-level anomalies that indicate an attacker has deployed malicious containers or compromised existing ones.
         - **Incident response capability:** Without container-level metrics, security teams cannot determine which specific tasks or containers were involved in a breach, significantly slowing incident response and scope assessment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **ECS** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster.
+        4. Choose the **Monitoring** tab.
+        5. Review the **Container Insights** field.
+
+        A passing cluster shows Container Insights as **Enabled**. A failing cluster shows **Disabled**.
+
+        ### Audit via CLI
+
+        1. Describe the ECS cluster settings and filter for the Container Insights setting:
+
+        ```bash
+        aws ecs describe-clusters \
+          --clusters <cluster-name> \
+          --include SETTINGS \
+          --query 'clusters[*].settings'
+        ```
+
+        A passing cluster returns a settings entry with `"name": "containerInsights"` and `"value": "enabled"`. A failing cluster returns `"value": "disabled"` or no `containerInsights` entry.
       remediation:
         - id: console
           desc: |
@@ -22250,6 +25508,29 @@ queries:
         - **Enhanced control**: Customer-managed KMS keys allow organizations to manage the encryption key lifecycle.
         - **Compliance alignment**: Encryption of all storage volumes, including ephemeral storage, is required by many regulatory frameworks.
         - **Audit trail**: KMS key usage is logged in CloudTrail for auditing purposes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **ECS** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster.
+        4. Choose the **Configuration** tab.
+        5. Under **Encryption**, review the **KMS key** field for Fargate ephemeral storage.
+
+        A passing cluster shows a KMS key ARN configured for Fargate ephemeral storage encryption. A failing cluster shows no KMS key configured for this setting.
+
+        ### Audit via CLI
+
+        1. Describe the ECS cluster and check for a Fargate ephemeral storage KMS key:
+
+        ```bash
+        aws ecs describe-clusters \
+          --clusters <cluster-name> \
+          --include CONFIGURATIONS \
+          --query 'clusters[*].configuration.managedStorageConfiguration'
+        ```
+
+        A passing cluster returns a `managedStorageConfiguration` object with a non-empty `fargateEphemeralStorageKmsKeyId`. A failing cluster returns `null` or an empty `managedStorageConfiguration`.
       remediation:
         - id: console
           desc: |
@@ -22375,6 +25656,29 @@ queries:
         - **Modern standards**: ECDSA keys (P-256, P-384, P-521) offer equivalent security to much larger RSA keys with better performance.
         - **Compliance alignment**: PCI DSS, NIST, and other frameworks require minimum key sizes for TLS certificates.
         - **Future-proofing**: Stronger key algorithms provide better protection against advances in computing power.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open **AWS Certificate Manager**.
+        2. In the left navigation pane, choose **List certificates**.
+        3. Select a certificate.
+        4. Review the **Key algorithm** field in the certificate details.
+
+        A passing certificate shows a key algorithm of **RSA 2048**, **RSA 3072**, **RSA 4096**, **ECDSA P256**, **ECDSA P384**, or **ECDSA P521**. A failing certificate shows **RSA 1024** or any weaker algorithm.
+
+        ### Audit via CLI
+
+        1. List all ACM certificates and retrieve their key algorithms:
+
+        ```bash
+        aws acm list-certificates \
+          --query 'CertificateSummaryList[*].CertificateArn' \
+          --output text | tr '\t' '\n' | xargs -I{} aws acm describe-certificate \
+            --certificate-arn {} \
+            --query 'Certificate.{Domain:DomainName,KeyAlgorithm:KeyAlgorithm}'
+        ```
+
+        A passing certificate returns a `KeyAlgorithm` of `RSA_2048`, `RSA_3072`, `RSA_4096`, `EC_prime256v1`, `EC_secp384r1`, or `EC_secp521r1`. A failing certificate returns `RSA_1024`.
       remediation:
         - id: console
           desc: |
@@ -22508,6 +25812,28 @@ queries:
         - Prevents unauthorized access to sensitive environment variable values.
         - Enables audit logging of encryption key usage through AWS CloudTrail.
         - Provides fine-grained access control over who can decrypt environment variables.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Lambda** console.
+        2. In the left navigation pane, choose **Functions**.
+        3. Select a function.
+        4. Choose the **Configuration** tab, then select **Environment variables**.
+        5. Review the **Encryption configuration** section. If the function has environment variables, verify that a customer managed KMS key is listed.
+
+        A passing function with environment variables shows a custom KMS key ARN under Encryption configuration. A failing function shows the default AWS managed key or no KMS key configured despite having environment variables defined.
+
+        ### Audit via CLI
+
+        1. Retrieve the function configuration to check for a KMS key and environment variables:
+
+        ```bash
+        aws lambda get-function-configuration \
+          --function-name <function-name> \
+          --query '{KMSKeyArn:KMSKeyArn,EnvVarCount:length(Environment.Variables)}'
+        ```
+
+        A passing function that has environment variables returns a non-empty `KMSKeyArn`. A failing function returns an empty or null `KMSKeyArn` while `EnvVarCount` is greater than zero.
       remediation:
         - id: console
           desc: |
@@ -22655,6 +25981,28 @@ queries:
         - Prevents deployment of unauthorized or tampered Lambda function code.
         - Provides cryptographic verification of code package integrity.
         - Establishes a chain of trust from code build to deployment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Lambda** console.
+        2. In the left navigation pane, choose **Functions**.
+        3. Select a function.
+        4. Choose the **Configuration** tab, then select **Code signing**.
+        5. Review whether a code signing configuration is attached to the function.
+
+        A passing function shows a code signing configuration ARN with a signing profile and enforcement policy listed. A failing function shows no code signing configuration attached.
+
+        ### Audit via CLI
+
+        1. Retrieve the code signing configuration for a Lambda function:
+
+        ```bash
+        aws lambda get-function-code-signing-config \
+          --function-name <function-name> \
+          --query 'CodeSigningConfigArn'
+        ```
+
+        A passing function returns a non-empty `CodeSigningConfigArn`. A failing function returns a null or empty value.
       remediation:
         - id: console
           desc: |
@@ -22817,6 +26165,27 @@ queries:
         - Prevents credential theft through SSRF attacks by requiring session-based authentication.
         - Enforces PUT-based token requests that are blocked by most SSRF attack vectors.
         - Aligns with security best practices for instance metadata access.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **SageMaker** console.
+        2. In the left navigation pane, under **Notebook**, choose **Notebook instances**.
+        3. Select a notebook instance.
+        4. Under **Network**, review the **Minimum IMDS version** field.
+
+        A passing notebook instance shows **2** as the Minimum IMDS version. A failing notebook instance shows **1** or no value set.
+
+        ### Audit via CLI
+
+        1. Describe the SageMaker notebook instance and check the IMDS configuration:
+
+        ```bash
+        aws sagemaker describe-notebook-instance \
+          --notebook-instance-name <instance-name> \
+          --query 'InstanceMetadataServiceConfiguration.MinimumInstanceMetadataServiceVersion'
+        ```
+
+        A passing notebook instance returns `"2"`. A failing notebook instance returns `"1"` or no value.
       remediation:
         - id: console
           desc: |
@@ -22954,6 +26323,27 @@ queries:
         - Enforces the principle of least privilege by restricting administrator access.
         - Reduces the attack surface by preventing installation of unauthorized packages.
         - Limits the impact of potential container escape or code execution vulnerabilities.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **SageMaker** console.
+        2. In the left navigation pane, under **Notebook**, choose **Notebook instances**.
+        3. Select a notebook instance.
+        4. Under **Permissions and encryption**, review the **Root access** field.
+
+        A passing notebook instance shows **Disabled** for Root access. A failing notebook instance shows **Enabled**.
+
+        ### Audit via CLI
+
+        1. Describe the SageMaker notebook instance and check the root access setting:
+
+        ```bash
+        aws sagemaker describe-notebook-instance \
+          --notebook-instance-name <instance-name> \
+          --query 'RootAccess'
+        ```
+
+        A passing notebook instance returns `"Disabled"`. A failing notebook instance returns `"Enabled"`.
       remediation:
         - id: console
           desc: |
@@ -23090,6 +26480,27 @@ queries:
         - Provides centralized key management with full audit logging through CloudTrail.
         - Enables custom key rotation policies to meet compliance requirements.
         - Allows fine-grained access control through KMS key policies and grants.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **S3** console.
+        2. Select a bucket.
+        3. Choose the **Properties** tab.
+        4. Under **Default encryption**, review the **Encryption type** and **AWS KMS key** fields.
+
+        A passing bucket shows **Server-side encryption with AWS Key Management Service keys (SSE-KMS)** as the encryption type and lists a customer managed KMS key. A failing bucket shows **Server-side encryption with Amazon S3 managed keys (SSE-S3)** or shows an AWS managed key (`aws/s3`) rather than a customer managed key.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket encryption configuration:
+
+        ```bash
+        aws s3api get-bucket-encryption \
+          --bucket <bucket-name> \
+          --query 'ServerSideEncryptionConfiguration.Rules[*].ApplyServerSideEncryptionByDefault'
+        ```
+
+        A passing bucket returns `SSEAlgorithm` as `aws:kms` or `aws:kms:dsse`. A failing bucket returns `SSEAlgorithm` as `AES256` or returns a `KMSMasterKeyID` pointing to the default AWS managed key (`aws/s3`).
       remediation:
         - id: console
           desc: |
@@ -23253,6 +26664,27 @@ queries:
         - Provides centralized key management with full audit logging for build artifact encryption.
         - Enables custom key rotation policies for compliance requirements.
         - Allows fine-grained access control over who can decrypt build artifacts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **CodeBuild** console.
+        2. In the left navigation pane, choose **Build projects**.
+        3. Select a project.
+        4. Under **Artifacts**, review the **Encryption key** field.
+
+        A passing project shows a customer managed KMS key ARN as the encryption key. A failing project shows the default AWS managed key (typically displayed as `aws/s3`) or no custom key configured.
+
+        ### Audit via CLI
+
+        1. List all CodeBuild projects and describe each to check the encryption key:
+
+        ```bash
+        aws codebuild batch-get-projects \
+          --names <project-name> \
+          --query 'projects[*].{Name:name,EncryptionKey:encryptionKey}'
+        ```
+
+        A passing project returns an `EncryptionKey` ARN whose `KeyManager` is `CUSTOMER`. A failing project returns the default AWS managed key ARN or no value.
       remediation:
         - id: console
           desc: |
@@ -23406,6 +26838,28 @@ queries:
         - Ensures all snapshots maintain encryption at rest, protecting data in backup copies.
         - Prevents accidental exposure of plaintext data when snapshots are shared.
         - Maintains compliance with data protection requirements across all copies of data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon Neptune** service.
+        2. In the left navigation pane, select **Snapshots**.
+        3. Review each snapshot listed under **Cluster snapshots**.
+        4. Check the **Encrypted** column for each snapshot.
+
+        A passing snapshot shows **Yes** in the **Encrypted** column. A failing snapshot shows **No**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all Neptune cluster snapshots and their encryption status:
+
+        ```bash
+        aws neptune describe-db-cluster-snapshots \
+          --query "DBClusterSnapshots[*].{SnapshotId:DBClusterSnapshotIdentifier,Encrypted:StorageEncrypted}" \
+          --output table
+        ```
+
+        A passing snapshot returns `StorageEncrypted: true`. A failing snapshot returns `StorageEncrypted: false`.
+
       remediation:
         - id: console
           desc: |
@@ -23552,6 +27006,30 @@ queries:
         - Prevents instances from being used as unauthorized network bridges or traffic interceptors.
         - Maintains the integrity of VPC routing by ensuring instances only process their own traffic.
         - Reduces the risk of network-based attacks from compromised instances.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon EC2** service.
+        2. In the left navigation pane, select **Instances**.
+        3. Select an instance that is not in a `terminated` or `shutting-down` state.
+        4. In the instance details pane, select the **Networking** tab.
+        5. Locate the **Source/destination check** field.
+
+        A passing instance shows **Enabled** for source/destination check. A failing instance shows **Disabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to check the source/destination check setting for all running instances:
+
+        ```bash
+        aws ec2 describe-instances \
+          --filters "Name=instance-state-name,Values=running,stopped,pending" \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,SourceDestCheck:SourceDestCheck,State:State.Name}" \
+          --output table
+        ```
+
+        A passing instance returns `SourceDestCheck: true`. A failing instance returns `SourceDestCheck: false`.
+
       remediation:
         - id: console
           desc: |
@@ -23673,6 +27151,30 @@ queries:
         - **Boot integrity:** Prevents unauthorized modification of boot components.
         - **Malware protection:** Blocks rootkits and bootkits that tamper with the boot process.
         - **Modern security:** Aligns with current best practices for instance hardening.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon EC2** service.
+        2. In the left navigation pane, select **Instances**.
+        3. Select a running instance.
+        4. In the instance details pane, select the **Details** tab.
+        5. Locate the **Boot mode** and **Current instance boot mode** fields.
+
+        A passing instance shows **uefi** or **uefi-preferred** under **Current instance boot mode**. A failing instance shows **legacy-bios**.
+
+        ### Audit via CLI
+
+        1. Run the following command to retrieve the boot mode and current instance boot mode for all running instances:
+
+        ```bash
+        aws ec2 describe-instances \
+          --filters "Name=instance-state-name,Values=running" \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,BootMode:BootMode,CurrentBootMode:CurrentInstanceBootMode}" \
+          --output table
+        ```
+
+        A passing instance returns `CurrentInstanceBootMode` of `uefi` or `uefi-preferred`. A failing instance returns `CurrentInstanceBootMode` of `legacy-bios` or a blank value.
+
       remediation:
         - id: console
           desc: |
@@ -23779,6 +27281,29 @@ queries:
         - **Stronger isolation:** HVM provides hardware-level isolation between guest and host.
         - **Reduced attack surface:** Eliminates PV-specific hypervisor call interfaces.
         - **Modern security features:** HVM supports NitroTPM, Secure Boot, and other advanced security features.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon EC2** service.
+        2. In the left navigation pane, select **Instances**.
+        3. Add the **Virtualization** column to the table by choosing the column preferences icon and enabling it.
+        4. Review the **Virtualization** column for each running instance.
+
+        A passing instance shows **hvm** in the **Virtualization** column. A failing instance shows **paravirtual**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all running instances and their virtualization type:
+
+        ```bash
+        aws ec2 describe-instances \
+          --filters "Name=instance-state-name,Values=running" \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,VirtualizationType:VirtualizationType}" \
+          --output table
+        ```
+
+        A passing instance returns `VirtualizationType: hvm`. A failing instance returns `VirtualizationType: paravirtual`.
+
       remediation:
         - id: console
           desc: |
@@ -23894,6 +27419,36 @@ queries:
         - **Account-level enforcement:** Ensures all new EBS volumes are encrypted by default, including those used for hibernation.
         - **Credential protection:** Prevents exposure of in-memory secrets, tokens, and keys written during hibernation.
         - **Compliance:** Meets encryption-at-rest requirements for hibernation data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon EC2** service.
+        2. In the left navigation pane, select **Instances**.
+        3. Filter instances that have hibernation enabled: select an instance, choose the **Details** tab, and look for **Hibernation** set to **Enabled**.
+        4. For any hibernation-enabled instance, navigate to **EC2** > **Settings** (under **Account Attributes**) > **EBS encryption**.
+        5. Verify that **Always encrypt new EBS volumes** is enabled for the region.
+
+        A passing configuration shows **EBS encryption by default** as **Enabled**. A failing configuration shows it as **Disabled** while hibernation-enabled instances exist.
+
+        ### Audit via CLI
+
+        1. Check for running instances with hibernation configured:
+
+        ```bash
+        aws ec2 describe-instances \
+          --filters "Name=instance-state-name,Values=running" \
+          --query "Reservations[*].Instances[*].{InstanceId:InstanceId,HibernationConfigured:HibernationOptions.Configured}" \
+          --output table
+        ```
+
+        2. If any instances have `HibernationConfigured: true`, check EBS encryption by default for the region:
+
+        ```bash
+        aws ec2 get-ebs-encryption-by-default
+        ```
+
+        A passing account returns `EbsEncryptionByDefault: true`. A failing account returns `EbsEncryptionByDefault: false` while hibernation-enabled instances are present.
+
       remediation:
         - id: console
           desc: |
@@ -24015,6 +27570,36 @@ queries:
         - **DNS integrity:** Prevents DNS spoofing and cache poisoning attacks.
         - **Authentication:** Verifies that DNS responses originate from the authoritative source.
         - **Trust chain:** Establishes a chain of trust from the root DNS zone to your domain.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Route 53** service.
+        2. In the left navigation pane, select **Hosted zones**.
+        3. Select a public hosted zone (zones marked as **Private** are not applicable).
+        4. Choose the **DNSSEC signing** tab.
+        5. Review the **DNSSEC signing** status.
+
+        A passing hosted zone shows a **DNSSEC signing** status of **Enabled** with `Signing`. A failing hosted zone shows **DNSSEC signing** as **Disabled** or **Not signing**.
+
+        ### Audit via CLI
+
+        1. List all public hosted zones and their IDs:
+
+        ```bash
+        aws route53 list-hosted-zones \
+          --query "HostedZones[?Config.PrivateZone==\`false\`].{Id:Id,Name:Name}" \
+          --output table
+        ```
+
+        2. For each public hosted zone, check its DNSSEC status:
+
+        ```bash
+        aws route53 get-dnssec --hosted-zone-id <zone-id> \
+          --query "Status.ServeSignature"
+        ```
+
+        A passing hosted zone returns `"SIGNING"`. A failing hosted zone returns `"NOT_SIGNING"`.
+
       remediation:
         - id: console
           desc: |
@@ -24135,6 +27720,36 @@ queries:
         - **Threat detection:** Enables detection of DNS-based attacks including tunneling and exfiltration.
         - **Incident response:** Provides DNS query history for forensic analysis.
         - **Compliance:** Meets audit logging requirements for DNS infrastructure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Route 53** service.
+        2. In the left navigation pane, select **Hosted zones**.
+        3. Select a public hosted zone.
+        4. Choose the **Query logging** tab.
+        5. Check whether a query logging configuration is listed.
+
+        A passing hosted zone shows a configured **CloudWatch Logs log group** under **Query logging**. A failing hosted zone shows no query logging configuration.
+
+        ### Audit via CLI
+
+        1. List all public hosted zones:
+
+        ```bash
+        aws route53 list-hosted-zones \
+          --query "HostedZones[?Config.PrivateZone==\`false\`].{Id:Id,Name:Name}" \
+          --output table
+        ```
+
+        2. For each public hosted zone, check for a query logging configuration:
+
+        ```bash
+        aws route53 list-query-logging-configs --hosted-zone-id <zone-id> \
+          --query "QueryLoggingConfigs[*].{Id:Id,LogGroupArn:CloudWatchLogsLogGroupArn}"
+        ```
+
+        A passing hosted zone returns at least one query logging configuration entry. A failing hosted zone returns an empty list `[]`.
+
       remediation:
         - id: console
           desc: |
@@ -24261,6 +27876,28 @@ queries:
         - **Compromised endpoint detection:** Active health checks enable automatic failover away from compromised endpoints that stop responding correctly.
         - **Attack persistence prevention:** Ensures that DNS failover cannot be silently disabled to maintain traffic flow to attacker-controlled resources.
         - **Monitoring integrity:** Maintains accurate health status so that compromised endpoints are detected and isolated through DNS routing changes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Route 53** service.
+        2. In the left navigation pane, select **Health checks**.
+        3. Review the **Status** column for each health check.
+        4. Look for any health checks showing a **Disabled** status.
+
+        A passing health check shows **Active** (not disabled). A failing health check shows **Disabled** in the status column.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all health checks and their disabled status:
+
+        ```bash
+        aws route53 list-health-checks \
+          --query "HealthChecks[*].{Id:Id,Type:HealthCheckConfig.Type,Disabled:HealthCheckConfig.Disabled}" \
+          --output table
+        ```
+
+        A passing health check returns `Disabled: false` or `Disabled: None`. A failing health check returns `Disabled: true`.
+
       remediation:
         - id: console
           desc: |
@@ -24402,6 +28039,28 @@ queries:
         - **Encryption in transit:** Ensures health check traffic is encrypted.
         - **Endpoint authentication:** Validates the TLS certificate of monitored endpoints.
         - **Tamper protection:** Prevents manipulation of health check responses.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Route 53** service.
+        2. In the left navigation pane, select **Health checks**.
+        3. For each health check of type **HTTP endpoint** or **HTTP_STR_MATCH**, review the **Protocol** column.
+        4. Identify any health checks using **HTTP** instead of **HTTPS**.
+
+        A passing endpoint health check shows **HTTPS** or **HTTPS_STR_MATCH** as the protocol. A failing endpoint health check shows **HTTP** or **HTTP_STR_MATCH**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all health checks and their protocol type:
+
+        ```bash
+        aws route53 list-health-checks \
+          --query "HealthChecks[*].{Id:Id,Type:HealthCheckConfig.Type,FQDN:HealthCheckConfig.FullyQualifiedDomainName}" \
+          --output table
+        ```
+
+        A passing health check returns a `Type` of `HTTPS`, `HTTPS_STR_MATCH`, `CLOUDWATCH_METRIC`, or `CALCULATED`. A failing health check returns a `Type` of `HTTP` or `HTTP_STR_MATCH`.
+
       remediation:
         - id: console
           desc: |
@@ -24542,6 +28201,29 @@ queries:
         - **Network security:** Forces outbound traffic through controlled network paths with security inspection.
         - **Data protection:** Prevents direct data exfiltration from streaming sessions.
         - **Compliance:** Ensures network traffic is subject to organizational security policies.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon AppStream 2.0** service.
+        2. In the left navigation pane, select **Fleets**.
+        3. Select a fleet from the list.
+        4. In the fleet details, select the **Network access** section.
+        5. Review the **Default internet access** setting.
+
+        A passing fleet shows **Default internet access** as **Disabled**. A failing fleet shows **Default internet access** as **Enabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all AppStream fleets and their default internet access setting:
+
+        ```bash
+        aws appstream describe-fleets \
+          --query "Fleets[*].{Name:Name,DefaultInternetAccess:EnableDefaultInternetAccess,State:State}" \
+          --output table
+        ```
+
+        A passing fleet returns `EnableDefaultInternetAccess: false`. A failing fleet returns `EnableDefaultInternetAccess: true`.
+
       remediation:
         - id: console
           desc: |
@@ -24687,6 +28369,28 @@ queries:
         - **Session security:** Limits the duration a compromised session can remain active.
         - **Re-authentication:** Forces periodic re-authentication to verify user identity.
         - **Resource management:** Prevents resource waste from abandoned sessions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon AppStream 2.0** service.
+        2. In the left navigation pane, select **Fleets**.
+        3. Select a fleet from the list.
+        4. Review the **Maximum session duration** field in the fleet details.
+
+        A passing fleet shows a **Maximum session duration** of 600 minutes (36000 seconds) or less. A failing fleet shows a value greater than 600 minutes.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all AppStream fleets and their maximum user duration:
+
+        ```bash
+        aws appstream describe-fleets \
+          --query "Fleets[*].{Name:Name,MaxUserDurationInSeconds:MaxUserDurationInSeconds}" \
+          --output table
+        ```
+
+        A passing fleet returns `MaxUserDurationInSeconds` of 36000 or less. A failing fleet returns a value greater than 36000.
+
       remediation:
         - id: console
           desc: |
@@ -24816,6 +28520,28 @@ queries:
         - **Unattended sessions:** Automatically disconnects idle sessions to prevent unauthorized access.
         - **Least privilege:** Reduces the time window during which an abandoned session could be exploited.
         - **Resource efficiency:** Frees up fleet capacity from idle sessions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon AppStream 2.0** service.
+        2. In the left navigation pane, select **Fleets**.
+        3. Select a fleet from the list.
+        4. Review the **Idle disconnect timeout** field in the fleet details.
+
+        A passing fleet shows an **Idle disconnect timeout** between 1 and 15 minutes (1 to 900 seconds). A failing fleet shows 0 (no idle timeout) or a value greater than 900 seconds.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all AppStream fleets and their idle disconnect timeout:
+
+        ```bash
+        aws appstream describe-fleets \
+          --query "Fleets[*].{Name:Name,IdleDisconnectTimeoutInSeconds:IdleDisconnectTimeoutInSeconds}" \
+          --output table
+        ```
+
+        A passing fleet returns `IdleDisconnectTimeoutInSeconds` between 1 and 900. A failing fleet returns 0 or a value greater than 900.
+
       remediation:
         - id: console
           desc: |
@@ -24949,6 +28675,29 @@ queries:
         - **Data protection:** Prevents exfiltration of sensitive image build artifacts.
         - **Supply chain security:** Reduces risk of compromised software communicating externally during image creation.
         - **Network control:** Forces outbound traffic through monitored network paths.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon AppStream 2.0** service.
+        2. In the left navigation pane, select **Image builders**.
+        3. Select an image builder from the list.
+        4. In the image builder details, review the **Network access** section.
+        5. Check the **Default internet access** setting.
+
+        A passing image builder shows **Default internet access** as **Disabled**. A failing image builder shows **Default internet access** as **Enabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all AppStream image builders and their default internet access setting:
+
+        ```bash
+        aws appstream describe-image-builders \
+          --query "ImageBuilders[*].{Name:Name,DefaultInternetAccess:EnableDefaultInternetAccess,State:State}" \
+          --output table
+        ```
+
+        A passing image builder returns `EnableDefaultInternetAccess: false`. A failing image builder returns `EnableDefaultInternetAccess: true`.
+
       remediation:
         - id: console
           desc: |
@@ -25085,6 +28834,28 @@ queries:
         - **Patching:** Ensures the directory OS continues to receive security updates.
         - **Security features:** Leverages modern security capabilities available in Server 2019.
         - **Compliance:** Meets requirements for running supported, patched operating systems.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **AWS Directory Service** console.
+        2. In the left navigation pane, select **Directories**.
+        3. For each directory of type **AWS Managed Microsoft AD**, select the directory and review the details.
+        4. Locate the **OS version** field in the directory details.
+
+        A passing directory shows an **OS version** of **SERVER_2019** or newer. A failing directory shows **SERVER_2012**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all directories and their OS version:
+
+        ```bash
+        aws ds describe-directories \
+          --query "DirectoryDescriptions[?Type=='MicrosoftAD' && Stage=='Active'].{Id:DirectoryId,Name:Name,OsVersion:OsVersion,Stage:Stage}" \
+          --output table
+        ```
+
+        A passing directory returns `OsVersion: SERVER_2019` or a newer value. A failing directory returns `OsVersion: SERVER_2012`.
+
       remediation:
         - id: console
           desc: |
@@ -25216,6 +28987,29 @@ queries:
         - **Credential hygiene:** Eliminates multiple credential stores that could be targeted independently and reduces the password fatigue that leads to weak credential choices.
         - **Incident containment:** A single account disable instantly cuts off a compromised identity from all integrated resources, limiting blast radius.
         - **Compliance:** Meets centralized authentication requirements in SOC 2, NIST 800-53 (IA-2), and ISO 27001.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **AWS Directory Service** console.
+        2. In the left navigation pane, select **Directories**.
+        3. Select an active directory.
+        4. Choose the **Application management** tab.
+        5. Locate the **Single sign-on (SSO)** section and review its status.
+
+        A passing directory shows SSO status as **Enabled**. A failing directory shows SSO status as **Disabled**.
+
+        ### Audit via CLI
+
+        1. Run the following command to list all active directories and their SSO status:
+
+        ```bash
+        aws ds describe-directories \
+          --query "DirectoryDescriptions[?Stage=='Active'].{Id:DirectoryId,Name:Name,Type:Type,SsoEnabled:SsoEnabled}" \
+          --output table
+        ```
+
+        A passing directory returns `SsoEnabled: true`. A failing directory returns `SsoEnabled: false`.
+
       remediation:
         - id: console
           desc: |
@@ -25294,6 +29088,26 @@ queries:
         - **Account protection:** Prevents unauthorized access even when passwords are compromised.
         - **Phishing resistance:** Adds a factor that cannot be captured through phishing.
         - **Compliance:** Meets MFA requirements in PCI DSS, HIPAA, SOC 2, NIST 800-53, and other frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS Directory Service Console** at Services > Directory Service.
+        2. Select the Managed Microsoft AD directory you want to inspect.
+        3. Choose the **Networking & security** tab.
+        4. Under **Multi-factor authentication**, check the displayed RADIUS status.
+
+        A passing directory shows a RADIUS status of **Completed**. A failing directory shows a status of **Disabled** or no RADIUS configuration.
+
+        ### Audit via CLI
+
+        1. List all active Managed Microsoft AD directories and their RADIUS status:
+
+        ```bash
+        aws ds describe-directories \
+          --query "DirectoryDescriptions[?Type=='MicrosoftAD' && Stage=='Active'].{Id:DirectoryId,Name:Name,RadiusStatus:RadiusStatus}"
+        ```
+
+        A passing directory returns `"RadiusStatus": "Completed"`. A failing directory returns `"RadiusStatus": "Disabled"` or omits the `RadiusStatus` field entirely.
       remediation:
         - id: console
           desc: |
@@ -25417,6 +29231,27 @@ queries:
         - **Data protection:** Ensures all document data, backups, and snapshots are encrypted using AWS KMS, preventing unauthorized access to stored data.
         - **Compliance:** Meets regulatory requirements for encryption of data at rest in managed database services.
         - **Key management:** Leverages AWS KMS for centralized key management, access control policies, and automatic key rotation.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon DocumentDB Console** at Services > DocumentDB.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster to inspect.
+        4. Choose the **Configuration** tab.
+        5. Locate the **Encryption** field.
+
+        A passing cluster shows **Encryption: Enabled**. A failing cluster shows **Encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB clusters and their encryption status:
+
+        ```bash
+        aws docdb describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,Encrypted:StorageEncrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        A passing cluster returns `"Encrypted": true`. A failing cluster returns `"Encrypted": false`.
       remediation:
         - id: console
           desc: |
@@ -25567,6 +29402,36 @@ queries:
         - **Key control:** Provides full lifecycle control over encryption keys, including the ability to disable or revoke access.
         - **Audit visibility:** Enables detailed CloudTrail logging of all key usage for compliance and forensic purposes.
         - **Access separation:** Allows separation of duties between database administrators and key administrators.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon DocumentDB Console** at Services > DocumentDB.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster to inspect.
+        4. Choose the **Configuration** tab.
+        5. Locate the **KMS key** field and note the key ARN or alias displayed.
+        6. Open the **AWS KMS Console**, find the key, and verify that **Key type** is **Customer managed**.
+
+        A passing cluster shows a customer-managed KMS key (key type **Customer managed**). A failing cluster shows an AWS-managed key (`aws/docdb`) or no KMS key.
+
+        ### Audit via CLI
+
+        1. Retrieve the KMS key ID for each DocumentDB cluster:
+
+        ```bash
+        aws docdb describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For each non-empty `KmsKeyId`, confirm the key is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Manager:KeyManager}"
+        ```
+
+        A passing cluster has a `KmsKeyId` whose `KeyManager` value is `"CUSTOMER"`. A failing cluster has an empty `KmsKeyId` or a `KeyManager` value of `"AWS"`.
       remediation:
         - id: console
           desc: |
@@ -25715,6 +29580,27 @@ queries:
         - **Patch management:** Ensures security patches are applied automatically during the next maintenance window.
         - **Vulnerability reduction:** Minimizes the time window during which known vulnerabilities remain unpatched.
         - **Compliance:** Meets requirements for timely application of security updates in managed database services.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon DocumentDB Console** at Services > DocumentDB.
+        2. Select **Instances** in the left navigation panel.
+        3. Select the instance to inspect.
+        4. Choose the **Maintenance** tab.
+        5. Locate the **Auto minor version upgrade** field.
+
+        A passing instance shows **Auto minor version upgrade: Yes**. A failing instance shows **Auto minor version upgrade: No**.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB instances and their auto minor version upgrade setting:
+
+        ```bash
+        aws docdb describe-db-instances \
+          --query "DBInstances[*].{Instance:DBInstanceIdentifier,AutoUpgrade:AutoMinorVersionUpgrade}"
+        ```
+
+        A passing instance returns `"AutoUpgrade": true`. A failing instance returns `"AutoUpgrade": false`.
       remediation:
         - id: console
           desc: |
@@ -25854,6 +29740,27 @@ queries:
         - **Network boundary protection:** Removing public accessibility eliminates the most direct path for unauthorized access.
         - **Reduced attack surface:** Internet-borne reconnaissance and brute-force attempts no longer reach the database tier.
         - **Compliance alignment:** Satisfies network-segmentation requirements for regulated workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon DocumentDB Console** at Services > DocumentDB.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster that contains the instance, then open the **Instances** tab.
+        4. Select the instance to inspect.
+        5. Under **Connectivity & security**, check the **Publicly accessible** field.
+
+        A passing instance shows **Publicly accessible: No**. A failing instance shows **Publicly accessible: Yes**.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB instances and their public-access setting:
+
+        ```bash
+        aws docdb describe-db-instances \
+          --query "DBInstances[*].{Id:DBInstanceIdentifier,Public:PubliclyAccessible,SubnetGroup:DBSubnetGroup.DBSubnetGroupName}"
+        ```
+
+        A passing instance returns `"Public": false`. A failing instance returns `"Public": true`.
       remediation:
         - id: console
           desc: |
@@ -26017,6 +29924,36 @@ queries:
         - **Account protection:** Prevents unauthorized access even when passwords are compromised.
         - **Phishing resistance:** Adds a factor that cannot be captured through phishing alone.
         - **Compliance:** Meets MFA requirements in PCI DSS, HIPAA, SOC 2, NIST 800-53, and other frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon Cognito Console** at Services > Cognito.
+        2. Select **User pools** in the left navigation panel.
+        3. Select the user pool to inspect.
+        4. Choose the **Sign-in experience** tab.
+        5. Under **Multi-factor authentication**, review the MFA enforcement setting.
+
+        A passing user pool shows **MFA enforcement: Require MFA (ON)**. A failing user pool shows **Optional** or **Off**.
+
+        ### Audit via CLI
+
+        1. List all Cognito user pools:
+
+        ```bash
+        aws cognito-idp list-user-pools \
+          --max-results 60 \
+          --query "UserPools[*].{Id:Id,Name:Name}"
+        ```
+
+        2. Check the MFA configuration for each user pool:
+
+        ```bash
+        aws cognito-idp describe-user-pool \
+          --user-pool-id <user-pool-id> \
+          --query "UserPool.{Name:Name,MfaConfiguration:MfaConfiguration}"
+        ```
+
+        A passing user pool returns `"MfaConfiguration": "ON"`. A failing user pool returns `"MfaConfiguration": "OPTIONAL"` or `"MfaConfiguration": "OFF"`.
       remediation:
         - id: console
           desc: |
@@ -26159,6 +30096,36 @@ queries:
         - **Threat detection:** Identifies and responds to credential stuffing, brute-force attacks, and anomalous sign-in patterns.
         - **Compromised credentials:** Automatically detects when user credentials appear in known breach databases.
         - **Adaptive authentication:** Dynamically adjusts authentication requirements based on assessed risk level.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon Cognito Console** at Services > Cognito.
+        2. Select **User pools** in the left navigation panel.
+        3. Select the user pool to inspect.
+        4. Choose the **Sign-in experience** tab.
+        5. Under **Advanced security**, review the advanced security mode.
+
+        A passing user pool shows **Advanced security mode: Full-function (Enforced)**. A failing user pool shows **Audit only** or **Off**.
+
+        ### Audit via CLI
+
+        1. List all Cognito user pools:
+
+        ```bash
+        aws cognito-idp list-user-pools \
+          --max-results 60 \
+          --query "UserPools[*].{Id:Id,Name:Name}"
+        ```
+
+        2. Check the advanced security configuration for each user pool:
+
+        ```bash
+        aws cognito-idp describe-user-pool \
+          --user-pool-id <user-pool-id> \
+          --query "UserPool.{Name:Name,AdvancedSecurity:UserPoolAddOns.AdvancedSecurityMode}"
+        ```
+
+        A passing user pool returns `"AdvancedSecurity": "ENFORCED"`. A failing user pool returns `"AdvancedSecurity": "AUDIT"`, `"AdvancedSecurity": "OFF"`, or an empty `UserPoolAddOns` block.
       remediation:
         - id: console
           desc: |
@@ -26300,6 +30267,36 @@ queries:
         - **Access control:** Ensures all users must authenticate before receiving AWS credentials.
         - **Attack surface reduction:** Eliminates anonymous access to AWS resources through the identity pool.
         - **Credential protection:** Prevents distribution of AWS credentials to unauthenticated parties.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon Cognito Console** at Services > Cognito.
+        2. Select **Identity pools** in the left navigation panel.
+        3. Select the identity pool to inspect.
+        4. Choose the **User access** tab.
+        5. Under **Guest access**, review whether unauthenticated identities are enabled.
+
+        A passing identity pool shows **Guest access: Disabled**. A failing identity pool shows **Guest access: Enabled**.
+
+        ### Audit via CLI
+
+        1. List all Cognito identity pools:
+
+        ```bash
+        aws cognito-identity list-identity-pools \
+          --max-results 60 \
+          --query "IdentityPools[*].{Id:IdentityPoolId,Name:IdentityPoolName}"
+        ```
+
+        2. Check the unauthenticated identities setting for each pool:
+
+        ```bash
+        aws cognito-identity describe-identity-pool \
+          --identity-pool-id <identity-pool-id> \
+          --query "{Name:IdentityPoolName,AllowUnauth:AllowUnauthenticatedIdentities}"
+        ```
+
+        A passing identity pool returns `"AllowUnauth": false`. A failing identity pool returns `"AllowUnauth": true`.
       remediation:
         - id: console
           desc: |
@@ -26439,6 +30436,36 @@ queries:
         - **Privilege escalation prevention:** Prevents clients from selecting arbitrary IAM roles.
         - **Server-side control:** Ensures role assignment is controlled by server-side rules and configuration.
         - **Simplified security:** Reduces the attack surface by removing client-side role selection.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon Cognito Console** at Services > Cognito.
+        2. Select **Identity pools** in the left navigation panel.
+        3. Select the identity pool to inspect.
+        4. Choose the **User access** tab.
+        5. Under **Authenticated role selection**, verify whether the **Basic (Classic) authentication flow** is enabled.
+
+        A passing identity pool shows **Basic (Classic) flow: Disabled**. A failing identity pool shows **Basic (Classic) flow: Enabled**.
+
+        ### Audit via CLI
+
+        1. List all Cognito identity pools:
+
+        ```bash
+        aws cognito-identity list-identity-pools \
+          --max-results 60 \
+          --query "IdentityPools[*].{Id:IdentityPoolId,Name:IdentityPoolName}"
+        ```
+
+        2. Check the classic flow setting for each pool:
+
+        ```bash
+        aws cognito-identity describe-identity-pool \
+          --identity-pool-id <identity-pool-id> \
+          --query "{Name:IdentityPoolName,ClassicFlow:AllowClassicFlow}"
+        ```
+
+        A passing identity pool returns `"ClassicFlow": false` or omits the field (it defaults to disabled). A failing identity pool returns `"ClassicFlow": true`.
       remediation:
         - id: console
           desc: |
@@ -26576,6 +30603,36 @@ queries:
         - **Domain protection:** Prevents unauthorized domain transfers at the registry level.
         - **Service continuity:** Ensures domains remain under organizational control, preventing service disruptions.
         - **Email security:** Protects email delivery and prevents interception of sensitive communications.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Route 53 Console** at Services > Route 53.
+        2. Select **Registered domains** in the left navigation panel.
+        3. Select the domain name to inspect.
+        4. Under **Domain details**, locate the **Transfer lock** field.
+
+        A passing domain shows **Transfer lock: Enabled**. A failing domain shows **Transfer lock: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all Route 53 registered domains and their transfer lock status:
+
+        ```bash
+        aws route53domains list-domains \
+          --region us-east-1 \
+          --query "Domains[*].{Domain:DomainName,AutoRenew:AutoRenew,TransferLock:TransferLock}"
+        ```
+
+        Alternatively, inspect a specific domain in detail:
+
+        ```bash
+        aws route53domains get-domain-detail \
+          --region us-east-1 \
+          --domain-name example.com \
+          --query "{Domain:DomainName,StatusList:StatusList}"
+        ```
+
+        A passing domain returns `"TransferLock": true` in the list output, or includes `"clientTransferProhibited"` in the `StatusList`. A failing domain returns `"TransferLock": false` or lacks `clientTransferProhibited` in the status list.
       remediation:
         - id: console
           desc: |
@@ -26683,6 +30740,28 @@ queries:
         - **Social engineering prevention:** Hides contact details that attackers use for targeted phishing and impersonation.
         - **Spam reduction:** Prevents email harvesting from WHOIS records.
         - **Personnel privacy:** Protects the personal information of employees responsible for domain management.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Route 53 Console** at Services > Route 53.
+        2. Select **Registered domains** in the left navigation panel.
+        3. Select the domain name to inspect.
+        4. Under **Contact information**, review the **Privacy protection** status for the Admin, Registrant, and Tech contacts.
+
+        A passing domain shows **Privacy protection: Enabled** for all three contact types. A failing domain shows **Privacy protection: Disabled** for one or more contact types.
+
+        ### Audit via CLI
+
+        1. Check contact privacy settings for a domain:
+
+        ```bash
+        aws route53domains get-domain-detail \
+          --region us-east-1 \
+          --domain-name example.com \
+          --query "{Domain:DomainName,AdminPrivacy:AdminPrivacy,RegistrantPrivacy:RegistrantPrivacy,TechPrivacy:TechPrivacy}"
+        ```
+
+        A passing domain returns `true` for all three privacy fields: `AdminPrivacy`, `RegistrantPrivacy`, and `TechPrivacy`. A failing domain returns `false` for one or more of those fields.
       remediation:
         - id: console
           desc: |
@@ -26797,6 +30876,26 @@ queries:
         - **Domain continuity:** Prevents accidental domain expiration and subsequent hijacking.
         - **Service availability:** Ensures DNS resolution continues uninterrupted for all services depending on the domain.
         - **Operational safety:** Removes dependency on manual renewal processes that can fail due to personnel changes or missed notifications.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Route 53 Console** at Services > Route 53.
+        2. Select **Registered domains** in the left navigation panel.
+        3. Review the **Auto renew** column in the domain list.
+
+        A passing domain shows **Auto renew: Enabled**. A failing domain shows **Auto renew: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all Route 53 registered domains and their auto-renew setting:
+
+        ```bash
+        aws route53domains list-domains \
+          --region us-east-1 \
+          --query "Domains[*].{Domain:DomainName,AutoRenew:AutoRenew,Expiry:Expiry}"
+        ```
+
+        A passing domain returns `"AutoRenew": true`. A failing domain returns `"AutoRenew": false`.
       remediation:
         - id: console
           desc: |
@@ -26907,6 +31006,27 @@ queries:
         - **Data confidentiality:** Encrypts all data in transit between clients and the cluster, preventing eavesdropping.
         - **Authentication:** TLS provides mutual authentication, ensuring clients connect to the legitimate cluster endpoint.
         - **Compliance:** Meets encryption-in-transit requirements in PCI DSS, HIPAA, SOC 2, and other frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon MemoryDB Console** at Services > MemoryDB for Redis.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster to inspect.
+        4. Choose the **Settings** tab.
+        5. Locate the **Encryption in transit** field.
+
+        A passing cluster shows **Encryption in transit: Yes**. A failing cluster shows **Encryption in transit: No**.
+
+        ### Audit via CLI
+
+        1. List all MemoryDB clusters and their TLS status:
+
+        ```bash
+        aws memorydb describe-clusters \
+          --query "Clusters[*].{Name:Name,TLS:TLSEnabled,Status:Status}"
+        ```
+
+        A passing cluster returns `"TLS": true`. A failing cluster returns `"TLS": false`.
       remediation:
         - id: console
           desc: |
@@ -27045,6 +31165,36 @@ queries:
         - **Key control:** Provides full lifecycle control over encryption keys, including the ability to disable or revoke access.
         - **Audit visibility:** Enables detailed CloudTrail logging of all key usage for compliance and forensic purposes.
         - **Access separation:** Allows separation of duties between database administrators and key administrators.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon MemoryDB Console** at Services > MemoryDB for Redis.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster to inspect.
+        4. Choose the **Settings** tab.
+        5. Locate the **KMS key ID** field and note the key ARN or alias displayed.
+        6. Open the **AWS KMS Console**, find the key, and verify that **Key type** is **Customer managed**.
+
+        A passing cluster shows a customer-managed KMS key (key type **Customer managed**). A failing cluster shows an AWS-owned key or no custom KMS key.
+
+        ### Audit via CLI
+
+        1. List all MemoryDB clusters and their KMS key IDs:
+
+        ```bash
+        aws memorydb describe-clusters \
+          --query "Clusters[*].{Name:Name,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For each non-empty `KmsKeyId`, confirm the key is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Manager:KeyManager}"
+        ```
+
+        A passing cluster has a non-empty `KmsKeyId` whose `KeyManager` value is `"CUSTOMER"`. A failing cluster has an empty or absent `KmsKeyId`, or a `KeyManager` value of `"AWS"`.
       remediation:
         - id: console
           desc: |
@@ -27188,6 +31338,27 @@ queries:
         - **Patch management:** Ensures security patches are applied automatically during the next maintenance window.
         - **Vulnerability reduction:** Minimizes the time window during which known vulnerabilities remain unpatched.
         - **Compliance:** Meets requirements for timely application of security updates in managed database services.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon MemoryDB Console** at Services > MemoryDB for Redis.
+        2. Select **Clusters** in the left navigation panel.
+        3. Select the cluster to inspect.
+        4. Choose the **Maintenance** tab.
+        5. Locate the **Auto minor version upgrade** field.
+
+        A passing cluster shows **Auto minor version upgrade: Yes**. A failing cluster shows **Auto minor version upgrade: No**.
+
+        ### Audit via CLI
+
+        1. List all MemoryDB clusters and their auto minor version upgrade setting:
+
+        ```bash
+        aws memorydb describe-clusters \
+          --query "Clusters[*].{Name:Name,AutoUpgrade:AutoMinorVersionUpgrade}"
+        ```
+
+        A passing cluster returns `"AutoUpgrade": true`. A failing cluster returns `"AutoUpgrade": false`.
       remediation:
         - id: console
           desc: |
@@ -27326,6 +31497,33 @@ queries:
         - **Data protection:** Ensures all data records in the stream are encrypted at rest using AWS KMS.
         - **Compliance:** Meets regulatory requirements for encryption of data at rest in streaming services.
         - **Defense in depth:** Adds a layer of protection beyond IAM access controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Kinesis** > **Data streams**.
+        2. For each stream, select the stream name.
+        3. Open the **Configuration** tab and locate **Server-side encryption**.
+        4. Check the **Status** field.
+
+        A passing stream shows **Enabled** with an encryption type of **KMS**. A failing stream shows **Disabled** or no encryption type.
+
+        ### Audit via CLI
+
+        1. List all Kinesis data streams:
+
+        ```bash
+        aws kinesis list-streams --query "StreamNames"
+        ```
+
+        2. For each stream, check the encryption status:
+
+        ```bash
+        aws kinesis describe-stream-summary --stream-name <stream-name> \
+          --query "StreamDescriptionSummary.{Name:StreamName,Encryption:EncryptionType,KeyId:KeyId}"
+        ```
+
+        A passing stream returns `"EncryptionType": "KMS"`. A failing stream returns `"EncryptionType": "NONE"` or omits the field entirely.
+
       remediation:
         - id: console
           desc: |
@@ -27465,6 +31663,34 @@ queries:
         - **Key control:** Provides full lifecycle control over encryption keys, including the ability to disable or revoke access.
         - **Audit visibility:** Enables detailed CloudTrail logging of all key usage for compliance and forensic purposes.
         - **Access separation:** Allows separation of duties between stream administrators and key administrators.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Kinesis** > **Data streams**.
+        2. Select the stream name.
+        3. Open the **Configuration** tab and review **Server-side encryption**.
+        4. Note the KMS key ARN or alias shown.
+
+        A passing stream shows a customer-managed KMS key ARN (not `alias/aws/kinesis`). A failing stream either shows no encryption or uses the AWS-managed `alias/aws/kinesis` key.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption configuration for a stream:
+
+        ```bash
+        aws kinesis describe-stream-summary --stream-name <stream-name> \
+          --query "StreamDescriptionSummary.{Name:StreamName,Encryption:EncryptionType,KeyId:KeyId}"
+        ```
+
+        2. If encryption is KMS, verify the key manager:
+
+        ```bash
+        aws kms describe-key --key-id <key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Manager:KeyManager}"
+        ```
+
+        A passing stream returns `"KeyManager": "CUSTOMER"`. A failing stream returns `"KeyManager": "AWS"` or has `"EncryptionType": "NONE"`.
+
       remediation:
         - id: console
           desc: |
@@ -27609,6 +31835,33 @@ queries:
         - **Data protection:** Encrypts data at rest within the delivery stream buffer using AWS KMS.
         - **End-to-end security:** Ensures data is protected during the buffering phase before delivery to the destination.
         - **Compliance:** Meets regulatory requirements for encryption of data at rest in data pipeline services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Data Firehose**.
+        2. Select the delivery stream name.
+        3. Open the **Configuration** tab and locate **Server-side encryption**.
+        4. Check the **Status** field.
+
+        A passing delivery stream shows **Enabled** under server-side encryption. A failing delivery stream shows **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all Firehose delivery streams:
+
+        ```bash
+        aws firehose list-delivery-streams --query "DeliveryStreamNames"
+        ```
+
+        2. For each stream, check the encryption configuration:
+
+        ```bash
+        aws firehose describe-delivery-stream --delivery-stream-name <stream-name> \
+          --query "DeliveryStreamDescription.{Name:DeliveryStreamName,Encryption:DeliveryStreamEncryptionConfiguration}"
+        ```
+
+        A passing delivery stream returns a `DeliveryStreamEncryptionConfiguration` object with `"Status": "ENABLED"`. A failing delivery stream returns `"Status": "DISABLED"` or an empty configuration.
+
       remediation:
         - id: console
           desc: |
@@ -27765,6 +32018,32 @@ queries:
         - **Configuration integrity:** Ensures workgroup-level encryption and output location settings cannot be bypassed by individual users.
         - **Data protection:** Guarantees all query results are written to the approved S3 location with the configured encryption.
         - **Centralized control:** Enables administrators to enforce security policies consistently across all workgroup users.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Athena** > **Workgroups**.
+        2. Select each workgroup name.
+        3. Review the **Settings** section for **Override client-side settings**.
+
+        A passing workgroup shows **Override client-side settings** as enabled. A failing workgroup shows the setting as disabled, meaning clients can override workgroup configuration.
+
+        ### Audit via CLI
+
+        1. List all Athena workgroups:
+
+        ```bash
+        aws athena list-work-groups --query "WorkGroups[*].Name"
+        ```
+
+        2. For each enabled workgroup, check the enforcement setting:
+
+        ```bash
+        aws athena get-work-group --work-group <workgroup-name> \
+          --query "WorkGroup.Configuration.EnforceWorkGroupConfiguration"
+        ```
+
+        A passing workgroup returns `true`. A failing workgroup returns `false` or omits the field.
+
       remediation:
         - id: console
           desc: |
@@ -27907,6 +32186,32 @@ queries:
         - **Data protection:** Ensures all query results are encrypted at rest in S3 using SSE-S3, SSE-KMS, or CSE-KMS.
         - **Defense in depth:** Provides encryption independent of S3 bucket default encryption settings.
         - **Compliance:** Meets requirements for encryption of data at rest for query output in analytics services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Athena** > **Workgroups**.
+        2. Select each workgroup name.
+        3. Review the **Settings** section under **Query result configuration** for the **Encrypt query results** setting.
+
+        A passing workgroup shows an encryption type (SSE_S3, SSE_KMS, or CSE_KMS) configured for query results. A failing workgroup shows no encryption configured for query results.
+
+        ### Audit via CLI
+
+        1. List all Athena workgroups:
+
+        ```bash
+        aws athena list-work-groups --query "WorkGroups[*].Name"
+        ```
+
+        2. For each enabled workgroup, check the encryption configuration:
+
+        ```bash
+        aws athena get-work-group --work-group <workgroup-name> \
+          --query "WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration"
+        ```
+
+        A passing workgroup returns an object with an `EncryptionOption` field (such as `SSE_S3`, `SSE_KMS`, or `CSE_KMS`). A failing workgroup returns `null` or an empty response.
+
       remediation:
         - id: console
           desc: |
@@ -28070,6 +32375,26 @@ queries:
         - **Data protection:** Ensures all data at rest on workspace volumes is encrypted using AWS KMS.
         - **Compliance:** Meets encryption-at-rest requirements in PCI DSS, HIPAA, SOC 2, and other frameworks.
         - **Defense in depth:** Protects data even if underlying storage is accessed outside of normal WorkSpaces operations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon WorkSpaces** > **WorkSpaces**.
+        2. Select a workspace to review.
+        3. In the workspace details, check the **Root volume encryption** and **User volume encryption** fields.
+
+        A passing workspace shows both **Root volume encryption** and **User volume encryption** as **Enabled**. A failing workspace shows either or both fields as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all WorkSpaces and their encryption status:
+
+        ```bash
+        aws workspaces describe-workspaces \
+          --query "Workspaces[*].{Id:WorkspaceId,User:UserName,RootEncrypted:RootVolumeEncryptionEnabled,UserEncrypted:UserVolumeEncryptionEnabled}"
+        ```
+
+        A passing workspace returns `"RootVolumeEncryptionEnabled": true` and `"UserVolumeEncryptionEnabled": true` for both volume fields. A failing workspace returns `false` for either field.
+
       remediation:
         - id: console
           desc: |
@@ -28218,6 +32543,26 @@ queries:
         - **Device control:** Ensures users can only connect from devices with the WorkSpaces client installed, enabling managed device enforcement.
         - **Endpoint security:** Prevents access from unmanaged devices that may lack antivirus, encryption, or patch compliance.
         - **Session security:** Reduces exposure to browser-based attacks and session leakage risks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon WorkSpaces** > **Directories**.
+        2. Select the directory name.
+        3. Under **Access control options**, review the **Web browser** setting.
+
+        A passing directory shows **Web browser** as **Deny**. A failing directory shows **Web browser** as **Allow**.
+
+        ### Audit via CLI
+
+        1. List WorkSpaces directories and their web access setting:
+
+        ```bash
+        aws workspaces describe-workspace-directories \
+          --query "Directories[*].{Id:DirectoryId,Name:DirectoryName,WebAccess:WorkspaceAccessProperties.DeviceTypeWeb}"
+        ```
+
+        A passing directory returns `"DeviceTypeWeb": "DENY"`. A failing directory returns `"DeviceTypeWeb": "ALLOW"` or omits the field.
+
       remediation:
         - id: console
           desc: |
@@ -28340,6 +32685,26 @@ queries:
         - **Patch management:** Ensures all workspaces receive operating system and application security updates regularly.
         - **Vulnerability reduction:** Minimizes the window during which known vulnerabilities remain unpatched on workspace instances.
         - **Compliance:** Meets requirements for automated patch management in managed desktop environments.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon WorkSpaces** > **Directories**.
+        2. Select the directory name.
+        3. Review the **Maintenance mode** section in the directory details.
+
+        A passing directory shows **Maintenance mode** as **Enabled**. A failing directory shows **Maintenance mode** as **Disabled**.
+
+        ### Audit via CLI
+
+        1. Check maintenance mode for all WorkSpaces directories:
+
+        ```bash
+        aws workspaces describe-workspace-directories \
+          --query "Directories[*].{Id:DirectoryId,Name:DirectoryName,Maintenance:WorkspaceCreationProperties.EnableMaintenanceMode}"
+        ```
+
+        A passing directory returns `"EnableMaintenanceMode": true`. A failing directory returns `"EnableMaintenanceMode": false` or omits the field.
+
       remediation:
         - id: console
           desc: |
@@ -28451,6 +32816,29 @@ queries:
         - **Compliance requirements**: Security frameworks require network access to be restricted to the minimum necessary, and unrestricted inbound rules violate this principle.
 
         Restrict security group inbound rules to specific CIDR ranges such as corporate office IPs, VPN endpoints, or known management networks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon WorkSpaces** > **WorkSpaces**.
+        2. Note the security groups associated with each WorkSpace by selecting a workspace and reviewing its network details.
+        3. Navigate to **VPC** > **Security Groups**.
+        4. For each security group used by WorkSpaces, select it and review the **Inbound rules** tab.
+        5. Check for rules with source `0.0.0.0/0` or `::/0`.
+
+        A passing security group has no inbound rules with a source of `0.0.0.0/0` or `::/0`. A failing security group has one or more inbound rules permitting traffic from any source.
+
+        ### Audit via CLI
+
+        1. Identify security groups associated with WorkSpaces instances, then inspect each for unrestricted inbound rules:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --group-ids <workspace-security-group-ids> \
+          --query "SecurityGroups[*].{Id:GroupId,Name:GroupName,Rules:IpPermissions[?contains(IpRanges[].CidrIp,'0.0.0.0/0') || contains(Ipv6Ranges[].CidrIpv6,'::/0')]}"
+        ```
+
+        A passing security group returns an empty `Rules` array. A failing security group returns one or more inbound rule objects in the `Rules` array.
+
       remediation:
         - id: console
           desc: |
@@ -28585,6 +32973,26 @@ queries:
         - **Network isolation:** Ensures Neptune instances are only reachable from within the VPC.
         - **Reduced attack surface:** Eliminates the possibility of internet-based attacks against the database.
         - **Defense in depth:** Complements security group rules and IAM authentication by removing public network exposure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Neptune** > **Databases**.
+        2. Select each Neptune DB instance.
+        3. Under the **Connectivity & security** tab, review the **Publicly accessible** field.
+
+        A passing instance shows **Publicly accessible** as **No**. A failing instance shows **Publicly accessible** as **Yes**.
+
+        ### Audit via CLI
+
+        1. List all Neptune DB instances and their public accessibility setting:
+
+        ```bash
+        aws neptune describe-db-instances \
+          --query "DBInstances[*].{InstanceId:DBInstanceIdentifier,Public:PubliclyAccessible}"
+        ```
+
+        A passing instance returns `"PubliclyAccessible": false`. A failing instance returns `"PubliclyAccessible": true`.
+
       remediation:
         - id: console
           desc: |
@@ -28722,6 +33130,33 @@ queries:
         - **Timely patching:** Security patches are applied automatically during the maintenance window.
         - **Reduced operational risk:** Eliminates the need to manually track and apply updates.
         - **Consistent security posture:** Ensures all domains receive updates without relying on manual processes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon OpenSearch Service**.
+        2. Select the domain name.
+        3. Under the **General information** tab, locate **Auto software update** or open **Edit software update settings**.
+        4. Check whether **Automatic software updates** is enabled.
+
+        A passing domain shows **Automatic software updates** as **Enabled**. A failing domain shows the setting as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all OpenSearch domains:
+
+        ```bash
+        aws opensearch list-domain-names --query "DomainNames[*].DomainName"
+        ```
+
+        2. For each domain, check the auto software update setting:
+
+        ```bash
+        aws opensearch describe-domain --domain-name <domain-name> \
+          --query "DomainStatus.SoftwareUpdateOptions.AutoSoftwareUpdateEnabled"
+        ```
+
+        A passing domain returns `true`. A failing domain returns `false` or omits the field.
+
       remediation:
         - id: console
           desc: |
@@ -28849,6 +33284,38 @@ queries:
         - **Service availability:** Renewing certificates well before expiry prevents TLS handshake failures that take the endpoint offline.
         - **Certificate hygiene:** Surfacing expiring certificates drives the lifecycle discipline that protects every other certificate in the account.
         - **Compliance:** Satisfies cryptographic-key-management requirements that demand proactive certificate renewal.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon OpenSearch Service**.
+        2. Select the domain name and open the **General information** tab.
+        3. Check whether a **Custom endpoint** is configured.
+        4. If a custom endpoint is in use, note the certificate ARN listed under the domain's endpoint configuration.
+        5. Navigate to **AWS Certificate Manager** and locate the referenced certificate.
+        6. Review the **Expiration date** to confirm it is more than 30 days in the future.
+
+        A passing domain either has no custom endpoint enabled or has a custom endpoint backed by a certificate whose expiration date is more than 30 days away. A failing domain has a custom endpoint backed by a certificate that has already expired or expires within 30 days.
+
+        ### Audit via CLI
+
+        1. Retrieve the custom endpoint configuration and certificate ARN for the domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.DomainEndpointOptions.{Custom:CustomEndpointEnabled,Endpoint:CustomEndpoint,CertArn:CustomEndpointCertificateArn}"
+        ```
+
+        2. Inspect the certificate expiry:
+
+        ```bash
+        aws acm describe-certificate \
+          --certificate-arn <certificate-arn> \
+          --query "Certificate.{Domain:DomainName,Status:Status,NotAfter:NotAfter,RenewalEligibility:RenewalEligibility}"
+        ```
+
+        A passing domain either has `CustomEndpointEnabled` as `false`, or has a certificate whose `NotAfter` timestamp is more than 30 days from today. A failing domain has a certificate whose `NotAfter` timestamp is within 30 days or already past.
+
       remediation:
         - id: console
           desc: |
@@ -28985,6 +33452,33 @@ queries:
         - **Key control:** Provides full lifecycle control over encryption keys, including the ability to disable or revoke access.
         - **Audit visibility:** Enables detailed CloudTrail logging of all key usage for compliance and forensic purposes.
         - **Access separation:** Allows separation of duties between database administrators and key administrators.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Neptune** > **Databases**.
+        2. Select the Neptune DB cluster (not a DB instance).
+        3. Under the **Configuration** tab, locate **Encryption** and review the **AWS KMS key** field.
+
+        A passing cluster shows a customer-managed KMS key ARN (not the AWS-managed key). A failing cluster shows no KMS key or the default AWS-managed Neptune key.
+
+        ### Audit via CLI
+
+        1. List all Neptune clusters and their KMS key IDs:
+
+        ```bash
+        aws neptune describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,StorageEncrypted:StorageEncrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For each cluster with a KMS key, verify it is customer-managed:
+
+        ```bash
+        aws kms describe-key --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Manager:KeyManager}"
+        ```
+
+        A passing cluster returns `"KeyManager": "CUSTOMER"`. A failing cluster returns `"KeyManager": "AWS"`, has an empty `KmsKeyId`, or has `StorageEncrypted` set to `false`.
+
       remediation:
         - id: console
           desc: |
@@ -29138,6 +33632,33 @@ queries:
         - **Key control:** Organizations maintain full control over the encryption key lifecycle, including creation, rotation, and deletion.
         - **Access auditing:** All key usage is logged in CloudTrail, enabling security monitoring and compliance reporting.
         - **Compliance:** Meets regulatory requirements for customer-managed encryption of data at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Redshift** > **Clusters**.
+        2. Select the cluster identifier.
+        3. Under the **Database configurations** tab, locate **Encryption** and review the **KMS key ID** field.
+
+        A passing cluster shows a customer-managed KMS key ARN. A failing cluster shows no KMS key or only the AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List Redshift clusters and their KMS key IDs:
+
+        ```bash
+        aws redshift describe-clusters \
+          --query "Clusters[*].{ClusterId:ClusterIdentifier,Encrypted:Encrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For each encrypted cluster, verify the key is customer-managed:
+
+        ```bash
+        aws kms describe-key --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyId:KeyId,Manager:KeyManager}"
+        ```
+
+        A passing cluster returns `"KeyManager": "CUSTOMER"`. A failing cluster returns `"KeyManager": "AWS"`, has an empty `KmsKeyId`, or has `"Encrypted": false`.
+
       remediation:
         - id: console
           desc: |
@@ -29292,6 +33813,26 @@ queries:
         - **Timely Patching:** Ensures clusters receive security patches as soon as they are available.
         - **Reduced Vulnerability Window:** Minimizes the time clusters are exposed to known security issues.
         - **Compliance:** Meets patch management requirements under frameworks such as NIST 800-53 (SI-2), ISO 27001, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Redshift** > **Clusters**.
+        2. Select the cluster identifier.
+        3. Open the **Maintenance** tab and review the **Maintenance track** field.
+
+        A passing cluster shows **Maintenance track** set to **Current**. A failing cluster shows **Maintenance track** set to **Trailing**.
+
+        ### Audit via CLI
+
+        1. Check the maintenance track for all Redshift clusters:
+
+        ```bash
+        aws redshift describe-clusters \
+          --query "Clusters[*].{Cluster:ClusterIdentifier,MaintenanceTrack:MaintenanceTrackName}"
+        ```
+
+        A passing cluster returns `"MaintenanceTrackName": "Current"`. A failing cluster returns `"MaintenanceTrackName": "Trailing"`.
+
       remediation:
         - id: console
           desc: |
@@ -29434,6 +33975,34 @@ queries:
         - **Key control:** Organizations maintain full control over the encryption key lifecycle, including creation, rotation, and deletion.
         - **Access auditing:** All key usage is logged in CloudTrail, enabling security monitoring and compliance reporting.
         - **Compliance:** Meets regulatory requirements for customer-managed encryption of data at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon FSx** under Storage.
+        2. Select each file system in the list.
+        3. On the **Summary** tab, locate the **KMS key ID** field under Encryption.
+
+        A passing file system shows a customer-managed KMS key ARN (format: `arn:aws:kms:<region>:<account>:key/<key-id>`). A failing file system shows the AWS-managed key alias `aws/fsx` or an empty KMS key field.
+
+        ### Audit via CLI
+
+        1. List all FSx file systems and their KMS key IDs:
+
+        ```bash
+        aws fsx describe-file-systems \
+          --query "FileSystems[*].{FileSystemId:FileSystemId,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For each returned KMS key ARN, confirm it is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyManager:KeyManager,KeyId:KeyId}"
+        ```
+
+        A passing file system returns a `KmsKeyId` value with `KeyManager` equal to `CUSTOMER`. A failing file system returns a `KmsKeyId` referencing the `aws/fsx` alias or returns `KeyManager` equal to `AWS`.
+
       remediation:
         - id: console
           desc: |
@@ -29590,6 +34159,44 @@ queries:
         - **Key control:** Organizations maintain full control over the encryption key lifecycle, including creation, rotation, and deletion.
         - **Access auditing:** All key usage is logged in CloudTrail, enabling security monitoring and compliance reporting.
         - **Compliance:** Meets regulatory requirements for customer-managed encryption of data at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon OpenSearch Service**.
+        2. Select each domain in the list.
+        3. On the **Security configuration** tab, locate the **Encryption at rest** section.
+        4. Check the **KMS key** field to determine whether a customer-managed key is in use.
+
+        A passing domain shows a customer-managed KMS key ARN (not the default `aws/es` alias). A failing domain shows `aws/es` or no KMS key configured.
+
+        ### Audit via CLI
+
+        1. List all OpenSearch domains:
+
+        ```bash
+        aws opensearch list-domain-names \
+          --query "DomainNames[*].DomainName" \
+          --output text
+        ```
+
+        2. Check the encryption configuration for each domain:
+
+        ```bash
+        aws opensearch describe-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.EncryptionAtRestOptions"
+        ```
+
+        3. For each returned KMS key ID, verify it is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing domain returns `KeyManager` equal to `CUSTOMER`. A failing domain returns `KeyManager` equal to `AWS`, or the `KmsKeyId` references the `aws/es` alias.
+
       remediation:
         - id: console
           desc: |
@@ -29744,6 +34351,27 @@ queries:
         - **Data protection:** Ensures all outputs from Glue jobs are encrypted at rest.
         - **Log security:** Encrypts CloudWatch logs generated during job execution.
         - **Compliance:** Meets requirements for encryption of data processing pipelines.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Jobs**.
+        3. Select each job and review its details.
+        4. Under the **Job details** tab, locate the **Security configuration** field.
+
+        A passing job shows a named security configuration assigned. A failing job shows an empty or missing **Security configuration** field.
+
+        ### Audit via CLI
+
+        1. List all Glue jobs and their security configurations:
+
+        ```bash
+        aws glue get-jobs \
+          --query "Jobs[*].{Name:Name,SecurityConfiguration:SecurityConfiguration}"
+        ```
+
+        A passing job returns a non-empty `SecurityConfiguration` value. A failing job returns `null` or an empty string for `SecurityConfiguration`.
+
       remediation:
         - id: console
           desc: |
@@ -29916,6 +34544,27 @@ queries:
         - **Log security:** Encrypts CloudWatch logs generated during crawler execution, protecting sensitive data excerpts and schema details from unauthorized readers.
         - **Pipeline integrity:** Maintains consistent encryption across the entire Glue data pipeline, eliminating gaps that could be exploited to access sensitive information.
         - **Compliance:** Meets encryption-at-rest requirements for data processing and cataloging across frameworks such as NIST SP 800-53 SC-28 and ISO 27001.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Crawlers**.
+        3. Select each crawler and review its details.
+        4. Under the **Crawler details** tab, locate the **Security configuration** field.
+
+        A passing crawler shows a named security configuration assigned. A failing crawler shows an empty or missing **Security configuration** field.
+
+        ### Audit via CLI
+
+        1. List all Glue crawlers and their security configurations:
+
+        ```bash
+        aws glue get-crawlers \
+          --query "Crawlers[*].{Name:Name,SecurityConfig:CrawlerSecurityConfiguration}"
+        ```
+
+        A passing crawler returns a non-empty `SecurityConfig` value. A failing crawler returns `null` or an empty string for `SecurityConfig`.
+
       remediation:
         - id: console
           desc: |
@@ -30064,6 +34713,26 @@ queries:
         - **Metadata protection:** Encrypts all table definitions, schema information, and partition metadata in the Data Catalog.
         - **Credential security:** Encrypts connection passwords stored in the catalog.
         - **Compliance:** Meets encryption requirements for data catalog and metadata services.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Settings** under **Data catalog**.
+        3. Review the **Metadata encryption** and **Encrypt connection passwords** settings.
+
+        A passing account shows **Metadata encryption** enabled with a KMS key selected. A failing account shows **Metadata encryption** disabled or not configured.
+
+        ### Audit via CLI
+
+        1. Retrieve the current Data Catalog encryption settings:
+
+        ```bash
+        aws glue get-data-catalog-encryption-settings \
+          --query "DataCatalogEncryptionSettings"
+        ```
+
+        A passing account returns `CatalogEncryptionMode` set to `SSE-KMS` under `EncryptionAtRest`. A failing account returns `CatalogEncryptionMode` set to `DISABLED` or an empty/default configuration.
+
       remediation:
         - id: console
           desc: |
@@ -30238,6 +34907,27 @@ queries:
         - **Defense in depth:** Provides encryption at the Glue level independent of S3 bucket policies, ensuring protection even if bucket-level controls are misconfigured.
         - **Access control:** When using SSE-KMS, adds KMS key permissions as an additional access control layer beyond IAM policies for S3 access.
         - **Compliance:** Meets encryption requirements for data processing output across frameworks such as NIST SP 800-53 SC-28 and ISO 27001.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Security configurations**.
+        3. Select each security configuration.
+        4. Review the **S3 encryption** field under **Encryption configuration**.
+
+        A passing security configuration shows **S3 encryption** set to **SSE-KMS** or **SSE-S3**. A failing security configuration shows **S3 encryption** set to **DISABLED**.
+
+        ### Audit via CLI
+
+        1. List all Glue security configurations and their S3 encryption settings:
+
+        ```bash
+        aws glue get-security-configurations \
+          --query "SecurityConfigurations[*].{Name:Name,S3Encryption:EncryptionConfiguration.S3Encryption}"
+        ```
+
+        A passing security configuration returns `S3EncryptionMode` with a value other than `DISABLED` (for example, `SSE-KMS` or `SSE-S3`). A failing security configuration returns `S3EncryptionMode` equal to `DISABLED`.
+
       remediation:
         - id: console
           desc: |
@@ -30390,6 +35080,27 @@ queries:
         - **Log confidentiality:** Encrypts all CloudWatch logs generated by Glue jobs and crawlers.
         - **Access control:** Adds KMS-based access control on top of IAM permissions for log access.
         - **Compliance:** Meets encryption requirements for logging and monitoring data.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Security configurations**.
+        3. Select each security configuration.
+        4. Review the **CloudWatch logs encryption** field under **Encryption configuration**.
+
+        A passing security configuration shows **CloudWatch logs encryption** set to **SSE-KMS** with a KMS key. A failing security configuration shows **CloudWatch logs encryption** set to **DISABLED**.
+
+        ### Audit via CLI
+
+        1. List all Glue security configurations and their CloudWatch encryption settings:
+
+        ```bash
+        aws glue get-security-configurations \
+          --query "SecurityConfigurations[*].{Name:Name,CloudWatchEncryption:EncryptionConfiguration.CloudWatchEncryption}"
+        ```
+
+        A passing security configuration returns `CloudWatchEncryptionMode` with a value other than `DISABLED` (for example, `SSE-KMS`). A failing security configuration returns `CloudWatchEncryptionMode` equal to `DISABLED`.
+
       remediation:
         - id: console
           desc: |
@@ -30542,6 +35253,27 @@ queries:
         - **State protection:** Encrypts job processing state and metadata using client-side encryption (CSE-KMS).
         - **Tamper prevention:** Encryption helps ensure bookmark integrity and prevents unauthorized modification.
         - **Compliance:** Completes the encryption coverage across all Glue security configuration components.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Security configurations**.
+        3. Select each security configuration.
+        4. Review the **Job bookmark encryption** field under **Encryption configuration**.
+
+        A passing security configuration shows **Job bookmark encryption** set to **CSE-KMS** with a KMS key. A failing security configuration shows **Job bookmark encryption** set to **DISABLED**.
+
+        ### Audit via CLI
+
+        1. List all Glue security configurations and their job bookmark encryption settings:
+
+        ```bash
+        aws glue get-security-configurations \
+          --query "SecurityConfigurations[*].{Name:Name,JobBookmarksEncryption:EncryptionConfiguration.JobBookmarksEncryption}"
+        ```
+
+        A passing security configuration returns `JobBookmarksEncryptionMode` with a value other than `DISABLED` (for example, `CSE-KMS`). A failing security configuration returns `JobBookmarksEncryptionMode` equal to `DISABLED`.
+
       remediation:
         - id: console
           desc: |
@@ -30698,6 +35430,27 @@ queries:
         - **Improved security defaults:** Newer versions include hardened default configurations and updated dependency libraries with fewer known vulnerabilities.
         - **Supply chain security:** Updated Glue versions use patched versions of open-source dependencies (Spark, Hadoop, Python packages), reducing supply chain risk.
         - **Compliance:** Meets requirements for running supported software versions (NIST SI-2, ISO 27001 A.8.8).
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **AWS Glue**.
+        2. In the left navigation panel, select **Jobs**.
+        3. For each job, select the job name and open the **Job details** tab.
+        4. Locate the **Glue version** field and verify it is set to **3.0** or later.
+
+        A passing job shows a Glue version of **3.0** or higher. A failing job shows Glue version **2.0**, **1.0**, **0.9**, or an unspecified version.
+
+        ### Audit via CLI
+
+        1. List all Glue jobs and their configured Glue versions:
+
+        ```bash
+        aws glue get-jobs \
+          --query "Jobs[*].{Name:Name,GlueVersion:GlueVersion}"
+        ```
+
+        A passing job returns `GlueVersion` set to `3.0` or `4.0`. A failing job returns `GlueVersion` set to `2.0`, `1.0`, `0.9`, or returns `null`.
+
       remediation:
         - id: console
           desc: |
@@ -30835,6 +35588,37 @@ queries:
         - **Anomaly detection:** Surfaces instance-level behavioral changes (CPU spikes, memory exhaustion, network anomalies) that may indicate active compromise or lateral movement.
         - **Faster incident response:** Detailed status descriptors (Ok, Warning, Degraded, Severe) allow security teams to triage and prioritize investigation based on severity.
         - **Forensic capability:** Enhanced health events provide a timeline of environment changes useful for post-incident analysis and root cause determination.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Elastic Beanstalk**.
+        2. Select each environment in the list.
+        3. Select **Configuration** in the left navigation panel.
+        4. In the **Monitoring** category, select **Edit**.
+        5. Locate the **Health reporting** setting under **Health monitoring rule customization**.
+
+        A passing environment shows **Health reporting** set to **Enhanced**. A failing environment shows **Health reporting** set to **Basic**.
+
+        ### Audit via CLI
+
+        1. List all Elastic Beanstalk environments:
+
+        ```bash
+        aws elasticbeanstalk describe-environments \
+          --query "Environments[*].{Name:EnvironmentName,ApplicationName:ApplicationName}"
+        ```
+
+        2. For each environment, check the health reporting system type:
+
+        ```bash
+        aws elasticbeanstalk describe-configuration-settings \
+          --application-name <application-name> \
+          --environment-name <environment-name> \
+          --query "ConfigurationSettings[*].OptionSettings[?Namespace=='aws:elasticbeanstalk:healthreporting:system' && OptionName=='SystemType']"
+        ```
+
+        A passing environment returns `Value` equal to `enhanced`. A failing environment returns `Value` equal to `basic` or returns no result for that namespace and option.
+
       remediation:
         - id: console
           desc: |
@@ -30983,6 +35767,27 @@ queries:
         - **Data-in-transit encryption:** Ensures all connections through the proxy are encrypted with TLS.
         - **Credential protection:** Prevents database credentials from being transmitted in plaintext.
         - **Compliance:** Meets encryption-in-transit requirements for database connections.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon RDS**.
+        2. In the left navigation panel, select **Proxies**.
+        3. Select each proxy.
+        4. On the **Connectivity** tab, locate the **Transport Layer Security** field.
+
+        A passing proxy shows **Require Transport Layer Security** enabled (checked). A failing proxy shows **Require Transport Layer Security** disabled or unchecked.
+
+        ### Audit via CLI
+
+        1. List all RDS proxies and their TLS requirement settings:
+
+        ```bash
+        aws rds describe-db-proxies \
+          --query "DBProxies[*].{Name:DBProxyName,RequireTLS:RequireTLS}"
+        ```
+
+        A passing proxy returns `RequireTLS` equal to `true`. A failing proxy returns `RequireTLS` equal to `false`.
+
       remediation:
         - id: console
           desc: |
@@ -31135,6 +35940,27 @@ queries:
         - **Data leakage prevention:** Prevents sensitive query data from being written to CloudWatch Logs.
         - **Least privilege:** Reduces the amount of sensitive information stored outside the database.
         - **Signal-to-noise ratio:** Excessive debug logging can obscure security-relevant events, making it harder to detect and investigate incidents in CloudWatch Logs.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon RDS**.
+        2. In the left navigation panel, select **Proxies**.
+        3. Select each proxy.
+        4. On the **Configuration** tab, locate the **Enhanced logging** field.
+
+        A passing proxy shows **Enhanced logging** disabled (unchecked). A failing proxy shows **Enhanced logging** enabled (checked).
+
+        ### Audit via CLI
+
+        1. List all RDS proxies and their debug logging settings:
+
+        ```bash
+        aws rds describe-db-proxies \
+          --query "DBProxies[*].{Name:DBProxyName,DebugLogging:DebugLogging}"
+        ```
+
+        A passing proxy returns `DebugLogging` equal to `false`. A failing proxy returns `DebugLogging` equal to `true`.
+
       remediation:
         - id: console
           desc: |
@@ -31264,6 +36090,26 @@ queries:
         - **Data-at-rest encryption:** Ensures all backup data is encrypted using AWS KMS.
         - **Safe sharing:** Encrypted snapshots maintain protection even when shared across accounts.
         - **Compliance:** Meets encryption requirements for database backups and disaster recovery data.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon DocumentDB**.
+        2. In the left navigation panel, select **Snapshots**.
+        3. For each manual and automated snapshot, locate the **Encrypted** column.
+
+        A passing snapshot shows **Yes** in the **Encrypted** column. A failing snapshot shows **No** in the **Encrypted** column.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB cluster snapshots and their encryption status:
+
+        ```bash
+        aws docdb describe-db-cluster-snapshots \
+          --query "DBClusterSnapshots[*].{SnapshotId:DBClusterSnapshotIdentifier,Encrypted:StorageEncrypted,Status:Status}"
+        ```
+
+        A passing snapshot returns `Encrypted` equal to `true`. A failing snapshot returns `Encrypted` equal to `false`.
+
       remediation:
         - id: console
           desc: |
@@ -31384,6 +36230,34 @@ queries:
         - **Key control:** Provides full control over the encryption key lifecycle including rotation and deletion.
         - **Access auditing:** CloudTrail logs all uses of customer-managed keys for compliance auditing.
         - **Granular access:** Key policies enable fine-grained control over who can access encrypted snapshot data.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon MemoryDB**.
+        2. In the left navigation panel, select **Snapshots**.
+        3. For each snapshot, select the snapshot name and review the **KMS key** field on the details page.
+
+        A passing snapshot shows a customer-managed KMS key ARN (format: `arn:aws:kms:<region>:<account>:key/<key-id>`). A failing snapshot shows no KMS key or an AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all MemoryDB snapshots and their KMS key IDs:
+
+        ```bash
+        aws memorydb describe-snapshots \
+          --query "Snapshots[*].{Name:Name,KmsKeyId:KmsKeyId,Status:Status}"
+        ```
+
+        2. For each returned KMS key ARN, confirm it is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing snapshot returns a non-empty `KmsKeyId` with `KeyManager` equal to `CUSTOMER`. A failing snapshot returns `null` or an empty `KmsKeyId`, or returns `KeyManager` equal to `AWS`.
+
       remediation:
         - id: console
           desc: |
@@ -31514,6 +36388,27 @@ queries:
         - **Least privilege:** Custom ACLs restrict users to only necessary commands and key patterns.
         - **Separation of duties:** Different ACLs for different applications prevent lateral movement.
         - **Data protection:** Prevents unauthorized users from running destructive or administrative commands.
+      audit: |
+        ### Audit via Console
+
+        1. Open the AWS Management Console and navigate to **Amazon MemoryDB**.
+        2. In the left navigation panel, select **Clusters**.
+        3. For each cluster, select the cluster name.
+        4. On the **Security** tab, locate the **Access control list** field.
+
+        A passing cluster shows a custom ACL name (not `open-access`). A failing cluster shows `open-access` in the **Access control list** field.
+
+        ### Audit via CLI
+
+        1. List all MemoryDB clusters and their assigned ACLs:
+
+        ```bash
+        aws memorydb describe-clusters \
+          --query "Clusters[*].{Name:Name,ACLName:ACLName}"
+        ```
+
+        A passing cluster returns an `ACLName` value that is not `open-access`. A failing cluster returns `ACLName` equal to `open-access`.
+
       remediation:
         - id: console
           desc: |
@@ -31668,6 +36563,30 @@ queries:
         - **Data-in-transit encryption:** Ensures notification messages are encrypted during delivery using TLS.
         - **Message integrity:** HTTPS prevents message tampering during transmission.
         - **Compliance:** Meets encryption-in-transit requirements for notification delivery.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SNS**.
+        2. In the left navigation pane, select **Subscriptions**.
+        3. Review the **Protocol** column for each subscription.
+        4. Filter or sort by protocol to identify any subscriptions using **http** (not https).
+
+        A passing subscription shows **https** in the Protocol column. A failing subscription shows **http** in the Protocol column.
+
+        ### Audit via CLI
+
+        1. List all SNS topics, then for each topic list its subscriptions and check for HTTP-protocol entries:
+
+        ```bash
+        aws sns list-topics --query 'Topics[*].TopicArn' --output text | tr '\t' '\n' | while read arn; do
+          aws sns list-subscriptions-by-topic \
+            --topic-arn "$arn" \
+            --query 'Subscriptions[?Protocol==`http`].[TopicArn,SubscriptionArn,Protocol,Endpoint]' \
+            --output table
+        done
+        ```
+
+        A passing topic returns no rows (no HTTP-protocol subscriptions). A failing topic returns one or more rows showing subscriptions with `Protocol` equal to `http`.
       remediation:
         - id: console
           desc: |
@@ -31811,6 +36730,30 @@ queries:
         - Prevents data exfiltration from ML model containers.
         - Reduces the blast radius if a model container is compromised.
         - Supports defense-in-depth by enforcing network-level restrictions alongside IAM policies.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Inference**, select **Models**.
+        3. Select each model to open its detail page.
+        4. Under **Model settings**, check the **Network isolation** field.
+
+        A passing model shows **Network isolation: Enabled**. A failing model shows **Network isolation: Disabled** or has no network isolation setting.
+
+        ### Audit via CLI
+
+        1. List all SageMaker models and check the `EnableNetworkIsolation` field for each:
+
+        ```bash
+        aws sagemaker list-models --query 'Models[*].ModelName' --output text | tr '\t' '\n' | while read model; do
+          aws sagemaker describe-model \
+            --model-name "$model" \
+            --query '{ModelName:ModelName,EnableNetworkIsolation:EnableNetworkIsolation}' \
+            --output table
+        done
+        ```
+
+        A passing model returns `EnableNetworkIsolation: true`. A failing model returns `EnableNetworkIsolation: false` or omits the field entirely.
       remediation:
         - id: console
           desc: |
@@ -31949,6 +36892,30 @@ queries:
         - Restricts network access to model containers using security groups and NACLs.
         - Keeps data transfer within the AWS private network.
         - Enables integration with VPC endpoints for secure access to AWS services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Inference**, select **Models**.
+        3. Select each model to open its detail page.
+        4. Under **Model settings**, check the **VPC** section for configured subnets and security groups.
+
+        A passing model shows a VPC ID, subnet IDs, and security group IDs under the VPC section. A failing model shows no VPC configuration.
+
+        ### Audit via CLI
+
+        1. List all SageMaker models and check the `VpcConfig` field for each:
+
+        ```bash
+        aws sagemaker list-models --query 'Models[*].ModelName' --output text | tr '\t' '\n' | while read model; do
+          aws sagemaker describe-model \
+            --model-name "$model" \
+            --query '{ModelName:ModelName,VpcConfig:VpcConfig}' \
+            --output table
+        done
+        ```
+
+        A passing model returns a `VpcConfig` object containing `Subnets` and `SecurityGroupIds`. A failing model returns `null` or an empty object for `VpcConfig`.
       remediation:
         - id: console
           desc: |
@@ -32082,6 +37049,32 @@ queries:
         - Prevents exfiltration of sensitive training data and model artifacts.
         - Reduces risk from untrusted or third-party training algorithms.
         - Enforces a zero-trust network posture for ML training workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Training**, select **Training jobs**.
+        3. Select each training job to open its detail page.
+        4. Under **Network**, check the **Network isolation** field.
+
+        A passing training job shows **Network isolation: Enabled**. A failing training job shows **Network isolation: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all SageMaker training jobs and check the `EnableNetworkIsolation` field for each:
+
+        ```bash
+        aws sagemaker list-training-jobs \
+          --query 'TrainingJobSummaries[*].TrainingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-training-job \
+            --training-job-name "$job" \
+            --query '{TrainingJobName:TrainingJobName,EnableNetworkIsolation:EnableNetworkIsolation}' \
+            --output table
+        done
+        ```
+
+        A passing training job returns `EnableNetworkIsolation: true`. A failing training job returns `EnableNetworkIsolation: false` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -32159,6 +37152,32 @@ queries:
         - Protects sensitive data exchanged between distributed training instances.
         - Ensures compliance with encryption-in-transit requirements.
         - Prevents interception of model parameters during distributed training.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Training**, select **Training jobs**.
+        3. Select each training job to open its detail page.
+        4. Under **Security**, check the **Inter-container traffic encryption** field.
+
+        A passing training job shows **Inter-container traffic encryption: Enabled**. A failing training job shows **Inter-container traffic encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all SageMaker training jobs and check the `EnableInterContainerTrafficEncryption` field for each:
+
+        ```bash
+        aws sagemaker list-training-jobs \
+          --query 'TrainingJobSummaries[*].TrainingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-training-job \
+            --training-job-name "$job" \
+            --query '{TrainingJobName:TrainingJobName,EnableInterContainerTrafficEncryption:EnableInterContainerTrafficEncryption}' \
+            --output table
+        done
+        ```
+
+        A passing training job returns `EnableInterContainerTrafficEncryption: true`. A failing training job returns `EnableInterContainerTrafficEncryption: false` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -32236,6 +37255,32 @@ queries:
         - Restricts network access using security groups and NACLs.
         - Enables private connectivity to S3, ECR, and other AWS services via VPC endpoints.
         - Keeps training data transfer within the AWS private network.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Training**, select **Training jobs**.
+        3. Select each training job to open its detail page.
+        4. Under **Network**, check the **VPC** section for configured subnets and security groups.
+
+        A passing training job shows a VPC ID, subnet IDs, and security group IDs in the VPC section. A failing training job shows no VPC configuration.
+
+        ### Audit via CLI
+
+        1. List all SageMaker training jobs and check the `VpcConfig` field for each:
+
+        ```bash
+        aws sagemaker list-training-jobs \
+          --query 'TrainingJobSummaries[*].TrainingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-training-job \
+            --training-job-name "$job" \
+            --query '{TrainingJobName:TrainingJobName,VpcConfig:VpcConfig}' \
+            --output table
+        done
+        ```
+
+        A passing training job returns a `VpcConfig` object with `Subnets` and `SecurityGroupIds` populated. A failing training job returns `null` or an empty object for `VpcConfig`.
       remediation:
         - id: console
           desc: |
@@ -32313,6 +37358,32 @@ queries:
         - Prevents exfiltration of sensitive data during processing.
         - Reduces risk from third-party or untrusted processing code.
         - Enforces defense-in-depth alongside IAM and VPC controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Processing**, select **Processing jobs**.
+        3. Select each processing job to open its detail page.
+        4. Under **Network**, check the **Network isolation** field.
+
+        A passing processing job shows **Network isolation: Enabled**. A failing processing job shows **Network isolation: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all SageMaker processing jobs and check the `EnableNetworkIsolation` field within `NetworkConfig` for each:
+
+        ```bash
+        aws sagemaker list-processing-jobs \
+          --query 'ProcessingJobSummaries[*].ProcessingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-processing-job \
+            --processing-job-name "$job" \
+            --query '{ProcessingJobName:ProcessingJobName,EnableNetworkIsolation:NetworkConfig.EnableNetworkIsolation}' \
+            --output table
+        done
+        ```
+
+        A passing processing job returns `EnableNetworkIsolation: true` under `NetworkConfig`. A failing processing job returns `EnableNetworkIsolation: false` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -32387,6 +37458,32 @@ queries:
         - Protects sensitive data exchanged between distributed processing instances.
         - Ensures compliance with encryption-in-transit requirements.
         - Prevents interception of intermediate processing data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Processing**, select **Processing jobs**.
+        3. Select each processing job to open its detail page.
+        4. Under **Security**, check the **Inter-container traffic encryption** field.
+
+        A passing processing job shows **Inter-container traffic encryption: Enabled**. A failing processing job shows **Inter-container traffic encryption: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all SageMaker processing jobs and check the `EnableInterContainerTrafficEncryption` field within `NetworkConfig` for each:
+
+        ```bash
+        aws sagemaker list-processing-jobs \
+          --query 'ProcessingJobSummaries[*].ProcessingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-processing-job \
+            --processing-job-name "$job" \
+            --query '{ProcessingJobName:ProcessingJobName,EnableInterContainerTrafficEncryption:NetworkConfig.EnableInterContainerTrafficEncryption}' \
+            --output table
+        done
+        ```
+
+        A passing processing job returns `EnableInterContainerTrafficEncryption: true` under `NetworkConfig`. A failing processing job returns `EnableInterContainerTrafficEncryption: false` or omits the field.
       remediation:
         - id: console
           desc: |
@@ -32460,6 +37557,32 @@ queries:
         - Restricts network access using security groups and NACLs.
         - Enables private connectivity to S3 and other AWS services via VPC endpoints.
         - Keeps data transfer within the AWS private network.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Processing**, select **Processing jobs**.
+        3. Select each processing job to open its detail page.
+        4. Under **Network**, check the **VPC** section for configured subnets and security groups.
+
+        A passing processing job shows a VPC ID, subnet IDs, and security group IDs in the VPC section. A failing processing job shows no VPC configuration.
+
+        ### Audit via CLI
+
+        1. List all SageMaker processing jobs and check the `VpcConfig` field within `NetworkConfig` for each:
+
+        ```bash
+        aws sagemaker list-processing-jobs \
+          --query 'ProcessingJobSummaries[*].ProcessingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-processing-job \
+            --processing-job-name "$job" \
+            --query '{ProcessingJobName:ProcessingJobName,VpcConfig:NetworkConfig.VpcConfig}' \
+            --output table
+        done
+        ```
+
+        A passing processing job returns a `VpcConfig` object with `Subnets` and `SecurityGroupIds` populated under `NetworkConfig`. A failing processing job returns `null` or an empty object for `VpcConfig`.
       remediation:
         - id: console
           desc: |
@@ -32551,6 +37674,32 @@ queries:
         - Enables centralized key management and rotation through AWS KMS.
         - Provides audit trail of encryption key usage via CloudTrail.
         - Supports compliance with frameworks requiring encryption at rest.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, select **Domains**.
+        3. Select each domain to open its detail page.
+        4. Under **Domain settings**, check the **Encryption key** field in the **General settings** section.
+
+        A passing domain shows a KMS key ARN or alias in the **Encryption key** field. A failing domain shows **None** or an empty value for the encryption key.
+
+        ### Audit via CLI
+
+        1. List all SageMaker domains and check the `KmsKeyId` field for each:
+
+        ```bash
+        aws sagemaker list-domains \
+          --query 'Domains[*].DomainId' \
+          --output text | tr '\t' '\n' | while read domain; do
+          aws sagemaker describe-domain \
+            --domain-id "$domain" \
+            --query '{DomainId:DomainId,DomainName:DomainName,KmsKeyId:KmsKeyId}' \
+            --output table
+        done
+        ```
+
+        A passing domain returns a non-empty `KmsKeyId` value. A failing domain returns `null` or an empty string for `KmsKeyId`.
       remediation:
         - id: console
           desc: |
@@ -32695,6 +37844,32 @@ queries:
         - Remove every AWS access key pattern from hyperparameters.
         - Use the training job's `iamRole` (instance profile) for all AWS access.
         - Rotate any credentials that have ever appeared in a hyperparameter. Consider them compromised.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Training**, select **Training jobs**.
+        3. Select each training job to open its detail page.
+        4. Under **Hyperparameters**, review the parameter keys and values for any that resemble AWS credential names (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_security_token`) or values matching AWS access key ID patterns (`AKIA...`, `ASIA...`, `AROA...`, etc.).
+
+        A passing training job shows no hyperparameter keys or values matching AWS credential patterns. A failing training job contains one or more hyperparameter keys or values that match known AWS credential patterns.
+
+        ### Audit via CLI
+
+        1. List all SageMaker training jobs, retrieve their hyperparameters, and inspect for AWS credential patterns:
+
+        ```bash
+        aws sagemaker list-training-jobs \
+          --query 'TrainingJobSummaries[*].TrainingJobName' \
+          --output text | tr '\t' '\n' | while read job; do
+          aws sagemaker describe-training-job \
+            --training-job-name "$job" \
+            --query '{TrainingJobName:TrainingJobName,HyperParameters:HyperParameters}' \
+            --output json
+        done
+        ```
+
+        A passing training job returns `HyperParameters` with no keys named `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, or `aws_security_token`, and no values matching `(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}`. A failing training job contains one or more such keys or values.
       remediation:
         - id: console
           desc: |
@@ -32774,6 +37949,38 @@ queries:
         - Forces a documented approval step for every third-party model entering the private hub.
         - Provides a discoverable record for compliance audits covering supply-chain vetting.
         - Surfaces un-reviewed content quickly so it can be deleted or reviewed before deployment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, select **Hub** (under JumpStart or the AI/ML section).
+        3. Open each private hub and review its content items.
+        4. For each content item sourced from the public SageMaker JumpStart hub (items with a non-empty **Source ARN** pointing to the public hub), check whether a **Markdown** documentation field has been populated.
+
+        A passing hub content item shows a non-empty markdown field describing who reviewed the model, what scans were run, and its approved use cases. A failing hub content item has an empty or absent markdown field.
+
+        ### Audit via CLI
+
+        1. List all private hubs, then for each hub list content items and check for a populated `HubContentMarkdown` field:
+
+        ```bash
+        aws sagemaker list-hubs \
+          --query 'HubSummaries[*].HubName' \
+          --output text | tr '\t' '\n' | while read hub; do
+          aws sagemaker list-hub-contents \
+            --hub-name "$hub" \
+            --hub-content-type Model \
+            --query 'HubContentSummaries[?SageMakerPublicHubContentArn!=null].[HubContentName,SageMakerPublicHubContentArn]' \
+            --output table
+          aws sagemaker list-hub-contents \
+            --hub-name "$hub" \
+            --hub-content-type Notebook \
+            --query 'HubContentSummaries[?SageMakerPublicHubContentArn!=null].[HubContentName,SageMakerPublicHubContentArn]' \
+            --output table
+        done
+        ```
+
+        For each flagged item, retrieve its details with `aws sagemaker describe-hub-content --hub-name <hub> --hub-content-name <name> --hub-content-type Model --hub-content-version <version> --query HubContentMarkdown`. A passing item returns a non-empty markdown string. A failing item returns `null` or an empty string.
       remediation:
         - id: console
           desc: |
@@ -32850,6 +38057,39 @@ queries:
         - Requires reviewer accountability via a mandatory `approvalDescription`.
         - Ensures the registered validation specification actually ran before approval.
         - Creates an auditable trail for compliance frameworks covering model risk management.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker Studio**.
+        2. In the left navigation pane, select **Model Registry**.
+        3. Select each model package group and open its model versions.
+        4. Filter for versions with **Approval status: Approved**.
+        5. For each approved version, check the **Approval description** field and confirm the **Skip model validation** setting was not set to **All**.
+
+        A passing approved model package shows a non-empty approval description and does not have skip model validation set to All. A failing approved model package has an empty approval description or has skip model validation set to All.
+
+        ### Audit via CLI
+
+        1. List all model package groups, then for each group retrieve approved versions and check `ApprovalDescription` and `SkipModelValidation`:
+
+        ```bash
+        aws sagemaker list-model-package-groups \
+          --query 'ModelPackageGroupSummaryList[*].ModelPackageGroupName' \
+          --output text | tr '\t' '\n' | while read group; do
+          aws sagemaker list-model-packages \
+            --model-package-group-name "$group" \
+            --model-approval-status Approved \
+            --query 'ModelPackageSummaryList[*].ModelPackageArn' \
+            --output text | tr '\t' '\n' | while read arn; do
+            aws sagemaker describe-model-package \
+              --model-package-name "$arn" \
+              --query '{ModelPackageArn:ModelPackageArn,ApprovalStatus:ModelApprovalStatus,SkipModelValidation:SkipModelValidation,ApprovalDescription:ApprovalDescription}' \
+              --output table
+          done
+        done
+        ```
+
+        A passing approved model package returns a non-empty `ApprovalDescription` and `SkipModelValidation` not equal to `All`. A failing model package returns an empty or null `ApprovalDescription`, or returns `SkipModelValidation: All`.
       remediation:
         - id: console
           desc: |
@@ -32941,6 +38181,32 @@ queries:
         - Centralizes Git credential storage in Secrets Manager.
         - Provides an audit trail when credentials are read by SageMaker workloads.
         - Enables rotation without modifying notebook/lifecycle/training-job code.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Notebook**, select **Git repositories**.
+        3. Select each repository to open its detail page.
+        4. Under **Git configuration**, check the **Secret** field for a Secrets Manager secret ARN.
+
+        A passing code repository shows a Secrets Manager secret ARN in the **Secret** field. A failing code repository shows an empty or absent **Secret** field.
+
+        ### Audit via CLI
+
+        1. List all SageMaker code repositories and check the `SecretArn` field within the `GitConfig` for each:
+
+        ```bash
+        aws sagemaker list-code-repositories \
+          --query 'CodeRepositorySummaryList[*].CodeRepositoryName' \
+          --output text | tr '\t' '\n' | while read repo; do
+          aws sagemaker describe-code-repository \
+            --code-repository-name "$repo" \
+            --query '{CodeRepositoryName:CodeRepositoryName,SecretArn:GitConfig.SecretArn}' \
+            --output table
+        done
+        ```
+
+        A passing code repository returns a non-empty `SecretArn` within `GitConfig`. A failing code repository returns `null` or an empty string for `SecretArn`.
       remediation:
         - id: console
           desc: |
@@ -33054,6 +38320,35 @@ queries:
         - Prevents monitoring containers from reaching external endpoints.
         - Protects sensitive inference data as it is processed by monitoring workloads.
         - Aligns monitoring posture with the production endpoint it is validating.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SageMaker**.
+        2. In the left navigation pane, under **Model Monitor**, select each job definition type: **Data quality**, **Model quality**, **Model bias**, and **Model explainability**.
+        3. Select each job definition to open its detail page.
+        4. Under **Network configuration**, verify that both **Enable network isolation** and **Enable inter-container traffic encryption** are set to **Enabled**.
+
+        A passing monitoring job definition shows both network isolation and inter-container traffic encryption enabled. A failing monitoring job definition shows either control as disabled or not configured.
+
+        ### Audit via CLI
+
+        1. Check all four monitoring job definition types for the required network configuration settings:
+
+        ```bash
+        for cmd in list-data-quality-job-definitions list-model-quality-job-definitions list-model-bias-job-definitions list-model-explainability-job-definitions; do
+          describe_cmd=$(echo $cmd | sed 's/list/describe/' | sed 's/definitions/definition/')
+          aws sagemaker $cmd \
+            --query 'JobDefinitionSummaries[*].MonitoringJobDefinitionName' \
+            --output text | tr '\t' '\n' | while read defn; do
+            aws sagemaker $describe_cmd \
+              --job-definition-name "$defn" \
+              --query '{Name:JobDefinitionName,EnableNetworkIsolation:NetworkConfig.EnableNetworkIsolation,EnableInterContainerTrafficEncryption:NetworkConfig.EnableInterContainerTrafficEncryption}' \
+              --output table
+          done
+        done
+        ```
+
+        A passing monitoring job definition returns `EnableNetworkIsolation: true` and `EnableInterContainerTrafficEncryption: true` under `NetworkConfig`. A failing definition returns `false` or `null` for either field.
       remediation:
         - id: console
           desc: |
@@ -33236,6 +38531,35 @@ queries:
         - Prevents inherited account-wide administrator access for every SageMaker user.
         - Contains the blast radius of a compromised notebook or training job.
         - Aligns the domain with the principle of least privilege.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon SageMaker Console** and navigate to **Domains** in the left pane.
+        2. Select each domain and choose **Edit**.
+        3. Under **General settings**, locate the **Default execution role** ARN.
+        4. Open the **IAM Console**, navigate to **Roles**, and select that role.
+        5. On the **Permissions** tab, review the attached policies list.
+
+        A passing domain shows no `AdministratorAccess` policy attached to the default execution role. A failing domain shows `AdministratorAccess` in the attached policies list.
+
+        ### Audit via CLI
+
+        1. List all SageMaker domains and retrieve each default execution role, then check whether `AdministratorAccess` is attached:
+
+        ```bash
+        aws sagemaker list-domains \
+          --query "Domains[*].DomainId" \
+          --output text | tr '\t' '\n' | while read did; do
+            role=$(aws sagemaker describe-domain --domain-id "$did" \
+              --query "DefaultUserSettings.ExecutionRole" --output text)
+            echo "Domain $did role: $role"
+            aws iam list-attached-role-policies \
+              --role-name "$(basename $role)" \
+              --query "AttachedPolicies[?PolicyName=='AdministratorAccess']"
+        done
+        ```
+
+        A passing domain returns an empty list `[]` for the `AdministratorAccess` query. A failing domain returns an entry containing `"PolicyName": "AdministratorAccess"`.
       remediation:
         - id: console
           desc: |
@@ -33311,6 +38635,35 @@ queries:
         - Prevents a compromised notebook from taking over the whole AWS account.
         - Limits supply-chain risk from malicious Python/JupyterLab packages.
         - Supports regulatory frameworks that require demonstrable least privilege for ML workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon SageMaker Console** and navigate to **Notebook** > **Notebook instances**.
+        2. Select each notebook instance and review the **IAM role** ARN shown in the details.
+        3. Open the **IAM Console**, navigate to **Roles**, and select that role.
+        4. On the **Permissions** tab, review the attached policies list.
+
+        A passing notebook instance shows no `AdministratorAccess` policy attached to its IAM role. A failing notebook instance shows `AdministratorAccess` in the attached policies list.
+
+        ### Audit via CLI
+
+        1. List all notebook instances and check whether `AdministratorAccess` is attached to each role:
+
+        ```bash
+        aws sagemaker list-notebook-instances \
+          --query "NotebookInstances[*].NotebookInstanceName" \
+          --output text | tr '\t' '\n' | while read name; do
+            role=$(aws sagemaker describe-notebook-instance \
+              --notebook-instance-name "$name" \
+              --query "RoleArn" --output text)
+            echo "Notebook $name role: $role"
+            aws iam list-attached-role-policies \
+              --role-name "$(basename $role)" \
+              --query "AttachedPolicies[?PolicyName=='AdministratorAccess']"
+        done
+        ```
+
+        A passing notebook instance returns an empty list `[]` for the `AdministratorAccess` query. A failing notebook instance returns an entry containing `"PolicyName": "AdministratorAccess"`.
       remediation:
         - id: console
           desc: |
@@ -33382,6 +38735,37 @@ queries:
         - Prevents poisoned algorithm containers or scripts from pivoting to full account access.
         - Limits the impact of upstream supply-chain compromises.
         - Forces explicit, auditable permissions for each training and processing workload.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon SageMaker Console** and navigate to **Training** > **Training jobs** (and similarly **Processing** > **Processing jobs**).
+        2. Select each job and note the **IAM role** ARN in the job details.
+        3. Open the **IAM Console**, navigate to **Roles**, and select that role.
+        4. On the **Permissions** tab, review the attached policies list.
+
+        A passing training or processing job shows no `AdministratorAccess` policy attached to its IAM role. A failing job shows `AdministratorAccess` in the attached policies list.
+
+        ### Audit via CLI
+
+        1. List training jobs and check each role for `AdministratorAccess`:
+
+        ```bash
+        aws sagemaker list-training-jobs \
+          --query "TrainingJobSummaries[*].TrainingJobName" \
+          --output text | tr '\t' '\n' | while read name; do
+            role=$(aws sagemaker describe-training-job \
+              --training-job-name "$name" \
+              --query "RoleArn" --output text)
+            aws iam list-attached-role-policies \
+              --role-name "$(basename $role)" \
+              --query "AttachedPolicies[?PolicyName=='AdministratorAccess']" \
+              --output text && echo "Job: $name"
+        done
+        ```
+
+        2. Repeat for processing jobs using `list-processing-jobs` and `describe-processing-job`.
+
+        A passing job returns an empty result for the `AdministratorAccess` query. A failing job returns an entry containing `AdministratorAccess`.
       remediation:
         - id: console
           desc: |
@@ -33468,6 +38852,29 @@ queries:
         - **Accountability:** Audit logs attribute administrative actions to specific IAM principals, enabling accountability and forensic investigation.
         - **Threat detection:** Log data can be shipped to SIEM systems or CloudWatch Logs Insights to detect anomalous administrative patterns.
         - **Compliance:** Supports audit trail requirements across multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MQ Console** and select **Brokers** in the left pane.
+        2. Select each ActiveMQ broker.
+        3. Under the **Logs** section of the broker details page, verify that **Audit logs** shows **Enabled**.
+
+        A passing broker shows **Audit logs: Enabled**. A failing broker shows **Audit logs: Disabled** or no audit log configuration.
+
+        ### Audit via CLI
+
+        1. List all brokers and check the audit logging configuration for each:
+
+        ```bash
+        aws mq list-brokers \
+          --query "BrokerSummaries[*].BrokerId" \
+          --output text | tr '\t' '\n' | while read bid; do
+            aws mq describe-broker --broker-id "$bid" \
+              --query "{Id:BrokerId,Engine:EngineType,Audit:Logs.Audit}"
+        done
+        ```
+
+        A passing ActiveMQ broker returns `"Audit": true`. A failing ActiveMQ broker returns `"Audit": false` or `"Audit": null`.
       remediation:
         - id: console
           desc: |
@@ -33609,6 +39016,29 @@ queries:
         - **Operational visibility:** General logs provide insight into broker health, client connectivity, and message throughput.
         - **Security monitoring:** Connection and authentication events in general logs can reveal unauthorized access attempts.
         - **Incident response:** Log data is critical for reconstructing the timeline of events during a security incident.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MQ Console** and select **Brokers** in the left pane.
+        2. Select each broker.
+        3. Under the **Logs** section of the broker details page, verify that **General logs** shows **Enabled**.
+
+        A passing broker shows **General logs: Enabled**. A failing broker shows **General logs: Disabled** or no general log configuration.
+
+        ### Audit via CLI
+
+        1. List all brokers and check the general logging configuration for each:
+
+        ```bash
+        aws mq list-brokers \
+          --query "BrokerSummaries[*].BrokerId" \
+          --output text | tr '\t' '\n' | while read bid; do
+            aws mq describe-broker --broker-id "$bid" \
+              --query "{Id:BrokerId,Engine:EngineType,General:Logs.General}"
+        done
+        ```
+
+        A passing broker returns `"General": true`. A failing broker returns `"General": false` or `"General": null`.
       remediation:
         - id: console
           desc: |
@@ -33750,6 +39180,33 @@ queries:
         - **Network isolation:** Deploying brokers in a VPC without public accessibility ensures only authorized resources within the VPC can reach the broker endpoints.
         - **Reduced attack surface:** Eliminates exposure to internet-based scanning, brute-force, and exploitation attempts.
         - **Defense in depth:** Complements authentication controls by ensuring that network-layer access is restricted to trusted sources.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MQ Console** and select **Brokers** in the left pane.
+        2. Select each broker.
+        3. Under **Details**, locate the **Public accessibility** field.
+
+        A passing broker shows **Public accessibility: No**. A failing broker shows **Public accessibility: Yes**.
+
+        ### Audit via CLI
+
+        1. List all brokers and check whether each is publicly accessible:
+
+        ```bash
+        aws mq list-brokers \
+          --query "BrokerSummaries[*].{Id:BrokerId,Name:BrokerName,State:BrokerState}" \
+          --output table
+        ```
+
+        2. For each broker ID, retrieve the public accessibility setting:
+
+        ```bash
+        aws mq describe-broker --broker-id <broker-id> \
+          --query "{Id:BrokerId,Name:BrokerName,PubliclyAccessible:PubliclyAccessible}"
+        ```
+
+        A passing broker returns `"PubliclyAccessible": false`. A failing broker returns `"PubliclyAccessible": true`.
       remediation:
         - id: console
           desc: |
@@ -33894,6 +39351,30 @@ queries:
         - **Key control:** Customer-managed keys give organizations full lifecycle control, including rotation and revocation.
         - **Audit trail:** All KMS key usage is logged to CloudTrail, providing a complete record of data access events.
         - **Compliance:** Satisfies encryption key management requirements in multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MSK Console** and select **Clusters** in the left pane.
+        2. Select each cluster.
+        3. On the **Properties** tab, expand **Security** and locate **Encryption at rest**.
+        4. Verify that a customer-managed **KMS key** ARN (not the AWS-managed default) is listed.
+
+        A passing cluster shows a customer-managed KMS key ARN under **Encryption at rest**. A failing cluster shows `AWS managed key` or no key configured.
+
+        ### Audit via CLI
+
+        1. List all MSK clusters and check the encryption at rest configuration:
+
+        ```bash
+        aws kafka list-clusters \
+          --query "ClusterInfoList[*].ClusterArn" \
+          --output text | tr '\t' '\n' | while read arn; do
+            aws kafka describe-cluster --cluster-arn "$arn" \
+              --query "{Name:ClusterInfo.ClusterName,KMSKeyId:ClusterInfo.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId}"
+        done
+        ```
+
+        A passing cluster returns a non-empty `KMSKeyId` value containing a customer-managed key ARN. A failing cluster returns an empty or null `KMSKeyId`.
       remediation:
         - id: console
           desc: |
@@ -34041,6 +39522,30 @@ queries:
         - **Confidentiality:** TLS encryption prevents eavesdropping on Kafka message streams in transit across the network.
         - **Integrity:** TLS protects against tampering with messages as they travel between clients and brokers.
         - **Compliance:** Satisfies in-transit encryption requirements under PCI DSS, HIPAA, NIST SP 800-53 SC-8, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MSK Console** and select **Clusters** in the left pane.
+        2. Select each cluster.
+        3. On the **Properties** tab, expand **Security** and locate **Encryption in transit**.
+        4. Verify that **Client-broker encryption** is set to **TLS**.
+
+        A passing cluster shows **Client-broker encryption: TLS**. A failing cluster shows **TLS preferred** or **Plaintext**.
+
+        ### Audit via CLI
+
+        1. List all MSK clusters and check the client-broker encryption in transit setting:
+
+        ```bash
+        aws kafka list-clusters \
+          --query "ClusterInfoList[*].ClusterArn" \
+          --output text | tr '\t' '\n' | while read arn; do
+            aws kafka describe-cluster --cluster-arn "$arn" \
+              --query "{Name:ClusterInfo.ClusterName,ClientBroker:ClusterInfo.EncryptionInfo.EncryptionInTransit.ClientBroker}"
+        done
+        ```
+
+        A passing cluster returns `"ClientBroker": "TLS"`. A failing cluster returns `"ClientBroker": "TLS_PLAINTEXT"` or `"ClientBroker": "PLAINTEXT"`.
       remediation:
         - id: console
           desc: |
@@ -34192,6 +39697,30 @@ queries:
         - **Security monitoring:** Broker logs contain connection and authentication events that can indicate unauthorized access attempts.
         - **Compliance:** Logging requirements under NIST SP 800-53 AU-6, ISO 27001 A.8.15, and SOC 2 CC7.2 require collection and review of audit logs from critical infrastructure.
         - **Operational insight:** Logs support diagnosis of performance issues, replication failures, and consumer lag.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MSK Console** and select **Clusters** in the left pane.
+        2. Select each cluster.
+        3. On the **Properties** tab, expand **Monitoring and logging** and locate **Broker log delivery**.
+        4. Verify that at least one log destination (CloudWatch Logs, Amazon S3, or Kinesis Data Firehose) is enabled.
+
+        A passing cluster shows at least one broker log delivery destination enabled. A failing cluster shows all delivery destinations disabled or none configured.
+
+        ### Audit via CLI
+
+        1. List all MSK clusters and check their logging configuration:
+
+        ```bash
+        aws kafka list-clusters \
+          --query "ClusterInfoList[*].ClusterArn" \
+          --output text | tr '\t' '\n' | while read arn; do
+            aws kafka describe-cluster --cluster-arn "$arn" \
+              --query "{Name:ClusterInfo.ClusterName,Logging:ClusterInfo.LoggingInfo}"
+        done
+        ```
+
+        A passing cluster returns a `Logging` object with at least one broker log destination showing `"Enabled": true`. A failing cluster returns `null` for `Logging` or all destinations showing `"Enabled": false`.
       remediation:
         - id: console
           desc: |
@@ -34331,6 +39860,30 @@ queries:
         - **Confidentiality:** TLS prevents on-path attackers from reading replicated messages.
         - **Integrity:** TLS protects against tampering with the replication stream between clusters.
         - **Compliance:** Satisfies in-transit encryption requirements for regulated topic data.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon MSK Console** and select **Replicators** in the left pane.
+        2. Select each replicator.
+        3. Under **Kafka cluster configuration**, review the source and target cluster entries.
+        4. For any cluster listed as an **Apache Kafka cluster** (external, non-MSK), confirm that **Encryption in transit** is set to **TLS**.
+
+        A passing replicator shows **TLS** for all external Apache Kafka cluster connections. A failing replicator shows **PLAINTEXT** or **TLS_PLAINTEXT** for at least one external cluster connection.
+
+        ### Audit via CLI
+
+        1. List all MSK replicators and inspect the encryption in transit type for each external Kafka cluster:
+
+        ```bash
+        aws kafka list-replicators \
+          --query "Replicators[*].ReplicatorArn" \
+          --output text | tr '\t' '\n' | while read arn; do
+            aws kafka describe-replicator --replicator-arn "$arn" \
+              --query "KafkaClusters[].{Alias:KafkaClusterAlias,BootstrapServers:ApacheKafkaCluster.BootstrapServers,EncryptionType:ApacheKafkaCluster.EncryptionInTransit.Type}"
+        done
+        ```
+
+        A passing replicator returns `"EncryptionType": "TLS"` for every entry that has a non-null `BootstrapServers` value. A failing replicator returns `"EncryptionType": "PLAINTEXT"` or `null` for at least one external cluster.
       remediation:
         - id: console
           desc: |
@@ -34433,6 +39986,31 @@ queries:
         - **Confidentiality of audit data:** Restricting public access prevents adversaries from using log data for reconnaissance.
         - **Compliance:** CIS AWS Foundations Benchmark explicitly requires that the CloudTrail S3 bucket not be publicly accessible.
         - **Integrity protection:** Preventing public write access stops attackers from tampering with or deleting log files.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS CloudTrail Console**, navigate to **Trails**, and note the S3 bucket name used by each trail.
+        2. Open the **Amazon S3 Console** and select that bucket.
+        3. Choose the **Permissions** tab.
+        4. Under **Block public access (bucket settings)**, confirm all four settings are enabled.
+        5. Also review the **Bucket policy** and **Access control list (ACL)** for any public grants.
+
+        A passing bucket shows all four Block Public Access settings enabled and no public grants in the policy or ACL. A failing bucket shows one or more Block Public Access settings disabled or a public-access grant present.
+
+        ### Audit via CLI
+
+        1. Retrieve the CloudTrail S3 bucket name and check its public access block configuration:
+
+        ```bash
+        aws cloudtrail describe-trails \
+          --query "trailList[*].S3BucketName" \
+          --output text | tr '\t' '\n' | while read bucket; do
+            echo "Bucket: $bucket"
+            aws s3api get-public-access-block --bucket "$bucket"
+        done
+        ```
+
+        A passing bucket returns all four fields set to `true` (`BlockPublicAcls`, `IgnorePublicAcls`, `BlockPublicPolicy`, `RestrictPublicBuckets`). A failing bucket returns `false` for at least one field or returns an error indicating no public access block is configured.
       remediation:
         - id: console
           desc: |
@@ -34540,6 +40118,30 @@ queries:
         - **Log integrity monitoring:** S3 access logs reveal unauthorized attempts to read or delete CloudTrail log files.
         - **Forensic capability:** Access logs provide evidence of tampering with audit data during incident investigations.
         - **Compliance:** Satisfies audit logging requirements that extend to protection of the audit logs themselves.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS CloudTrail Console**, navigate to **Trails**, and note the S3 bucket name used by each trail.
+        2. Open the **Amazon S3 Console** and select that bucket.
+        3. Choose the **Properties** tab.
+        4. Under **Server access logging**, verify that logging is **Enabled** and a target bucket is configured.
+
+        A passing bucket shows **Server access logging: Enabled** with a target bucket specified. A failing bucket shows **Server access logging: Disabled** or no logging configuration.
+
+        ### Audit via CLI
+
+        1. Retrieve the CloudTrail S3 bucket name and check its server access logging configuration:
+
+        ```bash
+        aws cloudtrail describe-trails \
+          --query "trailList[*].S3BucketName" \
+          --output text | tr '\t' '\n' | while read bucket; do
+            echo "Bucket: $bucket"
+            aws s3api get-bucket-logging --bucket "$bucket"
+        done
+        ```
+
+        A passing bucket returns a `LoggingEnabled` object containing a `TargetBucket` value. A failing bucket returns an empty object `{}` indicating no server access logging is configured.
       remediation:
         - id: console
           desc: |
@@ -34659,6 +40261,32 @@ queries:
         - **Data recovery:** PITR enables restoration to any second within the recovery window, minimizing data loss in the event of accidental or malicious modification.
         - **Resilience:** Protects critical application data from application-level bugs, operator errors, and ransomware-style data destruction.
         - **Compliance:** Satisfies data backup and recovery requirements in multiple regulatory and security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon DynamoDB Console** and select **Tables** in the left pane.
+        2. Select each table.
+        3. Choose the **Backups** tab.
+        4. Under **Point-in-time recovery (PITR)**, verify the status shows **Enabled**.
+
+        A passing table shows **Point-in-time recovery: Enabled**. A failing table shows **Point-in-time recovery: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all DynamoDB tables and check PITR status for each:
+
+        ```bash
+        aws dynamodb list-tables \
+          --query "TableNames[]" \
+          --output text | tr '\t' '\n' | while read table; do
+            aws dynamodb describe-continuous-backups \
+              --table-name "$table" \
+              --query "{Table:TableName,PITRStatus:ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus}" \
+              --output table
+        done
+        ```
+
+        A passing table returns `"PITRStatus": "ENABLED"`. A failing table returns `"PITRStatus": "DISABLED"`.
       remediation:
         - id: console
           desc: |
@@ -34793,6 +40421,34 @@ queries:
         Real-time monitoring of unauthorized API calls helps security teams identify and respond to potential breaches before significant damage occurs. Without this alarm, unauthorized access attempts may go undetected for extended periods.
 
         CIS AWS Foundations Benchmark recommends monitoring for these events to maintain continuous awareness of access control violations across all AWS services.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon CloudWatch Console** and navigate to **Logs** > **Log groups**.
+        2. Select the log group associated with your CloudTrail trail.
+        3. Choose **Metric filters** and look for a filter whose pattern contains `AccessDenied` or `UnauthorizedAccess`.
+        4. Navigate to **Alarms** > **All alarms** and verify that an alarm is configured for the corresponding metric.
+
+        A passing account has at least one metric filter matching unauthorized API call patterns with a corresponding alarm. A failing account has no such metric filter or has the filter but no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check all CloudWatch Logs metric filters for patterns matching unauthorized API calls:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'AccessDenied') || contains(filterPattern, 'UnauthorizedAccess')]"
+        ```
+
+        2. Verify that an alarm exists for the matching metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[*].{Name:AlarmName,Metric:MetricName,Namespace:Namespace}" \
+          --output table
+        ```
+
+        A passing account returns at least one metric filter entry containing `AccessDenied` or `UnauthorizedAccess` in the `filterPattern`, and a corresponding alarm for that metric. A failing account returns an empty list for the filter query or no alarm for the matching metric.
       remediation:
         - id: console
           desc: |
@@ -34969,6 +40625,34 @@ queries:
         Monitoring for MFA-less logins allows security teams to identify users who bypass MFA requirements and take corrective action. This is particularly important for privileged accounts with broad permissions across your AWS environment.
 
         CIS AWS Foundations Benchmark recommends this control to enforce MFA usage and detect policy violations in real time.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon CloudWatch Console** and navigate to **Logs** > **Log groups**.
+        2. Select the log group associated with your CloudTrail trail.
+        3. Choose **Metric filters** and look for a filter whose pattern contains both `ConsoleLogin` and `MFAUsed`.
+        4. Navigate to **Alarms** > **All alarms** and verify that an alarm is configured for the corresponding metric.
+
+        A passing account has at least one metric filter matching console sign-in without MFA with a corresponding alarm. A failing account has no such metric filter or has the filter but no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check all CloudWatch Logs metric filters for patterns matching MFA-less console logins:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'ConsoleLogin') && contains(filterPattern, 'MFAUsed')]"
+        ```
+
+        2. Verify that an alarm exists for the matching metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[*].{Name:AlarmName,Metric:MetricName,Namespace:Namespace}" \
+          --output table
+        ```
+
+        A passing account returns at least one metric filter entry containing both `ConsoleLogin` and `MFAUsed` in the `filterPattern`, and a corresponding alarm for that metric. A failing account returns an empty list for the filter query or no alarm for the matching metric.
       remediation:
         - id: console
           desc: |
@@ -35145,6 +40829,35 @@ queries:
         Any use of root credentials in day-to-day operations is a significant security concern and may indicate that an attacker has gained access to the root account. Immediate alerting on root usage enables rapid incident response.
 
         CIS AWS Foundations Benchmark strongly recommends monitoring root account activity to comply with the principle of least privilege and to detect potential account compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern references both `userIdentity.type` and `Root`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter matching root account usage events and a corresponding alarm in an OK or ALARM state. A failing account has no metric filter matching root usage or no alarm associated with such a filter.
+
+        ### Audit via CLI
+
+        1. List all CloudWatch log groups and check their metric filters for a root account usage pattern:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'Root') && contains(filterPattern, 'userIdentity')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'Root')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one metric filter entry and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -35321,6 +41034,35 @@ queries:
         Unauthorized or accidental IAM policy changes could grant excessive permissions to users or roles, potentially leading to privilege escalation or data exposure. Real-time alerting on IAM policy changes allows security teams to review and remediate unintended modifications promptly.
 
         CIS AWS Foundations Benchmark recommends monitoring IAM policy changes to maintain continuous visibility into access control modifications and prevent privilege escalation attacks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes IAM policy change events such as `CreatePolicy`, `DeletePolicy`, or `AttachRolePolicy`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter matching IAM policy change events and a corresponding alarm. A failing account has no such metric filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for IAM policy change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreatePolicy') || contains(filterPattern, 'DeletePolicy') || contains(filterPattern, 'AttachRolePolicy')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'IAMPolicy') || contains(MetricName, 'PolicyChange')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -35497,6 +41239,35 @@ queries:
         Attackers who gain sufficient privileges may attempt to disable CloudTrail to cover their tracks. Immediate alerting on CloudTrail configuration changes ensures that any tampering with the audit log system is detected and investigated promptly.
 
         CIS AWS Foundations Benchmark requires monitoring CloudTrail configuration changes to protect the integrity of the audit logging infrastructure itself.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes CloudTrail events such as `CreateTrail`, `UpdateTrail`, `DeleteTrail`, `StartLogging`, or `StopLogging`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter matching CloudTrail configuration change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for CloudTrail configuration change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreateTrail') || contains(filterPattern, 'UpdateTrail') || contains(filterPattern, 'DeleteTrail') || contains(filterPattern, 'StopLogging')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'CloudTrail')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -35673,6 +41444,35 @@ queries:
         Early detection of authentication failures enables security teams to lock down accounts under attack, investigate the source of repeated failures, and take preventative action before an attacker succeeds. Without this monitoring, account takeover attempts may go unnoticed.
 
         CIS AWS Foundations Benchmark recommends monitoring console authentication failures to detect and respond to unauthorized access attempts targeting the management console.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern matches `ConsoleLogin` events combined with a failed authentication condition.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing console authentication failures and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for console authentication failure events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'ConsoleLogin') && contains(filterPattern, 'Failed')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'ConsoleAuth') || contains(MetricName, 'AuthFailure')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -35849,6 +41649,35 @@ queries:
         Disabling or deleting a CMK is an irreversible or time-sensitive operation that can cause widespread service disruption and data loss. Immediate alerting on these events allows administrators to cancel scheduled key deletions within the waiting period and prevent accidental or malicious data loss.
 
         CIS AWS Foundations Benchmark recommends this control to protect encryption key availability and detect ransomware-style attacks targeting KMS keys.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes `DisableKey` or `ScheduleKeyDeletion` events from `kms.amazonaws.com`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing CMK disable or scheduled deletion events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for CMK disable or deletion events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'DisableKey') || contains(filterPattern, 'ScheduleKeyDeletion')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'CMK') || contains(MetricName, 'KMS')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36025,6 +41854,35 @@ queries:
         Monitoring S3 bucket policy changes enables security teams to detect misconfiguration events that could lead to data breaches. This is especially important given the high frequency of data exposure incidents caused by misconfigured S3 buckets.
 
         CIS AWS Foundations Benchmark recommends monitoring S3 bucket policy changes to prevent unauthorized data exposure and enforce data governance policies across your object storage environment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes S3 bucket policy events such as `PutBucketAcl`, `PutBucketPolicy`, or `DeleteBucketPolicy`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing S3 bucket policy change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for S3 bucket policy change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'PutBucketPolicy') || contains(filterPattern, 'PutBucketAcl') || contains(filterPattern, 'DeleteBucketPolicy')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'S3') || contains(MetricName, 'Bucket')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36201,6 +42059,35 @@ queries:
         Disabling AWS Config's configuration recorder or delivery channel would blind your organization to configuration changes across AWS resources, defeating a key compliance and security monitoring capability. Alerting on these events ensures that such tampering is detected immediately.
 
         CIS AWS Foundations Benchmark recommends monitoring AWS Config changes to protect the integrity of your compliance monitoring infrastructure and detect attempts to disable configuration tracking.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes AWS Config events such as `StopConfigurationRecorder` or `DeleteDeliveryChannel`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing AWS Config configuration change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for AWS Config change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'StopConfigurationRecorder') || contains(filterPattern, 'DeleteDeliveryChannel')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'Config')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36377,6 +42264,35 @@ queries:
         Monitoring security group changes allows security teams to detect overly permissive rules being added, such as rules allowing unrestricted ingress from the internet. Prompt detection and remediation of such changes reduces the window of exposure.
 
         CIS AWS Foundations Benchmark recommends monitoring security group changes to maintain network security posture and detect unauthorized modifications to network access controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes security group events such as `AuthorizeSecurityGroupIngress`, `AuthorizeSecurityGroupEgress`, `RevokeSecurityGroupIngress`, `RevokeSecurityGroupEgress`, `CreateSecurityGroup`, or `DeleteSecurityGroup`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing security group change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for security group change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'AuthorizeSecurityGroupIngress') || contains(filterPattern, 'AuthorizeSecurityGroupEgress')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'SecurityGroup')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36553,6 +42469,35 @@ queries:
         Unlike security groups which are stateful, NACLs are stateless and operate at the subnet boundary, making them a critical layer of defense-in-depth. Changes to NACLs can affect all resources within a subnet simultaneously, amplifying the impact of misconfiguration.
 
         CIS AWS Foundations Benchmark recommends monitoring NACL changes to maintain subnet-level network security and detect unauthorized modifications to your network access control infrastructure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes NACL events such as `CreateNetworkAcl`, `CreateNetworkAclEntry`, `DeleteNetworkAcl`, `DeleteNetworkAclEntry`, `ReplaceNetworkAclEntry`, or `ReplaceNetworkAclAssociation`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing NACL change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for NACL change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreateNetworkAcl') || contains(filterPattern, 'DeleteNetworkAcl')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'NetworkACL') || contains(MetricName, 'NACL')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36729,6 +42674,35 @@ queries:
         Changes to network gateways can fundamentally alter the connectivity of your AWS environment, potentially opening new attack surfaces or disrupting existing secure connections. Monitoring these changes ensures that any unauthorized modifications to network topology are detected promptly.
 
         CIS AWS Foundations Benchmark recommends monitoring network gateway changes to maintain visibility into VPC connectivity changes and detect unauthorized exposure of internal resources to the internet.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes network gateway events such as `CreateCustomerGateway`, `DeleteCustomerGateway`, `AttachInternetGateway`, `CreateInternetGateway`, `DeleteInternetGateway`, or `DetachInternetGateway`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing network gateway change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for network gateway change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreateCustomerGateway') || contains(filterPattern, 'AttachInternetGateway')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'NetworkGateway') || contains(MetricName, 'Gateway')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -36905,6 +42879,35 @@ queries:
         Route table changes can be used in attacks to intercept or redirect network traffic, enabling man-in-the-middle attacks or data exfiltration. Monitoring route table changes provides visibility into potential traffic redirection attempts in your AWS network infrastructure.
 
         CIS AWS Foundations Benchmark recommends monitoring route table changes to maintain the integrity of network routing and detect unauthorized attempts to redirect or intercept network traffic within your VPCs.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes route table events such as `CreateRoute`, `CreateRouteTable`, `ReplaceRoute`, `ReplaceRouteTableAssociation`, `DeleteRouteTable`, `DeleteRoute`, or `DisassociateRouteTable`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing route table change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for route table change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreateRoute') || contains(filterPattern, 'CreateRouteTable')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'RouteTable') || contains(MetricName, 'Route')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -37081,6 +43084,35 @@ queries:
         Unauthorized creation, modification, or deletion of VPCs could be indicators of an attacker attempting to establish persistence or pivot within your AWS environment. Monitoring VPC changes provides visibility into fundamental network topology modifications that could affect your entire infrastructure.
 
         CIS AWS Foundations Benchmark recommends monitoring VPC changes to detect unauthorized modifications to your network isolation boundaries and maintain visibility into changes to the core network infrastructure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern includes VPC events such as `CreateVpc`, `DeleteVpc`, `ModifyVpcAttribute`, `AcceptVpcPeeringConnection`, `CreateVpcPeeringConnection`, `DeleteVpcPeeringConnection`, or `RejectVpcPeeringConnection`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing VPC change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for VPC change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'CreateVpc') || contains(filterPattern, 'DeleteVpc')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'VPC')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -37257,6 +43289,35 @@ queries:
         Changes to Service Control Policies (SCPs), organizational units, or account membership in AWS Organizations can override security controls applied at the account level. Monitoring these changes is critical for organizations using AWS Organizations to enforce security guardrails across all member accounts.
 
         CIS AWS Foundations Benchmark recommends monitoring AWS Organizations changes to detect unauthorized modifications to your multi-account governance structure and service control policies.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console using the management account and navigate to **CloudWatch**.
+        2. Select **Log groups** in the left navigation pane.
+        3. Open the log group associated with your CloudTrail trail in the management account.
+        4. Choose **Metric filters** and review the list of filters.
+        5. Confirm that at least one filter pattern references `organizations.amazonaws.com` or key organizational events such as `CreateAccount`, `AttachPolicy`, `DeleteOrganization`, or `UpdatePolicy`.
+        6. Navigate to **Alarms** and verify that an alarm exists tied to that metric, with an SNS action configured.
+
+        A passing account has at least one metric filter capturing AWS Organizations change events and a corresponding alarm. A failing account has no such filter or no associated alarm.
+
+        ### Audit via CLI
+
+        1. Check metric filters for AWS Organizations change events:
+
+        ```bash
+        aws logs describe-metric-filters \
+          --query "metricFilters[?contains(filterPattern, 'organizations.amazonaws.com')]"
+        ```
+
+        2. Verify an alarm exists for the corresponding metric:
+
+        ```bash
+        aws cloudwatch describe-alarms \
+          --query "MetricAlarms[?contains(MetricName, 'Organization')].{AlarmName:AlarmName,MetricName:MetricName,State:StateValue}"
+        ```
+
+        A passing account returns at least one matching metric filter and a corresponding alarm. A failing account returns empty results for either command.
       remediation:
         - id: console
           desc: |
@@ -37445,6 +43506,34 @@ queries:
         - Reduces the impact of compromised instances by preventing arbitrary outbound communications.
         - Limits the blast radius of a breach by restricting lateral movement and data exfiltration paths.
         - Supports compliance with network segmentation and egress filtering requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **EC2** service.
+        2. Select **Security Groups** under **Network & Security** in the left navigation pane.
+        3. For each security group, select the group and open the **Outbound rules** tab.
+        4. Review the outbound rules for any rule with protocol set to **All traffic**, destination **0.0.0.0/0** (or **::/0** for IPv6), and all port ranges.
+        5. Any security group that has such a rule is not compliant.
+
+        A passing security group has no outbound rule permitting all traffic to 0.0.0.0/0 or ::/0 on all protocols. A failing security group has at least one such unrestricted egress rule.
+
+        ### Audit via CLI
+
+        1. List security groups that have an unrestricted egress rule allowing all traffic:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissionsEgress[?IpProtocol=='-1' && IpRanges[?CidrIp=='0.0.0.0/0']]].{GroupId:GroupId,GroupName:GroupName,VpcId:VpcId}"
+        ```
+
+        2. Also check for IPv6 unrestricted egress:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissionsEgress[?IpProtocol=='-1' && Ipv6Ranges[?CidrIpv6=='::/0']]].{GroupId:GroupId,GroupName:GroupName,VpcId:VpcId}"
+        ```
+
+        A passing account returns an empty list for both commands. A failing account returns one or more security groups with unrestricted egress rules.
       remediation:
         - id: console
           desc: |
@@ -37598,6 +43687,33 @@ queries:
         - Prevents root account takeover even if credentials are compromised through phishing or credential stuffing.
         - Ensures the most privileged account identity requires physical possession of a hardware token to authenticate.
         - Satisfies compliance requirements mandating hardware MFA for privileged or administrative accounts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console as the root user.
+        2. Select your account name in the upper right corner and choose **Security credentials**.
+        3. In the **Multi-factor authentication (MFA)** section, review the type of MFA device associated with the root account.
+        4. Confirm that the device type is **Hardware TOTP token** or **FIDO security key** and not a virtual (software-based) authenticator app.
+
+        A passing root account shows a hardware MFA device registered with no virtual MFA device present. A failing root account either has no MFA device, or has only a virtual MFA device registered.
+
+        ### Audit via CLI
+
+        1. Generate and retrieve the IAM credential report to check root MFA status:
+
+        ```bash
+        aws iam generate-credential-report
+        aws iam get-credential-report --query "Content" --output text | base64 -d | awk -F',' 'NR==1 || $1=="<root_account>"'
+        ```
+
+        2. Check whether a virtual MFA device is associated with the root account:
+
+        ```bash
+        aws iam list-virtual-mfa-devices \
+          --query "VirtualMFADevices[?contains(SerialNumber, 'root-account-mfa-device')]"
+        ```
+
+        A passing root account shows `mfa_active` as `true` in the credential report and returns an empty list from the virtual MFA devices query. A failing root account either shows `mfa_active` as `false`, or returns a virtual MFA device entry indicating that no hardware device is in use.
       remediation:
         - id: console
           desc: |
@@ -37689,6 +43805,21 @@ queries:
         - **Attack surface reduction:** Removing expired certificates and rotating their associated keys eliminates potential impersonation vectors from compromised private keys.
         - **Credential hygiene:** Reduces the inventory to only valid, actively managed certificates, ensuring that compromised legacy keys cannot be used for impersonation.
         - **Lifecycle management:** Enforcing certificate cleanup drives adoption of proper rotation practices that limit key exposure time.
+      audit: |
+        ### Audit via Console
+
+        IAM server certificates cannot be listed or reviewed directly in the AWS Console. Use the AWS CLI path below to inspect expiration dates.
+
+        ### Audit via CLI
+
+        1. List all server certificates stored in IAM along with their expiration dates:
+
+        ```bash
+        aws iam list-server-certificates \
+          --query "ServerCertificateMetadataList[*].{Name:ServerCertificateName,Expiration:Expiration}"
+        ```
+
+        A passing account returns an empty list or shows only certificates whose `Expiration` value is in the future. A failing account returns one or more certificates whose `Expiration` date is earlier than the current date.
       remediation:
         - id: console
           desc: |
@@ -37781,6 +43912,28 @@ queries:
         - **Root credential protection:** Eliminates a reason to use root credentials, reducing exposure of the most privileged account in the environment.
         - **Forensic traceability:** Creates attributable, auditable identities for support interactions that can be distinguished from attacker activity during incident investigation.
         - **Blast radius containment:** Ensures support access is scoped to a dedicated role with limited permissions rather than the unrestricted root account.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **IAM**.
+        2. In the left navigation, choose **Policies**.
+        3. Search for **AWSSupportAccess** and select the policy.
+        4. Choose the **Policy usage** tab.
+        5. Verify that the policy is attached to at least one user, role, or group.
+
+        A passing account shows one or more entities attached under Policy usage. A failing account shows no entities attached to the AWSSupportAccess policy.
+
+        ### Audit via CLI
+
+        1. Query the AWSSupportAccess managed policy for its attached entities:
+
+        ```bash
+        aws iam list-entities-for-policy \
+          --policy-arn arn:aws:iam::aws:policy/AWSSupportAccess \
+          --query "{Users:PolicyUsers,Roles:PolicyRoles,Groups:PolicyGroups}"
+        ```
+
+        A passing account returns at least one entry in `Users`, `Roles`, or `Groups`. A failing account returns empty arrays for all three fields.
       remediation:
         - id: console
           desc: |
@@ -37922,6 +44075,27 @@ queries:
         - **Operational hygiene:** Stale credentials often indicate poor offboarding processes or abandoned service integrations that should be cleaned up.
 
         By default, credentials unused for 90 days or more are flagged. This threshold can be adjusted using the `mondooAWSSecurityCredentialInactivityThreshold` property.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **IAM**.
+        2. In the left navigation, choose **Credential report**.
+        3. Choose **Download report** to obtain the CSV file.
+        4. Open the report and examine the `password_last_used`, `access_key_1_last_used_date`, and `access_key_2_last_used_date` columns.
+        5. Flag any row where an active credential column (`password_enabled`, `access_key_1_active`, `access_key_2_active`) is `true` and the corresponding last-used date is either `N/A` (never used) or more than 90 days ago.
+
+        A passing account has no active credentials with a null or stale last-used date. A failing account has one or more active credentials that have never been used or have not been used in over 90 days.
+
+        ### Audit via CLI
+
+        1. Generate and download the credential report:
+
+        ```bash
+        aws iam generate-credential-report
+        aws iam get-credential-report --query 'Content' --output text | base64 --decode
+        ```
+
+        A passing account shows no rows where an active credential (`password_enabled=true`, `access_key_1_active=true`, or `access_key_2_active=true`) has a `N/A` or a last-used date older than 90 days. A failing account shows one or more such rows.
       remediation:
         - id: console
           desc: |
@@ -38060,6 +44234,28 @@ queries:
         - Improves incident response by providing detailed traces of function execution and service calls.
         - Enables detection of anomalous invocation patterns or unexpected downstream API calls.
         - Supports compliance with logging and monitoring requirements for serverless workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Lambda**.
+        2. Choose **Functions** in the left navigation.
+        3. Select the function to review.
+        4. Choose the **Configuration** tab and select **Monitoring and operations tools**.
+        5. Under **AWS X-Ray**, verify that **Active tracing** is enabled.
+
+        A passing function shows Active tracing as **Enabled**. A failing function shows Active tracing as **Disabled** or not configured.
+
+        ### Audit via CLI
+
+        1. Retrieve the tracing configuration for a Lambda function:
+
+        ```bash
+        aws lambda get-function-configuration \
+          --function-name <function-name> \
+          --query "TracingConfig.Mode"
+        ```
+
+        A passing function returns `"Active"`. A failing function returns `"PassThrough"` or no tracing configuration.
       remediation:
         - id: console
           desc: |
@@ -38221,6 +44417,29 @@ queries:
         - Eliminates the confused deputy attack vector by binding Lambda invoke permissions to a specific source resource ARN.
         - Ensures that only the intended AWS resource can trigger the function, even if another resource in the same service is compromised.
         - Reduces the blast radius of misconfigured cross-service permissions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Lambda**.
+        2. Choose **Functions** in the left navigation and select the function to review.
+        3. Choose the **Configuration** tab and select **Permissions**.
+        4. Under **Resource-based policy statements**, expand each statement that grants `Allow` to an AWS service principal (for example, `s3.amazonaws.com`, `sns.amazonaws.com`, `events.amazonaws.com`).
+        5. Verify that each such statement includes a `Condition` block specifying `aws:SourceArn` or `aws:SourceAccount`.
+
+        A passing function has no Allow statements for service principals without a source ARN or source account condition. A failing function has one or more Allow statements for service principals that lack such a condition.
+
+        ### Audit via CLI
+
+        1. Retrieve and parse the resource-based policy for a Lambda function:
+
+        ```bash
+        aws lambda get-policy \
+          --function-name <function-name> \
+          --query "Policy" \
+          --output text | python3 -m json.tool
+        ```
+
+        A passing function either has no policy or has all Allow statements for service principals constrained by a `Condition` that includes `aws:SourceArn` or `aws:SourceAccount`. A failing function returns a policy with at least one Allow statement for a service principal that has no such condition.
       remediation:
         - id: console
           desc: |
@@ -38384,6 +44603,25 @@ queries:
         - Prevents permanent object deletion by requiring a second authentication factor for destructive operations.
         - Protects against ransomware attacks that target cloud storage by deleting or encrypting versioned objects.
         - Supports compliance with data protection requirements mandating controls against unauthorized data destruction.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **S3**.
+        2. Select the bucket to review.
+        3. Choose the **Properties** tab.
+        4. Under **Bucket Versioning**, check the MFA delete setting.
+
+        A passing bucket shows MFA delete as **Enabled** alongside versioning. A failing bucket shows MFA delete as **Disabled** or shows that versioning is not enabled.
+
+        ### Audit via CLI
+
+        1. Check the versioning and MFA delete configuration for a bucket:
+
+        ```bash
+        aws s3api get-bucket-versioning --bucket <bucket-name>
+        ```
+
+        A passing bucket returns `"Status": "Enabled"` and `"MFADelete": "Enabled"`. A failing bucket returns `"MFADelete": "Disabled"`, an absent `MFADelete` field, or versioning not enabled.
       remediation:
         - id: console
           desc: |
@@ -38528,6 +44766,27 @@ queries:
         - **Confidentiality:** Prevents interception of search queries, results, and authentication credentials in transit.
         - **Integrity:** TLS protects against tampering with data exchanged between clients and the Elasticsearch cluster.
         - **Compliance:** Satisfies in-transit encryption requirements under PCI DSS, HIPAA, NIST SP 800-53 SC-8, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Elasticsearch Service** (or **Amazon OpenSearch Service**).
+        2. Choose **Domains** in the left navigation and select the domain to review.
+        3. Choose the **Security configuration** tab (or **Actions** > **Edit security configuration**).
+        4. Under **HTTPS**, verify that **Require HTTPS for all traffic to the domain** is enabled.
+
+        A passing domain shows HTTPS enforcement as **Enabled**. A failing domain shows it as **Disabled** or not configured.
+
+        ### Audit via CLI
+
+        1. Retrieve the HTTPS enforcement setting for an Elasticsearch domain:
+
+        ```bash
+        aws es describe-elasticsearch-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.DomainEndpointOptions.EnforceHTTPS"
+        ```
+
+        A passing domain returns `true`. A failing domain returns `false` or null.
       remediation:
         - id: console
           desc: |
@@ -38671,6 +44930,27 @@ queries:
         - **Strong encryption:** TLS 1.2+ provides modern cipher suites and eliminates vulnerabilities present in older protocol versions.
         - **Downgrade protection:** Prevents attackers from forcing connections to use weaker protocol versions.
         - **Compliance:** Meets TLS version requirements mandated by PCI DSS 3.2.1+, NIST SP 800-52, and industry best practices.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Elasticsearch Service** (or **Amazon OpenSearch Service**).
+        2. Choose **Domains** in the left navigation and select the domain to review.
+        3. Choose the **Security configuration** tab (or **Actions** > **Edit security configuration**).
+        4. Under **HTTPS**, verify that the **TLS security policy** is set to **Policy-Min-TLS-1-2-2019-07** or **Policy-Min-TLS-1-2-PFS-2023-10**.
+
+        A passing domain shows a TLS policy of `Policy-Min-TLS-1-2-2019-07` or stronger. A failing domain shows `Policy-Min-TLS-1-0-2020-07` or a weaker policy.
+
+        ### Audit via CLI
+
+        1. Retrieve the TLS security policy for an Elasticsearch domain:
+
+        ```bash
+        aws es describe-elasticsearch-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.DomainEndpointOptions.TLSSecurityPolicy"
+        ```
+
+        A passing domain returns `"Policy-Min-TLS-1-2-2019-07"` or `"Policy-Min-TLS-1-2-PFS-2023-10"`. A failing domain returns `"Policy-Min-TLS-1-0-2020-07"` or any value below TLS 1.2.
       remediation:
         - id: console
           desc: |
@@ -38816,6 +45096,27 @@ queries:
         - **Access monitoring:** Audit logs reveal who is accessing your Elasticsearch data and what operations they perform.
         - **Incident response:** Log data provides the forensic trail needed to investigate security incidents involving Elasticsearch data.
         - **Compliance:** Satisfies audit logging requirements under NIST SP 800-53 AU-6, ISO 27001 A.8.15, and SOC 2 CC7.2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon Elasticsearch Service** (or **Amazon OpenSearch Service**).
+        2. Choose **Domains** in the left navigation and select the domain to review.
+        3. Choose the **Logs** tab.
+        4. Under **Audit logs**, verify that logging is **Enabled** and a CloudWatch Logs log group is configured.
+
+        A passing domain shows audit logs as **Enabled** with a log group ARN. A failing domain shows audit logs as **Disabled** or shows no log group configured.
+
+        ### Audit via CLI
+
+        1. Retrieve the audit log publishing options for an Elasticsearch domain:
+
+        ```bash
+        aws es describe-elasticsearch-domain \
+          --domain-name <domain-name> \
+          --query "DomainStatus.LogPublishingOptions.AUDIT_LOGS"
+        ```
+
+        A passing domain returns an object with `"Enabled": true` and a `CloudWatchLogsLogGroupArn`. A failing domain returns `"Enabled": false`, null, or no `AUDIT_LOGS` key.
       remediation:
         - id: console
           desc: |
@@ -38962,6 +45263,36 @@ queries:
         - **Data protection:** Encrypts data on local cluster volumes and S3 storage, protecting against unauthorized access at the storage layer.
         - **Key management:** Uses AWS KMS for centralized key management, rotation, and access control.
         - **Compliance:** Satisfies at-rest encryption requirements across multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EMR**.
+        2. Select the cluster to review.
+        3. Choose the **Summary** tab and locate the **Security and access** section.
+        4. Find the **Security configuration** name and note it.
+        5. Navigate to **Security configurations** in the left panel, select the configuration, and verify that **At-rest encryption** is enabled under the **Encryption** section.
+
+        A passing cluster is associated with a security configuration that shows at-rest encryption as enabled. A failing cluster has no security configuration or one where at-rest encryption is disabled.
+
+        ### Audit via CLI
+
+        1. Describe the cluster to find its security configuration:
+
+        ```bash
+        aws emr describe-cluster \
+          --cluster-id <cluster-id> \
+          --query "Cluster.{SecurityConfig:SecurityConfiguration,Encryption:EncryptionConfiguration}"
+        ```
+
+        2. Retrieve the security configuration details:
+
+        ```bash
+        aws emr describe-security-configuration \
+          --name <security-configuration-name> \
+          --query "SecurityConfiguration"
+        ```
+
+        A passing cluster has a security configuration where `EncryptionConfiguration.EnableAtRestEncryption` is `true`. A failing cluster has no security configuration or one where `EnableAtRestEncryption` is `false`.
       remediation:
         - id: console
           desc: |
@@ -39139,6 +45470,36 @@ queries:
         - **Network protection:** TLS encryption prevents interception of data flowing between cluster nodes and between the cluster and S3.
         - **Defense in depth:** Complements at-rest encryption to protect data throughout its lifecycle.
         - **Compliance:** Satisfies in-transit encryption requirements under PCI DSS, HIPAA, NIST SP 800-53 SC-8, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EMR**.
+        2. Select the cluster to review.
+        3. Choose the **Summary** tab and locate the **Security and access** section.
+        4. Note the **Security configuration** name.
+        5. Navigate to **Security configurations** in the left panel, select the configuration, and verify that **In-transit encryption** is enabled under the **Encryption** section.
+
+        A passing cluster is associated with a security configuration that shows in-transit encryption as enabled. A failing cluster has no security configuration or one where in-transit encryption is disabled.
+
+        ### Audit via CLI
+
+        1. Describe the cluster to find its security configuration:
+
+        ```bash
+        aws emr describe-cluster \
+          --cluster-id <cluster-id> \
+          --query "Cluster.SecurityConfiguration"
+        ```
+
+        2. Retrieve the security configuration details:
+
+        ```bash
+        aws emr describe-security-configuration \
+          --name <security-configuration-name> \
+          --query "SecurityConfiguration"
+        ```
+
+        A passing cluster has a security configuration where `EncryptionConfiguration.EnableInTransitEncryption` is `true`. A failing cluster has no security configuration or one where `EnableInTransitEncryption` is `false`.
       remediation:
         - id: console
           desc: |
@@ -39302,6 +45663,27 @@ queries:
         - **Operational visibility:** Persistent logs enable post-mortem analysis of failed jobs and performance issues.
         - **Security auditing:** Logs capture information about data access patterns, authentication events, and job execution that support security investigations.
         - **Compliance:** Meets logging and audit trail requirements under NIST SP 800-53 AU-6 and SOC 2 CC7.2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon EMR**.
+        2. Select the cluster to review.
+        3. Choose the **Summary** tab.
+        4. Under **Log URI**, verify that an S3 path is configured for log storage.
+
+        A passing cluster shows a populated **Log URI** field pointing to an S3 location. A failing cluster shows no Log URI or an empty value.
+
+        ### Audit via CLI
+
+        1. Check the log URI configured for an EMR cluster:
+
+        ```bash
+        aws emr describe-cluster \
+          --cluster-id <cluster-id> \
+          --query "Cluster.LogUri"
+        ```
+
+        A passing cluster returns a non-empty S3 URI such as `"s3://my-bucket/emr-logs/"`. A failing cluster returns `null` or an empty string.
       remediation:
         - id: console
           desc: |
@@ -39457,6 +45839,27 @@ queries:
         - **Data protection:** SSE encrypts data cached in DAX, ensuring sensitive DynamoDB data remains protected even in the caching layer.
         - **Compliance:** Satisfies at-rest encryption requirements that extend to all copies of data, including caches.
         - **Defense in depth:** Complements DynamoDB table-level encryption by extending protection to the DAX caching layer.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **DynamoDB**.
+        2. In the left navigation, choose **DAX** and then **Clusters**.
+        3. Select the cluster to review.
+        4. Choose the **Settings** tab.
+        5. Under **Encryption**, verify that server-side encryption (SSE) status is **ENABLED**.
+
+        A passing cluster shows SSE status as **ENABLED**. A failing cluster shows SSE status as **DISABLED**.
+
+        ### Audit via CLI
+
+        1. Check the SSE status of all DAX clusters:
+
+        ```bash
+        aws dax describe-clusters \
+          --query "Clusters[*].{Name:ClusterName,SSEStatus:SSEDescription.Status}"
+        ```
+
+        A passing cluster returns `"SSEStatus": "ENABLED"`. A failing cluster returns `"SSEStatus": "DISABLED"` or null.
       remediation:
         - id: console
           desc: |
@@ -39607,6 +46010,29 @@ queries:
         - **Least privilege:** Restricting queue policies to specific AWS accounts, IAM roles, or services ensures only authorized entities can interact with the queue.
         - **Data protection:** Prevents unauthorized parties from reading or injecting messages that may contain sensitive application data.
         - **Compliance:** Satisfies access control requirements under NIST SP 800-53 AC-3, ISO 27001 A.8.20, and SOC 2 CC6.3.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon SQS**.
+        2. Select the queue to review.
+        3. Choose the **Access policy** tab.
+        4. Examine the policy document for any `Effect: Allow` statements where `Principal` is `"*"` or `{"AWS": "*"}` without a restricting condition.
+
+        A passing queue has no Allow statements with wildcard principals, or any wildcard principal is constrained by a condition such as `aws:SourceArn` or `aws:PrincipalOrgID`. A failing queue has at least one unconstrained Allow statement granting access to `*`.
+
+        ### Audit via CLI
+
+        1. Retrieve the access policy for a queue and inspect it for wildcard principals:
+
+        ```bash
+        aws sqs get-queue-attributes \
+          --queue-url <queue-url> \
+          --attribute-names Policy \
+          --query "Attributes.Policy" \
+          --output text | python3 -m json.tool
+        ```
+
+        A passing queue returns a policy with no Allow statements where `Principal` equals `"*"` or `{"AWS": "*"}` without conditions. A failing queue returns a policy containing one or more such unconstrained wildcard Allow statements.
       remediation:
         - id: console
           desc: |
@@ -39761,6 +46187,36 @@ queries:
         - Use AWS Secrets Manager or AWS Systems Manager Parameter Store to manage secrets securely.
         - Reference secrets in task definitions using the `secrets` field with `valueFrom` instead of the `environment` field.
         - Implement automated secret rotation through Secrets Manager.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to **Amazon ECS**.
+        2. Choose **Task definitions** in the left navigation.
+        3. Select the task definition family and then the active revision.
+        4. Expand each container definition and review the **Environment variables** section.
+        5. Check whether any environment variable names match sensitive patterns such as `DB_PASSWORD`, `API_KEY`, `SECRET_KEY`, or `AWS_SECRET_ACCESS_KEY`, or whether any values resemble access keys (starting with `AKIA`, `ASIA`, etc.) or private key headers.
+
+        A passing task definition has no environment variables with sensitive names or secret-like values. A failing task definition has at least one environment variable that stores a plaintext secret.
+
+        ### Audit via CLI
+
+        1. List all active task definition ARNs:
+
+        ```bash
+        aws ecs list-task-definitions \
+          --status ACTIVE \
+          --query "taskDefinitionArns"
+        ```
+
+        2. Inspect a specific task definition's container environment variables:
+
+        ```bash
+        aws ecs describe-task-definition \
+          --task-definition <task-definition-arn> \
+          --query "taskDefinition.containerDefinitions[*].{Name:name,Env:environment}"
+        ```
+
+        A passing task definition returns container definitions where no environment variable name matches a known secret pattern and no value resembles an access key or private key. A failing task definition returns one or more environment variables with names or values consistent with plaintext secrets.
       remediation:
         - id: console
           desc: |
@@ -39894,6 +46350,30 @@ queries:
         - Delete default VPCs in all regions to prevent accidental use.
         - Create custom VPCs with properly configured subnets, route tables, and security groups.
         - Enforce VPC selection through service control policies or IAM conditions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **VPC** console.
+        2. In the left navigation pane, select **Your VPCs**.
+        3. In the VPC list, look at the **Default VPC** column.
+        4. Repeat this check in every AWS region by switching regions in the console.
+
+        A passing account shows no VPC with **Default VPC = Yes** in any region. A failing account shows at least one VPC marked as the default.
+
+        ### Audit via CLI
+
+        1. Run the following command for each region to list default VPCs:
+
+        ```bash
+        for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
+          echo "Region: $region"
+          aws ec2 describe-vpcs --region "$region" \
+            --filters "Name=isDefault,Values=true" \
+            --query "Vpcs[].VpcId" --output text
+        done
+        ```
+
+        A passing account returns no VPC IDs for any region. A failing account returns one or more VPC IDs, indicating a default VPC is present.
       remediation:
         - id: console
           desc: |
@@ -39990,6 +46470,35 @@ queries:
         - **Data protection:** Ensures all data on local disks is encrypted, preventing unauthorized access to intermediate processing data.
         - **Compliance:** Meets regulatory requirements for encryption of data at rest on compute instances.
         - **Defense in depth:** Adds an additional layer of protection beyond network-level controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon EMR** console.
+        2. In the left navigation pane, select **Security configurations**.
+        3. For each security configuration, select its name to view details.
+        4. Under **Encryption**, expand **At-rest encryption** and check whether **Local disk encryption** is listed as enabled.
+        5. For each running cluster, select the cluster and verify it is associated with a security configuration that has local disk encryption enabled.
+
+        A passing cluster is associated with a security configuration that has **Local disk encryption** enabled. A failing cluster has no security configuration, or its security configuration does not enable local disk encryption.
+
+        ### Audit via CLI
+
+        1. List all EMR clusters and check their security configurations:
+
+        ```bash
+        aws emr list-clusters --active \
+          --query "Clusters[*].{Id:Id,Name:Name,SecurityConfiguration:SecurityConfiguration}"
+        ```
+
+        2. For each security configuration name returned, inspect its encryption settings:
+
+        ```bash
+        aws emr describe-security-configuration \
+          --name <security-configuration-name> \
+          --query "SecurityConfiguration"
+        ```
+
+        A passing cluster returns a security configuration whose `EncryptionConfiguration.AtRestEncryptionConfiguration.LocalDiskEncryptionConfiguration` is present and `EnableAtRestEncryption` is `true`. A failing cluster has no security configuration or one that lacks a `LocalDiskEncryptionConfiguration` block.
       remediation:
         - id: console
           desc: |
@@ -40166,6 +46675,27 @@ queries:
         - **Real-time monitoring:** Enables immediate detection of suspicious API activity through CloudWatch metric filters and alarms.
         - **Automated response:** CloudWatch alarms can trigger SNS notifications, Lambda functions, or other automated remediation actions.
         - **Compliance:** Meets requirements for continuous monitoring and real-time alerting in security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **CloudTrail** console.
+        2. In the left navigation pane, select **Trails**.
+        3. For each multi-region trail, select the trail name to view its details.
+        4. Under the **CloudWatch Logs** section, verify that a **Log group** ARN is listed.
+
+        A passing trail shows a CloudWatch Logs log group ARN in the **CloudWatch Logs** section. A failing trail shows **Not configured** or an empty **Log group** field.
+
+        ### Audit via CLI
+
+        1. List multi-region trails and their CloudWatch Logs configuration:
+
+        ```bash
+        aws cloudtrail describe-trails \
+          --include-shadow-trails false \
+          --query "trailList[?IsMultiRegionTrail==\`true\`].{Name:Name,LogGroup:CloudWatchLogsLogGroupArn}"
+        ```
+
+        A passing trail returns a non-null `CloudWatchLogsLogGroupArn` value. A failing trail returns `null` or an empty string for `CloudWatchLogsLogGroupArn`.
       remediation:
         - id: console
           desc: |
@@ -40322,6 +46852,26 @@ queries:
         - **Ransomware resilience:** Backups ensure data can be restored after adversarial destruction, removing the attacker's leverage.
         - **Incident recovery:** Enables restoration to a known-good state after a cache poisoning or data destruction attack.
         - **Compliance:** Meets regulatory requirements for data backup and recovery capabilities.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon ElastiCache** console.
+        2. In the left navigation pane, select **Redis clusters**.
+        3. For each cluster, select the cluster name to view its details.
+        4. On the **Description** tab, locate the **Backup retention period** field.
+
+        A passing cluster shows a **Backup retention period** greater than 0 days. A failing cluster shows **Backup retention period: 0** or **Disabled**.
+
+        ### Audit via CLI
+
+        1. List Redis replication groups and their snapshot retention settings:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query "ReplicationGroups[*].{Id:ReplicationGroupId,SnapshotRetentionLimit:SnapshotRetentionLimit}"
+        ```
+
+        A passing replication group returns a `SnapshotRetentionLimit` value greater than `0`. A failing replication group returns `0` for `SnapshotRetentionLimit`.
       remediation:
         - id: console
           desc: |
@@ -40467,6 +47017,26 @@ queries:
         - **Ransomware resilience:** Automated backups ensure data can be restored after adversarial destruction, removing the attacker's leverage.
         - **Point-in-time recovery:** Enables restoration to the moment before an attack, minimizing data loss from SQL injection, insider threats, or credential compromise.
         - **Forensic capability:** Backup snapshots can be used to compare pre-attack and post-attack database states during incident investigation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon RDS** console.
+        2. In the left navigation pane, select **Databases**.
+        3. For each DB instance, select its identifier to view its details.
+        4. On the **Maintenance & backups** tab, locate the **Backup retention period** field.
+
+        A passing DB instance shows a **Backup retention period** greater than 0 days. A failing DB instance shows **Backup retention period: 0 days** or no backup window configured.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances and their backup retention periods:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{DBInstanceId:DBInstanceIdentifier,BackupRetentionPeriod:BackupRetentionPeriod}"
+        ```
+
+        A passing DB instance returns a `BackupRetentionPeriod` value greater than `0`. A failing DB instance returns `0` for `BackupRetentionPeriod`.
       remediation:
         - id: console
           desc: |
@@ -40610,6 +47180,27 @@ queries:
         - **Attack detection:** Enables identification of SQL injection, data exfiltration, and unauthorized workloads through abnormal query patterns and resource consumption.
         - **Forensic analysis:** Historical performance data supports post-incident investigation by preserving evidence of attacker activity.
         - **Anomaly baselining:** Establishes normal query patterns so that deviations from attacker activity can be identified and alerted on.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon RDS** console.
+        2. In the left navigation pane, select **Databases**.
+        3. For each DB instance, select its identifier to view its details.
+        4. On the **Monitoring** tab, check whether the **Performance Insights** section shows an active dashboard or indicates the feature is enabled.
+        5. Alternatively, on the **Configuration** tab, look for **Performance Insights** and its status.
+
+        A passing DB instance shows **Performance Insights: Enabled**. A failing DB instance shows **Performance Insights: Disabled** or the section is absent.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances and check Performance Insights status:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{DBInstanceId:DBInstanceIdentifier,PerformanceInsightsEnabled:PerformanceInsightsEnabled}"
+        ```
+
+        A passing DB instance returns `"PerformanceInsightsEnabled": true`. A failing DB instance returns `"PerformanceInsightsEnabled": false` or the field is absent.
       remediation:
         - id: console
           desc: |
@@ -40757,6 +47348,26 @@ queries:
         - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
         - **Defense in depth:** Complements IAM policies by adding instance-level protection that survives credential compromise.
         - **Incident response window:** The additional step buys time for automated alerting to detect and respond to unauthorized modification attempts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon RDS** console.
+        2. In the left navigation pane, select **Databases**.
+        3. For each DB instance, select its identifier to view its details.
+        4. On the **Configuration** tab, locate the **Deletion protection** field.
+
+        A passing DB instance shows **Deletion protection: Enabled**. A failing DB instance shows **Deletion protection: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances and their deletion protection status:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{DBInstanceId:DBInstanceIdentifier,DeletionProtection:DeletionProtection}"
+        ```
+
+        A passing DB instance returns `"DeletionProtection": true`. A failing DB instance returns `"DeletionProtection": false`.
       remediation:
         - id: console
           desc: |
@@ -40900,6 +47511,26 @@ queries:
         - **Destructive attack prevention:** Requires an attacker to make two API calls (disable protection, then delete), creating an additional detection opportunity via CloudTrail.
         - **Defense in depth:** Complements IAM policies by adding cluster-level protection that survives credential compromise.
         - **Incident response window:** The additional step buys time for automated alerting to detect and respond to unauthorized modification attempts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon RDS** console.
+        2. In the left navigation pane, select **Databases**.
+        3. Filter the list to show **Clusters** and select each Aurora cluster identifier.
+        4. On the **Configuration** tab, locate the **Deletion protection** field.
+
+        A passing DB cluster shows **Deletion protection: Enabled**. A failing DB cluster shows **Deletion protection: Disabled**.
+
+        ### Audit via CLI
+
+        1. List all RDS DB clusters and their deletion protection status:
+
+        ```bash
+        aws rds describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,DeletionProtection:DeletionProtection}"
+        ```
+
+        A passing DB cluster returns `"DeletionProtection": true`. A failing DB cluster returns `"DeletionProtection": false`.
       remediation:
         - id: console
           desc: |
@@ -41045,6 +47676,26 @@ queries:
         - **Enhanced control:** Organizations can manage key policies, enforce key rotation, and revoke access as needed.
         - **Compliance:** Meets regulatory requirements that mandate customer-managed encryption keys.
         - **Auditability:** All encryption and decryption operations are logged in CloudTrail.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon ECR** console.
+        2. In the left navigation pane, select **Repositories**.
+        3. For each repository, select its name to view details.
+        4. On the **Settings** tab, locate the **Encryption configuration** section and check the **Encryption type**.
+
+        A passing repository shows **Encryption type: KMS**. A failing repository shows **Encryption type: AES-256** (the default).
+
+        ### Audit via CLI
+
+        1. List all ECR private repositories and their encryption types:
+
+        ```bash
+        aws ecr describe-repositories \
+          --query "repositories[*].{Name:repositoryName,EncryptionType:encryptionConfiguration.encryptionType,KmsKey:encryptionConfiguration.kmsKey}"
+        ```
+
+        A passing repository returns `"EncryptionType": "KMS"` with a non-null `KmsKey`. A failing repository returns `"EncryptionType": "AES256"` or omits the KMS key.
       remediation:
         - id: console
           desc: |
@@ -41190,6 +47841,26 @@ queries:
         - **Attack detection:** Enables real-time alerting on suspicious query patterns, failed authentication attempts, and unauthorized administrative actions through CloudWatch.
         - **Forensic investigation:** Provides audit trails that allow security teams to reconstruct attacker activity, identify compromised accounts, and determine the scope of data exposure.
         - **Anomaly detection:** Centralized logs enable baselining of normal query patterns so that unauthorized graph traversal or bulk data extraction can be identified.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon Neptune** console.
+        2. In the left navigation pane, select **Databases**.
+        3. Select each Neptune cluster identifier to view its details.
+        4. On the **Logs and events** tab (or **Configuration** tab depending on console version), locate the **Published logs** or **Log exports** section and check whether **Audit** log export is enabled.
+
+        A passing Neptune cluster shows **Audit** listed under enabled log exports. A failing cluster shows no log exports configured or the audit log type is absent.
+
+        ### Audit via CLI
+
+        1. List all Neptune clusters and their enabled CloudWatch log exports:
+
+        ```bash
+        aws neptune describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,LogExports:EnabledCloudwatchLogsExports}"
+        ```
+
+        A passing cluster returns `"LogExports"` containing `"audit"`. A failing cluster returns an empty list or a list that does not include `"audit"`.
       remediation:
         - id: console
           desc: |
@@ -41329,6 +48000,26 @@ queries:
         - **Monitoring:** Enables real-time monitoring of database operations through CloudWatch.
         - **Forensics:** Provides detailed audit trails for security investigations.
         - **Alerting:** Enables automated alerting on suspicious database activities through CloudWatch alarms.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon DocumentDB** console.
+        2. In the left navigation pane, select **Clusters**.
+        3. Select each cluster identifier to view its details.
+        4. On the **Logs** tab, locate the **Enabled log exports** section and verify that **Audit** is listed.
+
+        A passing DocumentDB cluster shows **Audit** listed under enabled log exports. A failing cluster shows no log exports or does not include audit logs.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB clusters and their enabled CloudWatch log exports:
+
+        ```bash
+        aws docdb describe-db-clusters \
+          --query "DBClusters[*].{ClusterId:DBClusterIdentifier,LogExports:EnabledCloudwatchLogsExports}"
+        ```
+
+        A passing cluster returns `"LogExports"` containing `"audit"`. A failing cluster returns an empty list or a list that does not include `"audit"`.
       remediation:
         - id: console
           desc: |
@@ -41473,6 +48164,25 @@ queries:
         - **Incomplete visibility:** Without aggregation, security teams must check each region individually for compliance data.
         - **Regulatory gaps:** Many compliance frameworks require a centralized view of all infrastructure configuration across the entire organization.
         - **Incident response delays:** During security incidents, the inability to quickly query configuration data across all regions slows investigation and remediation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Config** console.
+        2. In the left navigation pane, select **Aggregators**.
+        3. Verify that at least one configuration aggregator is listed.
+
+        A passing account shows one or more aggregators in the list. A failing account shows an empty aggregators list with a prompt to create one.
+
+        ### Audit via CLI
+
+        1. List all AWS Config configuration aggregators:
+
+        ```bash
+        aws configservice describe-configuration-aggregators \
+          --query "ConfigurationAggregators[*].{Name:ConfigurationAggregatorName,CreationTime:CreationTime}"
+        ```
+
+        A passing account returns one or more aggregator entries. A failing account returns an empty list `[]`.
       remediation:
         - id: console
           desc: |
@@ -41606,6 +48316,26 @@ queries:
         - **Incomplete compliance posture:** Resources created in regions not covered by the aggregator will not appear in compliance dashboards, creating a false sense of security.
         - **Shadow infrastructure:** Attackers or unauthorized users may provision resources in uncovered regions to avoid detection.
         - **Regulatory requirements:** Frameworks such as CIS AWS Foundations Benchmark require Config to aggregate data across all regions to ensure comprehensive visibility.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Config** console.
+        2. In the left navigation pane, select **Aggregators**.
+        3. Select each aggregator name to view its details.
+        4. Under **Source accounts and regions**, verify that **All regions** is selected rather than a specific list of regions.
+
+        A passing aggregator shows **All regions** selected under source regions. A failing aggregator shows only specific regions selected, leaving some regions uncovered.
+
+        ### Audit via CLI
+
+        1. Check each aggregator for all-regions coverage:
+
+        ```bash
+        aws configservice describe-configuration-aggregators \
+          --query "ConfigurationAggregators[*].{Name:ConfigurationAggregatorName,AccountAllRegions:AccountAggregationSources[0].AllAwsRegions,OrgAllRegions:OrganizationAggregationSource.AllAwsRegions}"
+        ```
+
+        A passing aggregator returns `true` for either `AccountAllRegions` or `OrgAllRegions`. A failing aggregator returns `false` or `null` for both fields.
       remediation:
         - id: console
           desc: |
@@ -41753,6 +48483,34 @@ queries:
         - **Supply chain risk:** Publicly accessible images can be analyzed by attackers to discover vulnerabilities and develop targeted exploits.
         - **Intellectual property:** Container images may contain proprietary business logic and trade secrets.
         - **Compliance violations:** Many regulatory frameworks prohibit public exposure of application artifacts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Amazon ECR** console.
+        2. In the left navigation pane, select **Repositories**.
+        3. For each repository, select its name and navigate to the **Permissions** tab.
+        4. Review the repository policy JSON. Look for any `Statement` where `Principal` is set to `"*"` or `{"AWS": "*"}`.
+
+        A passing repository has no policy, or its policy contains no statement granting access to the `*` principal. A failing repository has a policy statement with `Principal: "*"` or `Principal: {AWS: "*"}`, granting public access.
+
+        ### Audit via CLI
+
+        1. List all private repositories, then check each policy:
+
+        ```bash
+        aws ecr describe-repositories \
+          --query "repositories[*].repositoryName" --output text
+        ```
+
+        2. For each repository name, retrieve its policy:
+
+        ```bash
+        aws ecr get-repository-policy \
+          --repository-name <repo-name> \
+          --query "policyText"
+        ```
+
+        A passing repository returns no policy or a policy with no `Principal` set to `"*"` or `{"AWS": "*"}`. A failing repository returns a policy containing a statement where `Principal` is `"*"` or `{"AWS": "*"}`.
       remediation:
         - id: console
           desc: |
@@ -41924,6 +48682,35 @@ queries:
         - Use IAM instance profiles instead of embedding AWS credentials.
         - Store secrets in AWS Secrets Manager or SSM Parameter Store and retrieve them at boot time.
         - Use EC2 instance metadata service (IMDSv2) for temporary credentials.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Instances**, select **Launch templates**.
+        3. For each launch template, select its name and review each version.
+        4. Select a version, scroll to **Advanced details**, and expand the **User data** field.
+        5. Inspect the decoded user data for patterns such as AWS access key prefixes (`AKIA`, `ASIA`), private key headers (`-----BEGIN RSA PRIVATE KEY-----`), or plaintext credential assignments.
+
+        A passing launch template has no user data, or user data that contains no hard-coded secrets or credential patterns. A failing launch template contains user data with embedded AWS keys, private keys, passwords, or API tokens.
+
+        ### Audit via CLI
+
+        1. List all launch templates:
+
+        ```bash
+        aws ec2 describe-launch-templates \
+          --query "LaunchTemplates[*].{Id:LaunchTemplateId,Name:LaunchTemplateName}"
+        ```
+
+        2. For each template, retrieve user data from all versions:
+
+        ```bash
+        aws ec2 describe-launch-template-versions \
+          --launch-template-id <template-id> \
+          --query "LaunchTemplateVersions[*].{Version:VersionNumber,UserData:LaunchTemplateData.UserData}"
+        ```
+
+        Decode the base64-encoded user data and scan for secret patterns. A passing launch template returns no user data, empty user data, or user data free of AWS key patterns, private key headers, and credential assignments. A failing launch template returns user data that contains recognizable secret patterns such as `AKIA`-prefixed keys or `-----BEGIN PRIVATE KEY-----` headers.
       remediation:
         - id: console
           desc: |
@@ -42074,6 +48861,36 @@ queries:
         - Enable logging on all multi-region CloudTrail trails.
         - Set up CloudWatch alarms to detect when logging is stopped.
         - Use AWS Organizations SCPs to prevent disabling of CloudTrail logging.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **CloudTrail** console.
+        2. In the left navigation pane, choose **Trails**.
+        3. Review each trail listed. In the **Logging** column, verify the status shows **On**.
+        4. For each multi-region trail, confirm the **Logging** status is active.
+
+        A passing trail shows **Logging: On** in the trail list. A failing trail shows **Logging: Off**.
+
+        ### Audit via CLI
+
+        1. List all trails to identify multi-region trails:
+
+        ```bash
+        aws cloudtrail describe-trails \
+          --include-shadow-trails false \
+          --query "trailList[?IsMultiRegionTrail==\`true\`].{Name:Name,HomeRegion:HomeRegion}"
+        ```
+
+        2. For each multi-region trail, check the logging status:
+
+        ```bash
+        aws cloudtrail get-trail-status \
+          --name <trail-name> \
+          --query "{IsLogging:IsLogging,LatestDeliveryTime:LatestDeliveryTime}"
+        ```
+
+        A passing trail returns `"IsLogging": true`. A failing trail returns `"IsLogging": false`.
+
       remediation:
         - id: console
           desc: |
@@ -42185,6 +49002,39 @@ queries:
         - Remove public sharing from all EBS snapshots.
         - Use AWS Config rules to detect publicly shared snapshots.
         - Share snapshots only with specific, trusted AWS accounts when necessary.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Elastic Block Store**, choose **Snapshots**.
+        3. Set the **Owner** filter to **Owned by me**.
+        4. For each snapshot, review the **Permissions** column or select the snapshot and check the **Permissions** tab.
+        5. Confirm that no snapshot has **Public** permissions set.
+
+        A passing snapshot shows **Private** permissions. A failing snapshot shows **Public** in the permissions.
+
+        ### Audit via CLI
+
+        1. List all your snapshots and check their permissions:
+
+        ```bash
+        aws ec2 describe-snapshots \
+          --owner-ids self \
+          --query "Snapshots[*].{SnapshotId:SnapshotId,Description:Description}" \
+          --output table
+        ```
+
+        2. For each snapshot, check whether it is publicly accessible:
+
+        ```bash
+        aws ec2 describe-snapshot-attribute \
+          --snapshot-id <snapshot-id> \
+          --attribute createVolumePermission \
+          --query "CreateVolumePermissions"
+        ```
+
+        A passing snapshot returns an empty array `[]` or only specific account IDs. A failing snapshot returns `[{"Group": "all"}]`, indicating public access.
+
       remediation:
         - id: console
           desc: |
@@ -42317,6 +49167,27 @@ queries:
         - **Data exposure:** Unencrypted EBS volumes can be read by anyone with physical access to the underlying storage hardware or by copying the volume/snapshot to another account.
         - **Compliance:** PCI DSS, HIPAA, SOC 2, and CIS AWS Foundations Benchmark all require encryption of data at rest.
         - **Blast radius:** Because launch configurations are used by Auto Scaling groups, a single misconfiguration propagates to every instance the group launches.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Auto Scaling**, choose **Launch Configurations**.
+        3. Select a launch configuration and review the **Storage** section.
+        4. For each listed EBS volume in **Block devices**, confirm the **Encrypted** column shows **Yes**.
+
+        A passing launch configuration shows all EBS volumes with **Encrypted: Yes**. A failing configuration shows one or more volumes with **Encrypted: No** or no encryption indicator.
+
+        ### Audit via CLI
+
+        1. List all launch configurations and their EBS encryption settings:
+
+        ```bash
+        aws autoscaling describe-launch-configurations \
+          --query "LaunchConfigurations[*].{Name:LaunchConfigurationName,BlockDevices:BlockDeviceMappings[*].{Device:DeviceName,Encrypted:Ebs.Encrypted}}"
+        ```
+
+        A passing launch configuration returns `"Encrypted": true` for every block device mapping. A failing configuration returns `"Encrypted": false` or `null` for one or more block devices.
+
       remediation:
         - id: console
           desc: |
@@ -42479,6 +49350,27 @@ queries:
         - **Credential exposure:** If an instance with a public IP is compromised, the attacker has a direct path out to exfiltrate data.
         - **Auto Scaling blast radius:** A launch configuration with `associatePublicIpAddress: true` ensures every instance launched by the group gets a public IP, multiplying the risk.
         - **Best practice:** Instances should use NAT gateways, VPC endpoints, or load balancers for internet connectivity rather than direct public IPs.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Auto Scaling**, choose **Launch Configurations**.
+        3. Select a launch configuration and review the **Network settings** or **Details** tab.
+        4. Check the **Assign public IP address** setting.
+
+        A passing launch configuration shows **Assign public IP address: No** or does not assign a public IP. A failing configuration shows **Assign public IP address: Yes**.
+
+        ### Audit via CLI
+
+        1. List all launch configurations and their public IP assignment setting:
+
+        ```bash
+        aws autoscaling describe-launch-configurations \
+          --query "LaunchConfigurations[*].{Name:LaunchConfigurationName,AssociatePublicIpAddress:AssociatePublicIpAddress}"
+        ```
+
+        A passing launch configuration returns `"AssociatePublicIpAddress": false` or `null`. A failing configuration returns `"AssociatePublicIpAddress": true`.
+
       remediation:
         - id: console
           desc: |
@@ -42616,6 +49508,27 @@ queries:
         - **Compliance:** CIS AWS Foundations Benchmark requires IMDSv2 enforcement.
 
         IMDSv2 mitigates these risks by requiring a session token obtained via an HTTP PUT request, which SSRF attacks typically cannot perform.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EC2** console.
+        2. In the left navigation pane, under **Auto Scaling**, choose **Launch Configurations**.
+        3. Select a launch configuration and choose the **Details** tab.
+        4. Under **Advanced details**, review the **Metadata version** field.
+
+        A passing launch configuration shows **Metadata version: V2 only (token required)**. A failing configuration shows **Metadata version: V1 and V2 (token optional)** or has no metadata options configured.
+
+        ### Audit via CLI
+
+        1. List all launch configurations and their metadata options:
+
+        ```bash
+        aws autoscaling describe-launch-configurations \
+          --query "LaunchConfigurations[*].{Name:LaunchConfigurationName,HttpTokens:MetadataOptions.HttpTokens}"
+        ```
+
+        A passing launch configuration returns `"HttpTokens": "required"`. A failing configuration returns `"HttpTokens": "optional"` or `null`.
+
       remediation:
         - id: console
           desc: |
@@ -42769,6 +49682,37 @@ queries:
         - Create a CMK in KMS for RDS encryption.
         - Enable encryption with the CMK when creating new RDS instances.
         - For existing instances, create an encrypted snapshot with the CMK and restore from it.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Databases**.
+        3. Select an instance and choose the **Configuration** tab.
+        4. In the **Encryption** section, review the **AWS KMS key** value.
+        5. Open the AWS KMS console and verify that the key shown is a customer-managed key (its **Key manager** is **Customer**).
+
+        A passing instance shows a customer-managed KMS key ARN in the Encryption section. A failing instance shows an AWS-managed key alias such as `aws/rds` or no encryption.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption configuration for an RDS instance:
+
+        ```bash
+        aws rds describe-db-instances \
+          --db-instance-identifier <instance-id> \
+          --query "DBInstances[*].{ID:DBInstanceIdentifier,Encrypted:StorageEncrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. Verify the key manager for the returned KMS key:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing instance returns `StorageEncrypted: true` and the key's `KeyManager` is `"CUSTOMER"`. A failing instance returns `StorageEncrypted: false` or the key's `KeyManager` is `"AWS"`.
+
       remediation:
         - id: console
           desc: |
@@ -42925,6 +49869,37 @@ queries:
         - Create a CMK in KMS for RDS cluster encryption.
         - Enable encryption with the CMK when creating new Aurora clusters.
         - For existing clusters, create an encrypted snapshot with the CMK and restore from it.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Databases**.
+        3. Select a cluster and choose the **Configuration** tab.
+        4. In the **Encryption** section, review the **AWS KMS key** value.
+        5. Open the AWS KMS console and verify that the key shown is a customer-managed key (its **Key manager** is **Customer**).
+
+        A passing cluster shows a customer-managed KMS key ARN in the Encryption section. A failing cluster shows an AWS-managed key alias such as `aws/rds` or no encryption.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption configuration for an RDS cluster:
+
+        ```bash
+        aws rds describe-db-clusters \
+          --db-cluster-identifier <cluster-id> \
+          --query "DBClusters[*].{ID:DBClusterIdentifier,Encrypted:StorageEncrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. Verify the key manager for the returned KMS key:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing cluster returns `StorageEncrypted: true` and the key's `KeyManager` is `"CUSTOMER"`. A failing cluster returns `StorageEncrypted: false` or the key's `KeyManager` is `"AWS"`.
+
       remediation:
         - id: console
           desc: |
@@ -43067,6 +50042,36 @@ queries:
         - Copy existing snapshots with CMK encryption.
         - Ensure source RDS instances use CMK encryption so snapshots inherit the key.
         - Regularly audit snapshot encryption configurations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Snapshots**.
+        3. Select a snapshot and review the **Encryption** field in the snapshot details.
+        4. Open the AWS KMS console and verify that the key shown is a customer-managed key (its **Key manager** is **Customer**).
+
+        A passing snapshot shows a customer-managed KMS key ARN in the Encryption field. A failing snapshot shows an AWS-managed key alias such as `aws/rds` or no encryption.
+
+        ### Audit via CLI
+
+        1. Retrieve the encryption configuration for an RDS snapshot:
+
+        ```bash
+        aws rds describe-db-snapshots \
+          --db-snapshot-identifier <snapshot-id> \
+          --query "DBSnapshots[*].{ID:DBSnapshotIdentifier,Encrypted:Encrypted,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. Verify the key manager for the returned KMS key:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing snapshot returns `Encrypted: true` and the key's `KeyManager` is `"CUSTOMER"`. A failing snapshot returns `Encrypted: false` or the key's `KeyManager` is `"AWS"`.
+
       remediation:
         - id: console
           desc: |
@@ -43190,6 +50195,28 @@ queries:
         - Launch EMR clusters in private subnets.
         - Use VPN or AWS Systems Manager Session Manager for administrative access.
         - Configure security groups to restrict access to known IP ranges.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EMR** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster and review the **Summary** tab.
+        4. Check the **Master public DNS** field.
+
+        A passing cluster shows an empty or absent **Master public DNS** field. A failing cluster shows a public DNS hostname in that field, indicating the master node is internet-accessible.
+
+        ### Audit via CLI
+
+        1. Check whether an EMR cluster has a public master DNS name:
+
+        ```bash
+        aws emr describe-cluster \
+          --cluster-id <cluster-id> \
+          --query "Cluster.MasterPublicDnsName"
+        ```
+
+        A passing cluster returns `null` or an empty string. A failing cluster returns a public DNS hostname such as `ec2-1-2-3-4.compute-1.amazonaws.com`.
+
       remediation:
         - id: console
           desc: |
@@ -43344,6 +50371,37 @@ queries:
         - Configure a CMK for EMR log encryption when creating clusters.
         - Create a KMS key policy that restricts access to authorized principals.
         - Monitor KMS key usage via CloudTrail for audit purposes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EMR** console.
+        2. In the left navigation pane, choose **Clusters**.
+        3. Select a cluster and review the **Summary** tab. Check that **Log URI** is set.
+        4. Under **Security and access**, review the **Security configuration** field. If logging is enabled, a security configuration should be attached.
+        5. Open the **EMR** console, choose **Security configurations**, select the referenced configuration, and verify that **S3 encryption** is configured with a **SSE-KMS** mode using a CMK.
+
+        A passing cluster shows a security configuration attached that includes CMK-based S3 encryption for logs. A failing cluster with logging enabled shows no security configuration or one with no CMK-based S3 encryption.
+
+        ### Audit via CLI
+
+        1. Retrieve the cluster's log URI and security configuration:
+
+        ```bash
+        aws emr describe-cluster \
+          --cluster-id <cluster-id> \
+          --query "Cluster.{LogUri:LogUri,SecurityConfiguration:SecurityConfiguration}"
+        ```
+
+        2. If a security configuration is attached, inspect its encryption settings:
+
+        ```bash
+        aws emr describe-security-configuration \
+          --name <security-configuration-name> \
+          --query "SecurityConfiguration"
+        ```
+
+        A passing cluster with logging enabled returns a security configuration name and the configuration's `S3EncryptionConfiguration.EncryptionMode` is `SSE-KMS` with an `AwsKmsKey` set to a CMK ARN. A failing cluster returns no security configuration or one without CMK-based S3 encryption.
+
       remediation:
         - id: console
           desc: |
@@ -43522,6 +50580,36 @@ queries:
         - Create dedicated security groups for Neptune clusters with specific inbound rules.
         - Restrict access to only the application subnets and ports required.
         - Regularly audit security group rules for Neptune clusters.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Neptune** console.
+        2. In the left navigation pane, choose **Databases** and select a cluster.
+        3. Under the **Connectivity & security** tab, review the **VPC security groups** list.
+        4. Confirm that the security group named **default** is not present in the list.
+
+        A passing cluster lists only custom, purpose-built security groups with no entry named **default**. A failing cluster shows a security group named **default** in the list.
+
+        ### Audit via CLI
+
+        1. Retrieve the security groups for a Neptune cluster:
+
+        ```bash
+        aws neptune describe-db-clusters \
+          --db-cluster-identifier <cluster-id> \
+          --query "DBClusters[*].VpcSecurityGroups"
+        ```
+
+        2. For each security group ID returned, look up the group name:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --group-ids <sg-id> \
+          --query "SecurityGroups[*].{ID:GroupId,Name:GroupName}"
+        ```
+
+        A passing cluster returns no security group with `GroupName` equal to `"default"`. A failing cluster returns at least one security group with `GroupName` equal to `"default"`.
+
       remediation:
         - id: console
           desc: |
@@ -43665,6 +50753,36 @@ queries:
         - Create dedicated security groups for DocumentDB clusters with specific inbound rules.
         - Restrict access to only the application subnets and port 27017 (or custom port).
         - Regularly audit security group rules for DocumentDB clusters.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **DocumentDB** console.
+        2. In the left navigation pane, choose **Clusters** and select a cluster.
+        3. Under the **Connectivity & security** tab, review the **VPC security groups** list.
+        4. Confirm that the security group named **default** is not present in the list.
+
+        A passing cluster lists only custom, purpose-built security groups with no entry named **default**. A failing cluster shows a security group named **default** in the list.
+
+        ### Audit via CLI
+
+        1. Retrieve the security groups for a DocumentDB cluster:
+
+        ```bash
+        aws docdb describe-db-clusters \
+          --db-cluster-identifier <cluster-id> \
+          --query "DBClusters[*].VpcSecurityGroups"
+        ```
+
+        2. For each security group ID returned, look up the group name:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --group-ids <sg-id> \
+          --query "SecurityGroups[*].{ID:GroupId,Name:GroupName}"
+        ```
+
+        A passing cluster returns no security group with `GroupName` equal to `"default"`. A failing cluster returns at least one security group with `GroupName` equal to `"default"`.
+
       remediation:
         - id: console
           desc: |
@@ -43812,6 +50930,37 @@ queries:
         - Configure a CMK when enabling Secrets Manager integration for Redshift.
         - Create a KMS key policy that restricts access to authorized principals.
         - Enable automatic key rotation on the CMK.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **Redshift** console.
+        2. In the left navigation pane, choose **Clusters** and select a cluster.
+        3. Under the **Properties** tab, find the **Database configurations** section.
+        4. Locate the **Admin password managed by Secrets Manager** field and check the listed KMS key.
+        5. Open the AWS KMS console and confirm that the key's **Key manager** is **Customer**.
+
+        A passing cluster shows a customer-managed KMS key for the Secrets Manager-managed password. A failing cluster shows an AWS-managed key alias or has Secrets Manager integration without a CMK.
+
+        ### Audit via CLI
+
+        1. Retrieve the Secrets Manager KMS key ID for a Redshift cluster:
+
+        ```bash
+        aws redshift describe-clusters \
+          --cluster-identifier <cluster-id> \
+          --query "Clusters[*].{ID:ClusterIdentifier,MasterPasswordSecretKmsKeyId:MasterPasswordSecretKmsKeyId}"
+        ```
+
+        2. Verify the key manager for the returned KMS key:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing cluster returns a non-empty `MasterPasswordSecretKmsKeyId` and the key's `KeyManager` is `"CUSTOMER"`. A failing cluster returns an empty or null `MasterPasswordSecretKmsKeyId`, or the key's `KeyManager` is `"AWS"`.
+
       remediation:
         - id: console
           desc: |
@@ -43954,6 +51103,28 @@ queries:
         - **Stronger cryptographic baseline:** Eliminates connections from legacy clients that would negotiate weak ciphers or outdated TLS versions vulnerable to known attacks.
         - **Attack surface reduction:** Removes support for legacy TLS stacks that may be susceptible to downgrade attacks or known protocol vulnerabilities.
         - **Security posture consistency:** Ensures all client connections meet a minimum TLS capability baseline, simplifying security monitoring and compliance.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **CloudFront** console.
+        2. Choose **Distributions** and select a distribution.
+        3. Under the **General** tab, choose **Edit** in the **Settings** section.
+        4. In the **Custom SSL certificate** section, review the **SSL support method** field.
+
+        A passing distribution shows **SSL support method: SNI** (Server Name Indication). A failing distribution shows **SSL support method: Dedicated IP** or has the dedicated IP option selected.
+
+        ### Audit via CLI
+
+        1. Retrieve the SSL support method for a CloudFront distribution:
+
+        ```bash
+        aws cloudfront get-distribution \
+          --id <distribution-id> \
+          --query "Distribution.DistributionConfig.ViewerCertificate.SSLSupportMethod"
+        ```
+
+        A passing distribution returns `"sni-only"`. A failing distribution returns `"vip"` (dedicated IP) or `"static-ip"`.
+
       remediation:
         - id: console
           desc: |
@@ -44090,6 +51261,27 @@ queries:
         - **Abuse detection:** Access logs enable detection of unusual traffic patterns such as content scraping, credential stuffing against origin APIs, or DDoS attacks.
         - **Compliance:** Many regulatory frameworks require logging of access to web-facing resources. CIS AWS Foundations Benchmark recommends enabling CloudFront access logging.
         - **Cost analysis:** Logs help identify unexpected traffic sources that may be inflating CloudFront costs.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **CloudFront** console.
+        2. Choose **Distributions** and select a distribution.
+        3. Under the **General** tab, review the **Standard logging** field in the **Settings** section.
+
+        A passing distribution shows **Standard logging: On** with an S3 bucket configured. A failing distribution shows **Standard logging: Off**.
+
+        ### Audit via CLI
+
+        1. Retrieve the logging configuration for a CloudFront distribution:
+
+        ```bash
+        aws cloudfront get-distribution \
+          --id <distribution-id> \
+          --query "Distribution.DistributionConfig.Logging"
+        ```
+
+        A passing distribution returns a logging object with `"Enabled": true` and a non-empty `Bucket`. A failing distribution returns `"Enabled": false` or an absent `Logging` block.
+
       remediation:
         - id: console
           desc: |
@@ -44232,6 +51424,27 @@ queries:
         - Enable TLS encryption on all DAX clusters.
         - Note that encryption in transit cannot be enabled on existing clusters; you must create a new cluster with encryption enabled.
         - Update client applications to use the TLS-enabled DAX endpoint.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **DynamoDB** service.
+        2. In the left navigation pane, select **DAX** and then **Clusters**.
+        3. Select each cluster and view the **Cluster details** panel.
+        4. Locate the **Cluster endpoint encryption** field.
+
+        A passing cluster shows `TLS` as the cluster endpoint encryption type. A failing cluster shows `NONE`.
+
+        ### Audit via CLI
+
+        1. List all DAX clusters and their endpoint encryption types:
+
+        ```bash
+        aws dax describe-clusters \
+          --query "Clusters[*].{Name:ClusterName,EncryptionType:ClusterEndpointEncryptionType}"
+        ```
+
+        A passing cluster returns `"EncryptionType": "TLS"`. A failing cluster returns `"EncryptionType": "NONE"`.
+
       remediation:
         - id: console
           desc: |
@@ -44372,6 +51585,36 @@ queries:
         - Enable the `initProcessEnabled` flag in ECS task definition container definitions.
         - This adds a lightweight init process (Tini) that properly handles signal forwarding and zombie reaping.
         - Test container shutdown behavior after enabling init.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Elastic Container Service** console.
+        2. In the left navigation pane, select **Task definitions**.
+        3. Select each active task definition and choose the latest revision.
+        4. Select each container definition and expand **Linux parameters**.
+        5. Check whether **Enable init process** is selected.
+
+        A passing container definition shows **Enable init process** checked. A failing container definition shows that option unchecked.
+
+        ### Audit via CLI
+
+        1. List all active task definition ARNs:
+
+        ```bash
+        aws ecs list-task-definitions --status ACTIVE \
+          --query "taskDefinitionArns"
+        ```
+
+        2. For each task definition, inspect the `initProcessEnabled` flag for all container definitions:
+
+        ```bash
+        aws ecs describe-task-definition \
+          --task-definition <task-definition-arn> \
+          --query "taskDefinition.containerDefinitions[*].{Name:name,InitProcessEnabled:linuxParameters.initProcessEnabled}"
+        ```
+
+        A passing container definition returns `"InitProcessEnabled": true`. A failing container definition returns `null` or `false`.
+
       remediation:
         - id: console
           desc: |
@@ -44517,6 +51760,27 @@ queries:
         - Deploy Lambda functions in private subnets within a VPC.
         - Configure security groups with the minimum required outbound rules.
         - Use VPC endpoints for AWS service access instead of NAT gateways where possible.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Lambda** console.
+        2. Select **Functions** and open each function.
+        3. Choose the **Configuration** tab and then **VPC**.
+        4. Review the **VPC**, **Subnets**, and **Security groups** fields.
+
+        A passing function shows a VPC ID, at least one subnet, and at least one security group. A failing function shows **No VPC** or blank VPC configuration.
+
+        ### Audit via CLI
+
+        1. List all Lambda functions and their VPC configuration:
+
+        ```bash
+        aws lambda list-functions \
+          --query "Functions[*].{Name:FunctionName,VpcId:VpcConfig.VpcId}"
+        ```
+
+        A passing function returns a non-empty `VpcId` value. A failing function returns `null` or an empty string for `VpcId`.
+
       remediation:
         - id: console
           desc: |
@@ -44666,6 +51930,35 @@ queries:
         - Replace wildcard principals with specific AWS account IDs or IAM ARNs.
         - Add conditions such as `aws:PrincipalOrgID` to restrict access to your organization.
         - Use ECR repository policies in combination with IAM policies for defense in depth.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Elastic Container Registry** console.
+        2. Select **Repositories** and open each repository.
+        3. In the left pane, select **Permissions** and review each statement.
+        4. Check whether any statement has `Effect: Allow`, a wildcard `Principal` (i.e., `"*"` or `{"AWS": "*"}`), and no `Condition` block.
+
+        A passing repository has no policy statements granting unconditional wildcard principal access. A failing repository has at least one `Allow` statement with a wildcard principal and no conditions.
+
+        ### Audit via CLI
+
+        1. List all private repository names:
+
+        ```bash
+        aws ecr describe-repositories \
+          --query "repositories[*].repositoryName"
+        ```
+
+        2. Retrieve the policy for each repository and inspect for wildcard principals:
+
+        ```bash
+        aws ecr get-repository-policy \
+          --repository-name <repository-name> \
+          --query "policyText"
+        ```
+
+        A passing repository returns a policy with no `Allow` statements containing `"Principal": "*"` or `"Principal": {"AWS": "*"}` without a condition. A failing repository returns a policy with such a statement present.
+
       remediation:
         - id: console
           desc: |
@@ -44827,6 +52120,35 @@ queries:
         - Create a CMK in KMS for ElastiCache encryption.
         - Enable encryption at rest with the CMK when creating new clusters.
         - For existing clusters, create a backup and restore to a new cluster with CMK encryption.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **ElastiCache** console.
+        2. In the left navigation pane, select **Redis caches** or **Memcached clusters**, depending on the engine in use.
+        3. Select each replication group and open the **Details** tab.
+        4. Under **Encryption**, review the **Encryption at rest** setting and the associated **KMS key**.
+
+        A passing replication group shows encryption at rest enabled and a customer-managed KMS key ARN. A failing replication group shows no encryption, an AWS-owned key, or an AWS-managed key (`aws/elasticache`).
+
+        ### Audit via CLI
+
+        1. List all replication groups and their encryption details:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query "ReplicationGroups[*].{ID:ReplicationGroupId,AtRestEncryption:AtRestEncryptionEnabled,KmsKeyId:KmsKeyId}"
+        ```
+
+        2. For a reported KMS key ARN, confirm the key manager is `CUSTOMER`:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-key-id> \
+          --query "KeyMetadata.{KeyManager:KeyManager,KeyId:KeyId}"
+        ```
+
+        A passing replication group returns `"AtRestEncryption": true` with a `KmsKeyId` whose `KeyManager` is `CUSTOMER`. A failing replication group returns `"AtRestEncryption": false`, a null `KmsKeyId`, or a key with `KeyManager` of `AWS`.
+
       remediation:
         - id: console
           desc: |
@@ -44976,6 +52298,42 @@ queries:
         - Configure CMK encryption when creating Kinesis streams.
         - Migrate existing streams by updating the encryption settings to use a CMK.
         - Monitor KMS key usage via CloudTrail for audit purposes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Kinesis** console.
+        2. Select **Data streams** in the left navigation pane.
+        3. Select each stream and open the **Configuration** tab.
+        4. Under **Server-side encryption**, review the **Status** and the **KMS key**.
+
+        A passing stream shows **Enabled** with a customer-managed KMS key. A failing stream shows **Disabled** or uses an AWS-managed key (`aws/kinesis`).
+
+        ### Audit via CLI
+
+        1. List all Kinesis streams:
+
+        ```bash
+        aws kinesis list-streams --query "StreamNames"
+        ```
+
+        2. For each stream, check the encryption type and key ID:
+
+        ```bash
+        aws kinesis describe-stream-summary \
+          --stream-name <stream-name> \
+          --query "StreamDescriptionSummary.{EncryptionType:EncryptionType,KeyId:KeyId}"
+        ```
+
+        3. Confirm the key is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <key-id> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing stream returns `"EncryptionType": "KMS"` with a `KeyId` whose `KeyManager` is `CUSTOMER`. A failing stream returns `"EncryptionType": "NONE"` or has a `KeyManager` of `AWS`.
+
       remediation:
         - id: console
           desc: |
@@ -45124,6 +52482,42 @@ queries:
         - Configure CMK encryption when creating DynamoDB tables.
         - Update existing tables to use CMK encryption (this can be done without downtime).
         - Monitor KMS key usage via CloudTrail for audit purposes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **DynamoDB** console.
+        2. Select **Tables** in the left navigation pane.
+        3. Select each table and choose the **Additional settings** tab.
+        4. Under **Encryption at rest**, review the **Encryption type** and the associated KMS key.
+
+        A passing table shows **Customer managed key (CMK)** with a customer-managed KMS key ARN. A failing table shows **Owned by Amazon DynamoDB** (AWS-owned key) or **AWS managed key**.
+
+        ### Audit via CLI
+
+        1. List all DynamoDB tables:
+
+        ```bash
+        aws dynamodb list-tables --query "TableNames"
+        ```
+
+        2. For each table, inspect the SSE description:
+
+        ```bash
+        aws dynamodb describe-table \
+          --table-name <table-name> \
+          --query "Table.SSEDescription"
+        ```
+
+        3. Confirm the KMS key is customer-managed:
+
+        ```bash
+        aws kms describe-key \
+          --key-id <kms-master-key-arn> \
+          --query "KeyMetadata.KeyManager"
+        ```
+
+        A passing table returns `"SSEType": "KMS"` with a `KMSMasterKeyArn` whose `KeyManager` is `CUSTOMER`. A failing table returns `null` for `SSEDescription` or has a `KeyManager` of `AWS`.
+
       remediation:
         - id: console
           desc: |
@@ -45273,6 +52667,41 @@ queries:
         - **Key control:** Customer-managed keys give organizations full lifecycle control, including rotation and revocation.
         - **Audit trail:** All KMS key usage is logged to CloudTrail, providing a complete record of data access events.
         - **Compliance:** Satisfies encryption key management requirements in multiple regulatory and security frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon Keyspaces** console.
+        2. Select **Tables** in the left navigation pane.
+        3. Select each table and choose the **Additional settings** tab.
+        4. Under **Encryption**, review the **Encryption type** and associated KMS key.
+
+        A passing table shows **Customer managed key** with a customer-managed KMS key ARN. A failing table shows **AWS owned key** or **AWS managed key**.
+
+        ### Audit via CLI
+
+        1. List all keyspaces:
+
+        ```bash
+        aws keyspaces list-keyspaces --query "keyspaces[*].keyspaceName"
+        ```
+
+        2. For each keyspace, list tables and check their encryption:
+
+        ```bash
+        aws keyspaces list-tables \
+          --keyspace-name <keyspace-name> \
+          --query "tables[*].resourceArn"
+        ```
+
+        ```bash
+        aws keyspaces get-table \
+          --keyspace-name <keyspace-name> \
+          --table-name <table-name> \
+          --query "{EncryptionType:encryptionSpecification.type,KmsKeyId:encryptionSpecification.kmsKeyIdentifier}"
+        ```
+
+        A passing table returns `"EncryptionType": "CUSTOMER_MANAGED_KMS_KEY"` with a non-empty `KmsKeyId`. A failing table returns `"EncryptionType": "AWS_OWNED_KMS_KEY"`.
+
       remediation:
         - id: console
           desc: |
@@ -45413,6 +52842,35 @@ queries:
         - **Ransomware resilience:** PITR enables restoration to any second within the recovery window, ensuring data can be recovered after adversarial destruction.
         - **Attack recovery:** Enables restoration to the moment before a data destruction or corruption attack, minimizing data loss from compromised credentials or insider threats.
         - **Forensic comparison:** PITR snapshots can be used to compare pre-attack and post-attack table states during incident investigation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **Amazon Keyspaces** console.
+        2. Select **Tables** in the left navigation pane.
+        3. Select each table and choose the **Backups** tab.
+        4. Review the **Point-in-time recovery** status.
+
+        A passing table shows **Point-in-time recovery** as **Enabled**. A failing table shows it as **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all keyspaces:
+
+        ```bash
+        aws keyspaces list-keyspaces --query "keyspaces[*].keyspaceName"
+        ```
+
+        2. For each keyspace and table, check the PITR status:
+
+        ```bash
+        aws keyspaces get-table \
+          --keyspace-name <keyspace-name> \
+          --table-name <table-name> \
+          --query "{PointInTimeRecovery:pointInTimeRecovery.status}"
+        ```
+
+        A passing table returns `"PointInTimeRecovery": "ENABLED"`. A failing table returns `"PointInTimeRecovery": "DISABLED"`.
+
       remediation:
         - id: console
           desc: |
@@ -45534,6 +52992,30 @@ queries:
         - **Data exfiltration prevention:** Disabling URL redirection prevents the streaming session from sending content to the client browser.
         - **DLP enforcement:** Ensures that data loss prevention controls within the streaming environment cannot be bypassed through URL redirection.
         - **Network boundary integrity:** Maintains the isolation between the streaming session and the client device.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **AppStream 2.0** console.
+        2. Select **Stacks** in the left navigation pane.
+        3. Select each stack and choose the **User settings** tab.
+        4. Under **Clipboard, file transfer, print, and smart card settings**, locate **Host-to-client URL redirection**.
+        5. Verify the setting shows **Disabled**.
+
+        A passing stack shows **Host-to-client URL redirection** as **Disabled**. A failing stack shows it as **Enabled**.
+
+        ### Audit via CLI
+
+        1. List all AppStream stacks and inspect their user settings for URL redirection:
+
+        ```bash
+        aws appstream describe-stacks \
+          --query "Stacks[*].{Name:Name,UserSettings:UserSettings}"
+        ```
+
+        Review the `UserSettings` array for an entry with `"Action": "DOMAIN_SMART_CARD_SIGN_IN"` or look for the absence of a `HOST_TO_CLIENT_URL_REDIRECTION` action set to `ENABLED`. Because the AppStream API does not surface a dedicated field for this setting, also verify via the console.
+
+        A passing stack returns no `UserSettings` entry enabling host-to-client URL redirection. A failing stack returns a `UserSettings` entry with `"Action": "HOST_TO_CLIENT_URL_REDIRECTION"` and `"Permission": "ENABLED"`.
+
       remediation:
         - id: console
           desc: |
@@ -45610,6 +53092,35 @@ queries:
         - **DNS visibility:** Custom DNS servers enable query logging for threat detection and forensic analysis.
         - **DNS filtering:** Allows blocking of known malicious domains, reducing the attack surface.
         - **Centralized control:** Provides a single point of DNS policy enforcement across the VPC.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. In the left navigation pane, select **Your VPCs**.
+        3. Select each VPC and review the **DHCP options set** in the details panel.
+        4. Select the linked DHCP options set ID and check the **domain-name-servers** configuration value.
+
+        A passing VPC has a DHCP options set whose `domain-name-servers` value is a custom IP address, not `AmazonProvidedDNS`. A failing VPC uses `AmazonProvidedDNS`.
+
+        ### Audit via CLI
+
+        1. List all VPCs and their associated DHCP options:
+
+        ```bash
+        aws ec2 describe-vpcs \
+          --query "Vpcs[*].{VpcId:VpcId,DhcpOptionsId:DhcpOptionsId}"
+        ```
+
+        2. For each DHCP options set, check the domain-name-servers value:
+
+        ```bash
+        aws ec2 describe-dhcp-options \
+          --dhcp-options-ids <dhcp-options-id> \
+          --query "DhcpOptions[*].DhcpConfigurations[?Key=='domain-name-servers'].Values[*].Value"
+        ```
+
+        A passing DHCP options set returns custom IP addresses, not `AmazonProvidedDNS`. A failing DHCP options set returns `AmazonProvidedDNS`.
+
       remediation:
         - id: console
           desc: |
@@ -45755,6 +53266,28 @@ queries:
         - **Least privilege:** Restricts endpoint access to only the resources that need it.
         - **Lateral movement prevention:** Limits an attacker's ability to access AWS services from compromised resources.
         - **Audit trail:** Security group rules provide a clear, auditable record of intended access patterns.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. In the left navigation pane, select **Endpoints**.
+        3. Filter the endpoint list by **Type: Interface**.
+        4. For each interface endpoint, review the **Security groups** column or detail panel.
+
+        A passing endpoint shows one or more security groups attached. A failing endpoint shows no security groups listed.
+
+        ### Audit via CLI
+
+        1. List all interface VPC endpoints and their security groups:
+
+        ```bash
+        aws ec2 describe-vpc-endpoints \
+          --filters Name=vpc-endpoint-type,Values=Interface \
+          --query "VpcEndpoints[*].{EndpointId:VpcEndpointId,Service:ServiceName,SecurityGroups:Groups[*].GroupId}"
+        ```
+
+        A passing endpoint returns a non-empty `SecurityGroups` array. A failing endpoint returns an empty array `[]` or `null` for `SecurityGroups`.
+
       remediation:
         - id: console
           desc: |
@@ -45882,6 +53415,27 @@ queries:
         - **Unauthorized access prevention:** Ensures that only explicitly approved consumers can connect to the service.
         - **Access governance:** Provides a review step before granting network-level access to internal services.
         - **Blast radius reduction:** Limits the exposure of internal services to known, trusted accounts.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. In the left navigation pane, select **Endpoint services**.
+        3. Select each endpoint service and review the **Details** tab.
+        4. Check the **Acceptance required** field.
+
+        A passing endpoint service shows **Acceptance required: Yes**. A failing endpoint service shows **Acceptance required: No**.
+
+        ### Audit via CLI
+
+        1. List all VPC endpoint service configurations and their acceptance setting:
+
+        ```bash
+        aws ec2 describe-vpc-endpoint-service-configurations \
+          --query "ServiceConfigurations[*].{ServiceId:ServiceId,ServiceName:ServiceName,AcceptanceRequired:AcceptanceRequired}"
+        ```
+
+        A passing endpoint service returns `"AcceptanceRequired": true`. A failing endpoint service returns `"AcceptanceRequired": false`.
+
       remediation:
         - id: console
           desc: |
@@ -45995,6 +53549,35 @@ queries:
         - **Gap detection:** Identifies subnets that lack network traffic logging, which may hide malicious activity.
         - **Targeted monitoring:** Enables focused security monitoring for sensitive network segments.
         - **Compliance coverage:** Supports audit requirements for comprehensive network logging.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. In the left navigation pane, select **Subnets**.
+        3. Select each subnet and choose the **Flow logs** tab.
+        4. Check whether at least one flow log is listed and its status is **Active**.
+
+        A passing subnet shows at least one active flow log. A failing subnet shows no flow logs or only flow logs in an error state.
+
+        ### Audit via CLI
+
+        1. List all subnets:
+
+        ```bash
+        aws ec2 describe-subnets \
+          --query "Subnets[*].SubnetId"
+        ```
+
+        2. For each subnet, check whether flow logs are configured:
+
+        ```bash
+        aws ec2 describe-flow-logs \
+          --filter "Name=resource-id,Values=<subnet-id>" \
+          --query "FlowLogs[*].{FlowLogId:FlowLogId,Status:FlowLogStatus}"
+        ```
+
+        A passing subnet returns at least one flow log with `"Status": "ACTIVE"`. A failing subnet returns an empty array `[]`.
+
       remediation:
         - id: console
           desc: |
@@ -46113,6 +53696,28 @@ queries:
         - **Reliable log delivery:** Ensures that flow log data is actually delivered to CloudWatch for analysis and alerting.
         - **Eliminates false confidence:** Detects flow logs that appear configured but are not functioning due to missing IAM permissions.
         - **Incident readiness:** Guarantees that network traffic data is available when needed for security investigations.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and navigate to the **VPC** console.
+        2. In the left navigation pane, select **Your VPCs**.
+        3. Select each VPC and choose the **Flow logs** tab.
+        4. For each flow log with **Log destination type: CloudWatch Logs**, verify that the **IAM role** column shows a role ARN.
+
+        A passing flow log shows a valid IAM role ARN in the **IAM role** column. A failing flow log targeting CloudWatch Logs shows no IAM role.
+
+        ### Audit via CLI
+
+        1. List all CloudWatch-destination flow logs and check for a missing IAM role:
+
+        ```bash
+        aws ec2 describe-flow-logs \
+          --filter "Name=log-destination-type,Values=cloud-watch-logs" \
+          --query "FlowLogs[*].{FlowLogId:FlowLogId,ResourceId:ResourceId,IamRoleArn:DeliverLogsPermissionArn}"
+        ```
+
+        A passing flow log returns a non-null, non-empty `IamRoleArn`. A failing flow log returns `null` for `IamRoleArn`.
+
       remediation:
         - id: console
           desc: |
@@ -46267,6 +53872,27 @@ queries:
         - **Least privilege access:** Limits VPN client traffic to only authorized destinations and ports.
         - **Credential compromise mitigation:** Reduces the blast radius if VPN credentials are stolen.
         - **Network segmentation:** Enforces network boundaries between VPN clients and sensitive infrastructure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **VPC Console**.
+        2. In the left navigation pane, choose **Client VPN endpoints**.
+        3. For each endpoint listed, select it and choose the **Security groups** tab.
+        4. Review the **Security group IDs** column.
+
+        A passing endpoint shows one or more security group IDs attached. A failing endpoint shows an empty security groups list.
+
+        ### Audit via CLI
+
+        1. List all Client VPN endpoints and their associated security groups:
+
+        ```bash
+        aws ec2 describe-client-vpn-endpoints \
+          --query "ClientVpnEndpoints[].{EndpointId:ClientVpnEndpointId,SecurityGroups:SecurityGroupIds}" \
+          --output table
+        ```
+
+        A passing endpoint returns a non-empty `SecurityGroups` list. A failing endpoint returns an empty array `[]` or null for `SecurityGroups`.
       remediation:
         - id: console
           desc: |
@@ -46411,6 +54037,37 @@ queries:
         - **Network segmentation:** Ensures prefix lists enforce meaningful IP restrictions rather than allowing all traffic.
         - **Hidden exposure prevention:** Prevents broad access rules from being obscured behind prefix list references.
         - **Cascading risk reduction:** A single prefix list fix can tighten access across all security groups and route tables that reference it.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **VPC Console**.
+        2. In the left navigation pane, choose **Managed prefix lists**.
+        3. Filter the list to show only customer-managed prefix lists (owner is not `AWS`).
+        4. Select each prefix list and review its entries in the **Entries** tab.
+        5. Check whether any entry uses the CIDR `0.0.0.0/0` or `::/0`.
+
+        A passing prefix list shows no entries with `0.0.0.0/0` or `::/0`. A failing prefix list contains one or more entries with those broad CIDRs.
+
+        ### Audit via CLI
+
+        1. List all customer-managed prefix lists:
+
+        ```bash
+        aws ec2 describe-managed-prefix-lists \
+          --filters "Name=owner-id,Values=self" \
+          --query "PrefixLists[].{Id:PrefixListId,Name:PrefixListName}" \
+          --output table
+        ```
+
+        2. For each prefix list ID, check for overly broad CIDR entries:
+
+        ```bash
+        aws ec2 get-managed-prefix-list-entries \
+          --prefix-list-id <prefix-list-id> \
+          --query "Entries[?Cidr=='0.0.0.0/0' || Cidr=='::/0']"
+        ```
+
+        A passing prefix list returns an empty array `[]`. A failing prefix list returns one or more entries with `0.0.0.0/0` or `::/0`.
       remediation:
         - id: console
           desc: |
@@ -46567,6 +54224,38 @@ queries:
         - **Information disclosure prevention:** Restricts visibility of internal automation logic to authorized accounts only.
         - **Attack surface reduction:** Prevents adversaries from studying your operational procedures to plan targeted attacks.
         - **Least-privilege enforcement:** Ensures document access follows organizational boundaries rather than being open to the world.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open **AWS Systems Manager**.
+        2. In the left navigation pane, choose **Documents**, then select the **Owned by me** tab.
+        3. For each document listed, select it and choose the **Permissions** tab.
+        4. Review the **Account IDs** list under shared accounts.
+        5. Check whether `All` appears in the list, which indicates public sharing.
+
+        A passing document shows no entry of `All` in the shared accounts list. A failing document shows `All` as one of the shared account IDs.
+
+        ### Audit via CLI
+
+        1. List all documents owned by the current account:
+
+        ```bash
+        aws ssm list-documents \
+          --filters "Key=Owner,Values=Self" \
+          --query "DocumentIdentifiers[].Name" \
+          --output text
+        ```
+
+        2. For each document name, check its sharing permissions:
+
+        ```bash
+        aws ssm describe-document-permission \
+          --name <document-name> \
+          --permission-type Share \
+          --query "AccountIds"
+        ```
+
+        A passing document returns an empty list or a list containing only specific account IDs. A failing document returns a list that includes `All` or `all`.
       remediation:
         - id: console
           desc: |
@@ -46684,6 +54373,37 @@ queries:
         - **Vulnerability prevention:** Ensures that patches with known issues are never installed, even as transitive dependencies.
         - **Policy enforcement:** Maintains the integrity of the patch rejection list as an absolute block rather than a suggestion.
         - **Compliance assurance:** Demonstrates consistent patch management controls to auditors.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open **AWS Systems Manager**.
+        2. In the left navigation pane, under **Patch Manager**, choose **Patch baselines**.
+        3. Filter to show custom (non-default) patch baselines.
+        4. Select each custom baseline and choose **View details**.
+        5. Under **Patch exceptions**, locate the **Rejected patches action** field.
+
+        A passing patch baseline shows a **Rejected patches action** of **Block**. A failing patch baseline shows **Allow as dependency**.
+
+        ### Audit via CLI
+
+        1. List all non-default patch baselines:
+
+        ```bash
+        aws ssm describe-patch-baselines \
+          --filters "Key=NAME_PREFIX,Values=" \
+          --query "BaselineIdentities[?DefaultBaseline==\`false\`].{Id:BaselineId,Name:BaselineName}" \
+          --output table
+        ```
+
+        2. For each custom baseline ID, check the rejected patches action:
+
+        ```bash
+        aws ssm get-patch-baseline \
+          --baseline-id <baseline-id> \
+          --query "{BaselineId:BaselineId,RejectedPatchesAction:RejectedPatchesAction}"
+        ```
+
+        A passing patch baseline returns `"RejectedPatchesAction": "BLOCK"`. A failing patch baseline returns `"RejectedPatchesAction": "ALLOW_AS_DEPENDENCY"`.
       remediation:
         - id: console
           desc: |
@@ -46823,6 +54543,27 @@ queries:
         - **Blast radius reduction:** Limits the scope of maintenance window tasks to explicitly registered targets.
         - **Least-privilege enforcement:** Ensures that automated operations only affect intended resources.
         - **Change management:** Provides clear accountability for which resources are affected by scheduled maintenance.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open **AWS Systems Manager**.
+        2. In the left navigation pane, choose **Maintenance Windows**.
+        3. For each maintenance window listed, select it and choose **View details**.
+        4. Review the **Allow unregistered targets** field in the window details.
+
+        A passing maintenance window shows **Allow unregistered targets** set to **false** or unchecked. A failing maintenance window shows **Allow unregistered targets** set to **true** or checked.
+
+        ### Audit via CLI
+
+        1. List all maintenance windows and their unassociated targets setting:
+
+        ```bash
+        aws ssm describe-maintenance-windows \
+          --query "WindowIdentities[].{WindowId:WindowId,Name:Name,AllowUnassociatedTargets:AllowUnassociatedTargets}" \
+          --output table
+        ```
+
+        A passing maintenance window shows `AllowUnassociatedTargets` as `false`. A failing maintenance window shows `AllowUnassociatedTargets` as `true`.
       remediation:
         - id: console
           desc: |
@@ -46971,6 +54712,34 @@ queries:
         - **Log integrity:** Ensures only trusted accounts can write to log destinations, preserving the forensic value of log data.
         - **Cost control:** Prevents unauthorized accounts from generating unexpected log volume and associated storage or processing costs.
         - **Attack surface reduction:** Eliminates a vector for log injection attacks that could be used to mask malicious activity.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open **CloudWatch**.
+        2. In the left navigation pane, under **Logs**, choose **Destinations**.
+        3. For each destination listed, select it to view the **Access policy**.
+        4. Review the policy document for any `Principal` set to `"*"` (wildcard).
+
+        A passing log destination has an access policy with all principals scoped to specific AWS account IDs or ARNs. A failing log destination has an access policy with `"Principal": "*"` or `"AWS": "*"`.
+
+        ### Audit via CLI
+
+        1. List all CloudWatch log destinations:
+
+        ```bash
+        aws logs describe-destinations \
+          --query "destinations[].{Name:destinationName,AccessPolicy:accessPolicy}" \
+          --output table
+        ```
+
+        2. Review the `AccessPolicy` field for each destination. To isolate destinations with wildcard principals:
+
+        ```bash
+        aws logs describe-destinations \
+          --query "destinations[?contains(accessPolicy, '\"*\"')].{Name:destinationName,AccessPolicy:accessPolicy}"
+        ```
+
+        A passing destination returns an access policy with no wildcard `"*"` principal. A failing destination returns an access policy that contains `"*"` as a principal value.
       remediation:
         - id: console
           desc: |
@@ -47080,6 +54849,35 @@ queries:
         - **Access control enforcement:** Only explicitly authorized AWS principals can request connections to the endpoint service.
         - **Defense in depth:** Combines with `AcceptanceRequired` to provide two layers of access control for PrivateLink services.
         - **Operational overhead reduction:** Reduces the volume of unauthorized connection requests that operators must review and reject.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **VPC Console**.
+        2. In the left navigation pane, under **PrivateLink and Lattice**, choose **Endpoint services**.
+        3. Select each endpoint service and choose the **Allow principals** tab.
+        4. Verify that the **Allowed principals** list is not empty and does not contain `*`.
+
+        A passing endpoint service shows a non-empty allowed principals list containing only specific account IDs or ARNs. A failing endpoint service shows an empty principals list or a wildcard `*` entry.
+
+        ### Audit via CLI
+
+        1. List all VPC endpoint service configurations:
+
+        ```bash
+        aws ec2 describe-vpc-endpoint-service-configurations \
+          --query "ServiceConfigurations[].{ServiceId:ServiceId,ServiceName:ServiceName}" \
+          --output table
+        ```
+
+        2. For each service ID, check the allowed principals:
+
+        ```bash
+        aws ec2 describe-vpc-endpoint-service-permissions \
+          --service-id <service-id> \
+          --query "AllowedPrincipals[].Principal"
+        ```
+
+        A passing endpoint service returns a non-empty list with no `"*"` entry. A failing endpoint service returns an empty list or contains `"*"` as a principal.
       remediation:
         - id: console
           desc: |
@@ -47202,6 +55000,35 @@ queries:
         - **Operational visibility:** Logs capture execution details that are essential for debugging and performance analysis.
         - **Security monitoring:** Execution logs enable detection of unauthorized or anomalous workflow invocations.
         - **Compliance:** Satisfies audit logging requirements across multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Step Functions Console**.
+        2. In the left navigation pane, choose **State machines**.
+        3. Select each state machine and review its configuration details.
+        4. Under the **Logging** section, check the **Log level** field.
+
+        A passing state machine shows a log level of **ALL**, **ERROR**, or **FATAL** with a CloudWatch Logs destination configured. A failing state machine shows a log level of **OFF** or no logging configuration.
+
+        ### Audit via CLI
+
+        1. List all state machines:
+
+        ```bash
+        aws stepfunctions list-state-machines \
+          --query "stateMachines[].{Name:name,Arn:stateMachineArn}" \
+          --output table
+        ```
+
+        2. For each state machine ARN, check the logging configuration:
+
+        ```bash
+        aws stepfunctions describe-state-machine \
+          --state-machine-arn <state-machine-arn> \
+          --query "{Name:name,LoggingLevel:loggingConfiguration.level}"
+        ```
+
+        A passing state machine returns a `LoggingLevel` of `ALL`, `ERROR`, or `FATAL`. A failing state machine returns a `LoggingLevel` of `OFF` or returns null for the logging configuration.
       remediation:
         - id: console
           desc: |
@@ -47357,6 +55184,35 @@ queries:
         - **Key control:** Full control over key lifecycle including rotation and deletion.
         - **Audit trail:** All encryption operations are logged in CloudTrail when using a customer-managed key.
         - **Compliance:** Satisfies encryption key management requirements in PCI DSS, HIPAA, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Step Functions Console**.
+        2. In the left navigation pane, choose **State machines**.
+        3. Select each state machine and review its configuration details.
+        4. Under the **Encryption** section, check the **Encryption key type** field.
+
+        A passing state machine shows **Customer managed KMS key** as the encryption type. A failing state machine shows **AWS owned key** as the encryption type.
+
+        ### Audit via CLI
+
+        1. List all state machines:
+
+        ```bash
+        aws stepfunctions list-state-machines \
+          --query "stateMachines[].stateMachineArn" \
+          --output text
+        ```
+
+        2. For each state machine ARN, check the encryption configuration:
+
+        ```bash
+        aws stepfunctions describe-state-machine \
+          --state-machine-arn <state-machine-arn> \
+          --query "{Name:name,EncryptionType:encryptionConfiguration.type,KmsKeyId:encryptionConfiguration.kmsKeyId}"
+        ```
+
+        A passing state machine returns an `EncryptionType` of `CUSTOMER_MANAGED_KMS_KEY` with a populated `KmsKeyId`. A failing state machine returns an `EncryptionType` of `AWS_OWNED_KEY`.
       remediation:
         - id: console
           desc: |
@@ -47510,6 +55366,28 @@ queries:
         - **Blast radius reduction:** Restricting sharing to your organization limits exposure of critical resources.
         - **Policy enforcement:** Organization-only sharing respects SCPs and organizational policies.
         - **Compliance:** Satisfies access control requirements across multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS RAM Console**.
+        2. In the left navigation pane, choose **Resource shares**.
+        3. Select each resource share and review its **Details** tab.
+        4. Locate the **Allow external principals** field.
+
+        A passing resource share shows **Allow external principals** set to **No**. A failing resource share shows **Allow external principals** set to **Yes**.
+
+        ### Audit via CLI
+
+        1. List all resource shares and their external principals setting:
+
+        ```bash
+        aws ram get-resource-shares \
+          --resource-owner SELF \
+          --query "resourceShares[].{Name:name,Arn:resourceShareArn,AllowExternal:allowExternalPrincipals}" \
+          --output table
+        ```
+
+        A passing resource share returns `AllowExternal` as `false`. A failing resource share returns `AllowExternal` as `true`.
       remediation:
         - id: console
           desc: |
@@ -47640,6 +55518,38 @@ queries:
         - **Least privilege:** Replace wildcard principals with specific account IDs or organizational unit ARNs.
         - **Access control:** Ensures only known, authorized accounts can access shared resources.
         - **Auditability:** Specific principals enable meaningful audit trails of resource access.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS RAM Console**.
+        2. In the left navigation pane, choose **Resource shares**.
+        3. Select each resource share and choose the **Principals** tab.
+        4. Review the list of principals associated with the share.
+        5. Check for any entry that is `*` (wildcard).
+
+        A passing resource share shows only specific account IDs, user ARNs, role ARNs, or organizational unit ARNs in the principals list. A failing resource share shows `*` as one of the principals.
+
+        ### Audit via CLI
+
+        1. List all resource shares owned by this account:
+
+        ```bash
+        aws ram get-resource-shares \
+          --resource-owner SELF \
+          --query "resourceShares[].{Name:name,Arn:resourceShareArn}" \
+          --output table
+        ```
+
+        2. For each resource share ARN, list the associated principals:
+
+        ```bash
+        aws ram get-principals \
+          --resource-owner SELF \
+          --resource-share-arns <resource-share-arn> \
+          --query "principals[].id"
+        ```
+
+        A passing resource share returns a list of principals that contains no `"*"` entry. A failing resource share returns a list that includes `"*"`.
       remediation:
         - id: console
           desc: |
@@ -47778,6 +55688,34 @@ queries:
         - **Data protection:** Encrypted protocols prevent interception of file contents and credentials.
         - **Credential security:** SFTP and FTPS protect authentication credentials from network sniffing.
         - **Compliance:** Meets encryption-in-transit requirements across PCI DSS, HIPAA, and SOC 2 frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Transfer Family Console**.
+        2. In the left navigation pane, choose **Servers**.
+        3. Select each server and review its **Protocols** field in the server details.
+        4. Check whether **FTP** is listed among the enabled protocols.
+
+        A passing server shows only **SFTP**, **FTPS**, or **AS2** in the protocols list. A failing server shows **FTP** as one of the enabled protocols.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family servers and their protocols:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[].{ServerId:ServerId,Protocols:Protocols}" \
+          --output table
+        ```
+
+        2. To filter only servers with FTP enabled:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[?contains(Protocols, 'FTP')].{ServerId:ServerId,Protocols:Protocols}"
+        ```
+
+        A passing server returns a `Protocols` list that does not contain `FTP`. A failing server returns a `Protocols` list that includes `FTP`.
       remediation:
         - id: console
           desc: |
@@ -47910,6 +55848,34 @@ queries:
         - **Network isolation:** VPC endpoints restrict access to trusted networks only.
         - **Defense in depth:** Security groups and NACLs provide additional layers of access control.
         - **Reduced attack surface:** Eliminates direct internet exposure of file transfer services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Transfer Family Console**.
+        2. In the left navigation pane, choose **Servers**.
+        3. For each server listed, review the **Endpoint type** column in the server list view.
+        4. Alternatively, select a server and review **Endpoint type** in the server details.
+
+        A passing server shows an **Endpoint type** of **VPC** or **VPC Endpoint**. A failing server shows an **Endpoint type** of **Public**.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family servers and their endpoint types:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[].{ServerId:ServerId,EndpointType:EndpointType}" \
+          --output table
+        ```
+
+        2. To isolate servers using the public endpoint type:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[?EndpointType=='PUBLIC'].{ServerId:ServerId,EndpointType:EndpointType}"
+        ```
+
+        A passing server returns an `EndpointType` of `VPC` or `VPC_ENDPOINT`. A failing server returns an `EndpointType` of `PUBLIC`.
       remediation:
         - id: console
           desc: |
@@ -48049,6 +56015,35 @@ queries:
         - **Audit trail:** Logs provide a complete record of all file transfer activity.
         - **Data loss prevention:** Log analysis can detect unusual transfer patterns indicating data exfiltration.
         - **Compliance:** Satisfies audit logging requirements across multiple regulatory frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Transfer Family Console**.
+        2. In the left navigation pane, choose **Servers**.
+        3. Select each server and review its **CloudWatch logging** section in the server details.
+        4. Check whether a **Logging role** IAM ARN is configured.
+
+        A passing server shows a CloudWatch logging role ARN in the **Logging role** field. A failing server shows an empty or unconfigured logging role.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family servers and their logging role configuration:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[].ServerId" \
+          --output text
+        ```
+
+        2. For each server ID, check the logging role:
+
+        ```bash
+        aws transfer describe-server \
+          --server-id <server-id> \
+          --query "{ServerId:Server.ServerId,LoggingRole:Server.LoggingRole}"
+        ```
+
+        A passing server returns a non-empty `LoggingRole` ARN. A failing server returns `null` or an empty string for `LoggingRole`.
       remediation:
         - id: console
           desc: |
@@ -48185,6 +56180,35 @@ queries:
         - **Cryptographic strength:** Modern security policies enforce stronger encryption algorithms and key exchange methods.
         - **Protocol security:** Newer policies deprecate weak protocols and cipher suites.
         - **Compliance:** Meets cryptographic requirements across PCI DSS, HIPAA, and SOC 2 frameworks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **AWS Transfer Family Console**.
+        2. In the left navigation pane, choose **Servers**.
+        3. Select each server and review the **Security policy** field in the server details.
+        4. Check whether the policy name is `TransferSecurityPolicy-2018-11`.
+
+        A passing server shows a security policy name other than `TransferSecurityPolicy-2018-11`, such as `TransferSecurityPolicy-2024-01`. A failing server shows `TransferSecurityPolicy-2018-11` as the configured security policy.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family servers and their security policy names:
+
+        ```bash
+        aws transfer list-servers \
+          --query "Servers[].ServerId" \
+          --output text
+        ```
+
+        2. For each server ID, check the security policy name:
+
+        ```bash
+        aws transfer describe-server \
+          --server-id <server-id> \
+          --query "{ServerId:Server.ServerId,SecurityPolicyName:Server.SecurityPolicyName}"
+        ```
+
+        A passing server returns a `SecurityPolicyName` other than `TransferSecurityPolicy-2018-11`. A failing server returns `"SecurityPolicyName": "TransferSecurityPolicy-2018-11"`.
       remediation:
         - id: console
           desc: |
@@ -48310,6 +56334,27 @@ queries:
         - **Credential stuffing defense:** External identity providers support MFA, conditional access, and anomaly detection that static service-managed passwords cannot provide.
         - **Centralized revocation:** Compromised identities can be disabled across all services simultaneously through the external provider, eliminating the delay of per-server user management.
         - **Security monitoring integration:** External providers feed authentication events into centralized logging and SIEM systems, enabling detection of brute-force attacks and anomalous access patterns.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS Transfer Family Console**.
+        2. Select **Servers** from the left navigation.
+        3. For each listed server, review the **Identity provider type** column.
+
+        A passing server shows an identity provider type of **AWS Directory Service**, **Custom identity provider (API Gateway)**, or **AWS Lambda** — not **Service managed**. A failing server shows **Service managed**.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family servers and check their identity provider type:
+
+        ```bash
+        aws transfer list-servers \
+          --query 'Servers[*].{ServerId:ServerId,IdentityProviderType:IdentityProviderType}' \
+          --output table
+        ```
+
+        A passing server returns an `IdentityProviderType` value of `API_GATEWAY`, `AWS_DIRECTORY_SERVICE`, or `AWS_LAMBDA`. A failing server returns `SERVICE_MANAGED`.
+
       remediation:
         - id: console
           desc: |
@@ -48443,6 +56488,29 @@ queries:
         - **Data exfiltration prevention:** Blocks unauthorized outbound communication from mesh services.
         - **Zero trust:** Enforces explicit allowlisting of all external service dependencies.
         - **Blast radius reduction:** Compromised services cannot reach arbitrary external endpoints.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS App Mesh Console**.
+        2. Select **Meshes** from the left navigation.
+        3. For each mesh, choose the mesh name to open its details.
+        4. Under **Mesh details**, review the **Egress filter** value.
+
+        A passing mesh shows an egress filter type of **DROP_ALL**. A failing mesh shows **ALLOW_ALL**.
+
+        ### Audit via CLI
+
+        1. List all meshes and retrieve their egress filter configuration:
+
+        ```bash
+        aws appmesh list-meshes --query 'meshes[*].meshName' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws appmesh describe-mesh --mesh-name {} \
+            --query '{MeshName:mesh.meshName,EgressFilter:mesh.spec.egressFilter.type}'
+        ```
+
+        A passing mesh returns `"EgressFilter": "DROP_ALL"`. A failing mesh returns `"EgressFilter": "ALLOW_ALL"`.
+
       remediation:
         - id: console
           desc: |
@@ -48581,6 +56649,36 @@ queries:
         - **Session security:** Shorter sessions limit the impact of compromised credentials.
         - **Re-authentication:** Forces users to re-authenticate regularly, verifying continued authorization.
         - **Compliance:** Meets session management requirements in NIST, PCI DSS, and SOC 2.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS IAM Identity Center Console**.
+        2. Select **Permission sets** from the left navigation.
+        3. For each permission set, choose the permission set name to open its details.
+        4. Review the **Session duration** value under the **General settings** section.
+
+        A passing permission set shows a session duration of **12 hours or less** (for example, PT1H, PT4H, PT8H, or PT12H). A failing permission set shows a duration exceeding 12 hours (for example, PT24H).
+
+        ### Audit via CLI
+
+        1. Retrieve the Identity Center instance ARN, then list and inspect all permission sets:
+
+        ```bash
+        INSTANCE_ARN=$(aws sso-admin list-instances \
+          --query 'Instances[0].InstanceArn' --output text)
+
+        aws sso-admin list-permission-sets \
+          --instance-arn "$INSTANCE_ARN" \
+          --query 'PermissionSets[]' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws sso-admin describe-permission-set \
+            --instance-arn "$INSTANCE_ARN" \
+            --permission-set-arn {} \
+            --query '{Name:PermissionSet.Name,SessionDuration:PermissionSet.SessionDuration}'
+        ```
+
+        A passing permission set returns a `SessionDuration` of PT12H or less. A failing permission set returns a `SessionDuration` greater than PT12H (such as PT24H).
+
       remediation:
         - id: console
           desc: |
@@ -48688,6 +56786,36 @@ queries:
         - **Backdoor detection:** Managed policies are centrally visible and auditable, eliminating inline policies as a hiding spot for attacker-planted permissions.
         - **Change tracking:** Versioned managed policies provide audit trails that reveal when permissions were modified, supporting detection of unauthorized changes.
         - **Access review accuracy:** Centralized policies are discoverable by automated compliance tools, ensuring all permissions are included in access reviews.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS IAM Identity Center Console**.
+        2. Select **Permission sets** from the left navigation.
+        3. For each permission set, choose the permission set name.
+        4. Under **Permissions**, review the **Inline policy** section.
+
+        A passing permission set shows no inline policy (the section is empty or absent). A failing permission set shows an inline policy document with one or more statements.
+
+        ### Audit via CLI
+
+        1. Retrieve the Identity Center instance ARN, then check each permission set for an inline policy:
+
+        ```bash
+        INSTANCE_ARN=$(aws sso-admin list-instances \
+          --query 'Instances[0].InstanceArn' --output text)
+
+        aws sso-admin list-permission-sets \
+          --instance-arn "$INSTANCE_ARN" \
+          --query 'PermissionSets[]' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws sso-admin get-inline-policy-for-permission-set \
+            --instance-arn "$INSTANCE_ARN" \
+            --permission-set-arn {} \
+            --query 'InlinePolicy'
+        ```
+
+        A passing permission set returns an empty string or `null` for `InlinePolicy`. A failing permission set returns a non-empty JSON policy document.
+
       remediation:
         - id: console
           desc: |
@@ -48799,6 +56927,32 @@ queries:
         - **Persistence detection:** Group-based assignments ensure all access is visible in group membership reviews, eliminating user-level assignments as a hiding spot for attacker-planted access.
         - **Incident response completeness:** Removing a compromised user from all groups revokes all access when assignments are group-based, preventing persistence through direct assignments.
         - **Access review coverage:** Group-based access is discoverable by automated compliance tools, ensuring all assignments are included in access reviews and no stealthy user-level grants are missed.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS IAM Identity Center Console**.
+        2. Select **AWS accounts** from the left navigation.
+        3. For each account listed, choose the account name.
+        4. Under **Assigned users and groups**, review the **Type** column for each assignment.
+
+        A passing account shows only **Group** entries in the Type column. A failing account shows one or more **User** entries, indicating direct user-level assignments.
+
+        ### Audit via CLI
+
+        1. Retrieve the Identity Center instance ARN and list account assignments across all accounts:
+
+        ```bash
+        INSTANCE_ARN=$(aws sso-admin list-instances \
+          --query 'Instances[0].InstanceArn' --output text)
+
+        aws sso-admin list-account-assignments-for-principal \
+          --instance-arn "$INSTANCE_ARN" \
+          --principal-type USER \
+          --query 'AccountAssignments[*].{AccountId:AccountId,PrincipalType:PrincipalType,PrincipalId:PrincipalId}'
+        ```
+
+        A passing environment returns an empty list (no USER-type assignments). A failing environment returns one or more account assignments with `"PrincipalType": "USER"`.
+
       remediation:
         - id: console
           desc: |
@@ -48930,6 +57084,31 @@ queries:
         - **Least privilege:** Ensure resource policies grant access only to specific, authorized principals.
         - **Secret protection:** Prevents unauthorized access to sensitive credentials and configuration data.
         - **Blast radius reduction:** Restricting access limits the impact of policy misconfigurations.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS Secrets Manager Console**.
+        2. Select each secret from the list.
+        3. Under **Resource permissions**, review the resource policy JSON.
+        4. Check all `Allow` statements for a `Principal` value of `"*"` or `{"AWS": "*"}`.
+
+        A passing secret has no resource policy or has a policy with all `Allow` statements scoped to specific AWS principals. A failing secret has a policy with at least one `Allow` statement whose `Principal` is `"*"` or `{"AWS": "*"}`.
+
+        ### Audit via CLI
+
+        1. List all secrets, then retrieve and inspect each resource policy:
+
+        ```bash
+        aws secretsmanager list-secrets \
+          --query 'SecretList[*].ARN' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws secretsmanager get-resource-policy \
+            --secret-id {} \
+            --query '{SecretId:ARN,Policy:ResourcePolicy}'
+        ```
+
+        A passing secret returns no `ResourcePolicy` or returns a policy that contains no `Allow` statements with `"Principal": "*"` or `"Principal": {"AWS": "*"}`. A failing secret returns a policy with a wildcard principal in an Allow statement.
+
       remediation:
         - id: console
           desc: |
@@ -49096,6 +57275,27 @@ queries:
         - An attacker with IAM credentials to connect to the serial console could access instances even if network security groups block all inbound traffic.
         - Serial console access is not needed for normal operations and should be disabled when not actively troubleshooting.
         - CIS AWS Foundations Benchmark recommends disabling serial console access.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **EC2 Dashboard** in the AWS Management Console.
+        2. In the left navigation, under **Account attributes**, select **EC2 Serial Console**.
+        3. Review the current status for each region.
+
+        A passing region shows EC2 Serial Console access as **Disabled**. A failing region shows it as **Enabled**.
+
+        ### Audit via CLI
+
+        1. Check whether serial console access is enabled in each region:
+
+        ```bash
+        aws ec2 get-serial-console-access-status \
+          --query 'SerialConsoleAccessEnabled' \
+          --output text
+        ```
+
+        Repeat for each active region using `--region <region>`. A passing region returns `False`. A failing region returns `True`.
+
       remediation:
         - id: console
           desc: |
@@ -49195,6 +57395,27 @@ queries:
         - AMIs may contain hardcoded secrets, private keys, or internal network configurations.
         - Block public access for AMIs prevents accidental public sharing that could lead to data exposure.
         - This is a preventive control that stops the problem at the source rather than detecting it after the fact.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **EC2 Dashboard** in the AWS Management Console.
+        2. In the left navigation, under **Account attributes**, select **AMI block public access**.
+        3. Review the current status for each region.
+
+        A passing region shows AMI block public access as **Enabled** (block new public sharing). A failing region shows it as **Disabled** or **Not configured**.
+
+        ### Audit via CLI
+
+        1. Check the AMI block public access state for the current region:
+
+        ```bash
+        aws ec2 get-image-block-public-access-state \
+          --query 'ImageBlockPublicAccessState' \
+          --output text
+        ```
+
+        Repeat for each active region using `--region <region>`. A passing region returns `block-new-sharing`. A failing region returns `unblocked`.
+
       remediation:
         - id: console
           desc: |
@@ -49296,6 +57517,29 @@ queries:
         - SSRF vulnerabilities in applications running on EC2 instances can be exploited to steal IAM credentials via IMDSv1.
         - Launch templates define the configuration for new instances, so enforcing IMDSv2 in templates ensures all new instances are protected.
         - IMDSv2 is recommended by AWS and required by CIS AWS Foundations Benchmark.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **EC2 Dashboard** and select **Launch Templates** in the left navigation.
+        2. For each launch template, choose the template name.
+        3. Select the **Default version** tab and review the **Advanced details** section.
+        4. Check the **Metadata accessible** and **Metadata version** fields.
+
+        A passing launch template shows **Metadata version** set to **V2 only (token required)**. A failing launch template shows **V1 and V2 (optional)** or has no metadata options configured.
+
+        ### Audit via CLI
+
+        1. List all launch templates and check their metadata options:
+
+        ```bash
+        aws ec2 describe-launch-template-versions \
+          --versions '$Default' \
+          --query 'LaunchTemplateVersions[*].{TemplateId:LaunchTemplateId,TemplateName:LaunchTemplateName,HttpTokens:LaunchTemplateData.MetadataOptions.HttpTokens}' \
+          --output table
+        ```
+
+        A passing launch template returns `HttpTokens` as `required`. A failing launch template returns `optional` or does not include the `MetadataOptions` field.
+
       remediation:
         - id: console
           desc: |
@@ -49439,6 +57683,28 @@ queries:
         - With ACLs enabled, objects uploaded by other accounts may not be accessible to the bucket owner.
         - BucketOwnerEnforced ensures all access control is managed through IAM and bucket policies, providing a single source of truth.
         - AWS recommends disabling ACLs for most use cases as a security best practice.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **S3 Console** in the AWS Management Console.
+        2. Select each bucket.
+        3. Choose the **Permissions** tab.
+        4. Under **Object Ownership**, review the current setting.
+
+        A passing bucket shows **ACLs disabled (BucketOwnerEnforced)**. A failing bucket shows **ACLs enabled** (BucketOwnerPreferred or ObjectWriter).
+
+        ### Audit via CLI
+
+        1. List all buckets, then retrieve the ownership controls for each:
+
+        ```bash
+        aws s3api get-bucket-ownership-controls \
+          --bucket <bucket-name> \
+          --query 'OwnershipControls.Rules[*].ObjectOwnership'
+        ```
+
+        Run this for each bucket. A passing bucket returns `["BucketOwnerEnforced"]`. A failing bucket returns `["BucketOwnerPreferred"]`, `["ObjectWriter"]`, or an error indicating no ownership controls are configured.
+
       remediation:
         - id: console
           desc: |
@@ -49564,6 +57830,28 @@ queries:
         - Without Insights, detecting unusual activity requires manual analysis of CloudTrail logs or custom anomaly detection.
         - Insights generates findings for unusual write management events (ApiCallRateInsight) and API error rates (ApiErrorRateInsight).
         - Automated anomaly detection reduces mean time to detect security incidents.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **CloudTrail Console** in the AWS Management Console.
+        2. Select **Trails** from the left navigation.
+        3. For each trail, choose the trail name.
+        4. Under **Insights events**, review the enabled insight types.
+
+        A passing trail shows both **API call rate** and **API error rate** insights enabled. A failing trail shows neither or only one insight type enabled.
+
+        ### Audit via CLI
+
+        1. Retrieve the insight selectors configured for a trail:
+
+        ```bash
+        aws cloudtrail get-insight-selectors \
+          --trail-name <trail-name> \
+          --query 'InsightSelectors[*].InsightType'
+        ```
+
+        A passing trail returns `["ApiCallRateInsight", "ApiErrorRateInsight"]` (both types present). A failing trail returns an empty list or only one of the two insight types.
+
       remediation:
         - id: console
           desc: |
@@ -49707,6 +57995,27 @@ queries:
         - Standards provide continuously evaluated security controls that detect misconfigurations as they occur.
         - AWS Foundational Security Best Practices is the recommended baseline standard for all AWS accounts.
         - Compliance frameworks require continuous monitoring of security controls, which standards automate.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Security Hub Console** in the AWS Management Console.
+        2. Select **Security standards** from the left navigation.
+        3. Review the list of available standards and their status.
+
+        A passing account shows at least one security standard with a status of **Enabled**. A failing account shows all standards as **Disabled**, or Security Hub is not enabled at all.
+
+        ### Audit via CLI
+
+        1. Check whether Security Hub is enabled and retrieve the list of enabled standards:
+
+        ```bash
+        aws securityhub get-enabled-standards \
+          --query 'StandardsSubscriptions[*].{StandardsArn:StandardsArn,Status:StandardsStatus}' \
+          --output table
+        ```
+
+        A passing account returns at least one standards subscription with `StandardsStatus` of `READY`. A failing account returns an empty list or an error indicating Security Hub is not enabled.
+
       remediation:
         - id: console
           desc: |
@@ -49829,6 +58138,29 @@ queries:
         - Attackers can publish messages to public topics, potentially triggering downstream Lambda functions or other integrations.
         - Unauthorized subscribers can receive sensitive data published to the topic.
         - SNS topic policies should follow the principle of least privilege, restricting access to specific accounts and services.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **Amazon SNS Console** in the AWS Management Console.
+        2. Select **Topics** from the left navigation.
+        3. For each topic, choose the topic name.
+        4. Select the **Access policy** tab and review the policy JSON.
+        5. Check all `Allow` statements for a `Principal` value of `"*"` or `{"AWS": "*"}` without restrictive conditions.
+
+        A passing topic has no `Allow` statements with a wildcard principal, or all wildcard principals are constrained by conditions such as `aws:SourceAccount` or `aws:SourceArn`. A failing topic has at least one `Allow` statement with an unconditioned wildcard principal.
+
+        ### Audit via CLI
+
+        1. List all SNS topic ARNs, then retrieve and inspect each topic's access policy:
+
+        ```bash
+        aws sns get-topic-attributes \
+          --topic-arn <topic-arn> \
+          --query 'Attributes.Policy'
+        ```
+
+        A passing topic returns a policy with no `Allow` statements whose `Principal` is `"*"` or `{"AWS": "*"}` without conditions. A failing topic returns a policy containing a wildcard principal in an unconditioned Allow statement.
+
       remediation:
         - id: console
           desc: |
@@ -49991,6 +58323,32 @@ queries:
         - Private IP replication keeps data within the AWS network, reducing the attack surface.
         - Using private IP routing is required for environments with strict network isolation requirements.
         - Compliance frameworks require data in transit to use private network paths where available.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS Elastic Disaster Recovery Console**.
+        2. Select **Source servers** from the left navigation.
+        3. For each source server, choose the server name.
+        4. Select the **Replication settings** tab.
+        5. Review the **Data routing** setting.
+
+        A passing source server shows **Data routing** set to **Private IP**. A failing source server shows **Data routing** set to **Public IP**.
+
+        ### Audit via CLI
+
+        1. List all DRS source servers and retrieve their replication configuration:
+
+        ```bash
+        aws drs describe-source-servers \
+          --query 'items[*].sourceServerID' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws drs get-replication-configuration \
+            --source-server-id {} \
+            --query '{SourceServerId:sourceServerID,DataPlaneRouting:dataPlaneRouting}'
+        ```
+
+        A passing source server returns `"DataPlaneRouting": "PRIVATE_IP"`. A failing source server returns `"DataPlaneRouting": "PUBLIC_IP"`.
+
       remediation:
         - id: console
           desc: |
@@ -50100,6 +58458,32 @@ queries:
         - DR instances may not have the same hardening as production instances, making public exposure especially risky.
         - Private-only recovery instances require VPN or Direct Connect for access, ensuring controlled access paths.
         - During failover, security controls should remain as strict as production environments.
+      audit: |
+        ### Audit via Console
+
+        1. Navigate to the **AWS Elastic Disaster Recovery Console**.
+        2. Select **Source servers** from the left navigation.
+        3. For each source server, choose the server name.
+        4. Select the **Replication settings** tab.
+        5. Review the **Create public IP** setting.
+
+        A passing source server shows **Create public IP** as **Disabled**. A failing source server shows **Create public IP** as **Enabled**.
+
+        ### Audit via CLI
+
+        1. List all DRS source servers and check whether public IP creation is enabled:
+
+        ```bash
+        aws drs describe-source-servers \
+          --query 'items[*].sourceServerID' --output text | \
+          tr '\t' '\n' | \
+          xargs -I {} aws drs get-replication-configuration \
+            --source-server-id {} \
+            --query '{SourceServerId:sourceServerID,CreatePublicIP:createPublicIP}'
+        ```
+
+        A passing source server returns `"CreatePublicIP": false`. A failing source server returns `"CreatePublicIP": true`.
+
       remediation:
         - id: console
           desc: |
@@ -50220,6 +58604,28 @@ queries:
         - Enable `autoMinorVersionUpgrade` on every Neptune instance.
         - Configure a `preferredMaintenanceWindow` that matches your change-control calendar, and accept that minor patches land in that window.
         - Pair auto-upgrade with a cluster-level deletion-protection and backup-retention policy so an unexpected patch problem is recoverable.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon Neptune** console and select **Databases** in the left navigation.
+        2. For each Neptune cluster, select the cluster, then review the **Instances** tab.
+        3. Select each instance and choose **Modify**.
+        4. Under **Additional configuration**, check whether **Enable auto minor version upgrade** is selected.
+
+        A passing instance shows **Enable auto minor version upgrade** checked. A failing instance shows the option unchecked.
+
+        ### Audit via CLI
+
+        1. List all Neptune DB instances and check the `AutoMinorVersionUpgrade` field:
+
+        ```bash
+        aws neptune describe-db-instances \
+          --query "DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier,AutoMinorVersionUpgrade:AutoMinorVersionUpgrade}" \
+          --output table
+        ```
+
+        A passing instance returns `AutoMinorVersionUpgrade: true`. A failing instance returns `AutoMinorVersionUpgrade: false`.
+
       remediation:
         - id: console
           desc: |
@@ -50354,6 +58760,28 @@ queries:
         - Enable `autoMinorVersionUpgrade` on every DocumentDB instance in the cluster.
         - Validate that the cluster's `preferredMaintenanceWindow` falls inside your organization's change-control window.
         - Pair with backup-retention and deletion-protection to recover from an unexpected patch regression.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon DocumentDB** console and select **Clusters** in the left navigation.
+        2. Select the cluster and open the **Instances** tab.
+        3. For each instance, choose **Modify**.
+        4. Under **Maintenance**, check whether **Auto minor version upgrade** is enabled.
+
+        A passing instance shows **Auto minor version upgrade** enabled. A failing instance shows it disabled.
+
+        ### Audit via CLI
+
+        1. List all DocumentDB instances and check the `AutoMinorVersionUpgrade` field:
+
+        ```bash
+        aws docdb describe-db-instances \
+          --query "DBInstances[*].{DBInstanceIdentifier:DBInstanceIdentifier,ClusterIdentifier:DBClusterIdentifier,AutoMinorVersionUpgrade:AutoMinorVersionUpgrade}" \
+          --output table
+        ```
+
+        A passing instance returns `AutoMinorVersionUpgrade: true`. A failing instance returns `AutoMinorVersionUpgrade: false`.
+
       remediation:
         - id: console
           desc: |
@@ -50478,6 +58906,27 @@ queries:
         - Internet-exposed PostgreSQL instances are continuously scanned for default credentials, weak passwords, and unpatched vulnerabilities such as CVE-2024-10977.
         - A successful exploit of an exposed database results in immediate read/write access to every record, regardless of application-layer authorization.
         - Public exposure violates baseline expectations under PCI DSS, HIPAA, NIST 800-53 SC-7, and ISO 27001 A.8.22.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Type** `PostgreSQL` or **Port range** `5432` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 5432 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 5432:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`5432\` && ToPort>=\`5432\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: console
           desc: |
@@ -50626,6 +59075,27 @@ queries:
 
         - Internet-reachable MySQL endpoints are constantly probed for default `root` credentials and weak passwords.
         - Successful authentication grants the attacker every privilege the database user holds, including data exfiltration and destructive `DROP` operations.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Type** `MySQL/Aurora` or **Port range** `3306` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 3306 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 3306:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`3306\` && ToPort>=\`3306\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: console
           desc: |
@@ -50763,6 +59233,27 @@ queries:
 
         - The `MSSQL` service is a primary target for credential-stuffing botnets.
         - Successful logins lead to OS-level command execution via `xp_cmdshell` if it is enabled, escalating to full host compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `1433` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 1433 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 1433:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`1433\` && ToPort>=\`1433\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: console
           desc: |
@@ -50899,6 +59390,27 @@ queries:
         **Why this matters**
 
         Public exposure of the Oracle TNS listener has historically been used to enumerate SIDs, brute-force database credentials, and exploit listener-level vulnerabilities. Restricting the listener to internal subnets eliminates the entire class of internet-borne attacks against the database.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `1521` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 1521 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 1521:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`1521\` && ToPort>=\`1521\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51033,6 +59545,27 @@ queries:
 
         - Default MongoDB deployments historically lacked authentication, and exposed instances are still routinely discovered by search engines such as Shodan.
         - Even with authentication enabled, a public endpoint accelerates credential-stuffing and exposes pre-auth CVEs to the internet.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `27017` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 27017 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 27017:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`27017\` && ToPort>=\`27017\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51166,6 +59699,27 @@ queries:
         **Why this matters**
 
         Redis was historically deployed without authentication. Exposed instances are routinely abused via the `CONFIG`/`DEBUG`/`MODULE LOAD` commands to gain RCE on the host running the server.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `6379` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 6379 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 6379:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`6379\` && ToPort>=\`6379\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51299,6 +59853,27 @@ queries:
         **Why this matters**
 
         Memcached's default UDP responder amplifies a 200-byte query into multi-kilobyte responses, making any exposed instance a potential DDoS amplifier. The cached data itself is also typically unauthenticated.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `11211` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 11211 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 11211:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`11211\` && ToPort>=\`11211\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51433,6 +60008,27 @@ queries:
 
         - Default Elasticsearch installs historically had no authentication; exposed clusters are continuously indexed by attackers.
         - Compromised clusters routinely yield full-text customer records, application logs, and credentials.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `9200-9300` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing ports 9200-9300 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on ports 9200-9300:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`9300\` && ToPort>=\`9200\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51566,6 +60162,27 @@ queries:
         **Why this matters**
 
         WinRM provides remote command execution on Windows hosts and is a primary lateral-movement target. Exposing WinRM to the internet allows attackers to brute-force credentials, abuse NTLM relay, and execute commands directly on the host.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `5985-5986` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing ports 5985-5986 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on ports 5985-5986:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`5986\` && ToPort>=\`5985\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51700,6 +60317,27 @@ queries:
 
         - Port 2375 is unauthenticated by default. An exposed daemon allows any internet client to launch a container that mounts the host's `/` filesystem and writes to `/etc/cron.d`, instantly achieving root.
         - Even the TLS port 2376 must not be reachable from the internet; mTLS materials should be the only access path and they should be distributed through a private network.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `2375` or `2376` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing ports 2375-2376 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on ports 2375-2376:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`2376\` && ToPort>=\`2375\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51836,6 +60474,27 @@ queries:
 
         - Public API endpoints are continuously scanned for unauthenticated discovery, weak token configurations, and known control-plane CVEs.
         - Even when authentication is enforced, a public API server is the only piece of infrastructure that, if compromised, grants the attacker full cluster-wide privileges.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `6443` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing port 6443 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on port 6443:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`6443\` && ToPort>=\`6443\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -51971,6 +60630,27 @@ queries:
         **Why this matters**
 
         The kubelet API exposes pod listing, log streaming, and exec endpoints. Misconfigured kubelets that accept anonymous requests on port 10250 have been used for cryptojacking and post-exploitation reconnaissance. Port 10255 is fully unauthenticated and must never be reachable.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `10250-10255` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing ports 10250-10255 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on ports 10250-10255:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`10255\` && ToPort>=\`10250\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -52105,6 +60785,27 @@ queries:
 
         - Direct access to etcd bypasses every Kubernetes authorization layer.
         - A read-only etcd connection yields every Secret in plaintext (unless encryption-at-rest is configured); a writable connection allows the attacker to insert pods, ServiceAccounts, and RBAC bindings.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and select **Security Groups** under **Network & Security**.
+        2. For each security group, select the group and open the **Inbound rules** tab.
+        3. Look for any rule with **Port range** `2379-2380` and **Source** `0.0.0.0/0` or `::/0`.
+
+        A passing security group shows no inbound rule allowing ports 2379-2380 from `0.0.0.0/0` or `::/0`. A failing security group shows at least one such rule.
+
+        ### Audit via CLI
+
+        1. List security groups that allow unrestricted inbound traffic on ports 2379-2380:
+
+        ```bash
+        aws ec2 describe-security-groups \
+          --query "SecurityGroups[?IpPermissions[?FromPort<=\`2380\` && ToPort>=\`2379\` && (IpRanges[?CidrIp=='0.0.0.0/0'] || Ipv6Ranges[?CidrIpv6=='::/0'])]].{GroupId:GroupId,GroupName:GroupName}" \
+          --output table
+        ```
+
+        A passing security group returns no results in the query output. A failing security group appears in the results with its `GroupId` listed.
+
       remediation:
         - id: cli
           desc: |
@@ -52240,6 +60941,32 @@ queries:
         - Bucket policies are evaluated independently of Block Public Access settings; a misconfigured policy can still grant anonymous access if BPA is not enforced.
         - Public bucket policies have been the root cause of the largest known cloud data leaks (US Voter Records, Booz Allen, Accenture, Verizon).
         - Even buckets without PII can become a foothold: attackers can use writable public buckets to host malware, phishing pages, or pivot to other AWS services.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [S3 Console](https://console.aws.amazon.com/s3/) and select the bucket.
+        2. Choose **Permissions** then scroll to **Bucket policy**.
+        3. Review the policy JSON. Look for any `Statement` with `"Effect": "Allow"` whose `Principal` is `"*"` or `{"AWS": "*"}`.
+
+        A passing bucket either has no policy or has no `Allow` statement with a wildcard principal. A failing bucket has at least one `Allow` statement granting access to `"*"` or `{"AWS": "*"}`.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket policy and search for wildcard-principal Allow statements:
+
+        ```bash
+        aws s3api get-bucket-policy --bucket <bucket-name> \
+          --query 'Policy' --output text | python3 -c "
+        import sys, json
+        policy = json.load(sys.stdin)
+        for s in policy.get('Statement', []):
+            p = s.get('Principal', '')
+            if s.get('Effect') == 'Allow' and (p == '*' or p == {'AWS': '*'} or p.get('AWS') == '*'):
+                print('FAIL:', json.dumps(s))
+        "
+        ```
+
+        A passing bucket returns no output or an `NoSuchBucketPolicy` error (no policy). A failing bucket prints one or more `FAIL:` lines identifying the offending statement.
       remediation:
         - id: console
           desc: |
@@ -52390,6 +61117,35 @@ queries:
         **Why this matters**
 
         S3 endpoints accept HTTP and HTTPS by default. A `Deny` statement keyed on `aws:SecureTransport` is the only mechanism that prevents accidental plain-HTTP access by clients with bad TLS configuration.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [S3 Console](https://console.aws.amazon.com/s3/) and select the bucket.
+        2. Choose **Permissions** then scroll to **Bucket policy**.
+        3. Confirm the policy contains a `Deny` statement with `"Condition": {"Bool": {"aws:SecureTransport": "false"}}` covering `s3:*` on the bucket and its objects.
+
+        A passing bucket has a policy with a `Deny` statement on `aws:SecureTransport: false`. A failing bucket either has no policy or is missing that `Deny` statement.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket policy and search for a secure-transport deny:
+
+        ```bash
+        aws s3api get-bucket-policy --bucket <bucket-name> \
+          --query 'Policy' --output text | python3 -c "
+        import sys, json
+        policy = json.load(sys.stdin)
+        for s in policy.get('Statement', []):
+            cond = s.get('Condition', {}).get('Bool', {})
+            if s.get('Effect') == 'Deny' and cond.get('aws:SecureTransport') in ('false', False):
+                print('PASS: secure-transport Deny found')
+                break
+        else:
+            print('FAIL: no secure-transport Deny found')
+        "
+        ```
+
+        A passing bucket prints `PASS: secure-transport Deny found`. A failing bucket prints `FAIL: no secure-transport Deny found`.
       remediation:
         - id: console
           desc: |
@@ -52584,6 +61340,26 @@ queries:
         **Why this matters**
 
         Cross-account uploaders have historically retained ownership of objects, leading to scenarios where the bucket owner could neither delete nor secure objects in their own bucket. `BucketOwnerEnforced` deprecates ACLs in favor of a single, IAM-driven authorization model.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [S3 Console](https://console.aws.amazon.com/s3/) and select the bucket.
+        2. Choose **Permissions** then scroll to **Object Ownership**.
+        3. Confirm the setting shows **ACLs disabled (Bucket owner enforced)**.
+
+        A passing bucket shows **ACLs disabled (Bucket owner enforced)**. A failing bucket shows **Bucket owner preferred** or **Object writer**.
+
+        ### Audit via CLI
+
+        1. Retrieve the Object Ownership setting for the bucket:
+
+        ```bash
+        aws s3api get-bucket-ownership-controls \
+          --bucket <bucket-name> \
+          --query 'OwnershipControls.Rules[0].ObjectOwnership'
+        ```
+
+        A passing bucket returns `"BucketOwnerEnforced"`. A failing bucket returns `"BucketOwnerPreferred"`, `"ObjectWriter"`, or an `OwnershipControlsNotFoundError`.
       remediation:
         - id: console
           desc: |
@@ -52700,6 +61476,34 @@ queries:
         **Why this matters**
 
         AWS-managed keys cannot be rotated on demand and their key policies cannot be edited. Customer-managed keys give the workload owner full control of cryptographic material, supporting BYOK and regulatory residency requirements.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon SNS Console](https://console.aws.amazon.com/sns/) and choose **Topics**.
+        2. Select a topic and view its **Details** tab.
+        3. Locate the **Encryption** section. Confirm that a customer-managed KMS key ARN is shown, not `alias/aws/sns` or no key.
+        4. Repeat for every topic in scope.
+
+        A passing topic shows a customer-managed KMS key ARN in the **Encryption** section. A failing topic shows no encryption or `alias/aws/sns`.
+
+        ### Audit via CLI
+
+        1. List all topic ARNs, then check the KmsMasterKeyId attribute for each:
+
+        ```bash
+        aws sns list-topics --query 'Topics[*].TopicArn' --output text | \
+          tr '\t' '\n' | while read arn; do
+            key=$(aws sns get-topic-attributes --topic-arn "$arn" \
+              --query 'Attributes.KmsMasterKeyId' --output text 2>/dev/null)
+            if [ -z "$key" ] || [ "$key" = "None" ] || [ "$key" = "alias/aws/sns" ]; then
+              echo "FAIL: $arn ($key)"
+            else
+              echo "PASS: $arn ($key)"
+            fi
+          done
+        ```
+
+        A passing topic prints `PASS` with a customer-managed key ARN or alias. A failing topic prints `FAIL` with an empty, `None`, or `alias/aws/sns` value.
       remediation:
         - id: cli
           desc: |
@@ -52835,6 +61639,35 @@ queries:
         **Why this matters**
 
         Sensitive queue payloads benefit from CMK protection because key policies can be tightly scoped, keys can be rotated on demand, and access can be revoked by disabling the CMK. SSE-SQS and `aws/sqs` keys offer no such control.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon SQS Console](https://console.aws.amazon.com/sqs/) and select a queue.
+        2. Choose the **Encryption** tab.
+        3. Confirm that **Server-side encryption** is enabled with a customer-managed KMS key, not the Amazon SQS key (`alias/aws/sqs`) or SSE-SQS.
+        4. Repeat for every queue in scope.
+
+        A passing queue shows a customer-managed KMS key ARN under **Server-side encryption**. A failing queue shows SSE-SQS, `alias/aws/sqs`, or no encryption.
+
+        ### Audit via CLI
+
+        1. List queue URLs, then check the KmsMasterKeyId attribute for each:
+
+        ```bash
+        aws sqs list-queues --query 'QueueUrls[]' --output text | \
+          tr '\t' '\n' | while read url; do
+            key=$(aws sqs get-queue-attributes --queue-url "$url" \
+              --attribute-names KmsMasterKeyId \
+              --query 'Attributes.KmsMasterKeyId' --output text 2>/dev/null)
+            if [ -z "$key" ] || [ "$key" = "None" ] || [ "$key" = "alias/aws/sqs" ]; then
+              echo "FAIL: $url ($key)"
+            else
+              echo "PASS: $url ($key)"
+            fi
+          done
+        ```
+
+        A passing queue prints `PASS` with a customer-managed key ARN or alias. A failing queue prints `FAIL` with an empty, `None`, or `alias/aws/sqs` value.
       remediation:
         - id: cli
           desc: |
@@ -52952,6 +61785,27 @@ queries:
 
         - **Data exposure:** Keeping customer images `PRIVATE` (or scoped via image sharing) prevents proprietary content from being launched outside the owning organization.
         - **Credential containment:** Limits blast radius if secrets were accidentally baked into a gold image.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AppStream 2.0 Console](https://console.aws.amazon.com/appstream2/) and choose **Images** then **Image Registry**.
+        2. Filter the list to show only customer-built images by checking for a non-empty **Base image ARN** value.
+        3. Confirm that the **Visibility** column shows **Private** for every customer-built image.
+
+        A passing image shows **Private** visibility. A failing image shows **Public** visibility.
+
+        ### Audit via CLI
+
+        1. List customer-built images and check their visibility:
+
+        ```bash
+        aws appstream describe-images \
+          --type PRIVATE \
+          --query 'Images[?BaseImageArn!=null && BaseImageArn!=`""`].[Name,Visibility]' \
+          --output table
+        ```
+
+        A passing image returns `PRIVATE` in the Visibility column. A failing image returns `PUBLIC`.
       remediation:
         - id: console
           desc: |
@@ -53029,6 +61883,26 @@ queries:
 
         - **Clickjacking prevention:** Restricting `embedHostDomains` to known internal FQDNs blocks third-party sites from framing the streaming session.
         - **Defense in depth:** Pairs with browser CSP at the embedding origin.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AppStream 2.0 Console](https://console.aws.amazon.com/appstream2/) and choose **Stacks**.
+        2. Select each stack and choose **Edit**.
+        3. Under **Embed AppStream 2.0**, review each entry in the **Allowed domains** list. Confirm that no entry contains `*` or is an empty string.
+
+        A passing stack has no wildcard or empty entries in its embed host domain list. A failing stack has at least one entry containing `*` or an empty string.
+
+        ### Audit via CLI
+
+        1. Describe all stacks and check their EmbedHostDomains lists:
+
+        ```bash
+        aws appstream describe-stacks \
+          --query 'Stacks[*].[Name,EmbedHostDomains]' \
+          --output json
+        ```
+
+        Review the output and flag any stack whose `EmbedHostDomains` list contains a value with `*` or an empty string. A passing stack has a `null` or fully-qualified FQDN-only list. A failing stack has a wildcard or empty entry in the list.
       remediation:
         - id: console
           desc: |
@@ -53136,6 +62010,31 @@ queries:
 
         - **Network boundary enforcement:** Restricts portal access to known networks.
         - **Defense in depth:** Pairs with portal authentication so even valid credentials cannot be used from arbitrary networks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon WorkSpaces Web Console](https://console.aws.amazon.com/workspaces-web/) and choose **IP access settings**.
+        2. Select each IP access settings resource.
+        3. Review the **IP rules** list and confirm that neither `0.0.0.0/0` nor `::/0` appears as an allowed range.
+
+        A passing IP access settings resource contains only specific CIDR ranges and no `0.0.0.0/0` or `::/0`. A failing resource has `0.0.0.0/0` or `::/0` in its rule list.
+
+        ### Audit via CLI
+
+        1. List all IP access settings resources and inspect their rules:
+
+        ```bash
+        aws workspaces-web list-ip-access-settings \
+          --query 'ipAccessSettings[*].ipAccessSettingsArn' \
+          --output text | tr '\t' '\n' | while read arn; do
+            aws workspaces-web get-ip-access-settings \
+              --ip-access-settings-arn "$arn" \
+              --query 'ipAccessSettings.ipRules[*].ipRange' \
+              --output text
+          done
+        ```
+
+        A passing IP access settings resource returns only specific CIDR ranges with no `0.0.0.0/0` or `::/0`. A failing resource includes `0.0.0.0/0` or `::/0` in the output.
       remediation:
         - id: console
           desc: |
@@ -53236,6 +62135,40 @@ queries:
 
         - **Authentication continuity:** Detects imminent failure of origin authentication before clients are impacted.
         - **Bypass prevention:** Forces rotation before the certificate enters the post-expiry state where origin behavior may differ.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [CloudFront Console](https://console.aws.amazon.com/cloudfront/) and select a distribution.
+        2. Choose the **Origins** tab. For each origin that uses mTLS, note the ACM certificate ARN shown under **Origin mutual TLS**.
+        3. Open the [ACM Console](https://console.aws.amazon.com/acm/) in the appropriate region and locate the certificate.
+        4. Confirm that the **Expires in** value is at least 30 days in the future.
+
+        A passing origin shows a certificate with more than 30 days remaining. A failing origin shows an expired certificate or one with fewer than 30 days remaining.
+
+        ### Audit via CLI
+
+        1. List all distributions, extract origin mTLS certificate ARNs, and check their expiry:
+
+        ```bash
+        aws cloudfront list-distributions \
+          --query 'DistributionList.Items[*].Id' \
+          --output text | tr '\t' '\n' | while read id; do
+            aws cloudfront get-distribution \
+              --id "$id" \
+              --query 'Distribution.DistributionConfig.Origins.Items[*].{Domain:DomainName,Cert:CustomOriginConfig.OriginMtlsConfig.Certificate}' \
+              --output json
+          done
+        ```
+
+        For each certificate ARN returned, check its expiry:
+
+        ```bash
+        aws acm describe-certificate \
+          --certificate-arn <cert-arn> \
+          --query 'Certificate.NotAfter'
+        ```
+
+        A passing origin returns a `NotAfter` date more than 30 days from today. A failing origin returns an expired date or one within 30 days of today.
       remediation:
         - id: console
           desc: |
@@ -53302,6 +62235,26 @@ queries:
 
         - **Authentication enforcement:** Ensures CloudFront actually has CAs to validate against when mTLS is configured.
         - **Configuration hygiene:** Catches mid-rotation gaps before viewer clients are affected.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [CloudFront Console](https://console.aws.amazon.com/cloudfront/) and select **Trust stores** in the left navigation.
+        2. For each trust store, check the **Number of CA certificates** column.
+        3. Confirm the value is 1 or greater.
+
+        A passing trust store shows at least 1 CA certificate. A failing trust store shows 0 CA certificates.
+
+        ### Audit via CLI
+
+        1. List all CloudFront trust stores and check certificate counts:
+
+        ```bash
+        aws cloudfront list-trust-stores \
+          --query 'TrustStoreList.Items[*].[Id,Name,S3Key,NumberOfCaCertificates]' \
+          --output table
+        ```
+
+        A passing trust store shows a `NumberOfCaCertificates` value greater than 0. A failing trust store shows `0` in that column.
       remediation:
         - id: console
           desc: |
@@ -53365,6 +62318,26 @@ queries:
 
         - **Origin protection:** Prevents direct-to-origin requests that bypass edge controls.
         - **WAF enforcement:** Ensures the WAF cannot be skipped by routing around CloudFront.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [CloudFront Console](https://console.aws.amazon.com/cloudfront/) and select a distribution.
+        2. Choose the **Origins** tab. For each origin whose domain name matches `*.elb.amazonaws.com` or `*.internal`, review the **Origin TLS settings**.
+        3. Confirm that **Origin mutual TLS** is enabled and an ACM certificate is selected.
+
+        A passing origin shows mTLS enabled with a certificate configured. A failing internal-origin shows mTLS disabled or no certificate.
+
+        ### Audit via CLI
+
+        1. Retrieve all distribution origin configs and filter for ELB or internal origins:
+
+        ```bash
+        aws cloudfront list-distributions \
+          --query 'DistributionList.Items[*].[Id,Origins.Items[*].{Domain:DomainName,MtlsCert:CustomOriginConfig.OriginMtlsConfig.Certificate}]' \
+          --output json
+        ```
+
+        For any origin whose `Domain` contains `.elb.amazonaws.com` or `.internal`, confirm the `MtlsCert` field is non-null. A passing origin shows a non-null certificate ARN. A failing origin shows a `null` certificate value for an ELB or internal hostname.
       remediation:
         - id: console
           desc: |
@@ -53433,6 +62406,26 @@ queries:
 
         - **Validation continuity:** Forces rotation cadence on the CA bundle.
         - **Bypass prevention:** Reduces the window where expired CAs in the trust store can lead to inconsistent validation behavior.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [CloudFront Console](https://console.aws.amazon.com/cloudfront/) and select **Trust stores** in the left navigation.
+        2. For each trust store, check the **Last modified** column.
+        3. Confirm that the date is within the last 365 days.
+
+        A passing trust store shows a last-modified date within the past year. A failing trust store shows a last-modified date older than 365 days.
+
+        ### Audit via CLI
+
+        1. List all trust stores and their last-modified timestamps:
+
+        ```bash
+        aws cloudfront list-trust-stores \
+          --query 'TrustStoreList.Items[*].[Id,Name,LastModifiedTime]' \
+          --output table
+        ```
+
+        A passing trust store shows a `LastModifiedTime` within the last 365 days. A failing trust store shows a `LastModifiedTime` older than one year from today.
       remediation:
         - id: console
           desc: |
@@ -53504,6 +62497,43 @@ queries:
         - **Least privilege:** Restricts connector authority to only the buckets and actions required for the data exchange.
         - **Blast radius reduction:** Limits the exposure of an accidentally or maliciously misused connector.
         - **Audit completeness:** Requiring managed-only policies makes the wildcard scan authoritative rather than partial.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AWS Transfer Family Console](https://console.aws.amazon.com/transfer/) and select **Connectors**.
+        2. For each connector, note the **Access role** ARN.
+        3. Open the [IAM Console](https://console.aws.amazon.com/iam/), locate the role, and choose **Permissions**.
+        4. Confirm there are no inline policies attached. For each managed (attached) policy, expand the policy and verify no statement has `Action: s3:*` or `Resource: "*"` with `Effect: Allow`.
+
+        A passing connector access role has no inline policies and no Allow statement granting `s3:*` or a wildcard resource. A failing role has inline policies present or contains a managed policy with an overly broad Allow statement.
+
+        ### Audit via CLI
+
+        1. List connectors, retrieve each access role, and check for wildcards:
+
+        ```bash
+        aws transfer list-connectors \
+          --query 'Connectors[*].[ConnectorId,AccessRole]' \
+          --output text | tr '\t' '\n\n' | paste - - | while read id role; do
+            echo "=== Connector: $id, Role: $role ==="
+            role_name=$(echo "$role" | sed 's|.*role/||')
+            aws iam list-role-policies --role-name "$role_name" \
+              --query 'PolicyNames' --output text
+            aws iam list-attached-role-policies --role-name "$role_name" \
+              --query 'AttachedPolicies[*].PolicyArn' --output text
+          done
+        ```
+
+        For each attached policy ARN, review its default version document:
+
+        ```bash
+        aws iam get-policy-version \
+          --policy-arn <policy-arn> \
+          --version-id $(aws iam get-policy --policy-arn <policy-arn> --query 'Policy.DefaultVersionId' --output text) \
+          --query 'PolicyVersion.Document.Statement[*].{Effect:Effect,Action:Action,Resource:Resource}'
+        ```
+
+        A passing role shows no inline policies and no Allow statements with `s3:*` or `"*"` as the resource. A failing role either has inline policies or contains a statement with wildcard actions or resources.
       remediation:
         - id: console
           desc: |
@@ -53589,6 +62619,36 @@ queries:
 
         - **Forensic trail:** Ensures every transfer event is captured for audit and incident response.
         - **Data exfiltration detection:** Enables alerting on unusual transfer volume or destinations.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AWS Transfer Family Console](https://console.aws.amazon.com/transfer/) and select **Connectors**.
+        2. For each connector, check the **Details** section.
+        3. Confirm that a **Logging role** ARN is shown.
+
+        A passing connector shows a non-empty **Logging role** ARN. A failing connector shows no logging role configured.
+
+        ### Audit via CLI
+
+        1. List all connectors and check for a loggingRole on each:
+
+        ```bash
+        aws transfer list-connectors \
+          --query 'Connectors[*].ConnectorId' \
+          --output text | tr '\t' '\n' | while read id; do
+            logging=$(aws transfer describe-connector \
+              --connector-id "$id" \
+              --query 'Connector.LoggingRole' \
+              --output text 2>/dev/null)
+            if [ -z "$logging" ] || [ "$logging" = "None" ]; then
+              echo "FAIL: $id has no logging role"
+            else
+              echo "PASS: $id logging role = $logging"
+            fi
+          done
+        ```
+
+        A passing connector prints `PASS` with a logging role ARN. A failing connector prints `FAIL: ... has no logging role`.
       remediation:
         - id: console
           desc: |
@@ -53685,6 +62745,26 @@ queries:
 
         - **Network boundary:** Removes the public attack surface for the auth flow.
         - **Defense in depth:** Pairs with IP access settings and IAM Identity Center MFA to enforce both network and identity boundaries.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AWS Transfer Family Console](https://console.aws.amazon.com/transfer/) and select **Web Apps**.
+        2. For each web app, check the **Endpoint type** column.
+        3. Confirm that the endpoint type is not **PUBLIC**.
+
+        A passing web app shows an endpoint type other than **PUBLIC**. A failing web app shows **PUBLIC** as its endpoint type.
+
+        ### Audit via CLI
+
+        1. List all Transfer Family web apps and check their endpoint types:
+
+        ```bash
+        aws transfer list-web-apps \
+          --query 'WebApps[*].[WebAppId,EndpointType]' \
+          --output table
+        ```
+
+        A passing web app shows an endpoint type other than `PUBLIC` in the output. A failing web app shows `PUBLIC` in the `EndpointType` column.
       remediation:
         - id: console
           desc: |
@@ -53747,6 +62827,30 @@ queries:
 
         - **Data residue prevention:** Ensures cleartext or fan-out copies are removed when the workflow fails.
         - **Encryption posture:** Maintains the at-rest encryption guarantee even on partial failures.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Transfer Family Console** and navigate to **Workflows**.
+        2. For each workflow, select it and review the **Steps** tab to identify any steps of type `DECRYPT` or `COPY`.
+        3. For each workflow that contains a `DECRYPT` or `COPY` step, confirm that the **Exception handlers** section lists at least one step such as `DELETE` or `TAG`.
+
+        A passing workflow with `DECRYPT` or `COPY` steps shows one or more exception handler steps defined. A failing workflow shows an empty **Exception handlers** section alongside a `DECRYPT` or `COPY` nominal step.
+
+        ### Audit via CLI
+
+        1. List all Transfer workflows and inspect their steps and exception steps:
+
+        ```bash
+        aws transfer list-workflows --query 'Workflows[*].WorkflowId' --output text | \
+          tr '\t' '\n' | \
+          while read wid; do
+            echo "--- $wid ---"
+            aws transfer describe-workflow --workflow-id "$wid" \
+              --query '{Steps: Workflow.Steps[*].Type, OnExceptionSteps: Workflow.OnExceptionSteps}'
+          done
+        ```
+
+        A passing workflow returns a non-empty `OnExceptionSteps` array whenever `Steps` contains `DECRYPT` or `COPY`. A failing workflow returns `OnExceptionSteps: null` or `OnExceptionSteps: []` while one of its steps is `DECRYPT` or `COPY`.
       remediation:
         - id: console
           desc: |
@@ -53819,6 +62923,38 @@ queries:
         - Custom-model artifacts can leak the patterns and content of the training data through model inversion or membership inference attacks. Encrypting them with a CMK lets you delete the key to render the model unrecoverable.
         - A CMK gives you a key policy and grants you control over which principals can decrypt the model and its training-data outputs.
         - CloudTrail logs every CMK use, so you get a per-decryption audit trail that AWS-managed keys do not provide.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon Bedrock Console** and select **Custom models** under **Foundation models**.
+        2. Select each custom model and review the **Model details** page.
+        3. Under **Encryption**, confirm that a customer-managed KMS key ARN is shown rather than the AWS-managed default key.
+
+        A passing custom model shows a customer-managed KMS key ARN in the **Encryption** field. A failing custom model shows the AWS-managed key or no key listed.
+
+        ### Audit via CLI
+
+        1. List all Bedrock custom models and check the `modelKmsKeyArn` and key manager:
+
+        ```bash
+        aws bedrock list-custom-models --query 'modelSummaries[*].{Name:modelName,Arn:modelArn}' --output table
+        ```
+
+        2. For each model, retrieve the key details:
+
+        ```bash
+        aws bedrock get-custom-model --model-identifier <model-name-or-arn> \
+          --query '{Name:modelName,KmsKeyArn:modelKmsKeyArn}'
+        ```
+
+        3. Confirm the KMS key is customer-managed:
+
+        ```bash
+        aws kms describe-key --key-id <kms-key-arn> \
+          --query 'KeyMetadata.KeyManager'
+        ```
+
+        A passing custom model returns `"CUSTOMER"` for `KeyManager`. A failing custom model returns a null or empty `KmsKeyArn`, or returns `"AWS"` for `KeyManager`.
       remediation:
         - id: console
           desc: |
@@ -53942,6 +63078,35 @@ queries:
         - A web ACL with custom IP allow lists or rate-limiting alone does not block injection attacks at the application layer.
         - AWS keeps these managed rule groups current as new CVEs and exploit patterns emerge, so referencing them is more durable than maintaining hand-rolled signatures.
         - Skipping the SQLi or XSS rule group is the single most common cause of WAF-protected applications still being compromised by injection attacks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS WAF & Shield Console** and select **Web ACLs**.
+        2. For each web ACL, select it and go to the **Rules** tab.
+        3. Confirm that rules named `AWS-AWSManagedRulesCommonRuleSet`, `AWS-AWSManagedRulesSQLiRuleSet`, and `AWS-AWSManagedRulesKnownBadInputsRuleSet` (or equivalent managed rule group statements) are present and set to **Block** or **Count**.
+
+        A passing web ACL shows all three required AWS managed rule groups in the rules list. A failing web ACL is missing one or more of the required groups.
+
+        ### Audit via CLI
+
+        1. List all WAFv2 web ACLs and then inspect the rules of each:
+
+        ```bash
+        aws wafv2 list-web-acls --scope REGIONAL \
+          --query 'WebACLs[*].{Name:Name,Id:Id}' --output table
+        ```
+
+        2. For each web ACL, check which managed rule groups are referenced:
+
+        ```bash
+        aws wafv2 get-web-acl \
+          --name <web-acl-name> \
+          --scope REGIONAL \
+          --id <web-acl-id> \
+          --query 'WebACL.Rules[*].Statement.ManagedRuleGroupStatement.Name'
+        ```
+
+        A passing web ACL returns a list that includes `AWSManagedRulesCommonRuleSet`, `AWSManagedRulesSQLiRuleSet`, and `AWSManagedRulesKnownBadInputsRuleSet`. A failing web ACL returns a list missing one or more of those three group names.
       remediation:
         - id: console
           desc: |
@@ -54194,6 +63359,35 @@ queries:
         - A compromised privileged container can break out of its isolation boundary and attack other Batch jobs running on the same host.
         - Privileged mode bypasses the user-namespace and capability dropping that Batch jobs would otherwise inherit, raising the blast radius of any code-execution flaw.
         - Most Batch workloads do not need raw device access; the privileged flag is usually a leftover from local container debugging.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Batch Console** and select **Job definitions**.
+        2. Filter by **Status: Active** and select each job definition.
+        3. Under **Container properties**, check the **Privileged** field. For multi-node job definitions, inspect each node range.
+
+        A passing job definition shows **Privileged: false** or the field is absent. A failing job definition shows **Privileged: true** under any container properties section.
+
+        ### Audit via CLI
+
+        1. List active job definitions and inspect their container properties for the `privileged` flag:
+
+        ```bash
+        aws batch describe-job-definitions \
+          --status ACTIVE \
+          --query 'jobDefinitions[*].{Name:jobDefinitionName,Revision:revision,Privileged:containerProperties.privileged}' \
+          --output table
+        ```
+
+        2. For multi-node job definitions, check each node range:
+
+        ```bash
+        aws batch describe-job-definitions \
+          --status ACTIVE \
+          --query 'jobDefinitions[?nodeProperties!=`null`].{Name:jobDefinitionName,NodeRanges:nodeProperties.nodeRangeProperties[*].container.privileged}'
+        ```
+
+        A passing job definition returns `false` or `null` for `Privileged` in all container properties. A failing job definition returns `true` for `Privileged` in any container or node range container.
       remediation:
         - id: console
           desc: |
@@ -54286,6 +63480,36 @@ queries:
         - Public images can be replaced or yanked at any time by the publisher, breaking reproducibility and opening supply-chain attacks.
         - Images from private registries can be required to pass internal vulnerability scanning, signing, and admission policies before being usable as a Batch job source.
         - Pulling from public registries on every job submission depends on third-party availability and rate limits that are outside your control.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Batch Console** and select **Job definitions**.
+        2. Filter by **Status: Active** and select each job definition.
+        3. Under **Container properties**, review the **Image** field. Verify the image URI begins with a private registry host such as `123456789012.dkr.ecr.<region>.amazonaws.com/` rather than `public.ecr.aws/`, `docker.io/`, or a bare image name with no registry prefix.
+
+        A passing job definition shows a private ECR registry URI in the **Image** field. A failing job definition shows a public registry reference such as `public.ecr.aws/`, `docker.io/`, or an unqualified image name like `ubuntu:22.04`.
+
+        ### Audit via CLI
+
+        1. List active job definitions and inspect each container image reference:
+
+        ```bash
+        aws batch describe-job-definitions \
+          --status ACTIVE \
+          --query 'jobDefinitions[*].{Name:jobDefinitionName,Revision:revision,Image:containerProperties.image}' \
+          --output table
+        ```
+
+        2. Flag any image that begins with a public registry prefix or lacks a registry hostname:
+
+        ```bash
+        aws batch describe-job-definitions \
+          --status ACTIVE \
+          --query 'jobDefinitions[?containerProperties.image!=`null`].{Name:jobDefinitionName,Image:containerProperties.image}' | \
+          grep -E '(^|: )(public\.ecr\.aws|docker\.io|registry\.hub\.docker\.com|[^/.:]+/)'
+        ```
+
+        A passing job definition returns a private ECR URI starting with an account ID and `.dkr.ecr.`. A failing job definition returns an image URI starting with `public.ecr.aws/`, `docker.io/`, `registry.hub.docker.com/`, or a bare image name with no registry host.
       remediation:
         - id: console
           desc: |
@@ -54390,6 +63614,42 @@ queries:
         - A Batch instance with a public IP exposes the AMI's services and any container ports bound to the host network directly to the internet.
         - Public IPs widen the attack surface available to scanners that probe random IPv4 space looking for misconfigured services.
         - Private subnets force traffic through controlled egress paths, where a NAT gateway or VPC endpoint can be audited and rate-limited.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Batch Console** and select **Job queues**. Filter by **State: ENABLED**.
+        2. For each enabled job queue, select it and note the compute environments listed under **Compute environment order**.
+        3. For each compute environment, navigate to **Compute environments**, select the environment, and review the **Networking** section for the configured subnets.
+        4. Open the **VPC Console**, locate each subnet by ID, and check whether **Auto-assign public IPv4 address** is disabled.
+
+        A passing compute environment shows all configured subnets have **Auto-assign public IPv4 address** set to **No**. A failing compute environment shows at least one subnet with **Auto-assign public IPv4 address** set to **Yes**.
+
+        ### Audit via CLI
+
+        1. List enabled job queues and their compute environments:
+
+        ```bash
+        aws batch describe-job-queues \
+          --query 'jobQueues[?state==`ENABLED`].{Queue:jobQueueName,Envs:computeEnvironmentOrder[*].computeEnvironment}'
+        ```
+
+        2. For each compute environment, retrieve its subnet IDs:
+
+        ```bash
+        aws batch describe-compute-environments \
+          --compute-environments <env-arn> \
+          --query 'computeEnvironments[*].computeResources.subnets'
+        ```
+
+        3. For each subnet, check public IP assignment:
+
+        ```bash
+        aws ec2 describe-subnets \
+          --subnet-ids <subnet-id> \
+          --query 'Subnets[*].{SubnetId:SubnetId,MapPublicIpOnLaunch:MapPublicIpOnLaunch}'
+        ```
+
+        A passing compute environment returns `MapPublicIpOnLaunch: false` for every subnet. A failing compute environment returns `MapPublicIpOnLaunch: true` for at least one subnet.
       remediation:
         - id: console
           desc: |
@@ -54461,6 +63721,46 @@ queries:
         - A Batch job that processes untrusted data and assumes a wildcard role can be pivoted by an attacker into account-wide read or write access.
         - `iam:PassRole` combined with `Resource: "*"` lets the job role escalate to any other role in the account by passing it to a service.
         - Inline policies are not evaluated by this check because their content is not exposed via the IAM API in a structured way; the check fails when inline policies are present so they can be reviewed and converted to managed policies.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Batch Console** and select **Job definitions**. Filter by **Status: Active**.
+        2. For each job definition, select it and note the **Job role ARN** under **Container properties**.
+        3. Open the **IAM Console**, navigate to **Roles**, and select the job role.
+        4. Under **Permissions**, review each attached managed policy. Open each policy version and look for any `Allow` statement where `Action` or `Resource` is `"*"`.
+        5. Under **Inline policies**, confirm there are none present.
+
+        A passing job role shows no `Allow` statements with wildcard `Action` or `Resource` and has no inline policies. A failing job role shows at least one `Allow` statement with `"Action": "*"` or `"Resource": "*"`, or has one or more inline policies attached.
+
+        ### Audit via CLI
+
+        1. List the job role for each active job definition:
+
+        ```bash
+        aws batch describe-job-definitions \
+          --status ACTIVE \
+          --query 'jobDefinitions[?containerProperties.jobRoleArn!=`null`].{Name:jobDefinitionName,Role:containerProperties.jobRoleArn}'
+        ```
+
+        2. For each role, check for inline policies:
+
+        ```bash
+        aws iam list-role-policies --role-name <role-name> --query 'PolicyNames'
+        ```
+
+        3. Check attached managed policies for wildcard statements:
+
+        ```bash
+        aws iam list-attached-role-policies --role-name <role-name> --query 'AttachedPolicies[*].PolicyArn' --output text | \
+          tr '\t' '\n' | \
+          while read arn; do
+            version=$(aws iam get-policy --policy-arn "$arn" --query 'Policy.DefaultVersionId' --output text)
+            aws iam get-policy-version --policy-arn "$arn" --version-id "$version" \
+              --query 'PolicyVersion.Document.Statement[?Effect==`Allow`].{Action:Action,Resource:Resource}'
+          done
+        ```
+
+        A passing job role returns an empty list for inline policies and shows no `Allow` statement where `Action` or `Resource` contains `"*"`. A failing job role returns a non-empty inline policy list, or an attached policy document contains `"Action": "*"` or `"Resource": "*"` in an `Allow` statement.
       remediation:
         - id: console
           desc: |
@@ -54535,6 +63835,48 @@ queries:
         - A workflow that takes input from an untrusted source and passes it to a Lambda invocation parameter can become a confused-deputy primitive if the role can invoke any Lambda function.
         - Resource wildcards prevent meaningful least-privilege auditing because they mask which downstream resources the workflow actually depends on.
         - Inline policies are not evaluated structurally by this check; their presence fails the check so they can be reviewed and converted into managed policies that this control can audit.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Step Functions Console** and select **State machines**.
+        2. For each state machine, select it and note the **IAM role ARN** in the configuration details.
+        3. Open the **IAM Console**, navigate to **Roles**, and select the execution role.
+        4. Under **Permissions**, review each attached managed policy. Open each policy version and look for any `Allow` statement where `Resource` is `"*"`.
+        5. Under **Inline policies**, confirm there are none present.
+
+        A passing execution role shows no `Allow` statements with `"Resource": "*"` and has no inline policies. A failing execution role shows at least one `Allow` statement with `"Resource": "*"`, or has one or more inline policies attached.
+
+        ### Audit via CLI
+
+        1. List all state machines and their role ARNs:
+
+        ```bash
+        aws stepfunctions list-state-machines \
+          --query 'stateMachines[*].{Name:name,Arn:stateMachineArn}' --output table
+        ```
+
+        2. For each state machine, retrieve the execution role:
+
+        ```bash
+        aws stepfunctions describe-state-machine \
+          --state-machine-arn <state-machine-arn> \
+          --query 'roleArn'
+        ```
+
+        3. Check the role for inline policies and wildcard resource statements:
+
+        ```bash
+        aws iam list-role-policies --role-name <role-name> --query 'PolicyNames'
+        aws iam list-attached-role-policies --role-name <role-name> --query 'AttachedPolicies[*].PolicyArn' --output text | \
+          tr '\t' '\n' | \
+          while read arn; do
+            version=$(aws iam get-policy --policy-arn "$arn" --query 'Policy.DefaultVersionId' --output text)
+            aws iam get-policy-version --policy-arn "$arn" --version-id "$version" \
+              --query 'PolicyVersion.Document.Statement[?Effect==`Allow` && Resource==`*`]'
+          done
+        ```
+
+        A passing execution role returns an empty inline policy list and no `Allow` statements with `"Resource": "*"`. A failing execution role returns a non-empty inline policy list, or an attached policy document contains an `Allow` statement with `"Resource": "*"`.
       remediation:
         - id: console
           desc: |
@@ -54623,6 +63965,26 @@ queries:
         - SHA-1 collisions are computationally feasible and have been demonstrated against real-world signature schemes.
         - Modern TLS clients refuse SHA-1-signed certificates outright, breaking the services that depend on them.
         - The signing algorithm of a CA cannot be changed after the CA is created, so a SHA-1 CA must be replaced with a new SHA-256 or stronger CA.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Certificate Manager Console** and select **Private certificate authority** under **Private CAs**.
+        2. For each CA that is not in **Deleted** status, select it and view the **Subject** and **CA details** sections.
+        3. Confirm that the **Signing algorithm** shows `SHA256WITHRSA`, `SHA384WITHRSA`, `SHA512WITHRSA`, `SHA256WITHECDSA`, `SHA384WITHECDSA`, or `SHA512WITHECDSA`.
+
+        A passing Private CA shows a SHA-256, SHA-384, or SHA-512 signing algorithm. A failing Private CA shows `SHA1WITHRSA` or any other SHA-1-based algorithm.
+
+        ### Audit via CLI
+
+        1. List all Private CAs and inspect their signing algorithms:
+
+        ```bash
+        aws acm-pca list-certificate-authorities \
+          --query 'CertificateAuthorities[?Status!=`DELETED`].{Arn:Arn,Status:Status,SigningAlgorithm:CertificateAuthorityConfiguration.SigningAlgorithm}' \
+          --output table
+        ```
+
+        A passing Private CA returns a `SigningAlgorithm` value matching `SHA256WITHRSA`, `SHA384WITHRSA`, `SHA512WITHRSA`, `SHA256WITHECDSA`, `SHA384WITHECDSA`, or `SHA512WITHECDSA`. A failing Private CA returns `SHA1WITHRSA` or another SHA-1-based algorithm.
       remediation:
         - id: console
           desc: |
@@ -54758,6 +64120,26 @@ queries:
         - FIPS 140-2 Level 3 HSMs enforce tamper-resistance and identity-based authentication for key operations, which software-only key storage cannot provide.
         - The `keyStorageSecurityStandard` is fixed at CA creation time, so a CA created without explicit HSM storage cannot be upgraded in place.
         - Compliance frameworks such as PCI DSS, FedRAMP, and HIPAA expect CA private keys to live in hardware-backed key stores.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Certificate Manager Console** and select **Private certificate authority** under **Private CAs**.
+        2. For each CA that is not in **Deleted** status, select it and view the **CA details** section.
+        3. Confirm that **Key storage security standard** shows `FIPS_140_2_LEVEL_3_OR_HIGHER`.
+
+        A passing Private CA shows `FIPS_140_2_LEVEL_3_OR_HIGHER` for the key storage security standard. A failing Private CA shows `FIPS_140_2_LEVEL_2_OR_HIGHER` or any other value that does not meet Level 3.
+
+        ### Audit via CLI
+
+        1. List all Private CAs and inspect their key storage security standard:
+
+        ```bash
+        aws acm-pca list-certificate-authorities \
+          --query 'CertificateAuthorities[?Status!=`DELETED`].{Arn:Arn,Status:Status,KeyStorageSecurityStandard:KeyStorageSecurityStandard}' \
+          --output table
+        ```
+
+        A passing Private CA returns `FIPS_140_2_LEVEL_3_OR_HIGHER` for `KeyStorageSecurityStandard`. A failing Private CA returns any other value such as `FIPS_140_2_LEVEL_2_OR_HIGHER` or a null value.
       remediation:
         - id: console
           desc: |
@@ -54890,6 +64272,33 @@ queries:
         - SSH (22) and RDP (3389) exposed to the world receive constant credential-stuffing and brute-force attacks.
         - Database ports (MySQL 3306, PostgreSQL 5432, SQL Server 1433, MongoDB 27017, Redis 6379, Elasticsearch 9200) reveal data stores that often run with default credentials or no authentication.
         - Lightsail does not provide VPC-level controls equivalent to security groups for non-Lightsail traffic, so the instance firewall is the last line of defense.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon Lightsail Console** and select **Instances**.
+        2. For each instance, select it and go to the **Networking** tab.
+        3. Review the **IPv4 Firewall** rules. Look for any rule where **Source** is `Anywhere (0.0.0.0/0)` and the port range covers any of: 22 (SSH), 3389 (RDP), 3306 (MySQL), 5432 (PostgreSQL), 1433 (SQL Server), 27017 (MongoDB), 6379 (Redis), or 9200 (Elasticsearch).
+
+        A passing instance has no firewall rules that expose the listed sensitive ports to `0.0.0.0/0`. A failing instance has at least one rule permitting one of those ports from `Anywhere`.
+
+        ### Audit via CLI
+
+        1. List all Lightsail instances:
+
+        ```bash
+        aws lightsail get-instances \
+          --query 'instances[*].{Name:name,State:state.name}' --output table
+        ```
+
+        2. For each instance, retrieve the firewall rules and inspect for sensitive port exposure:
+
+        ```bash
+        aws lightsail get-instance-port-states \
+          --instance-name <instance-name> \
+          --query 'portStates[*].{FromPort:fromPort,ToPort:toPort,Protocol:protocol,Cidrs:cidrs}'
+        ```
+
+        A passing instance returns no rules where `Cidrs` contains `0.0.0.0/0` and the port range covers ports 22, 3389, 3306, 5432, 1433, 27017, 6379, or 9200. A failing instance returns at least one rule with `0.0.0.0/0` in `Cidrs` that spans one or more of those sensitive ports.
       remediation:
         - id: console
           desc: |
@@ -55047,6 +64456,26 @@ queries:
         - Database engines listen on well-known ports that internet scanners enumerate continuously, so a public Lightsail database is fingerprinted within minutes of being created.
         - Authentication on the database alone is too thin a defense for production data; CVEs against the engine, weak credentials, or a single leaked password become a full data breach.
         - A private Lightsail database can still be reached from Lightsail instances and peered VPCs through the Lightsail VPC peering feature.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon Lightsail Console** and select **Databases**.
+        2. For each database, select it and go to the **Networking** tab.
+        3. Confirm that **Public mode** is **Disabled**.
+
+        A passing Lightsail database shows **Public mode: Disabled**. A failing database shows **Public mode: Enabled**.
+
+        ### Audit via CLI
+
+        1. List all Lightsail relational databases and check the `publiclyAccessible` attribute:
+
+        ```bash
+        aws lightsail get-relational-databases \
+          --query 'relationalDatabases[*].{Name:name,Engine:engine,PubliclyAccessible:publiclyAccessible}' \
+          --output table
+        ```
+
+        A passing database returns `PubliclyAccessible: False`. A failing database returns `PubliclyAccessible: True`.
       remediation:
         - id: console
           desc: |
@@ -55155,6 +64584,34 @@ queries:
         - A route with `AuthorizationType: NONE` is open to any caller on the internet who can reach the API endpoint.
         - The default route key `$default` and catch-all route keys are easy to leave on `NONE` while testing and to forget about before going live.
         - Authorization is enforced per-route, so adding an authorizer at the API level does not protect routes that explicitly opt out.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **API Gateway Console** and select each v2 HTTP or WebSocket API.
+        2. In the left navigation pane, choose **Routes**.
+        3. For each route whose key does not start with `OPTIONS`, check the **Authorization** column. Confirm it shows a JWT, Lambda, or IAM authorizer rather than `NONE`.
+
+        A passing API shows every non-OPTIONS route with an authorization type other than `NONE`. A failing API shows at least one non-OPTIONS route with **Authorization: NONE**.
+
+        ### Audit via CLI
+
+        1. List all API Gateway v2 APIs:
+
+        ```bash
+        aws apigatewayv2 get-apis \
+          --query 'Items[*].{Name:Name,ApiId:ApiId,ProtocolType:ProtocolType}' --output table
+        ```
+
+        2. For each API, list the routes and their authorization types:
+
+        ```bash
+        aws apigatewayv2 get-routes \
+          --api-id <api-id> \
+          --query 'Items[*].{RouteKey:RouteKey,AuthorizationType:AuthorizationType,AuthorizerId:AuthorizerId}' \
+          --output table
+        ```
+
+        A passing API returns every non-OPTIONS route with `AuthorizationType` set to `JWT`, `AWS_IAM`, or `CUSTOM`. A failing API returns at least one non-OPTIONS route with `AuthorizationType: NONE`.
       remediation:
         - id: console
           desc: |
@@ -55285,6 +64742,33 @@ queries:
         - TLS 1.0 and TLS 1.1 have known cryptographic weaknesses including BEAST, POODLE, and weak cipher suites that no longer satisfy PCI DSS, HIPAA, and FedRAMP.
         - The security policy is set per endpoint configuration, so a multi-region domain can have one configuration on the strong policy and another on the weak one.
         - Enforcing `TLS_1_2` on the custom domain forces all clients to negotiate at least TLS 1.2, regardless of what the client library would default to.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **API Gateway Console** and select **Custom domain names**.
+        2. For each custom domain, select it and go to the **Domain name configurations** tab.
+        3. Confirm that every endpoint configuration shows **Security policy: TLS 1.2**.
+
+        A passing custom domain shows `TLS 1.2` for every endpoint configuration in the domain name configurations list. A failing custom domain shows `TLS 1.0` for at least one endpoint configuration.
+
+        ### Audit via CLI
+
+        1. List all API Gateway v2 custom domain names:
+
+        ```bash
+        aws apigatewayv2 get-domain-names \
+          --query 'Items[*].{DomainName:DomainName}' --output table
+        ```
+
+        2. For each domain, inspect the security policy on each endpoint configuration:
+
+        ```bash
+        aws apigatewayv2 get-domain-name \
+          --domain-name <domain-name> \
+          --query 'DomainNameConfigurations[*].{EndpointType:EndpointType,SecurityPolicy:SecurityPolicy}'
+        ```
+
+        A passing custom domain returns `SecurityPolicy: TLS_1_2` for every entry in `DomainNameConfigurations`. A failing custom domain returns `SecurityPolicy: TLS_1_0` for at least one entry.
       remediation:
         - id: console
           desc: |
@@ -55417,6 +64901,24 @@ queries:
         - The `DISABLED` mode leaves catalog metadata unencrypted at rest, exposing schema and connection details to any AWS Glue or KMS-unaware integrator that lands in the account.
         - `SSE-KMS` with a referenced KMS key id is the only catalog encryption mode that integrates with KMS audit logs and per-key access control.
         - The catalog also stores connection passwords, so loose catalog encryption can become a credential-leak path.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Glue Console** and select **Data Catalog** then **Settings**.
+        2. Under **Metadata encryption**, confirm that encryption is **Enabled** and that a customer-managed KMS key is selected (the key ARN is shown rather than the default AWS-managed key).
+
+        A passing Data Catalog settings page shows metadata encryption enabled with a customer-managed KMS key ARN. A failing page shows encryption disabled (`DISABLED`) or shows only the default AWS-managed key with no explicit key ID.
+
+        ### Audit via CLI
+
+        1. Retrieve the Glue Data Catalog encryption settings:
+
+        ```bash
+        aws glue get-data-catalog-encryption-settings \
+          --query 'DataCatalogEncryptionSettings.EncryptionAtRest'
+        ```
+
+        A passing Data Catalog returns `{"CatalogEncryptionMode": "SSE-KMS", "SseAwsKmsKeyId": "arn:aws:kms:..."}` with a non-empty `SseAwsKmsKeyId`. A failing Data Catalog returns `{"CatalogEncryptionMode": "DISABLED"}` or an object with `SSE-KMS` mode but a null or empty `SseAwsKmsKeyId`.
       remediation:
         - id: console
           desc: |
@@ -55576,6 +65078,26 @@ queries:
         - Job bookmarks record the position of incremental ETL runs and can leak data structure and processing patterns; encrypting them with `CSE-KMS` keeps them confidential at rest in the Glue metadata store.
         - S3 outputs from a Glue job inherit the security configuration's S3 encryption mode; pairing `SSE-KMS` with an explicit key id gives you a key policy that controls who can decrypt the resulting partitions.
         - A KmsKeyArn that is empty implies AWS managed defaults, which cannot be governed by your key administrators.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Glue** console and navigate to **Security configurations**.
+        2. For each security configuration, view its details and check the **S3 encryption** mode and **Job bookmark encryption** mode.
+        3. Confirm that **S3 encryption** is set to `SSE-KMS` with a non-empty KMS key ARN, and that **Job bookmark encryption** is set to `CSE-KMS` with a non-empty KMS key ARN.
+
+        A passing security configuration shows `SSE-KMS` and `CSE-KMS` both set with explicit customer-managed key ARNs. A failing configuration shows any other encryption mode, or shows `SSE-KMS`/`CSE-KMS` selected but with an empty KMS key ARN.
+
+        ### Audit via CLI
+
+        1. List all Glue security configurations and inspect the encryption settings for each:
+
+        ```bash
+        aws glue get-security-configurations \
+          --query 'SecurityConfigurations[*].{Name:Name,S3Mode:EncryptionConfiguration.S3Encryptions[0].S3EncryptionMode,S3Key:EncryptionConfiguration.S3Encryptions[0].KmsKeyArn,BookmarkMode:EncryptionConfiguration.JobBookmarksEncryption.JobBookmarksEncryptionMode,BookmarkKey:EncryptionConfiguration.JobBookmarksEncryption.KmsKeyArn}' \
+          --output table
+        ```
+
+        A passing security configuration returns `S3EncryptionMode` of `SSE-KMS`, `JobBookmarksEncryptionMode` of `CSE-KMS`, and non-empty `KmsKeyArn` values for both. A failing configuration returns any other mode value or an empty `KmsKeyArn`.
       remediation:
         - id: console
           desc: |
@@ -55764,6 +65286,29 @@ queries:
         - `SSE_S3` covers data-at-rest but provides no per-key audit trail, so you cannot determine who decrypted query results after the fact.
         - `SSE_KMS` and `CSE_KMS` both produce CloudTrail events for every decryption, which is essential for incident response on sensitive query output.
         - A workgroup whose encryption is enforced but whose `KmsKey` is empty falls back to AWS-owned keys, which sit outside customer key administration.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon Athena** console and choose **Workgroups** in the left navigation pane.
+        2. For each enabled workgroup, select the workgroup and choose **View details**.
+        3. Under **Query result configuration**, check that **Encrypt query results** is enabled, the encryption option is **SSE-KMS** or **CSE-KMS**, and a customer-managed KMS key is selected.
+
+        A passing workgroup shows an encryption option of `SSE-KMS` or `CSE-KMS` paired with a non-empty KMS key ARN and **Override client-side settings** enabled. A failing workgroup shows no encryption or shows `SSE-KMS`/`CSE-KMS` selected but with no KMS key specified.
+
+        ### Audit via CLI
+
+        1. List all Athena workgroups, then describe each to inspect the result configuration:
+
+        ```bash
+        aws athena list-work-groups \
+          --query 'WorkGroups[?State==`ENABLED`].Name' \
+          --output text | tr '\t' '\n' | while read wg; do
+          aws athena get-work-group --work-group "$wg" \
+            --query 'WorkGroup.{Name:Name,EncryptionOption:Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption,KmsKey:Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey}'
+        done
+        ```
+
+        A passing workgroup returns an `EncryptionOption` of `SSE_KMS` or `CSE_KMS` and a non-empty `KmsKey`. A failing workgroup returns a `null` encryption configuration, an `SSE_S3` option, or an empty `KmsKey`.
       remediation:
         - id: console
           desc: |
@@ -55938,6 +65483,30 @@ queries:
         - Anonymous endpoints can be abused for denial-of-service, cryptomining, or as part of a chain to reach internal resources the function can access.
         - Unauthenticated invocation bypasses the principle of least privilege and removes audit attribution from CloudTrail.
         - Setting `AuthType: AWS_IAM` requires callers to sign requests with SigV4 and lets resource policies and identity policies enforce who may invoke the function.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Lambda** console and select a function.
+        2. Choose the **Configuration** tab and select **Function URL**.
+        3. If a function URL exists, confirm that **Auth type** is set to `AWS_IAM`.
+        4. Repeat for all functions that have a function URL configured.
+
+        A passing function URL shows **Auth type: AWS_IAM**. A failing function URL shows **Auth type: NONE**.
+
+        ### Audit via CLI
+
+        1. List all Lambda functions, then retrieve the function URL configuration for each:
+
+        ```bash
+        aws lambda list-functions \
+          --query 'Functions[*].FunctionName' \
+          --output text | tr '\t' '\n' | while read fn; do
+          aws lambda get-function-url-config --function-name "$fn" 2>/dev/null \
+            --query '{FunctionName:FunctionArn,AuthType:AuthType}'
+        done
+        ```
+
+        A passing function URL config returns `AuthType` of `AWS_IAM`. A failing function URL config returns `AuthType` of `NONE`.
       remediation:
         - id: console
           desc: |
@@ -56053,6 +65622,28 @@ queries:
         - Some non-browser clients and older browser releases honor permissive headers anyway, allowing credential replay across origins.
         - Even before exploitation, the misconfiguration leaks information about the API surface and the operator's threat model.
         - Restricting `allow_origins` to the specific hostnames that may carry credentials enforces an explicit allowlist consistent with least privilege.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **API Gateway** console and select an HTTP API.
+        2. Choose **CORS** in the left navigation pane.
+        3. Check whether **Access-Control-Allow-Credentials** is enabled.
+        4. If credentials are enabled, verify that no `*` entry appears in the **Access-Control-Allow-Origin** list.
+        5. Repeat for all HTTP APIs in the account.
+
+        A passing API either has credentials disabled or specifies explicit origin hostnames. A failing API shows **Allow credentials** enabled alongside `*` in the allowed origins list.
+
+        ### Audit via CLI
+
+        1. List all API Gateway v2 APIs and inspect the CORS configuration of each:
+
+        ```bash
+        aws apigatewayv2 get-apis \
+          --query 'Items[*].{ApiId:ApiId,Name:Name,CorsConfig:CorsConfiguration}' \
+          --output json
+        ```
+
+        A passing API either omits `CorsConfiguration`, sets `AllowCredentials` to `false`, or lists only specific origins when `AllowCredentials` is `true`. A failing API returns `AllowCredentials: true` combined with `AllowOrigins` containing `*`.
       remediation:
         - id: console
           desc: |
@@ -56171,6 +65762,30 @@ queries:
         - Once the connection is open, per-route authorization still applies, but most backends assume the connection has already been authenticated upstream.
         - WebSocket abuse is hard to detect because there is no request/response log per message; access decisions must happen at connect time and on every route.
         - Setting `authorization_type` to `AWS_IAM`, `JWT`, or `CUSTOM` on every route forces the caller to present credentials at connect time and on every action.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **API Gateway** console and select a WebSocket API.
+        2. Choose **Routes** in the left navigation pane.
+        3. For each route (`$connect`, `$disconnect`, `$default`, and any custom routes), confirm that the **Authorization** setting is not `NONE`.
+        4. Repeat for all WebSocket APIs in the account.
+
+        A passing route shows an authorizer type of `AWS_IAM`, `JWT`, or `CUSTOM`. A failing route shows **Authorization: NONE**.
+
+        ### Audit via CLI
+
+        1. List WebSocket APIs, then retrieve all routes for each to check authorization type:
+
+        ```bash
+        aws apigatewayv2 get-apis \
+          --query 'Items[?ProtocolType==`WEBSOCKET`].ApiId' \
+          --output text | tr '\t' '\n' | while read api_id; do
+          aws apigatewayv2 get-routes --api-id "$api_id" \
+            --query 'Items[*].{RouteKey:RouteKey,AuthorizationType:AuthorizationType}'
+        done
+        ```
+
+        A passing route returns an `AuthorizationType` of `AWS_IAM`, `JWT`, or `CUSTOM`. A failing route returns `AuthorizationType` of `NONE`.
       remediation:
         - id: console
           desc: |
@@ -56258,6 +65873,27 @@ queries:
         - Injected events can mimic legitimate sources to trigger workflows that exfiltrate data or perform privileged operations.
         - Cross-account access is best granted to specific account IDs, organization IDs, or AWS service principals, never to `*` without conditions.
         - Even when a wildcard principal is technically required (cross-service integrations), it must be paired with `aws:SourceArn` or `aws:SourceAccount` conditions to constrain who can invoke it.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EventBridge** console and choose **Event buses** in the left navigation pane.
+        2. Select each custom event bus and choose the **Permissions** tab.
+        3. Review the resource-based policy. Look for any `Allow` statement where `Principal` is `"*"` or `{"AWS": "*"}` without a `Condition` block scoping access to a specific account or organization.
+        4. Repeat for all event buses in the account.
+
+        A passing event bus either has no resource policy or has a policy where every `Allow` statement names a specific principal or includes a scoping condition. A failing event bus has an `Allow` statement with a wildcard principal and no condition.
+
+        ### Audit via CLI
+
+        1. List all event buses and retrieve the policy for each to check for wildcard principals:
+
+        ```bash
+        aws events list-event-buses \
+          --query 'EventBuses[*].{Name:Name,Policy:Policy}' \
+          --output json
+        ```
+
+        A passing event bus returns an empty `Policy` or a policy whose `Allow` statements all specify named principals or include `Condition` blocks. A failing event bus returns a policy with a `Principal` of `"*"` or `{"AWS": "*"}` in an `Allow` statement that has no `Condition`.
       remediation:
         - id: console
           desc: |
@@ -56413,6 +66049,27 @@ queries:
         - Connection properties are exported by infrastructure-as-code tooling, so the plaintext value lands in Terraform state files and CI logs.
         - Rotating a plaintext credential requires editing every consumer; a Secrets Manager reference rotates centrally and audits every read.
         - Replacing the password with `SECRET_ID` keeps the secret in a system designed for credential storage, with KMS-backed encryption-at-rest and CloudTrail audit.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Glue** console and choose **Connections** in the left navigation pane.
+        2. Select each connection and choose **View details**.
+        3. Under **Connection properties**, confirm that no `PASSWORD` or `USERNAME` key-value pair is stored in plaintext. The credentials field should reference `SECRET_ID` pointing to an AWS Secrets Manager secret ARN.
+        4. Repeat for all connections in the account.
+
+        A passing connection shows connection properties that reference `SECRET_ID` rather than a plaintext `PASSWORD`. A failing connection shows a `PASSWORD` key present in the connection properties.
+
+        ### Audit via CLI
+
+        1. List all Glue connections and inspect the `ConnectionProperties` field for each:
+
+        ```bash
+        aws glue get-connections \
+          --query 'ConnectionList[*].{Name:Name,Props:ConnectionProperties}' \
+          --output json
+        ```
+
+        A passing connection returns `ConnectionProperties` that contains a `SECRET_ID` key and no `PASSWORD` key. A failing connection returns `ConnectionProperties` with a `PASSWORD` key present.
       remediation:
         - id: console
           desc: |
@@ -56515,6 +66172,29 @@ queries:
         - Removing the inbound SSH path eliminates a long-lived listener that has been used in past Cloud9 incidents.
         - SSM Session Manager produces a CloudTrail audit trail of every developer session that SSH does not.
         - Forcing `CONNECT_SSM` is the documented AWS guidance for Cloud9 environments that must operate in private subnets.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Cloud9** console.
+        2. For each environment, select the environment and choose **View details**.
+        3. Under **Network settings**, confirm that **Connection** is set to **Connect via Systems Manager (SSM)**, not **Connect via SSH**.
+        4. Repeat for all Cloud9 EC2 environments in the account.
+
+        A passing environment shows the connection type as **SSM**. A failing environment shows the connection type as **SSH**.
+
+        ### Audit via CLI
+
+        1. List all Cloud9 environments and describe each to check the connection type:
+
+        ```bash
+        aws cloud9 list-environments \
+          --query 'environmentIds' \
+          --output text | tr '\t' '\n' | xargs -n20 aws cloud9 describe-environments --environment-ids \
+          --query 'environments[*].{Name:name,ConnectionType:connectionType}' \
+          --output table
+        ```
+
+        A passing environment returns `connectionType` of `CONNECT_SSM`. A failing environment returns `connectionType` of `CONNECT_SSH`.
       remediation:
         - id: console
           desc: |
@@ -56612,6 +66292,32 @@ queries:
         - The relevant namespaces are `aws:elbv2:listener:443` for Application Load Balancers and `aws:elb:listener:443` for Classic Load Balancers. Enabling the listener and selecting an ACM certificate is what turns on HTTPS.
         - A misconfigured environment with only an HTTP listener cannot satisfy PCI DSS, HIPAA, or any baseline that requires TLS for web traffic.
         - Adding the HTTPS listener also enables clients to enforce HSTS and other browser controls that require TLS.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Elastic Beanstalk** console and select an environment.
+        2. Choose **Configuration** and locate the **Load balancer** section.
+        3. Confirm that a listener on port 443 exists with `Protocol = HTTPS` and a valid ACM certificate ARN assigned.
+        4. Repeat for all Beanstalk environments in the account.
+
+        A passing environment shows a port-443 HTTPS listener with `ListenerEnabled = true`. A failing environment has no port-443 listener or the listener is disabled.
+
+        ### Audit via CLI
+
+        1. List all Elastic Beanstalk environments, then retrieve the option settings for each to check the HTTPS listener:
+
+        ```bash
+        aws elasticbeanstalk describe-environments \
+          --query 'Environments[*].EnvironmentName' \
+          --output text | tr '\t' '\n' | while read env; do
+          aws elasticbeanstalk describe-configuration-settings \
+            --application-name "$(aws elasticbeanstalk describe-environments --environment-names "$env" --query 'Environments[0].ApplicationName' --output text)" \
+            --environment-name "$env" \
+            --query 'ConfigurationSettings[0].OptionSettings[?Namespace==`aws:elbv2:listener:443`]'
+        done
+        ```
+
+        A passing environment returns an option setting with `OptionName = ListenerEnabled` and `Value = true` under the `aws:elbv2:listener:443` namespace. A failing environment returns no such setting or returns `Value = false`.
       remediation:
         - id: console
           desc: |
@@ -56750,6 +66456,30 @@ queries:
         - Resolver query logging is the only AWS-native way to capture queries originating inside a VPC; public hosted zone query logging only captures queries to your own zones.
         - Detection rules for DNS tunneling, newly observed domains, and known bad indicators need this log stream as input.
         - A configured `aws_route53_resolver_query_log_config` is only useful when paired with an `aws_route53_resolver_query_log_config_association` for every VPC that needs logging.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Route 53** console and choose **Resolver** then **Query logging** in the left navigation pane.
+        2. Review the list of query logging configurations and their associated VPCs.
+        3. Confirm that every VPC in the account is associated with at least one query logging configuration that sends logs to a CloudWatch log group, S3 bucket, or Kinesis Data Firehose.
+
+        A passing configuration shows each VPC listed under an active query logging configuration. A failing setup shows VPCs with no associated query logging configuration.
+
+        ### Audit via CLI
+
+        1. List all Resolver query logging configurations and then list their VPC associations:
+
+        ```bash
+        aws route53resolver list-resolver-query-log-configs \
+          --query 'ResolverQueryLogConfigs[*].{Id:Id,Name:Name,DestinationArn:DestinationArn,Status:Status}' \
+          --output table
+
+        aws route53resolver list-resolver-query-log-config-associations \
+          --query 'ResolverQueryLogConfigAssociations[*].{ConfigId:ResolverQueryLogConfigId,ResourceId:ResourceId,Status:Status}' \
+          --output table
+        ```
+
+        A passing account returns at least one query logging configuration with `Status = CREATED` and at least one association per VPC with `Status = ACTIVE`. A failing account returns no configurations or has VPCs with no association records.
       remediation:
         - id: console
           desc: |
@@ -56850,6 +66580,34 @@ queries:
         - With the default AWS-owned KMS key, AWS controls the entire key lifecycle and there is no CloudTrail visibility into key usage, so backup access cannot be audited end-to-end.
         - A customer-managed key lets the data owner rotate, revoke, and audit access to every PITR-derived restore through KMS key policies and CloudTrail `kms:Decrypt` events.
         - Pairing PITR with a CMK satisfies regulatory requirements that demand customer-controlled key management for backups of regulated data.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **DynamoDB** console and choose **Tables**.
+        2. Select a table and open the **Additional settings** tab.
+        3. Under **Encryption**, confirm that the encryption type is **Customer managed key (KMS)** with a non-AWS-managed key ARN.
+        4. Under **Backups**, confirm that **Point-in-time recovery** shows **On**.
+        5. Repeat for all DynamoDB tables in the account.
+
+        A passing table shows **Encryption: Customer managed key** and **Point-in-time recovery: On**. A failing table shows the default AWS-owned or AWS-managed key, or shows PITR disabled.
+
+        ### Audit via CLI
+
+        1. List all DynamoDB tables, then describe each to check SSE and PITR configuration:
+
+        ```bash
+        aws dynamodb list-tables \
+          --query 'TableNames[]' \
+          --output text | tr '\t' '\n' | while read tbl; do
+          echo "=== $tbl ==="
+          aws dynamodb describe-table --table-name "$tbl" \
+            --query 'Table.{SSEType:SSEDescription.SSEType,KMSKeyArn:SSEDescription.KMSMasterKeyArn,KeyManager:SSEDescription.InaccessibleEncryptionDateTime}'
+          aws dynamodb describe-continuous-backups --table-name "$tbl" \
+            --query 'ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus'
+        done
+        ```
+
+        A passing table returns `SSEType: KMS` with a non-empty `KMSMasterKeyArn` and a PITR status of `ENABLED`. A failing table returns `SSEType: AES256` or an AWS-owned key, or returns PITR status of `DISABLED`.
       remediation:
         - id: console
           desc: |
@@ -57021,6 +66779,27 @@ queries:
         - When the cluster lacks `at_rest_encryption_enabled = true`, both the cluster and its snapshots fall back to AWS-owned key material that the customer cannot rotate, revoke, or audit.
         - A KMS key on the cluster propagates to every automated and manual snapshot, ensuring that restored data stays under the same key policy as the source cluster.
         - Pairing snapshot retention with a customer-controlled KMS key keeps backups aligned with the data-protection controls required for the live workload.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **ElastiCache** console and choose **Redis clusters** (or **Replication groups**).
+        2. Select a cluster and review the **Security** section for **Encryption at rest** status and the associated KMS key.
+        3. In the **Backup** section, confirm that the **Backup retention period** is greater than zero.
+        4. Repeat for all ElastiCache replication groups that have a non-zero snapshot retention limit.
+
+        A passing cluster shows **Encryption at rest: Enabled** with a customer-managed KMS key ARN and a backup retention period greater than zero. A failing cluster shows encryption at rest disabled, or shows no KMS key configured, when the retention period is non-zero.
+
+        ### Audit via CLI
+
+        1. Describe all ElastiCache replication groups and check at-rest encryption and snapshot retention:
+
+        ```bash
+        aws elasticache describe-replication-groups \
+          --query 'ReplicationGroups[*].{Id:ReplicationGroupId,AtRestEncryption:AtRestEncryptionEnabled,KmsKeyId:KmsKeyId,SnapshotRetentionLimit:SnapshotRetentionLimit}' \
+          --output table
+        ```
+
+        A passing replication group returns `AtRestEncryptionEnabled: true` with a non-empty `KmsKeyId` when `SnapshotRetentionLimit` is greater than zero. A failing group returns `AtRestEncryptionEnabled: false` or an empty `KmsKeyId` while `SnapshotRetentionLimit` is non-zero.
       remediation:
         - id: console
           desc: |
@@ -57161,6 +66940,30 @@ queries:
         - Video streams from cameras and connected devices frequently contain personal identifiable information, biometric data, or footage of regulated environments.
         - The AWS-managed key cannot be scoped with a key policy, so any principal with `kinesisvideo:GetMedia` permissions decrypts data without producing a discrete CloudTrail `kms:Decrypt` audit trail tied to a customer key.
         - A CMK lets the data owner enforce least privilege on decrypt operations, rotate key material on a controlled schedule, and revoke access at the key level when a device or partner is offboarded.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Kinesis Video Streams** console.
+        2. Select each video stream and review the **Encryption** section.
+        3. Confirm that **Encryption type** is **Customer-managed AWS KMS key** with a non-empty key ARN.
+        4. Repeat for all video streams in the account.
+
+        A passing stream shows a customer-managed KMS key ARN under **Encryption**. A failing stream shows the default AWS-managed `aws/kinesisvideo` key or no encryption key configured.
+
+        ### Audit via CLI
+
+        1. List all Kinesis Video Streams and describe each to check the KMS key configuration:
+
+        ```bash
+        aws kinesisvideo list-streams \
+          --query 'StreamInfoList[*].StreamName' \
+          --output text | tr '\t' '\n' | while read stream; do
+          aws kinesisvideo describe-stream --stream-name "$stream" \
+            --query 'StreamInfo.{StreamName:StreamName,KmsKeyId:KmsKeyId}'
+        done
+        ```
+
+        A passing stream returns a `KmsKeyId` that references a customer-managed key ARN (not `aws/kinesisvideo`). A failing stream returns a `KmsKeyId` of `aws/kinesisvideo` or an empty value.
       remediation:
         - id: console
           desc: |
@@ -57263,6 +67066,30 @@ queries:
         - EMR Studio workspaces routinely hold notebook code, query results, and small data extracts that include sensitive business or regulated data.
         - Without a CMK on the studio, every workspace artifact is encrypted with an AWS-owned key whose policy the customer cannot author, rotate, or revoke.
         - A customer-managed key tied to the studio makes notebook storage subject to the same audit and access-control rules as other regulated data and produces CloudTrail `kms:Decrypt` events for every workspace read.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon EMR** console and choose **Studios** in the left navigation pane.
+        2. Select each studio and review the **Encryption** section in the studio details.
+        3. Confirm that a customer-managed KMS key ARN is listed under **Encryption key**.
+        4. Repeat for all EMR Studios in the account.
+
+        A passing studio shows a customer-managed KMS key ARN under **Encryption key**. A failing studio shows no encryption key configured or shows the default AWS-managed key.
+
+        ### Audit via CLI
+
+        1. List all EMR Studios and inspect the encryption key ARN for each:
+
+        ```bash
+        aws emr list-studios \
+          --query 'Studios[*].StudioId' \
+          --output text | tr '\t' '\n' | while read studio_id; do
+          aws emr describe-studio --studio-id "$studio_id" \
+            --query 'Studio.{StudioId:StudioId,Name:Name,EncryptionKeyArn:EncryptionKeyArn}'
+        done
+        ```
+
+        A passing studio returns a non-empty `EncryptionKeyArn` that references a customer-managed KMS key. A failing studio returns an empty or null `EncryptionKeyArn`.
       remediation:
         - id: console
           desc: |
@@ -57396,6 +67223,31 @@ queries:
         - A DataSync task without `cloudwatch_log_group_arn` set leaves the operator with no audit record of what data moved, when, and whether the transfer completed cleanly.
         - Sending logs to a CloudWatch log group ensures that DataSync output lands somewhere subject to the existing CloudWatch retention and KMS encryption controls (covered by `mondoo-aws-security-cloudwatch-log-group-encrypted`).
         - This check stays narrowly scoped to the configuration on the DataSync task; cross-resource verification of the referenced log group's KMS key is performed by the dedicated CloudWatch log-group encryption check, so the two together provide end-to-end coverage.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **DataSync** console and choose **Tasks** in the left navigation pane.
+        2. Select each task and review the **Logging** section.
+        3. Confirm that **CloudWatch log group** is set to a non-empty log group ARN.
+        4. Navigate to that log group in **CloudWatch Logs** and confirm that the log group has a KMS key configured under **Encryption**.
+        5. Repeat for all DataSync tasks.
+
+        A passing task shows a CloudWatch log group ARN assigned in the logging configuration, and the referenced log group has a KMS key configured. A failing task shows no CloudWatch log group configured.
+
+        ### Audit via CLI
+
+        1. List all DataSync tasks and check the CloudWatch log group ARN for each:
+
+        ```bash
+        aws datasync list-tasks \
+          --query 'Tasks[*].TaskArn' \
+          --output text | tr '\t' '\n' | while read task_arn; do
+          aws datasync describe-task --task-arn "$task_arn" \
+            --query '{TaskArn:TaskArn,Name:Name,CloudWatchLogGroupArn:CloudWatchLogGroupArn}'
+        done
+        ```
+
+        A passing task returns a non-empty `CloudWatchLogGroupArn`. A failing task returns an empty or null `CloudWatchLogGroupArn`.
       remediation:
         - id: console
           desc: |
@@ -57504,6 +67356,25 @@ queries:
         - Attaching OAC keeps the bucket private at the resource policy level and forces every viewer request to flow through CloudFront, where WAF, logging, and TLS policies are enforced.
         - OAC also unlocks SigV4 access to buckets that require SSE-KMS, so the access boundary and the encryption boundary stay aligned.
         - Server-side encryption of the underlying S3 bucket is enforced by separate S3 checks; this check is scoped to the CloudFront origin binding so that misconfigurations are surfaced at the distribution rather than only at the bucket.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **CloudFront** console at https://console.aws.amazon.com/cloudfront/.
+        2. Select each distribution and open the **Origins** tab.
+        3. For every origin whose **Origin domain** ends in `.s3.amazonaws.com` or `.s3.<region>.amazonaws.com` (and is not an S3 static-website endpoint), confirm that **Origin access** shows a non-empty **Origin access control** name rather than **Public** or a legacy **Origin access identity**.
+
+        A passing distribution shows an origin access control name on every S3 origin. A failing distribution shows **Public** or a legacy origin access identity on at least one S3 origin.
+
+        ### Audit via CLI
+
+        1. List all distributions and check each S3 origin for an origin access control ID:
+
+        ```bash
+        aws cloudfront list-distributions \
+          --query 'DistributionList.Items[*].{Id:Id,Origins:Origins.Items[*].{Domain:DomainName,OAC:OriginAccessControlId}}'
+        ```
+
+        A passing distribution returns a non-empty `OAC` value for every S3 origin (domain matches `\.s3[.-][a-z0-9.-]*amazonaws\.com$`). A failing distribution returns an empty or null `OAC` on at least one S3 origin.
       remediation:
         - id: console
           desc: |
@@ -57674,6 +67545,26 @@ queries:
         - A listener that advertises a permissive policy negotiates down to the oldest version a client supports, so a single legacy client is enough to expose the entire data path.
         - The `ELBSecurityPolicy-TLS-1-2-*`, `ELBSecurityPolicy-TLS13-*`, and `ELBSecurityPolicy-FS-1-2-*` families pin the floor at TLS 1.2 and prefer forward-secret cipher suites, keeping recorded traffic safe even if long-lived keys leak in the future.
         - Pinning the policy also documents the operator's intent, so subsequent changes show up in diff review instead of being silently relaxed.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **EC2** console and choose **Load Balancers** in the left navigation.
+        2. Select each Application or Network Load Balancer and open the **Listeners** tab.
+        3. For every HTTPS or TLS listener, check the **Security policy** column.
+        4. Confirm the policy name starts with `ELBSecurityPolicy-TLS-1-2-`, `ELBSecurityPolicy-TLS13-`, or `ELBSecurityPolicy-FS-1-2-`, and is not `ELBSecurityPolicy-TLS-1-2-Ext-2018-06`.
+
+        A passing listener shows a current TLS 1.2-floor policy such as `ELBSecurityPolicy-TLS13-1-2-2021-06`. A failing listener shows `ELBSecurityPolicy-2016-08`, `ELBSecurityPolicy-TLS-1-0-2015-04`, or another policy that allows TLS 1.0 or 1.1.
+
+        ### Audit via CLI
+
+        1. List all HTTPS and TLS listeners and their security policies:
+
+        ```bash
+        aws elbv2 describe-listeners \
+          --query 'Listeners[?Protocol==`HTTPS` || Protocol==`TLS`].{ARN:ListenerArn,Protocol:Protocol,SslPolicy:SslPolicy}'
+        ```
+
+        A passing listener returns an `SslPolicy` that starts with `ELBSecurityPolicy-TLS-1-2-` (excluding `ELBSecurityPolicy-TLS-1-2-Ext-2018-06`), `ELBSecurityPolicy-TLS13-`, or `ELBSecurityPolicy-FS-1-2-`. A failing listener returns any other policy name.
       remediation:
         - id: console
           desc: |
@@ -57835,6 +67726,27 @@ queries:
         - The SigV4 authorization header is also sent on every request, so plaintext access exposes credentials in transit.
         - The `aws:SecureTransport` condition key is the only resource-policy mechanism that can refuse a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
         - Adding the `Deny` statement makes intent auditable in the queue's policy document instead of relying on every caller to opt in to TLS.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon SQS** console and select the queue.
+        2. Choose the **Access policy** tab.
+        3. Review the JSON policy document and look for a statement with `"Effect": "Deny"` that includes a `Condition` block containing `{"Bool": {"aws:SecureTransport": "false"}}`.
+
+        A passing queue shows a `Deny` statement with the `aws:SecureTransport: false` condition. A failing queue has no such statement in its policy, or has no policy at all.
+
+        ### Audit via CLI
+
+        1. Retrieve the queue URL, then fetch the queue's policy attribute:
+
+        ```bash
+        aws sqs get-queue-attributes \
+          --queue-url <queue-url> \
+          --attribute-names Policy \
+          --query 'Attributes.Policy'
+        ```
+
+        A passing queue returns a policy that contains a `Deny` statement whose `Condition.Bool["aws:SecureTransport"]` equals `"false"` or `false`. A failing queue returns a policy with no such statement, or returns `null` indicating no policy is attached.
       remediation:
         - id: console
           desc: |
@@ -58030,6 +67942,26 @@ queries:
         - SigV4 signed requests still include credential headers, so plaintext API calls expose the caller's signing material in transit.
         - The `aws:SecureTransport` condition is the only resource-policy mechanism that refuses a plaintext request; IAM identity policies cannot enforce it on cross-account or anonymous callers.
         - Adding the `Deny` statement also documents intent in the topic policy itself, so downstream reviewers do not need to infer encryption from network controls.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Amazon SNS** console and select the topic.
+        2. Choose the **Access policy** section under **Details**.
+        3. Review the JSON policy document and look for a statement with `"Effect": "Deny"` that includes a `Condition` block containing `{"Bool": {"aws:SecureTransport": "false"}}`.
+
+        A passing topic shows a `Deny` statement with the `aws:SecureTransport: false` condition. A failing topic has no such statement in its policy, or has no resource policy attached.
+
+        ### Audit via CLI
+
+        1. Retrieve the topic's policy attribute:
+
+        ```bash
+        aws sns get-topic-attributes \
+          --topic-arn <topic-arn> \
+          --query 'Attributes.Policy'
+        ```
+
+        A passing topic returns a policy that contains a `Deny` statement whose `Condition.Bool["aws:SecureTransport"]` equals `"false"` or `false`. A failing topic returns a policy with no such `Deny` statement, or returns an empty policy.
       remediation:
         - id: console
           desc: |
@@ -58222,6 +68154,30 @@ queries:
         - WebSocket sessions are long-lived, so a single weak negotiation can keep a vulnerable channel open for the lifetime of the connection.
         - Pinning the floor to `TLS_1_2` is the only resource-level control that forces clients to negotiate modern cipher suites; downstream WAF or CloudFront policies cannot retroactively raise the protocol version.
         - This check fires only when the account actually hosts WebSocket APIs, so the finding is scoped to the surface where WebSocket clients connect.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **API Gateway** console and choose **Custom domain names** in the left navigation.
+        2. For each custom domain that fronts a WebSocket API, select the domain and review **Domain details**.
+        3. Check the **Minimum TLS version** field and confirm it shows **TLS 1.2**.
+
+        A passing custom domain shows **TLS 1.2** as the minimum TLS version. A failing custom domain shows **TLS 1.0** or any value that permits older protocol versions.
+
+        ### Audit via CLI
+
+        1. Confirm that any WebSocket APIs exist, then list all v2 custom domains and their security policies:
+
+        ```bash
+        aws apigatewayv2 get-apis \
+          --query 'Items[?ProtocolType==`WEBSOCKET`].{Id:ApiId,Name:Name}'
+        ```
+
+        ```bash
+        aws apigatewayv2 get-domain-names \
+          --query 'Items[*].{Domain:DomainName,Configs:DomainNameConfigurations[*].SecurityPolicy}'
+        ```
+
+        A passing account either has no WebSocket APIs or returns `TLS_1_2` for every domain name configuration's `SecurityPolicy`. A failing account returns `TLS_1_0` on at least one domain name configuration.
       remediation:
         - id: console
           desc: |
@@ -58336,6 +68292,25 @@ queries:
         - DMS source endpoints also send authentication material (database username and password, or IAM auth tokens) every time the replication instance reconnects.
         - `require` validates that the wire protocol is TLS but does not verify the server certificate; `verify-ca` and `verify-full` are stronger because they catch MITM redirection to a rogue endpoint.
         - The control surface is the endpoint itself. The task and replication instance inherit whatever the endpoints negotiate, so this is where the floor must be set.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Database Migration Service** console and choose **Endpoints**.
+        2. Select each endpoint and open its **General** tab.
+        3. Confirm that **SSL mode** is set to `require`, `verify-ca`, or `verify-full` rather than `none`.
+
+        A passing endpoint shows an SSL mode of `require`, `verify-ca`, or `verify-full`. A failing endpoint shows `none`.
+
+        ### Audit via CLI
+
+        1. List all DMS endpoints and their SSL modes:
+
+        ```bash
+        aws dms describe-endpoints \
+          --query 'Endpoints[*].{ARN:EndpointArn,Id:EndpointIdentifier,Type:EndpointType,SslMode:SslMode}'
+        ```
+
+        A passing endpoint returns an `SslMode` value of `require`, `verify-ca`, or `verify-full`. A failing endpoint returns `SslMode: none`.
       remediation:
         - id: console
           desc: |
@@ -58467,6 +68442,31 @@ queries:
         - With TLS disabled at the listener, sidecar-to-sidecar traffic is plaintext gRPC or HTTP and any compromised workload on the same subnet can read or rewrite it.
         - `STRICT` mode refuses plaintext clients outright; `PERMISSIVE` mode accepts both TLS and plaintext during a migration window. Both are acceptable for this check, but `STRICT` is the recommended end state.
         - The TLS block is also where the certificate source is pinned to ACM, ACM Private CA, or a file-based cert, which keeps key material discoverable for audit.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS App Mesh** console and select the mesh.
+        2. Choose **Virtual nodes** and select each node.
+        3. For each listener, expand the listener details and confirm that **TLS mode** is set to `STRICT` or `PERMISSIVE`.
+
+        A passing virtual node shows every listener with a TLS mode of `STRICT` or `PERMISSIVE`. A failing virtual node shows at least one listener with no TLS configuration or TLS mode set to `DISABLED`.
+
+        ### Audit via CLI
+
+        1. List all meshes, then describe each virtual node's listener TLS configuration:
+
+        ```bash
+        aws appmesh list-meshes --query 'meshes[*].meshName'
+        ```
+
+        ```bash
+        aws appmesh describe-virtual-node \
+          --mesh-name <mesh-name> \
+          --virtual-node-name <node-name> \
+          --query 'virtualNode.spec.listeners[*].tls'
+        ```
+
+        A passing virtual node returns a `tls` object on every listener with `mode` equal to `STRICT` or `PERMISSIVE`. A failing virtual node returns `null` or an empty `tls` object on at least one listener.
       remediation:
         - id: console
           desc: |
@@ -58653,6 +68653,28 @@ queries:
         - TLS 1.0 and TLS 1.1 are deprecated by the IETF and prohibited by PCI DSS and most government baselines because their cipher suites rely on broken integrity primitives.
         - The `tls_config` block on a domain configuration is the only resource-level control that pins the cipher suite floor. Broker-side IAM and Thing policies do not see protocol version.
         - Pinning the policy also documents intent so subsequent infrastructure-as-code changes surface in diff review instead of being silently relaxed.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS IoT** console and choose **Settings** in the left navigation, then select **Domain configurations**.
+        2. Select each domain configuration and review its details.
+        3. Check the **Security policy** field and confirm it shows a value from the `IoTSecurityPolicy_TLS13_*` or `IoTSecurityPolicy_TLS_1_2_*` family.
+
+        A passing domain configuration shows a security policy that begins with `IoTSecurityPolicy_TLS13_` or `IoTSecurityPolicy_TLS_1_2_`. A failing domain configuration shows a policy from the `IoTSecurityPolicy_TLS_1_0_*` family or no explicit TLS policy.
+
+        ### Audit via CLI
+
+        1. List all IoT domain configurations and their TLS security policies:
+
+        ```bash
+        aws iot list-domain-configurations \
+          --query 'domainConfigurations[*].domainConfigurationName' \
+          --output text | xargs -I{} aws iot describe-domain-configuration \
+          --domain-configuration-name {} \
+          --query '{Name:domainConfigurationName,Policy:tlsConfig.securityPolicy}'
+        ```
+
+        A passing domain configuration returns a `Policy` value that starts with `IoTSecurityPolicy_TLS13_` or `IoTSecurityPolicy_TLS_1_2_`. A failing domain configuration returns a `Policy` value from the `IoTSecurityPolicy_TLS_1_0_*` family or returns `null`.
       remediation:
         - id: console
           desc: |
@@ -58764,6 +68786,32 @@ queries:
         - A rotation Lambda without `vpc_config` makes its outbound call from an AWS-managed network range, so the database's security group and network ACL cannot distinguish the legitimate caller from any other AWS workload.
         - Putting the rotation function in the same private subnets as the database lets the database security group accept only that function's security group, which is the same boundary used for regular application traffic.
         - This check focuses on the rotation Lambda's network configuration; the secret's encryption-at-rest and rotation cadence are enforced by separate Secrets Manager checks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **AWS Secrets Manager** console and select a secret with rotation enabled.
+        2. Under **Rotation configuration**, note the **Rotation Lambda ARN**.
+        3. Open the **Lambda** console, navigate to the rotation function, and choose the **Configuration** tab.
+        4. Select **VPC** and confirm that a VPC, at least one subnet, and a security group are configured.
+
+        A passing rotation Lambda shows a VPC, one or more private subnets, and a security group in its VPC configuration. A failing rotation Lambda shows no VPC association.
+
+        ### Audit via CLI
+
+        1. List secrets with rotation enabled and retrieve each rotation Lambda's VPC configuration:
+
+        ```bash
+        aws secretsmanager list-secrets \
+          --query 'SecretList[?RotationEnabled==`true`].{Name:Name,LambdaArn:RotationLambdaARN}'
+        ```
+
+        ```bash
+        aws lambda get-function-configuration \
+          --function-name <rotation-lambda-arn> \
+          --query 'VpcConfig.{SubnetIds:SubnetIds,SecurityGroupIds:SecurityGroupIds}'
+        ```
+
+        A passing rotation Lambda returns a non-empty `SubnetIds` list in its `VpcConfig`. A failing rotation Lambda returns an empty `SubnetIds` array or no `VpcConfig` block.
       remediation:
         - id: console
           desc: |
@@ -58892,6 +68940,28 @@ queries:
         - A customer-managed key lets the operator bind the domain's lifecycle to the same KMS policy and CloudTrail audit trail used for other regulated data.
         - The encryption key is locked at domain creation time and cannot be changed later, so this is the only opportunity to enforce CMK encryption for the domain's lifetime.
         - In-transit protection is not part of this check because CodeArtifact only exposes HTTPS endpoints; the only configurable boundary at rest is the KMS key.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **CodeArtifact** console and choose **Domains**.
+        2. Select each domain and open its **Details** section.
+        3. Confirm that **Encryption key** shows a customer-managed KMS key ARN (the ARN will reference the account's own key rather than an AWS-managed key alias).
+
+        A passing domain shows a customer-managed KMS key ARN under **Encryption key**. A failing domain shows an AWS-managed key or no encryption key configured.
+
+        ### Audit via CLI
+
+        1. List all CodeArtifact domains and inspect their encryption keys:
+
+        ```bash
+        aws codeartifact list-domains \
+          --query 'domains[*].name' \
+          --output text | xargs -I{} aws codeartifact describe-domain \
+          --domain {} \
+          --query '{Name:domain.name,EncryptionKey:domain.encryptionKey}'
+        ```
+
+        A passing domain returns an `EncryptionKey` ARN that points to a customer-managed KMS key (the ARN includes `key/` followed by a UUID, sourced from the same account). A failing domain returns an AWS-managed key alias such as `aws/codeartifact` or returns an empty `EncryptionKey` field.
       remediation:
         - id: console
           desc: |


### PR DESCRIPTION
## Summary

Full standards pass on the Mondoo AWS Security policy (`mondoo-aws-security`, 415 checks) to bring it in line with `content/CLAUDE.md`. Policy version `12.0.0` → `12.0.1`. One file changed: `content/mondoo-aws-security.mql.yaml`.

### Phase 1 — `audit:` sections (all 415 checks)

`content/CLAUDE.md` requires every check's `docs:` block to include `desc:`, `audit:`, and `remediation:`. **No AWS check had an `audit:` section.** All 415 checks now have an `### Audit via Console` and `### Audit via CLI` path with vendor-native verification steps.

### Phase 2 — `desc:` bodies rewritten to the docs template

Every check's `desc:` now follows the `content/CLAUDE.md` `docs:` shape: a lead assertion paragraph, a bulleted **Why this matters** section, and a bulleted **Risk mitigation** section. 238 checks needed work — prose "Why this matters" sections converted to bullets, missing **Risk mitigation** sections added, and hardcoded compliance/standards lists removed from prose.

### Phase 3 — Compliance framework mappings audited

Every `compliance/*` tag on all 415 checks was verified against the authoritative control text in `cnspec-enterprise-policies/frameworks/` — **~4,900 mappings across 12 frameworks**. **908 mappings corrected**: wrong-control mappings repointed to the strictly-fitting control, mappings with no fitting control set to `false`, and previously-`false` checks given a verified control where one genuinely fits. Every recommended control UID was validated to exist in its framework file before being written.

Recurring corrections:

- CMK-encryption checks were mapped to key-management controls — repointed to data-at-rest protection controls.
- Logging-enablement checks were conflated with runtime network-monitoring controls — separated into log-generation controls.
- Least-privilege checks were mapped to account-management / separation-of-duties controls — repointed to least-privilege controls.
- MFA checks were mapped to password-policy controls — repointed to strong-authentication controls.
- Threat-detection services (GuardDuty, Inspector) were mapped to logging controls — repointed to detection / system-monitoring controls.

## Testing

- `cnspec policy lint content/mondoo-aws-security.mql.yaml` → `valid policy bundle(s)`.
- `python3 content/validation/validate_remediation_commands.py aws` → `765 passed, 0 failed`.
- All 415 checks confirmed to carry `desc:`, `audit:`, and `remediation:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
