### PR TITLE
:memo: Bring the Google Workspace security policy up to authoring standards

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-google-workspace-security
     name: Mondoo Google Workspace Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -59,7 +59,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -68,25 +68,45 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: googleworkspace.users.all ( isEnforcedIn2Sv == true )
     docs:
       desc: |
-        This check verifies that 2-step verification (multi-factor authentication) is enforced for all Google Workspace users in your organization.
+        This check ensures that 2-step verification is configured to be enforced for every user in the Google Workspace organization. Workspace does not require a second factor by default, so an account protected only by a password can be taken over with stolen credentials.
 
         **Why this matters**
 
-        Multi-factor authentication is critical for protecting cloud-based productivity services that contain sensitive organizational data:
+        - **Account takeover prevention:** Even if passwords are stolen through phishing or breaches, attackers cannot access accounts without the second factor.
+        - **Credential stuffing defense:** Reused passwords from other compromised services cannot be used to sign in to Google Workspace.
+        - **Lateral movement prevention:** Compromised accounts cannot be used to reach shared documents, email, or connected services.
+        - **Compliance alignment:** SOC 2, ISO 27001, HIPAA, and other frameworks require or recommend multi-factor authentication for all users.
 
-          - **Account takeover prevention**: Even if passwords are stolen through phishing or breaches, attackers cannot access accounts without the second factor.
-          - **Credential stuffing defense**: Reused passwords from other compromised services cannot be used to access Google Workspace.
-          - **Compliance requirements**: SOC 2, ISO 27001, HIPAA, and other frameworks require or recommend MFA for all users.
-          - **Lateral movement prevention**: Compromised accounts cannot be used to access shared documents, email, or connected services.
-          - **Business email compromise**: BEC attacks often begin with account takeover, which MFA helps prevent.
+        **Risk mitigation**
 
-        Enforce 2-step verification at the organizational level to ensure consistent protection across all user accounts.
+        - **Business email compromise defense:** BEC attacks typically begin with account takeover, which a second factor helps prevent.
+        - **Consistent organization-wide protection:** Enforcing 2-step verification at the organizational level removes per-user gaps in authentication strength.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Security** > **Authentication** > **2-step verification**.
+        3. Confirm that **Allow users to turn on 2-step verification** is set to **On**.
+        4. Under **Enforcement**, confirm that enforcement is turned on for all users and not limited to a subset of organizational units.
+
+        A passing result shows enforcement turned on for the whole organization; a failing result shows enforcement off or applied to only some organizational units.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer"
+        ```
+
+        A passing response shows `isEnforcedIn2Sv` set to `true` for every user; a failing response shows one or more users with `isEnforcedIn2Sv` set to `false`.
       remediation:
         - id: console
           desc: |
@@ -110,34 +130,54 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).length <= 4
     docs:
       desc: |
-        This check verifies that your Google Workspace organization has no more than 4 users with super admin permissions.
+        This check ensures that the Google Workspace organization is configured to keep no more than four users with super admin permissions. Super admin accounts have unrestricted access to all organizational data and settings, so each one is a high-value target.
 
         **Why this matters**
 
-        Super admin accounts have unrestricted access to all organizational data and settings, making them high-value targets:
+        - **Attack surface expansion:** Each super admin account adds another potential compromise vector for attackers.
+        - **Privilege accumulation:** Organizations often gather super admins over time without removing former ones.
+        - **Audit clarity:** A small set of super admins makes it easier to track who made security-sensitive changes.
+        - **Compliance alignment:** Security frameworks recommend minimizing the number of highly privileged accounts.
 
-          - **Attack surface expansion**: Each super admin account increases the number of potential compromise vectors for attackers.
-          - **Privilege accumulation**: Organizations often accumulate super admins over time without removing former ones.
-          - **Audit complexity**: Too many super admins makes it difficult to track who made security-sensitive changes.
-          - **Compliance concerns**: Security frameworks recommend minimizing the number of highly privileged accounts.
-          - **Blast radius**: A compromised super admin can access all organizational data, users, and settings.
+        **Risk mitigation**
 
-        Limit super admin accounts to essential personnel and use delegated admin roles for users who need limited administrative access.
+        - **Reduced blast radius:** Fewer super admins limits the data, users, and settings exposed if one account is compromised.
+        - **Least privilege enforcement:** Delegated admin roles cover users who need limited administrative access without granting full control.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users**.
+        3. Add the filter **Admin role** and select **Super Admin**.
+        4. Count the users returned by the filter.
+
+        A passing result shows four or fewer super admin accounts; a failing result shows five or more.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Reports API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin"
+        ```
+
+        A passing response shows four or fewer users with `accounts:is_super_admin` set to `true`; a failing response shows five or more.
       remediation: |
         Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Admin roles for businesses](https://support.google.com/a/topic/9832445?hl=en&ref_topic=2785005) in the Google Workspace documentation.
     refs:
@@ -148,34 +188,54 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).length > 1
     docs:
       desc: |
-        This check verifies that your Google Workspace organization has more than one user with super admin permissions.
+        This check ensures that the Google Workspace organization is configured to keep more than one user with super admin permissions. A single super admin creates a single point of failure for all administrative access.
 
         **Why this matters**
 
-        Having only one super admin creates operational and security risks for your organization:
+        - **Single point of failure:** If the only super admin is unavailable, the organization cannot perform critical administrative tasks.
+        - **Account lockout risk:** If the single admin account is compromised or locked, there is no way to regain administrative access.
+        - **Emergency response:** Security incidents may require immediate administrative action that is impossible with an unavailable admin.
+        - **Business continuity:** Extended admin unavailability can disrupt onboarding, offboarding, and security operations.
 
-          - **Single point of failure**: If the sole super admin is unavailable, the organization cannot perform critical administrative tasks.
-          - **Account lockout risk**: If the single admin account is compromised or locked, there is no way to regain administrative access.
-          - **Emergency response**: Security incidents may require immediate administrative action that is impossible with an unavailable admin.
-          - **Business continuity**: Extended admin unavailability can disrupt onboarding, offboarding, and security operations.
-          - **Recovery complexity**: Google's account recovery process for organizations with a single locked admin is complex and time-consuming.
+        **Risk mitigation**
 
-        Maintain at least 2 super admin accounts held by trusted individuals to ensure administrative access is always available.
+        - **Resilient recovery:** Maintaining at least two trusted super admins avoids Google's lengthy recovery process for a sole locked admin.
+        - **Operational continuity:** A second admin keeps administrative access available when the primary admin is unreachable.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users**.
+        3. Add the filter **Admin role** and select **Super Admin**.
+        4. Count the users returned by the filter.
+
+        A passing result shows two or more super admin accounts; a failing result shows one or zero.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Reports API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin"
+        ```
+
+        A passing response shows two or more users with `accounts:is_super_admin` set to `true`; a failing response shows one or zero.
       remediation: |
         Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Admin roles for businesses](https://support.google.com/a/topic/9832445?hl=en&ref_topic=2785005) in the Google Workspace documentation.
     refs:
@@ -186,34 +246,53 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: googleworkspace.report.users.all(security["isLessSecureAppsAccessAllowed"] == false)
     docs:
       desc: |
-        This check verifies that users are not allowed to grant access to "less secure apps" that use legacy authentication methods without OAuth.
+        This check ensures that the Google Workspace organization is configured to block users from granting access to less secure apps that use legacy authentication without OAuth. Less secure apps bypass modern authentication controls and create a significant vulnerability.
 
         **Why this matters**
 
-        Less secure apps bypass modern authentication security controls, creating significant vulnerability:
+        - **No OAuth protection:** These apps require storing raw passwords instead of using secure token-based authentication.
+        - **MFA bypass:** Less secure apps often cannot support a second factor, negating 2-step verification enforcement.
+        - **Credential exposure:** Passwords stored in less secure apps can be extracted if those apps or devices are compromised.
+        - **Limited visibility:** Legacy authentication methods provide less logging and monitoring capability.
 
-          - **No OAuth protection**: These apps require storing raw passwords instead of using secure token-based authentication.
-          - **MFA bypass**: Less secure apps often cannot support multi-factor authentication, negating your 2FA enforcement.
-          - **Credential exposure**: Stored passwords in less secure apps can be extracted if those apps or devices are compromised.
-          - **Limited visibility**: Legacy authentication methods provide less logging and monitoring capability.
-          - **Attack vector**: Threat actors specifically target less secure app access as a way to bypass MFA requirements.
+        **Risk mitigation**
 
-        Block less secure app access organization-wide and migrate users to applications that support modern OAuth authentication.
+        - **Closed attack vector:** Blocking less secure app access removes a path threat actors use specifically to bypass MFA requirements.
+        - **Modern authentication adoption:** Disabling the setting drives users toward applications that support OAuth.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Security** > **Access and data control** > **Less secure apps**.
+        3. Confirm that **Disable access to less secure apps (Recommended)** is selected for all users.
+
+        A passing result shows less secure app access disabled for the whole organization; a failing result shows it allowed for some or all users.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Reports API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_less_secure_apps_access_allowed"
+        ```
+
+        A passing response shows `accounts:is_less_secure_apps_access_allowed` set to `false` for every user; a failing response shows one or more users with the value set to `true`.
       remediation: |
         Make sure to block the usage of less secure apps in Google Workspace. To learn how, read [Control access to less secure apps](https://support.google.com/a/answer/6260879?hl=en) in the Google Workspace documentation.
     refs:
@@ -226,7 +305,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -235,25 +314,45 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).all(security["numSecurityKeys"] >= 1)
     docs:
       desc: |
-        This check verifies that all super admin accounts have at least one hardware security key registered for 2-step verification.
+        This check ensures that every super admin account is configured with at least one hardware security key registered for 2-step verification. Super admins control the entire organization and need the strongest available authentication.
 
         **Why this matters**
 
-        Super admin accounts have complete control over the organization and require the strongest possible authentication protection:
+        - **Phishing immunity:** Hardware security keys are resistant to phishing because they verify the legitimate site origin.
+        - **SIM swapping protection:** Unlike SMS, security keys cannot be compromised through carrier social engineering.
+        - **Strong cryptographic verification:** Modern keys use FIDO2 and WebAuthn protocols that prevent credential interception.
+        - **Compliance alignment:** Many security frameworks recommend hardware tokens for privileged account protection.
 
-          - **Phishing immunity**: Hardware security keys are resistant to phishing attacks because they verify the legitimate site origin.
-          - **SIM swapping protection**: Unlike SMS, security keys cannot be compromised through carrier social engineering.
-          - **FIDO2/WebAuthn standard**: Modern security keys use cryptographic protocols that prevent credential interception.
-          - **Compliance requirements**: Many security frameworks recommend hardware tokens for privileged account protection.
-          - **High-value target**: Super admins can access all organizational data, making them priority targets for sophisticated attackers.
+        **Risk mitigation**
 
-        Require all super admin accounts to use FIDO2-compliant hardware security keys (such as YubiKey or Google Titan) for 2-step verification.
+        - **Hardened high-value targets:** Requiring keys for super admins removes the weakest second-factor methods from the accounts attackers prioritize.
+        - **Standardized strong factor:** FIDO2-compliant keys such as YubiKey or Google Titan provide consistent protection across all super admin accounts.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users** and filter by the **Super Admin** role.
+        3. Open each super admin and review the **Security** section.
+        4. Confirm that at least one security key is registered under the user's 2-step verification methods.
+
+        A passing result shows every super admin with a registered security key; a failing result shows a super admin with no security key.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Reports API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin,accounts:num_security_keys"
+        ```
+
+        A passing response shows every user with `accounts:is_super_admin` set to `true` also reporting `accounts:num_security_keys` of one or more; a failing response shows a super admin with `accounts:num_security_keys` of zero.
       remediation: |
         Make sure that all high-value targets such as Super Admins have some form of two-factor authentication enabled. Also make sure that they are using security keys for the 2-Step verification process. To learn about setting up security keys for the 2-Step verification process, read [Use a security key for 2-Step Verification](https://support.google.com/accounts/answer/6103523?hl=En).
     refs:
@@ -266,7 +365,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -275,28 +374,48 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-5
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       googleworkspace.connectedApps.none(
         scopes.any(_ == "https://mail.google.com/") || scopes.any(_ == "https://www.googleapis.com/auth/drive")
       )
     docs:
       desc: |
-        This check ensures that no third-party connected applications have been granted full access to Gmail or Google Drive. Full access scopes like `https://mail.google.com/` and `https://www.googleapis.com/auth/drive` allow applications to read, write, and delete all emails or files.
+        This check ensures that no third-party connected application is configured with full access to Gmail or Google Drive. Scopes such as `https://mail.google.com/` and `https://www.googleapis.com/auth/drive` allow an application to read, write, and delete all emails or files.
 
         **Why this matters**
 
-        Third-party applications with full Gmail or Drive access pose significant data security risks:
+        - **Data exfiltration:** Applications with full access can read and export all email messages or files from users' accounts.
+        - **Email manipulation:** Full Gmail access lets applications send, delete, or modify messages on behalf of users.
+        - **Untrusted developers:** Connected apps may be built by untrusted parties and used for data harvesting.
+        - **Persistent access:** OAuth tokens keep access alive even after a user changes their password.
 
-          - **Data exfiltration**: Applications with full access can read and export all email messages or files from users' accounts.
-          - **Email manipulation**: Full Gmail access allows applications to send, delete, or modify emails on behalf of users.
-          - **Unauthorized access**: Connected apps may be developed by untrusted parties and could be used for data harvesting.
-          - **Persistent access**: OAuth tokens provide ongoing access even after a user changes their password.
-          - **Supply chain risk**: Compromised third-party applications can be used as a vector to access organizational data.
+        **Risk mitigation**
 
-        Review all connected applications and revoke access for any that have overly broad scopes. Use the principle of least privilege when granting application access.
+        - **Supply chain containment:** Revoking broad scopes limits how a compromised third-party application can reach organizational data.
+        - **Least privilege enforcement:** Granting only the scopes an application needs reduces the data exposed by any single integration.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Security** > **Access and data control** > **API controls**.
+        3. Open **Manage Third-Party App Access** and review connected apps and their granted scopes.
+        4. Look for any app with the Gmail scope `https://mail.google.com/` or the Drive scope `https://www.googleapis.com/auth/drive`.
+
+        A passing result shows no connected app with full Gmail or Drive access; a failing result shows at least one app holding those scopes.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users/{userKey}/tokens"
+        ```
+
+        A passing response shows no token whose `scopes` array contains `https://mail.google.com/` or `https://www.googleapis.com/auth/drive`; a failing response shows a token granting either scope.
       remediation:
         - id: console
           desc: |
@@ -319,35 +438,54 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
-      compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-j
-      compliance/nist-csf-1: nist-csf-1-pr-ac-7
-      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-16
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-6
+      compliance/nist-csf-2: nist-csf-2-pr-aa-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-9
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: false
     mql: |
       googleworkspace.domains.all(verified == true)
     docs:
       desc: |
-        This check ensures that all domains registered in your Google Workspace organization are verified. Unverified domains may indicate misconfiguration or potential domain spoofing risks.
+        This check ensures that every domain registered in the Google Workspace organization is verified. An unverified domain indicates that DNS ownership was never confirmed, which points to misconfiguration or domain spoofing risk.
 
         **Why this matters**
 
-        Unverified domains in your Google Workspace environment create trust and security issues:
+        - **Domain spoofing:** Unverified domains could be used to send email that appears to come from the organization.
+        - **Incomplete setup:** An unverified domain means DNS verification was not completed, so email routing and other services may not be configured correctly.
+        - **Email deliverability:** SPF, DKIM, and DMARC require verified domain ownership to function correctly.
+        - **Organizational trust:** Users and external parties may receive mail from unverified domains, creating confusion about message authenticity.
 
-          - **Domain spoofing**: Unverified domains could be used to send emails that appear to come from your organization.
-          - **Incomplete setup**: Unverified domains indicate that DNS verification was not completed, meaning email routing and other services may not be properly configured.
-          - **Email deliverability**: Services like SPF, DKIM, and DMARC require verified domain ownership to function correctly.
-          - **Organizational trust**: Users and external parties may receive emails from unverified domains, creating confusion about message authenticity.
-          - **Compliance gaps**: Many security frameworks require organizations to verify and control all domains used for business communication.
+        **Risk mitigation**
 
-        Complete domain verification for all registered domains, or remove domains that are no longer needed.
+        - **Compliance alignment:** Verifying all business domains satisfies frameworks that require organizations to control every domain used for communication.
+        - **Reduced unused surface:** Removing domains that are no longer needed eliminates unverified entries that serve no purpose.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Account** > **Domains** > **Manage domains**.
+        3. Review the status column for every listed domain.
+
+        A passing result shows all domains marked as verified; a failing result shows one or more domains marked as unverified or pending verification.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/customer/my_customer/domains"
+        ```
+
+        A passing response shows `verified` set to `true` for every domain; a failing response shows one or more domains with `verified` set to `false`.
       remediation:
         - id: console
           desc: |
@@ -371,7 +509,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -379,10 +517,10 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-22
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       googleworkspace.calendars
         .all(
@@ -390,19 +528,39 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that no user calendars have public sharing enabled. When a calendar ACL rule has a scope type of "default" with a role other than "none," the calendar is accessible to anyone on the internet.
+        This check ensures that no user calendar is configured for public sharing. A calendar ACL rule with a scope type of `default` and a role other than `none` makes the calendar accessible to anyone on the internet.
 
         **Why this matters**
 
-        Publicly shared calendars expose sensitive organizational information:
+        - **Meeting intelligence:** Public calendars reveal participants, topics, and schedules that can be used for social engineering.
+        - **Organizational exposure:** Calendar data exposes reporting structures, team composition, and internal processes.
+        - **Travel schedules:** Executive calendars may reveal travel plans, creating physical security risks.
+        - **Business intelligence leakage:** Competitors can monitor public calendars to learn about upcoming projects, partnerships, and strategic initiatives.
 
-          - **Meeting intelligence**: Public calendars reveal meeting participants, topics, and schedules that can be used for social engineering.
-          - **Organizational structure**: Calendar data exposes reporting structures, team compositions, and internal processes.
-          - **Travel schedules**: Executive calendars may reveal travel plans, creating physical security risks.
-          - **Business intelligence**: Competitors can monitor public calendars to learn about upcoming projects, partnerships, and strategic initiatives.
-          - **Privacy violations**: Employee schedules, personal appointments, and medical appointments may be inadvertently exposed.
+        **Risk mitigation**
 
-        Ensure all calendars are shared only with specific users or groups within the organization, not publicly.
+        - **Privacy protection:** Restricting sharing keeps employee schedules and personal appointments from being inadvertently exposed.
+        - **Scoped access:** Sharing calendars only with specific internal users or groups removes anonymous public visibility.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Apps** > **Google Workspace** > **Calendar**.
+        3. Open **Sharing settings** and review **External sharing options for primary calendars**.
+        4. Confirm the setting is **Only free/busy information** or a more restrictive option rather than full public sharing.
+
+        A passing result shows external sharing limited to free/busy or disabled; a failing result shows calendar details shared with everyone.
+
+        ### Audit via API
+
+        Per-calendar access control lists are checked with the Calendar API. Query a calendar's ACL and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://www.googleapis.com/calendar/v3/calendars/{calendarId}/acl"
+        ```
+
+        A passing response shows no ACL rule with `scope.type` of `default` and a `role` other than `none`; a failing response shows such a rule, which grants public access.
       remediation:
         - id: console
           desc: |
@@ -430,34 +588,53 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ip-3
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: googleworkspace.users.none(ipWhitelisted == true)
     docs:
       desc: |
-        This check verifies that no users in your Google Workspace organization have the deprecated IP whitelisting setting enabled.
+        This check ensures that no user in the Google Workspace organization has the deprecated IP whitelisting setting enabled. The `ipWhitelisted` flag is a legacy setting that exempts users from IP-based access controls and weakens the organization's security posture.
 
         **Why this matters**
 
-        The `ipWhitelisted` flag is a legacy setting that exempts users from IP-based access controls, weakening your organization's security posture:
+        - **Security bypass:** IP-whitelisted users can skip network-based access restrictions such as context-aware access policies.
+        - **Deprecated control:** Google has deprecated this setting in favor of context-aware access, which provides more granular and secure controls.
+        - **Inconsistent enforcement:** Exempted users are not subject to the same access policies as everyone else, creating gaps in security coverage.
+        - **Audit blind spots:** Exempted users may access resources from untrusted networks without triggering security alerts.
 
-        - **Security bypass**: IP-whitelisted users can bypass network-based access restrictions such as context-aware access policies.
-        - **Deprecated control**: Google has deprecated this setting in favor of context-aware access, which provides more granular and secure controls.
-        - **Inconsistent enforcement**: Users with IP whitelisting enabled are not subject to the same access policies as other users, creating gaps in security coverage.
-        - **Audit blind spots**: Exempted users may access resources from untrusted networks without triggering security alerts.
-        - **Compliance risk**: Inconsistent access controls can violate security frameworks that require uniform policy enforcement.
+        **Risk mitigation**
 
-        Migrate any IP-whitelisted users to context-aware access policies and disable the legacy IP whitelisting setting.
+        - **Compliance alignment:** Removing the exemption satisfies frameworks that require uniform access policy enforcement.
+        - **Modern access controls:** Migrating affected users to context-aware access policies restores consistent, granular enforcement.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users**.
+        3. Open each user and review the **Security** section for the IP whitelisting setting.
+
+        A passing result shows no user with IP whitelisting enabled; a failing result shows one or more users with the legacy setting turned on.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer"
+        ```
+
+        A passing response shows `ipWhitelisted` set to `false` for every user; a failing response shows one or more users with `ipWhitelisted` set to `true`.
       remediation:
         - id: console
           desc: |
@@ -480,34 +657,54 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: googleworkspace.users.where(isAdmin == true).none(isGuestUser == true)
     docs:
       desc: |
-        This check verifies that no guest user accounts have been granted administrative privileges in your Google Workspace organization.
+        This check ensures that no guest user account is granted administrative privileges in the Google Workspace organization. Guest accounts are not subject to the same identity vetting and lifecycle management as full organizational accounts, so granting them admin rights is a significant risk.
 
         **Why this matters**
 
-        Guest accounts with administrative privileges represent a significant security risk:
+        - **Reduced accountability:** Guest accounts may not follow the same identity verification and lifecycle management as regular organizational accounts.
+        - **Weaker authentication:** Guest users may not be subject to the same authentication policies, MFA requirements, or conditional access controls as full members.
+        - **Audit trail gaps:** Actions performed by guest admin accounts can be harder to attribute to a specific individual during incident investigations.
+        - **Privilege escalation risk:** Guest accounts with admin rights can modify security settings, access sensitive data, and manage other user accounts.
 
-        - **Reduced accountability**: Guest accounts may not be subject to the same identity verification and lifecycle management as regular organizational accounts.
-        - **Weaker authentication**: Guest users may not be subject to the same authentication policies, MFA requirements, or conditional access controls as full organizational members.
-        - **Audit trail gaps**: Actions performed by guest admin accounts may be harder to attribute to specific individuals during incident investigations.
-        - **Privilege escalation risk**: Guest accounts with admin rights can modify security settings, access sensitive data, and manage other user accounts.
-        - **Compliance violations**: Security frameworks require that privileged access be granted only to identified, vetted individuals within the organization.
+        **Risk mitigation**
 
-        Remove administrative privileges from any guest accounts and ensure all administrators use full organizational accounts.
+        - **Compliance alignment:** Limiting admin rights to vetted organizational members satisfies frameworks that restrict privileged access to identified individuals.
+        - **Controlled administration:** Requiring administrators to use full organizational accounts brings their access under standard authentication and lifecycle controls.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users**.
+        3. Filter for users with admin roles and review each one's account details.
+        4. Confirm that none of the admin users are guest accounts.
+
+        A passing result shows every admin account is a full organizational account; a failing result shows a guest account with an admin role.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer"
+        ```
+
+        A passing response shows that no user with `isAdmin` set to `true` is a guest account; a failing response shows a guest account that also has `isAdmin` set to `true`.
       remediation:
         - id: console
           desc: |
@@ -530,7 +727,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -539,25 +736,44 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: googleworkspace.users.where(isAdmin == true).all(isEnrolledIn2Sv == true)
     docs:
       desc: |
-        This check verifies that all administrator accounts have completed 2-step verification (2SV) enrollment, not just that enforcement is turned on at the organizational level.
+        This check ensures that every administrator account has completed 2-step verification enrollment, not merely that enforcement is turned on at the organizational level. Enforcement sets the policy, but an admin in a grace period or mid-setup may still be protected only by a password.
 
         **Why this matters**
 
-        There is an important distinction between 2SV being enforced and 2SV being enrolled. Enforcement means the policy requires 2SV, but administrators may have a grace period or may not have completed setup yet:
+        - **Grace period exposure:** When 2-step verification enforcement is first enabled, admins often get a grace period to enroll, during which their accounts rely on passwords alone.
+        - **Incomplete rollout:** Newly created admin accounts may not have completed enrollment even when enforcement is active.
+        - **High-value targets:** Admin accounts are priority targets, so any window without an active second factor is a window of vulnerability.
+        - **Compliance gap:** Security frameworks require MFA to be actively in use, not just configured as a policy.
 
-        - **Grace period exposure**: When 2SV enforcement is first enabled, admins are often given a grace period to enroll, during which their accounts remain protected only by passwords.
-        - **Incomplete rollout**: Newly created admin accounts may not yet have completed 2SV enrollment even when enforcement is active.
-        - **High-value targets**: Admin accounts are priority targets for attackers, and any window without 2SV is a window of vulnerability.
-        - **Compliance gap**: Security frameworks require MFA to be actively in use, not just configured as a policy.
-        - **Account takeover risk**: An admin account without active 2SV enrollment can be compromised through password-only attacks.
+        **Risk mitigation**
 
-        Verify that all admin accounts have fully completed 2SV enrollment and are actively using a second factor for authentication.
+        - **Closed takeover window:** Confirming completed enrollment removes the exposure that lets an admin account fall to a password-only attack.
+        - **Verified second factor:** Checking enrollment status, not just policy, ensures every admin is actively using a second factor.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users** and filter for users with admin roles.
+        3. Open each admin's **Security** settings and review the 2-step verification enrollment status.
+
+        A passing result shows every admin enrolled in 2-step verification; a failing result shows an admin that has not completed enrollment.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer"
+        ```
+
+        A passing response shows every user with `isAdmin` set to `true` also reporting `isEnrolledIn2Sv` set to `true`; a failing response shows an admin user with `isEnrolledIn2Sv` set to `false`.
       remediation:
         - id: console
           desc: |
@@ -583,34 +799,53 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-j
-      compliance/nist-csf-1: nist-csf-1-pr-ac-7
-      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-5
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: googleworkspace.users.where(isAdmin == true).none(changePasswordAtNextLogin == true)
     docs:
       desc: |
-        This check verifies that no administrator accounts have the "change password at next login" flag set, which indicates a pending forced password change that has not yet been completed.
+        This check ensures that no administrator account has the change password at next login flag set, which indicates a forced password change that has not yet been completed. A pending reset leaves the account in an unresolved security state.
 
         **Why this matters**
 
-        Admin accounts with pending password resets represent an unresolved security state:
+        - **Compromised credential exposure:** A forced password change is often triggered because the current password may be compromised, and the account stays at risk until the change is completed.
+        - **Stale resets:** Reset flags that persist for a long time indicate that the administrator is not actively using or monitoring the account.
+        - **Account takeover window:** An attacker who knows the current password can sign in before the legitimate admin completes the change.
+        - **Incident response gap:** Admin accounts with pending resets may not be immediately usable for emergency response actions.
 
-        - **Compromised credential exposure**: The forced password change was likely triggered because the current password may be compromised, and until the change is completed, the account remains at risk.
-        - **Stale resets**: Password reset flags that persist for extended periods indicate that administrators are not actively using or monitoring their accounts.
-        - **Account takeover window**: An attacker who knows the current password can sign in before the legitimate admin completes the password change.
-        - **Incident response gap**: During a security incident, admin accounts with pending resets may not be immediately usable for emergency response actions.
-        - **Compliance concerns**: Security frameworks require that credential changes be completed promptly when required.
+        **Risk mitigation**
 
-        Ensure all admin password resets are completed promptly. If an admin account has had a pending reset for an extended period, investigate whether the account is still needed.
+        - **Prompt remediation:** Completing pending resets quickly satisfies frameworks that require credential changes to be finished without delay.
+        - **Account hygiene:** Investigating long-pending resets surfaces stale or abandoned admin accounts that should be removed or suspended.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
+        2. Go to **Directory** > **Users** and filter for users with admin roles.
+        3. Open each admin account and check whether a password change is pending at next sign-in.
+
+        A passing result shows no admin with a pending forced password change; a failing result shows an admin account flagged to change its password at next login.
+
+        ### Audit via API
+
+        Query the Google Admin SDK Directory API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+          "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer"
+        ```
+
+        A passing response shows every user with `isAdmin` set to `true` reporting `changePasswordAtNextLogin` set to `false`; a failing response shows an admin user with `changePasswordAtNextLogin` set to `true`.
       remediation:
         - id: console
           desc: |

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -173,8 +173,9 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin"
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin"
         ```
 
         A passing response shows four or fewer users with `accounts:is_super_admin` set to `true`; a failing response shows five or more.
@@ -231,8 +232,9 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin"
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin"
         ```
 
         A passing response shows two or more users with `accounts:is_super_admin` set to `true`; a failing response shows one or zero.
@@ -288,8 +290,9 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_less_secure_apps_access_allowed"
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_less_secure_apps_access_allowed"
         ```
 
         A passing response shows `accounts:is_less_secure_apps_access_allowed` set to `false` for every user; a failing response shows one or more users with the value set to `true`.
@@ -348,8 +351,9 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/2026-05-15?parameters=accounts:is_super_admin,accounts:num_security_keys"
+          "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin,accounts:num_security_keys"
         ```
 
         A passing response shows every user with `accounts:is_super_admin` set to `true` also reporting `accounts:num_security_keys` of one or more; a failing response shows a super admin with `accounts:num_security_keys` of zero.


### PR DESCRIPTION
Brings `mondoo-google-workspace-security` (12 checks) up to the `content/CLAUDE.md` authoring standards.

## Changes

- **Audit sections** — added an `audit:` block to all 12 checks, each with `### Audit via Admin Console` and `### Audit via API` (curl against the Google Admin SDK / Reports API) verification paths. Previously no check had an audit section.
- **Descriptions** — rewrote all 12 `desc:` bodies to the docs template: lead assertion paragraph, bulleted **Why this matters**, bulleted **Risk mitigation**.
- **Compliance tags** — verified every `compliance/*` tag on all 12 checks against the authoritative framework control text across all 12 active frameworks; remapped where a better control fits and set to `false` where no control matches (the `domains-verified` check has no genuine fit in HIPAA, PCI DSS, CSA CCM, or VDA ISA; the `minimum-super-admins` redundancy check has no fit in NIST 800-171).
- Version bump 1.2.0 → 1.2.1.

`cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)