### PR TITLE
:memo: Bring the Okta security policy up to authoring standards

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -168,6 +168,7 @@ cosmosdb
 countmax
 createinstance
 crio
+Crowdsourced
 crowdstrike
 cryptojacking
 cryptokey
@@ -693,6 +694,7 @@ ssldir
 ssllabs
 ssltest
 ssoadmin
+SSWS
 stalepath
 startswith
 stdio
@@ -804,6 +806,7 @@ winnuke
 WITHECDSA
 WITHRSA
 wlans
+wordlist
 workdir
 workspacesweb
 wpa

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.0
+    version: 2.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -95,18 +95,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     props:
       - uid: mondooOktaSecurityMaxOktaSuperAdmins
         title: Maximum number of Okta Super Admins
@@ -118,18 +118,38 @@ queries:
           mondoo.com/filter-icon: okta
     docs:
       desc: |
-        Admin roles allow you to control user access to a range of Okta functions. You can assign more than one role to an individual admin if their job requires them to perform actions that span multiple roles. This role can create other admins, assign or remove permissions, and perform all other admin activities. The super admin has the highest permissions of all admin roles.
+        This check ensures that the number of super admins in your Okta org is kept to the minimum required for operations. The super admin role holds the highest permissions of any admin role, so a large pool of super admins greatly widens the blast radius of a compromised account.
 
-        ## Okta Recommends
+        **Why this matters**
 
-        Limit the number of super admins only to users who require super admin access. An org shouldn't have more than:
+        - **Least privilege:** Restricting super admin assignments keeps broad control of the org in the hands of only those who genuinely need it.
+        - **Reduced attack surface:** Fewer super admin accounts means fewer high-value targets for attackers to phish or take over.
+        - **Clear accountability:** A small, well-defined set of super admins makes it easier to audit who can change critical org settings.
+        - **Containment:** Most administrative tasks can be performed with scoped roles, leaving super admin access reserved for exceptional needs.
 
-        - 50 percent of admins have super admin privileges
-        - 15 super admins
+        **Risk mitigation**
 
-        All other admins should only have the permissions as required for their role.
+        - **Limit super admin assignments:** Grant super admin only to users who require it, and assign all other admins the narrowest role their job demands.
+        - **Review regularly:** Run a recurring assessment of all admin privileges so unneeded super admin grants are revoked promptly.
+      audit: |
+        ### Audit via Admin Console
 
-        Plan for a recurring assessment of all admin privileges to ensure that these best practices are met.
+        1. In the Admin Console, go to **Security > Administrators**.
+        2. Under **Admin Roles**, apply the **Super** filter to display only super administrators.
+        3. Count the users shown and compare against your organization's approved limit.
+
+        A passing result shows a small number of super administrators within the approved threshold; a failing result shows more super admins than allowed or super admins who no longer need that level of access.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/users"
+        ```
+
+        For each returned user, fetch their assigned roles with `GET /api/v1/users/{id}/roles` and count entries where `type` is `SUPER_ADMIN`. A passing response keeps that count within the approved limit; a failing response returns more `SUPER_ADMIN` assignments than permitted.
       remediation:
         - id: console
           desc: |
@@ -159,18 +179,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-terraform-hcl
         tags:
@@ -190,23 +210,37 @@ queries:
           mondoo.com/filter-icon: okta
     docs:
       desc: |
-        Configure network blocklisting to deny access from known malicious IP addresses or locations from your Okta org.
+        This check ensures that your Okta org has at least one network zone configured as a blocklist with defined IP gateways. Okta evaluates blocklisted addresses before any policy runs, so requests from those addresses are rejected before they reach an authentication flow.
 
-        Admins can block access to their Okta org to IP addresses coming from network zones, IP zones, and dynamic zones. Network zones contain a list of IP addresses, and dynamic zones contain a list of locations, ASNs, or IP types. Okta doesn't allow blocklisted IP addresses to access any of your org's URLs. Okta blocks these requests before any type of policy evaluation occurs.
+        **Why this matters**
 
-        ### Okta recommends
+        - **Early enforcement:** Blocklisted IP addresses are denied before policy evaluation, stopping malicious traffic at the edge of your org.
+        - **Reduced exposure:** Known untrusted networks, locations, and proxy servers lose the ability to reach any of your org's URLs.
+        - **Defense in depth:** Network blocklisting complements MFA and sign-on policies by removing hostile sources from the picture entirely.
 
-        Block any known untrusted IP addresses, locations, or proxy servers to limit access to your org. If your org uses IP Trust for network zones, Okta also recommends blocking any IP addresses that are identified as a Tor anonymizer proxy. Only add IP addresses or locations that aren't associated with legitimate user activity.
+        **Risk mitigation**
 
-        ### Security impact
+        - **Maintain a blocklist zone:** Configure a network zone with `usage` set to blocklist and populate it with known malicious IP ranges.
+        - **Block anonymizing infrastructure:** Add Tor anonymizer proxies and other untrusted locations so attackers cannot hide their origin.
+      audit: |
+        ### Audit via Admin Console
 
-        Moderate
+        1. In the Admin Console, go to **Security > Networks**.
+        2. Review the list of network zones and identify any zone whose usage is set to block access.
+        3. Open each blocklist zone and confirm it contains defined IP gateways or dynamic conditions.
 
-        ## User impact
+        A passing result shows at least one active blocklist zone with populated gateways; a failing result shows no blocklist zone or a blocklist zone with no gateways defined.
 
-        Low
+        ### Audit via API
 
-        Legitimate users within your org see no change in behavior. Clients connecting from blocked network zones see a 403 (access denied) error.
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/trustedOrigins"
+        ```
+
+        Network zones are returned by `GET /api/v1/zones`. A passing response includes at least one zone with `usage` set to `BLOCKLIST` and a non-empty `gateways` array; a failing response has no blocklist zone or a blocklist zone with no gateways.
       remediation:
         - id: terraform
           desc: |
@@ -275,7 +309,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -284,9 +318,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-5-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-disable-weaker-mfa-factors-in-factor-enrollment-policies-api
         tags:
@@ -306,26 +340,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Enable strong MFA factors to improve resistance to phishing and man-in-the-middle attacks.
+        This check ensures that weaker authentication factors such as email, SMS, and voice are not available for self-enrollment in factor enrollment policies. These factors are vulnerable to phishing and adversary-in-the-middle attacks, so stronger factors should be used instead.
 
-        Admins can configure multifactor authentication (MFA) at the organization level or application level. When users sign in to Okta or an app, they're prompted to authenticate themselves. If you deploy strong factors, they provide better protection against phishing, adversary-in-the-middle attacks, and others.
+        **Why this matters**
 
-        ### Okta recommends
+        - **Phishing resistance:** Removing email, SMS, and voice factors steers users toward factors that resist credential interception.
+        - **Stronger assurance:** Push-based and hardware-backed factors provide far higher confidence in a user's identity than one-time codes sent over insecure channels.
+        - **Consistent posture:** Disabling weak factors org-wide prevents users from quietly choosing a weaker option during enrollment.
 
-        Update factor enrollment policies based on the following:
+        **Risk mitigation**
 
-        - Enable as primary factors: Okta Verify (with Push if available), Google Authenticator, WebAuthn
-        - Don't enable as secondary factors: Security Questions and SMS/Email/Voice
+        - **Disable weak factors:** Set email, SMS, and phone factors so they cannot be self-enrolled in any factor enrollment policy.
+        - **Promote strong factors:** Enable Okta Verify with push, Google Authenticator, and WebAuthn as the primary enrollment options.
+      audit: |
+        ### Audit via Admin Console
 
-        ### Security impact
+        1. In the Admin Console, go to **Security > Multifactor**.
+        2. Select **Factor Enrollment** and open each policy.
+        3. Confirm that email, SMS, and voice or phone factors are set to disabled rather than optional or required.
 
-        High
+        A passing result shows weak factors disabled in every factor enrollment policy; a failing result shows email, SMS, or phone factors set to optional or required.
 
-        ### User impact
+        ### Audit via API
 
-        High
+        Query the Okta API and inspect the result:
 
-        When signing in to their org, end users are prompted to enroll in required factors and may enroll in any factors set to optional. Factors that have been disabled aren't visible to end users.
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=MFA_ENROLL"
+        ```
+
+        For each policy, inspect `settings.factors`. A passing response shows the `okta_email`, `okta_sms`, and `phone_number` factors with self-enrollment neither optional nor required; a failing response shows any of those factors available for self-enrollment.
       remediation:
         - id: console
           desc: |
@@ -399,7 +444,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -408,9 +453,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-5-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-enable-okta-verify-with-push-for-mfa-api
         tags:
@@ -430,9 +475,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Okta Verify is a multifactor authentication (MFA) app developed by Okta. It lets users verify their identity when they sign in to Okta and makes it less likely that someone pretending to be the user can gain access to the account.
+        This check ensures that Okta Verify is enabled as a factor in at least one factor enrollment policy. Okta Verify lets users confirm their identity with a push notification or one-time code, making account takeover significantly harder.
 
-        To use Okta Verify, you must first enable and configure it for your org, and then your end users must install the Okta Verify app on their device and set it up. Then, when end users sign in to Okta, they can verify their identity by approving a push notification in the app, or by entering a one-time code provided by the app into Okta.
+        **Why this matters**
+
+        - **Strong authentication:** Okta Verify provides a phishing-resistant alternative to passwords and weaker one-time-code channels.
+        - **Push convenience:** Approving a push notification is fast for users while still requiring possession of an enrolled device.
+        - **Account takeover defense:** An attacker with only a stolen password cannot complete sign-in without the user's Okta Verify device.
+
+        **Risk mitigation**
+
+        - **Enable Okta Verify:** Configure Okta Verify as an available factor so users can enroll a trusted device.
+        - **Prefer push when available:** Use push-based verification to reduce reliance on codes that can be relayed by an attacker.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Multifactor**.
+        2. Select **Factor Enrollment** and open each policy.
+        3. Confirm that Okta Verify is set to optional or required in at least one policy.
+
+        A passing result shows Okta Verify available for enrollment; a failing result shows Okta Verify disabled across all factor enrollment policies.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=MFA_ENROLL"
+        ```
+
+        For each policy, inspect `settings.factors`. A passing response shows the `okta_otp` factor present and enabled in at least one policy; a failing response has no policy with Okta Verify enabled. The authenticator can also be confirmed with `GET /api/v1/authenticators`.
       remediation:
         - id: console
           desc: |
@@ -490,7 +563,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -499,9 +572,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-okta-mfa-access-api
         tags:
@@ -521,23 +594,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Enabling at least one required factor for your org ensures that end users assigned to a given policy are enrolled in MFA.
+        This check ensures that at least one active factor enrollment policy applies to the Everyone group with a required factor. Requiring a factor for all users guarantees that every end user is enrolled in MFA before they can sign in.
 
-        Once a required factor is set, you can also update your Okta sign-on policy to prompt users to enroll in the factor the next time they sign in.
+        **Why this matters**
 
-        ### Okta recommends
+        - **Universal coverage:** Applying a required factor to the Everyone group leaves no user without MFA.
+        - **No gaps:** A required factor must be enrolled before sign-in, so users cannot defer or skip MFA setup.
+        - **Baseline assurance:** Mandatory MFA establishes a consistent minimum authentication standard across the org.
 
-        Require at least one factor in every MFA enrollment policy.
+        **Risk mitigation**
 
-        ### Security impact
+        - **Require a factor:** Set at least one factor to required in an active factor enrollment policy that includes the Everyone group.
+        - **Prompt for enrollment:** Use a sign-on policy rule to prompt users to enroll in the required factor at next sign-in.
+      audit: |
+        ### Audit via Admin Console
 
-        High
+        1. In the Admin Console, go to **Security > Multifactor**.
+        2. Select **Factor Enrollment** and review the policy list.
+        3. Confirm that an active policy applies to the Everyone group and has at least one factor set to required.
 
-        ### End-user impact
+        A passing result shows an active enrollment policy covering all users with a required factor; a failing result shows no such policy or a policy with only optional factors.
 
-        Low
+        ### Audit via API
 
-        If a factor is required as part of the MFA enrollment policy, end users must enroll in the factor before they can sign in to their org. Setup varies depending on the factor specified.
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=MFA_ENROLL"
+        ```
+
+        A passing response includes a policy with `status` of `ACTIVE` whose `conditions.people.groups.include` contains the Everyone group ID and whose settings require a factor; a failing response has no active policy meeting those conditions.
       remediation:
         - id: console
           desc: |
@@ -613,18 +700,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-j
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
+      compliance/pci-dss-4: pcidss-requirement-8-2-8
       compliance/soc2-2017: soc2-control-cc6-1-8
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-okta-enforce-session-lifetime-api
         tags:
@@ -644,25 +731,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        The session lifetime determines the maximum idle time of a user's Okta session, and when the session expires.
+        This check ensures that every active sign-on policy rule enforces a limited session idle time and session lifetime. The Okta default session lifetime is two hours, and shorter limits reduce the window in which a hijacked session can be abused.
 
-        Shorter session lifetimes reduce the risk of malicious parties gaining access to a user's session.
+        **Why this matters**
 
-        The default session lifetime is two hours. A countdown timer appears to users when there are five minutes of session time remaining.
+        - **Reduced exposure:** Shorter session lifetimes shrink the time an attacker can use a stolen or abandoned session.
+        - **Reauthentication:** Idle and lifetime limits force users to sign in again, re-verifying their identity periodically.
+        - **Consistent enforcement:** Applying limits to every active rule ensures no policy leaves sessions open indefinitely.
 
-        ### Okta recommends
+        **Risk mitigation**
 
-        A session lifetime of two hours or less.
+        - **Bound session lifetime:** Set session lifetime to two hours or less in every active sign-on policy rule.
+        - **Limit idle time:** Configure a session idle timeout so unattended sessions expire without user action.
+      audit: |
+        ### Audit via Admin Console
 
-        ### Security impact
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select **Sign On** and open each policy.
+        3. Review each active rule and confirm the **Session expires after** value is within your approved limit.
 
-        High
+        A passing result shows every active sign-on rule with a bounded session lifetime and idle timeout; a failing result shows a rule with an excessive or unset session lifetime.
 
-        ### End-user impact
+        ### Audit via API
 
-        Moderate
+        Query the Okta API and inspect the result:
 
-        A countdown timer appears to users when there are five minutes of session time remaining.
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=OKTA_SIGN_ON"
+        ```
+
+        For each policy, fetch its rules with `GET /api/v1/policies/{policyId}/rules` and inspect `actions.signon.session`. A passing response shows `maxSessionIdleMinutes` and `maxSessionLifetimeMinutes` within the approved limits for every active rule; a failing response shows a rule exceeding those limits.
       remediation:
         - id: console
           desc: |
@@ -725,18 +824,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-j
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-okta-auth-openid-saml-api
         tags:
@@ -752,25 +851,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        SAML and OIDC are authentication protocols that reduce reliance on password-based authentication.
+        This check ensures that active applications using a supported sign-on mode are configured to authenticate with SAML or OIDC rather than password-based methods such as SWA. With SAML and OIDC, user credentials never leave Okta, unlike SWA where the username and password are passed to the third-party app.
 
-        SAML is an XML-based standard for exchanging authentication and authorization data between an Identity Provider (IdP) and a service provider (SP).
-        OpenID Connect (OIDC) is a protocol that sits on top of the OAuth 2.0 framework. The OIDC protocol allows otherwise different systems to interoperate and share authentication state and user profile information.
-        SWA is an SSO system developed by Okta to provide single sign-on for apps that don't support proprietary federated sign-on methods or SAML. In a SWA login, the username and password are passed to the third-party app whereas with SAML and OIDC, those credentials never leave Okta.
+        **Why this matters**
 
-        ### Okta recommends
+        - **Credential isolation:** SAML and OIDC keep user credentials within Okta instead of forwarding them to third-party apps.
+        - **Federated trust:** Standard protocols let otherwise different systems share authentication state securely.
+        - **Reduced password risk:** Moving away from SWA lowers reliance on stored passwords that can be leaked or reused.
 
-        Enable SAML or OIDC and disable SWA for applications when possible.
+        **Risk mitigation**
 
-        ### Security impact
+        - **Adopt SAML or OIDC:** Configure supported applications to use SAML 2.0 or OpenID Connect for sign-on.
+        - **Retire SWA where possible:** Replace SWA integrations with federated sign-on so credentials are not passed to external apps.
+      audit: |
+        ### Audit via Admin Console
 
-        High
+        1. In the Admin Console, go to **Applications > Applications**.
+        2. Review each active application and note its sign-on method.
+        3. Confirm that supported apps use SAML or OIDC rather than SWA.
 
-        ### User impact
+        A passing result shows active, supported applications configured for SAML or OIDC; a failing result shows a supported app still using SWA.
 
-        None
+        ### Audit via API
 
-        When signing in to their org, end users are prompted to enroll in required factors and may enroll in any factors set to optional. Factors that have been disabled aren't visible to end users.
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/apps"
+        ```
+
+        For each active application, inspect the `signOnMode` field. A passing response shows supported apps with `signOnMode` of `SAML_2_0` or `OPENID_CONNECT`; a failing response shows a supported app using a password-based sign-on mode.
       remediation:
         - id: console
           desc: |
@@ -855,15 +966,15 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/iso-27001-2022: iso-27001-2022-a-6-8
       compliance/nis-2: nis-2-21-2-b
-      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-1: nist-csf-1-de-cm-3
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -886,19 +997,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        When a user reports suspicious activity, admins can enable specific actions and System Log events to obtain further details about the activity.
+        This check ensures that Suspicious Activity Reporting is enabled so end users can flag unrecognized account activity. When a user reports suspicious activity, admins gain additional System Log events and actions to investigate the incident.
 
-        ### Okta Recommends
+        **Why this matters**
 
-        Enable Suspicious Activity Reporting for end-user reporting.
+        - **Early detection:** End users often notice unfamiliar sign-ins before automated systems, and reporting turns that awareness into actionable signal.
+        - **Richer telemetry:** Reports generate System Log events that give admins detail needed to investigate.
+        - **Faster response:** Surfacing suspicious activity quickly lets security teams contain account compromise sooner.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Enable reporting:** Turn on Suspicious Activity Reporting so users have a built-in channel to flag unrecognized activity.
+        - **Act on reports:** Review reported events in the System Log and respond to potential account takeover.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        2. Review the **Report Suspicious Activity** option.
+        3. Confirm the option is enabled.
 
-        Low
+        A passing result shows Suspicious Activity Reporting enabled; a failing result shows the option turned off.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/org/settings"
+        ```
+
+        The org security notification email settings expose a `reportSuspiciousActivityEnabled` field. A passing response shows that field set to `true`; a failing response shows it set to `false`. This setting is also visible in the Admin Console under Settings.
       remediation:
         - id: console
           desc: |
@@ -957,15 +1086,15 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-9
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -988,24 +1117,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        When enabled, this email notification notifies end users of any sign-in activity. The email contains user sign-on details such as the web browser, operating system used to sign in, and time and location of authentication.
+        This check ensures that sign-on notifications are enabled so end users receive an email when their account is used from a new or unrecognized client. The email includes the browser, operating system, time, and location of the sign-in.
 
-        ### Okta Recommends
+        **Why this matters**
 
-        Enable this email notification so end users are informed about new sign-on activity, which can inform them if a different user has signed in to their account.
+        - **User awareness:** End users are informed of new sign-in activity and can recognize a login they did not perform.
+        - **Detailed context:** The notification includes client and location details that help users judge whether activity is legitimate.
+        - **Crowdsourced detection:** Notifying every user turns the whole org into a sensor for unauthorized access.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Enable sign-on notifications:** Turn on new device email notifications so users learn of unfamiliar sign-ins.
+        - **Encourage reporting:** Pair notifications with a clear process for users to report sign-ins they do not recognize.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        2. Review the option that emails users about sign-in from a new device.
+        3. Confirm the option is enabled.
 
-        Low
+        A passing result shows new device sign-on notifications enabled; a failing result shows the option turned off.
 
-        End users receive an email notification if they sign in from a new or unrecognized client.
+        ### Audit via API
 
-        ### Known limitations
-        Currently, new sign-on notifications don't use Improved New Device Behavior Detection when sending email notifications for new sign-ins. Changes to `deviceToken` or browser cookies may not trigger a new sign-on email notification.
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/org/settings"
+        ```
+
+        The org security notification email settings expose a `sendEmailForNewDeviceEnabled` field. A passing response shows that field set to `true`; a failing response shows it set to `false`. This setting is also visible in the Admin Console under Settings.
       remediation:
         - id: console
           desc: |
@@ -1045,7 +1187,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -1053,7 +1195,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -1076,21 +1218,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Factor enrollment notifications for end users notifies end users of any activity on their account related to multifactor authentication (MFA) factor enrollment.
+        This check ensures that factor enrollment notifications are enabled so end users receive an email when a new MFA factor is enrolled on their account. The notification covers enrollments performed by the user or by an admin.
 
-        ### Okta Recommends
+        **Why this matters**
 
-        Enable this email notification so end users are informed about factor enrollment.
+        - **User awareness:** Users are alerted when a factor is added, so an unexpected enrollment stands out immediately.
+        - **Tamper detection:** An attacker who enrolls a new factor to maintain access cannot do so silently.
+        - **Account integrity:** Notifications give users a chance to challenge factor changes they did not authorize.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Enable enrollment notifications:** Turn on factor enrollment emails so users are informed of every new factor.
+        - **Investigate unexpected enrollments:** Treat unrecognized enrollment notices as a possible account compromise.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        2. Review the option that emails users about MFA factor enrollment.
+        3. Confirm the option is enabled.
 
-        Low
+        A passing result shows factor enrollment notifications enabled; a failing result shows the option turned off.
 
-        End users are sent a confirmation email if they or an admin enroll in a new factor for their account.
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/org/settings"
+        ```
+
+        The org security notification email settings expose a `sendEmailForFactorEnrollmentEnabled` field. A passing response shows that field set to `true`; a failing response shows it set to `false`. This setting is also visible in the Admin Console under Settings.
       remediation:
         - id: console
           desc: |
@@ -1130,7 +1288,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -1138,7 +1296,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -1161,21 +1319,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        When enabled, end users are sent an email notification to inform them that one or more factors have been reset for their account.
+        This check ensures that factor reset notifications are enabled so end users receive an email when one or more MFA factors are reset or removed from their account. The notification covers resets performed by the user or by an admin.
 
-        ### Okta Recommends
+        **Why this matters**
 
-        Enable this email notification to inform end users when one or more factors have been reset or removed.
+        - **User awareness:** Users are alerted when a factor is reset, so an unexpected change is noticed quickly.
+        - **Tamper detection:** An attacker resetting a factor to substitute their own device cannot do so without the user being informed.
+        - **Account integrity:** Notifications give users a chance to challenge factor resets they did not request.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Enable reset notifications:** Turn on factor reset emails so users are informed whenever a factor is reset or removed.
+        - **Investigate unexpected resets:** Treat unrecognized reset notices as a possible account compromise.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        2. Review the option that emails users about MFA factor resets.
+        3. Confirm the option is enabled.
 
-        Low
+        A passing result shows factor reset notifications enabled; a failing result shows the option turned off.
 
-        End users are sent an email notification if they or an admin reset a factor for their account.
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/org/settings"
+        ```
+
+        The org security notification email settings expose a `sendEmailForFactorResetEnabled` field. A passing response shows that field set to `true`; a failing response shows it set to `false`. This setting is also visible in the Admin Console under Settings.
       remediation:
         - id: console
           desc: |
@@ -1215,7 +1389,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
@@ -1223,7 +1397,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -1246,21 +1420,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        When enabled, end users are sent an email notification to inform them that the password for their account has changed. This email contains details such as the time and location of the password change.
+        This check ensures that password changed notifications are enabled so end users receive an email when the password on their account is changed or reset. The notification includes the time and location of the change.
 
-        ### Okta Recommends
+        **Why this matters**
 
-        Enable this email notification to inform end users when their password on their account has been changed or reset.
+        - **User awareness:** Users learn immediately when their password changes and can recognize a change they did not make.
+        - **Detailed context:** The notification includes time and location details that help users assess legitimacy.
+        - **Account takeover detection:** An attacker who changes a password to lock out the owner cannot do so without alerting them.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Enable change notifications:** Turn on password changed emails so users are informed of every password change or reset.
+        - **Investigate unexpected changes:** Treat unrecognized password change notices as a possible account compromise.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        2. Review the option that emails users when their password is changed.
+        3. Confirm the option is enabled.
 
-        Low
+        A passing result shows password changed notifications enabled; a failing result shows the option turned off.
 
-        End users are sent an email notification if they change or reset the password on their account. Password changed notifications aren't sent if the admin sets a temporary password for the account, changes the password by API or if the end user is in an inactive state.
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/org/settings"
+        ```
+
+        The org security notification email settings expose a `sendEmailForPasswordChangedEnabled` field. A passing response shows that field set to `true`; a failing response shows it set to `false`. This setting is also visible in the Admin Console under Settings.
       remediation:
         - id: console
           desc: |
@@ -1302,15 +1492,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordLength
@@ -1334,11 +1524,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify a minimum password length of at least eight characters. Longer passwords provide greater protection against brute force attacks.
+        This check ensures that every password policy enforces a strong minimum password length. Longer passwords are substantially harder to crack through brute force, and current industry guidance favors length over short but complex passwords.
 
-        Longer passwords are more difficult for users to remember, especially when combined with other complexity requirements (for example, require uppercase, lowercase, symbols, and so on). NIST recommends longer passwords that are easy to remember (“phrase-like”) but more difficult to obtain from brute force attacks.
+        **Why this matters**
 
-        These recommendations are provided by Okta as an example of typical password standards. They're derived from current cybersecurity industry best practices. They aren't intended to replace internationally recognized cybersecurity standards, such as ISO 27001, National Institute of Standards and Technology (NIST), PCI-DSS, or others. Your IT department may need to adjust these settings to comply with whichever cybersecurity standard your organization has chosen to follow.
+        - **Brute-force resistance:** Each additional character increases the effort an attacker needs to guess a password.
+        - **Memorable strength:** Longer phrase-like passwords can be both strong and easier for users to remember.
+        - **Consistent baseline:** Applying the requirement to every policy ensures no group of users is allowed weak passwords.
+
+        **Risk mitigation**
+
+        - **Set a strong minimum length:** Configure each password policy to require a long minimum password length.
+        - **Align with standards:** Adjust the length requirement to satisfy the cybersecurity standard your organization follows.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select the **Password** tab and open each policy.
+        3. Confirm the minimum password length meets your approved threshold.
+
+        A passing result shows every password policy enforcing a strong minimum length; a failing result shows a policy with a length below the threshold.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        For each policy, inspect `settings.password.complexity.minLength`. A passing response shows that value at or above your minimum length threshold for every policy; a failing response shows a policy below it.
       remediation:
         - id: console
           desc: |
@@ -1383,15 +1599,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-4
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordMaxLockoutAttempts
@@ -1415,15 +1631,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify the maximum number of invalid password attempts before locking the user's account. This provides protection against brute-force password attacks.
+        This check ensures that every password policy limits the number of invalid password attempts before an account is locked. Capping failed attempts protects accounts against brute-force and password-spraying attacks.
 
-        Users will be unable to access their accounts after multiple failed sign-ins.
+        **Why this matters**
 
-        Admins configure the account unlock options in the lockout options in password policy rules.
+        - **Brute-force defense:** Locking accounts after a few failed attempts stops automated password guessing.
+        - **Spraying resistance:** A lockout threshold limits how many guesses an attacker can make against each account.
+        - **Consistent baseline:** Applying the limit to every policy ensures no group of users is left without lockout protection.
 
-        If an admin doesn't enable any self-service or auto-unlock options, users must ask their admin to unlock their account.
+        **Risk mitigation**
 
-        When admins configure lockout policies, they should consider typical user sign-in patterns and security to determine how many attempts are allowed. A lockout policy that allows only a low number of attempts may cause more lockouts. For example, users may mistype passwords when signing in from a mobile device or when they've recently changed their passwords. Some applications may auto-retry cached passwords when they're changed, resulting in user lockouts. However, a lockout policy with too many attempts allowed increases the risk of credential attacks.
+        - **Set a lockout threshold:** Configure each password policy to lock accounts after a small number of invalid attempts.
+        - **Balance usability:** Choose a threshold that blocks attacks while allowing for occasional legitimate mistyped passwords.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select the **Password** tab and open each policy.
+        3. Confirm the **Lock out** setting limits invalid attempts to your approved maximum.
+
+        A passing result shows every password policy enforcing a lockout threshold within the limit; a failing result shows a policy with no lockout or too high a threshold.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        For each policy, inspect `settings.password.lockout.maxAttempts`. A passing response shows that value at or below your approved maximum for every policy; a failing response shows a policy exceeding it.
       remediation:
         - id: console
           desc: |
@@ -1466,15 +1704,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordminLowercase
@@ -1498,7 +1736,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify the minimum number of lowercase characters in a password. Complex passwords increase the security of your users' accounts.
+        This check ensures that every password policy requires at least one lowercase character. Character-class requirements increase password complexity and make passwords harder to guess.
+
+        **Why this matters**
+
+        - **Increased complexity:** Requiring a lowercase character expands the keyspace an attacker must search.
+        - **Guessing resistance:** Complexity rules reduce the chance that a password matches a common predictable pattern.
+        - **Consistent baseline:** Applying the requirement to every policy ensures all users meet the same complexity standard.
+
+        **Risk mitigation**
+
+        - **Require lowercase characters:** Configure each password policy to mandate at least one lowercase character.
+        - **Combine with other rules:** Pair this requirement with length and other character-class rules for stronger passwords.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select the **Password** tab and open each policy.
+        3. Confirm the complexity settings require a lowercase character.
+
+        A passing result shows every password policy requiring at least one lowercase character; a failing result shows a policy without that requirement.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        For each policy, inspect `settings.password.complexity.minLowerCase`. A passing response shows that value at one or higher for every policy; a failing response shows a policy with the value at zero.
       remediation:
         - id: console
           desc: |
@@ -1541,15 +1809,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordminNumber
@@ -1573,7 +1841,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify the minimum number of numeric characters in a password. Complex passwords increase the security of your users' accounts.
+        This check ensures that every password policy requires at least one numeric character. Character-class requirements increase password complexity and make passwords harder to guess.
+
+        **Why this matters**
+
+        - **Increased complexity:** Requiring a numeric character expands the keyspace an attacker must search.
+        - **Guessing resistance:** Complexity rules reduce the chance that a password matches a common predictable pattern.
+        - **Consistent baseline:** Applying the requirement to every policy ensures all users meet the same complexity standard.
+
+        **Risk mitigation**
+
+        - **Require numeric characters:** Configure each password policy to mandate at least one numeric character.
+        - **Combine with other rules:** Pair this requirement with length and other character-class rules for stronger passwords.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select the **Password** tab and open each policy.
+        3. Confirm the complexity settings require a numeric character.
+
+        A passing result shows every password policy requiring at least one numeric character; a failing result shows a policy without that requirement.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        For each policy, inspect `settings.password.complexity.minNumber`. A passing response shows that value at one or higher for every policy; a failing response shows a policy with the value at zero.
       remediation:
         - id: console
           desc: |
@@ -1616,15 +1914,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordminSymbol
@@ -1648,7 +1946,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify the minimum number of symbol characters in a password. Complex passwords increase the security of your users' accounts.
+        This check ensures that every password policy requires at least one symbol character. Character-class requirements increase password complexity and make passwords harder to guess.
+
+        **Why this matters**
+
+        - **Increased complexity:** Requiring a symbol character expands the keyspace an attacker must search.
+        - **Guessing resistance:** Complexity rules reduce the chance that a password matches a common predictable pattern.
+        - **Consistent baseline:** Applying the requirement to every policy ensures all users meet the same complexity standard.
+
+        **Risk mitigation**
+
+        - **Require symbol characters:** Configure each password policy to mandate at least one symbol character.
+        - **Combine with other rules:** Pair this requirement with length and other character-class rules for stronger passwords.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Select the **Password** tab and open each policy.
+        3. Confirm the complexity settings require a symbol character.
+
+        A passing result shows every password policy requiring at least one symbol character; a failing result shows a policy without that requirement.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        For each policy, inspect `settings.password.complexity.minSymbol`. A passing response shows that value at one or higher for every policy; a failing response shows a policy with the value at zero.
       remediation:
         - id: console
           desc: |
@@ -1691,15 +2019,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordminAge
@@ -1724,7 +2052,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        Specify the minimum time interval in minutes between password changes. Setting the minimum password interval protects against brute force attacks.
+        This check ensures that password policies enforce a minimum interval between password changes of at least 60 minutes. Okta sets no minimum age by default, which lets users change a password repeatedly in quick succession.
+
+        **Why this matters**
+
+        - **History enforcement:** A minimum age stops users from cycling rapidly through several password changes to defeat password history rules and return to a familiar password.
+        - **Credential stability:** Requiring a wait period keeps accounts on a deliberately chosen password rather than a throwaway value used only to satisfy a rotation prompt.
+        - **Defense against rapid abuse:** A waiting period limits how quickly a password can be churned after a reset, reducing the value of a single compromised reset action.
+
+        **Risk mitigation**
+
+        - **Brute force resilience:** Preventing instant repeated changes keeps reused passwords out of circulation, which slows attackers who rely on predictable credential patterns.
+        - **Policy integrity:** Enforcing a minimum age preserves the intent of password history and rotation controls so they cannot be trivially bypassed.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Age** section and read the **Minimum password age** value.
+
+        A passing result shows a minimum password age of 60 minutes or more for every policy; a failing result shows a minimum age below 60 minutes or no minimum set.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.age.minAgeMinutes` of 60 or greater for every policy; a failing response has a value below 60.
       remediation:
         - id: console
           desc: |
@@ -1767,15 +2125,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordexcludeUsername
@@ -1800,7 +2158,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check enforces whether the username must be excluded from the password. Complex passwords increase the security of your users' accounts.
+        This check ensures that password policies are configured to forbid a user's username from appearing in their password. Excluding the username removes a value that an attacker can easily guess or derive.
+
+        **Why this matters**
+
+        - **Predictability:** A username is public or easily discovered, so a password built around it offers little real entropy.
+        - **Targeted guessing:** Attackers routinely try the username as a password component, making such passwords a low-effort first guess.
+        - **Stronger credentials:** Forcing the username out of the password pushes users toward values that are harder to relate to their identity.
+
+        **Risk mitigation**
+
+        - **Credential stuffing resilience:** Passwords unrelated to the username are harder to derive from leaked account lists.
+        - **Brute force resilience:** Removing a known string from allowed passwords increases the effective search space an attacker must cover.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, confirm that **Common password requirements** restricts use of the username in the password.
+
+        A passing result shows the username restriction enabled for every policy; a failing result shows it disabled.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.complexity.excludeUsername` set to `true` for every policy; a failing response has it set to `false`.
       remediation:
         - id: console
           desc: |
@@ -1843,15 +2231,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordexcludeFirstname
@@ -1876,7 +2264,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check enforces whether the user's first name must be excluded from the password. Complex passwords increase the security of your users' accounts.
+        This check ensures that password policies are configured to forbid a user's first name from appearing in their password. Excluding personal attributes removes values that an attacker can easily learn and guess.
+
+        **Why this matters**
+
+        - **Predictability:** A first name is widely known and trivial to look up, so a password containing it carries little real strength.
+        - **Targeted guessing:** Attackers commonly try personal names when guessing passwords for a specific user.
+        - **Stronger credentials:** Blocking the first name steers users toward passwords that are not tied to their personal identity.
+
+        **Risk mitigation**
+
+        - **Social engineering resilience:** Passwords free of personal details resist guesses informed by public profiles and social media.
+        - **Brute force resilience:** Removing a known name from allowed passwords widens the search space an attacker must cover.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, confirm that **Common password requirements** restricts use of the first name in the password.
+
+        A passing result shows the first name restriction enabled for every policy; a failing result shows it disabled.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.complexity.excludeAttributes` containing `firstName` for every policy; a failing response omits it.
       remediation:
         - id: console
           desc: |
@@ -1919,15 +2337,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordexcludeLastName
@@ -1952,7 +2370,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check enforces whether the user's last name must be excluded from the password. Complex passwords increase the security of your users' accounts.
+        This check ensures that password policies are configured to forbid a user's last name from appearing in their password. Excluding personal attributes removes values that an attacker can easily learn and guess.
+
+        **Why this matters**
+
+        - **Predictability:** A last name is widely known and trivial to look up, so a password containing it carries little real strength.
+        - **Targeted guessing:** Attackers commonly try personal names when guessing passwords for a specific user.
+        - **Stronger credentials:** Blocking the last name steers users toward passwords that are not tied to their personal identity.
+
+        **Risk mitigation**
+
+        - **Social engineering resilience:** Passwords free of personal details resist guesses informed by public profiles and social media.
+        - **Brute force resilience:** Removing a known name from allowed passwords widens the search space an attacker must cover.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, confirm that **Common password requirements** restricts use of the last name in the password.
+
+        A passing result shows the last name restriction enabled for every policy; a failing result shows it disabled.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.complexity.excludeAttributes` containing `lastName` for every policy; a failing response omits it.
       remediation:
         - id: console
           desc: |
@@ -1995,15 +2443,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordDictionaryLookup
@@ -2028,7 +2476,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks passwords against a common password dictionary. Complex passwords increase the security of your users' accounts.
+        This check ensures that password policies are configured to screen new passwords against a dictionary of common passwords and reject any match. Okta can compare passwords against a known list of widely used values during enrollment and reset.
+
+        **Why this matters**
+
+        - **Common password risk:** Widely used passwords appear at the top of every attacker wordlist and are cracked almost instantly.
+        - **Enrollment-time defense:** Screening at the moment a password is set blocks weak choices before they ever protect an account.
+        - **Stronger credentials:** Rejecting dictionary matches forces users toward passwords that are not already public knowledge.
+
+        **Risk mitigation**
+
+        - **Credential stuffing resilience:** Passwords absent from common wordlists are far less likely to match values from public breach data.
+        - **Brute force resilience:** Eliminating predictable passwords removes the fast wins that dictionary attacks depend on.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, confirm that **Common password check** is enabled.
+
+        A passing result shows the common password check enabled for every policy; a failing result shows it disabled.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.complexity.dictionary.common.exclude` set to `true` for every policy; a failing response has it set to `false`.
       remediation:
         - id: console
           desc: |
@@ -2071,15 +2549,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-9
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordMaxAge
@@ -2104,7 +2582,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks the length in days a password is valid before expiry. Rotating passwords increases the security of your users' accounts.
+        This check ensures that password policies set a maximum password age so passwords expire within 90 days. Okta does not expire passwords by default, which lets a single credential remain valid indefinitely.
+
+        **Why this matters**
+
+        - **Exposure window:** A password that never expires gives an attacker who steals it unlimited time to use it.
+        - **Breach containment:** Regular expiry forces a credential change that can quietly evict an attacker holding an old password.
+        - **Hygiene enforcement:** A maximum age prompts users to refresh credentials that may have been shared, reused, or written down over time.
+
+        **Risk mitigation**
+
+        - **Stolen credential limitation:** Bounding password lifetime caps how long compromised credentials from breaches or phishing stay useful.
+        - **Stale account defense:** Expiry surfaces dormant or forgotten accounts that would otherwise keep working with an unchanged password.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Age** section and read the **Password expires** value.
+
+        A passing result shows passwords expiring within 90 days for every policy; a failing result shows expiry set to 0 (never) or longer than 90 days.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.age.maxAgeDays` greater than 0 and 90 or less for every policy; a failing response has it set to 0 or greater than 90.
       remediation:
         - id: console
           desc: |
@@ -2147,15 +2655,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordExpireWarning
@@ -2180,7 +2688,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks the length in days a user will be warned before password expiry. Rotating passwords increases the security of your users' accounts.
+        This check ensures that password policies warn users 15 days before their password expires. An expiration warning gives users advance notice to change their password on their own schedule.
+
+        **Why this matters**
+
+        - **Advance notice:** A warning period lets users update their password before it lapses rather than discovering the change at a critical moment.
+        - **Lockout avoidance:** Users who act on the warning avoid being locked out by an unexpected expiry.
+        - **Smoother rotation:** Predictable reminders make password expiry a routine task instead of a disruptive surprise.
+
+        **Risk mitigation**
+
+        - **Reduced reset pressure:** Early warnings cut the volume of urgent help desk resets, which lowers the chance of rushed and weak password choices.
+        - **Sustained policy adoption:** Clear notice keeps users cooperating with expiry rules instead of seeking ways around them.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Age** section and read the **Prompt user to change password before expiration** value.
+
+        A passing result shows a 15 day warning period for every policy; a failing result shows a different value or no warning configured.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.age.expireWarnDays` set to 15 for every policy; a failing response has 0 or any other value.
       remediation:
         - id: console
           desc: |
@@ -2223,15 +2761,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-7
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordHistoryCount
@@ -2256,7 +2794,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks the number of distinct passwords that must be created before they can be reused. Rotating passwords increases the security of your users' accounts.
+        This check ensures that password policies remember the last 24 passwords and prevent their reuse. Okta tracks recent passwords so users must choose a genuinely new value at each change.
+
+        **Why this matters**
+
+        - **Reuse prevention:** A deep history stops users from alternating between a small set of familiar passwords.
+        - **Rotation effectiveness:** Password expiry only improves security if the replacement is actually different from prior ones.
+        - **Stronger credentials:** Requiring 24 distinct passwords pushes users away from minor variations of an old favorite.
+
+        **Risk mitigation**
+
+        - **Compromised credential containment:** A wide history keeps a previously breached password from being reinstated on the account.
+        - **Predictability reduction:** Blocking reuse limits the value of credentials an attacker may have observed in the past.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Age** section and read the **Enforce password history** value.
+
+        A passing result shows a history of 24 or more passwords for every policy; a failing result shows fewer than 24 or no history enforced.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.age.historyCount` of 24 or greater for every policy; a failing response has a value below 24.
       remediation:
         - id: console
           desc: |
@@ -2299,15 +2867,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-4
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordAutoUnlock
@@ -2332,7 +2900,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks the number of minutes before a locked account is unlocked.
+        This check ensures that password policies keep a locked account locked for at least 30 minutes before it unlocks automatically. The automatic unlock delay controls how long a user must wait after exceeding the failed sign-in limit.
+
+        **Why this matters**
+
+        - **Attack slowdown:** A long lockout window forces an attacker to pause between rounds of guessing, sharply reducing their attempt rate.
+        - **Detection time:** Extended lockouts give security teams a wider window to notice and respond to an account under attack.
+        - **Deterrence:** A meaningful delay makes automated guessing too slow to be worthwhile.
+
+        **Risk mitigation**
+
+        - **Brute force resilience:** A 30 minute minimum caps how many password guesses an attacker can make per hour against an account.
+        - **Credential stuffing resilience:** Sustained lockouts blunt high-volume attacks that replay stolen credentials across many accounts.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Lock out** section and read the **Automatically unlock account after** value.
+
+        A passing result shows an automatic unlock delay of 30 minutes or more for every policy; a failing result shows a shorter delay.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.lockout.autoUnlockMinutes` of 30 or greater for every policy; a failing response has a value below 30.
       remediation:
         - id: console
           desc: |
@@ -2375,15 +2973,15 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordShowLockoutFailures
@@ -2408,7 +3006,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks whether a user should be informed when their account is locked.
+        This check ensures that password policies notify users when their account is locked after too many failed sign-in attempts. A lockout message tells the user why they cannot sign in instead of leaving them guessing.
+
+        **Why this matters**
+
+        - **User awareness:** A clear lockout message tells a legitimate user their account is locked rather than appearing simply broken.
+        - **Attack visibility:** An unexpected lockout notice can alert a user that someone is trying to guess their password.
+        - **Faster resolution:** Knowing the cause lets users follow the recovery path or contact support without delay.
+
+        **Risk mitigation**
+
+        - **Early breach detection:** Users who see unexplained lockouts can report suspicious activity that points to an attack in progress.
+        - **Reduced support load:** Informed users resolve lockouts through self-service or targeted help rather than generic troubleshooting.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Password settings**, locate the **Lock out** section and confirm that the option to show a lockout message to users is enabled.
+
+        A passing result shows the lockout message enabled for every policy; a failing result shows it disabled.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.password.lockout.showLockoutFailures` set to `true` for every policy; a failing response has it set to `false`.
       remediation:
         - id: console
           desc: |
@@ -2449,17 +3077,17 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordEmailRecovery
@@ -2484,7 +3112,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks whether email password recovery is enabled or disabled.
+        This check ensures that password policies keep email enabled as a self-service password recovery factor. Email recovery lets users reset a forgotten password through a verified link sent to their inbox.
+
+        **Why this matters**
+
+        - **Self-service recovery:** An active email factor lets users regain access without waiting on an administrator.
+        - **Verified channel:** Recovery email is sent to the address on the account, tying the reset to a controlled mailbox.
+        - **Operational continuity:** A working recovery path keeps users productive when they forget a password.
+
+        **Risk mitigation**
+
+        - **Reduced help desk exposure:** Self-service recovery cuts manual reset requests, which are a common target for social engineering.
+        - **Account lockout relief:** A reliable email path prevents legitimate users from being permanently locked out of their accounts.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Recovery settings**, confirm that **Email** is enabled as a recovery factor.
+
+        A passing result shows email recovery active for every policy; a failing result shows it inactive.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.recovery.factors.okta_email.status` set to `ACTIVE` for every policy; a failing response shows it as `INACTIVE`.
       remediation:
         - id: console
           desc: |
@@ -2525,17 +3183,17 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordSmsRecovery
@@ -2560,7 +3218,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks whether sms password recovery is enabled or disabled.
+        This check ensures that password policies keep SMS disabled as a password recovery factor. SMS messages travel over a channel that is exposed to interception and SIM-swap attacks.
+
+        **Why this matters**
+
+        - **Channel weakness:** SMS lacks end-to-end protection and can be intercepted or redirected by an attacker.
+        - **SIM-swap risk:** An attacker who hijacks a phone number can receive recovery codes meant for the legitimate user.
+        - **Stronger alternatives:** Email and app-based recovery factors offer better assurance than text messages.
+
+        **Risk mitigation**
+
+        - **Account takeover resilience:** Disabling SMS recovery removes a path attackers exploit through SIM swaps and number porting.
+        - **Reduced interception risk:** Recovery that avoids SMS keeps reset codes off a network channel known to leak.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Recovery settings**, confirm that **SMS** is not enabled as a recovery factor.
+
+        A passing result shows SMS recovery inactive for every policy; a failing result shows it active.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.recovery.factors.okta_sms.status` set to `INACTIVE` for every policy; a failing response shows it as `ACTIVE`.
       remediation:
         - id: console
           desc: |
@@ -2601,17 +3289,17 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
-      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
     props:
       - uid: mondooOktaSecurityOktaPasswordQuestionRecovery
@@ -2636,7 +3324,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This checks whether question password recovery is enabled or disabled.
+        This check ensures that password policies keep security questions disabled as a password recovery factor. Security question answers are often guessable or discoverable from public information.
+
+        **Why this matters**
+
+        - **Weak secrets:** Answers to common security questions can be researched, guessed, or found on social media.
+        - **Static values:** Question answers rarely change and cannot be rotated like a password.
+        - **Stronger alternatives:** Email and app-based recovery factors provide far better assurance than knowledge questions.
+
+        **Risk mitigation**
+
+        - **Account takeover resilience:** Disabling question recovery removes a path attackers exploit through open-source research on a target.
+        - **Social engineering resilience:** Recovery that avoids personal questions resists guesses based on publicly known facts.
+      audit: |
+        ### Audit via Admin Console
+
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Password** tab and select the password policy to review.
+        3. Under **Recovery settings**, confirm that **Security Question** is not enabled as a recovery factor.
+
+        A passing result shows security question recovery inactive for every policy; a failing result shows it active.
+
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=PASSWORD"
+        ```
+
+        A passing response has `settings.recovery.factors.recovery_question.status` set to `INACTIVE` for every policy; a failing response shows it as `ACTIVE`.
       remediation:
         - id: console
           desc: |
@@ -2677,18 +3395,18 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
-      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-de-cm-1
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
-      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-threatinsight-action-block-api
         tags:
@@ -2708,30 +3426,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Okta ThreatInsight is configured to actively block suspicious login attempts rather than only auditing or ignoring them.
+        This check ensures that Okta ThreatInsight is configured to actively block suspicious login attempts rather than only auditing or ignoring them. ThreatInsight evaluates sign-in requests against a database of known malicious IP addresses maintained by Okta, and the action setting decides what happens when a suspicious IP is seen.
 
-        ThreatInsight evaluates sign-in requests against a database of known malicious IP addresses maintained by Okta. The action setting determines what happens when a suspicious IP is detected:
+        **Why this matters**
 
-        - **none**: ThreatInsight is effectively disabled and takes no action.
-        - **audit**: Suspicious attempts are logged in the System Log but not blocked, allowing attackers to continue trying credentials.
-        - **block** (recommended): Suspicious IP addresses are blocked from authenticating before credentials are evaluated, preventing brute-force and credential-stuffing attacks.
+        - **Perimeter blocking:** With the block action, suspicious IP addresses are stopped before credentials are evaluated, halting attacks at the edge.
+        - **Audit-only gap:** The audit action records suspicious attempts but still lets attackers continue trying credentials against accounts.
+        - **Disabled by inaction:** The none action leaves ThreatInsight effectively off, providing no protection at all.
 
-        ### Okta recommends
+        **Risk mitigation**
 
-        Set ThreatInsight action to "block" to proactively block authentication attempts from known malicious IP addresses. This blocks requests before password evaluation, which means:
-          - Locked-out users won't have their lockout count incremented by malicious attempts
-          - Credential-stuffing attacks are stopped before they can validate stolen passwords
-          - Brute-force attempts are blocked at the perimeter
+        - **Credential stuffing resilience:** Blocking malicious IPs before password evaluation stops attackers from validating stolen credentials.
+        - **Lockout protection:** Requests blocked at the perimeter do not increment a user's failed attempt count, sparing legitimate users from malicious lockouts.
+      audit: |
+        ### Audit via Admin Console
 
-        ### Security impact
+        1. In the Admin Console, go to **Security > General**.
+        2. Locate the **Okta ThreatInsight Settings** section.
+        3. Read the configured **Action** value.
 
-        High
+        A passing result shows the action set to **Log and block**; a failing result shows **Log only** or that ThreatInsight is disabled.
 
-        ### User impact
+        ### Audit via API
 
-        Low
+        Query the Okta API and inspect the result:
 
-        Legitimate users are not affected. Only IP addresses identified as malicious by Okta's threat intelligence are blocked. If a legitimate user is affected, admins can add their IP to the ThreatInsight exclude list.
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/threats/configuration"
+        ```
+
+        A passing response has `action` set to `block`; a failing response shows `audit` or `none`.
       remediation:
         - id: console
           desc: |
@@ -2774,7 +3499,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
@@ -2805,26 +3530,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that all active trusted origins in Okta are configured to use HTTPS rather than HTTP.
-
-        Trusted origins define which URLs are allowed for CORS (Cross-Origin Resource Sharing) requests and redirect URIs in authentication flows. These origins handle sensitive authentication tokens, session cookies, and authorization codes.
+        This check ensures that all active trusted origins in Okta are configured to use HTTPS rather than HTTP. Trusted origins define which URLs are allowed for cross-origin resource sharing requests and redirect URIs, and these origins handle sensitive authentication tokens, session cookies, and authorization codes.
 
         **Why this matters**
 
-        - **Token interception**: HTTP origins transmit authentication tokens in plaintext, allowing network attackers to intercept OAuth tokens, session identifiers, and authorization codes via man-in-the-middle attacks
-        - **Session hijacking**: Cookies sent to HTTP origins can be captured and replayed, giving attackers access to authenticated sessions
-        - **Credential exposure**: CORS requests to HTTP origins can leak sensitive data including access tokens and user profile information to anyone observing network traffic
-        - **OAuth redirect attacks**: HTTP redirect URIs in OAuth flows allow attackers to intercept authorization codes before they reach the legitimate application
+        - **Token interception:** HTTP origins transmit authentication tokens in plaintext, allowing network attackers to capture OAuth tokens, session identifiers, and authorization codes.
+        - **Session hijacking:** Cookies sent to HTTP origins can be captured and replayed, giving attackers access to authenticated sessions.
+        - **Credential exposure:** Cross-origin requests to HTTP endpoints can leak sensitive authentication data to anyone observing the network path.
 
-        ### Security impact
+        **Risk mitigation**
 
-        High
+        - **Man-in-the-middle resilience:** Requiring HTTPS encrypts authentication traffic so attackers cannot read or alter tokens in transit.
+        - **Replay attack defense:** Encrypted transport keeps session cookies and authorization codes from being intercepted and reused.
+      audit: |
+        ### Audit via Admin Console
 
-        ### User impact
+        1. In the Admin Console, go to **Security > API**.
+        2. Open the **Trusted Origins** tab.
+        3. Review each active trusted origin and read its URL.
 
-        None
+        A passing result shows every active trusted origin URL beginning with `https://`; a failing result shows one or more origins beginning with `http://`.
 
-        Updating trusted origin URLs from HTTP to HTTPS is a backend configuration change. End users experience no disruption as long as the application supports HTTPS.
+        ### Audit via API
+
+        Query the Okta API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/trustedOrigins"
+        ```
+
+        A passing response has every active entry with an `origin` value starting with `https://`; a failing response has at least one active `origin` starting with `http://`.
       remediation:
         - id: console
           desc: |
@@ -2870,7 +3606,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -2879,9 +3615,9 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     variants:
       - uid: mondoo-okta-security-signon-requires-mfa-api
         tags:
@@ -2901,30 +3637,37 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that active sign-on policy rules require multi-factor authentication (MFA) for user sign-in.
-
-        Having MFA enrollment policies configured does not guarantee that MFA is actually enforced at sign-in. Sign-on policies control the authentication requirements when users access Okta, and each policy rule can independently enable or disable the MFA requirement. If sign-on rules do not require a factor, users can authenticate with only a password, regardless of MFA enrollment policies.
+        This check ensures that active sign-on policy rules require multi-factor authentication for user sign-in. Sign-on policies control the authentication requirements when users access Okta, and each rule can independently enable or disable the MFA requirement, so MFA enrollment alone does not guarantee it is enforced.
 
         **Why this matters**
 
-        - **Password-only access**: Without MFA enforcement in sign-on rules, compromised passwords grant full access to Okta and all connected applications
-        - **Enrollment without enforcement**: MFA enrollment policies ensure users register factors, but sign-on policies determine whether those factors are actually required at login. These are independent configurations.
-        - **Phishing vulnerability**: Password-only authentication is highly vulnerable to phishing, credential stuffing, and brute-force attacks
-        - **Compliance requirements**: Most security frameworks (SOC 2, ISO 27001, NIST 800-63B) require MFA for identity provider access
+        - **Password-only access:** Without MFA enforced in sign-on rules, a compromised password grants full access to Okta and every connected application.
+        - **Enrollment is not enforcement:** Enrollment policies make users register factors, but only sign-on rules require those factors at sign-in.
+        - **Per-rule gaps:** A single rule that omits the factor requirement creates an authentication path that bypasses MFA entirely.
 
-        ### Okta recommends
+        **Risk mitigation**
 
-        Require MFA in all active sign-on policy rules to ensure that factor enrollment translates into actual authentication enforcement.
+        - **Account takeover resilience:** Requiring a second factor blocks attackers who hold only a stolen or guessed password.
+        - **Phishing resilience:** MFA at sign-in stops credential phishing from converting directly into account access.
+      audit: |
+        ### Audit via Admin Console
 
-        ### Security impact
+        1. In the Admin Console, go to **Security > Authentication**.
+        2. Open the **Sign On** tab and select each active sign-on policy.
+        3. Review each active rule other than the catch-all rule and confirm it requires a second factor.
 
-        High
+        A passing result shows every active rule requiring multi-factor authentication; a failing result shows at least one active rule that does not require a factor.
 
-        ### User impact
+        ### Audit via API
 
-        Moderate
+        Query the Okta API and inspect the result:
 
-        Users are prompted for an additional factor when signing in. If they have already enrolled in a factor through MFA enrollment policies, no additional setup is needed.
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/policies?type=OKTA_SIGN_ON"
+        ```
+
+        For each active policy, retrieve its rules with `GET /api/v1/policies/{id}/rules`. A passing response has every active rule with `actions.signon.requireFactor` set to `true`; a failing response has at least one active rule with it set to `false`.
       remediation:
         - id: console
           desc: |
@@ -2980,18 +3723,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     props:
       - uid: maxOrgAdmins
         title: Maximum number of Okta Organization Admins
@@ -3003,30 +3746,37 @@ queries:
           mondoo.com/filter-icon: okta
     docs:
       desc: |
-        This check ensures that the number of users with the Organization Administrator (ORG_ADMIN) role does not exceed a safe threshold.
-
-        The Organization Administrator role grants nearly the same level of access as the Super Administrator. Org admins can manage users, groups, applications, and most organizational settings. While they cannot manage other administrators or certain security settings, the breadth of their access makes them high-value targets for attackers.
+        This check ensures that the number of users holding the Organization Administrator role stays within a safe threshold. The Organization Administrator role grants nearly the same access as the Super Administrator, covering management of users, groups, applications, and most organizational settings.
 
         **Why this matters**
 
-        - **Broad access**: Org admins can modify user accounts, reset credentials, assign applications, and change group memberships across the entire organization
-        - **Lateral movement**: Compromised org admin accounts enable attackers to escalate privileges, create backdoor accounts, and access sensitive applications
-        - **Reduced accountability**: A large number of org admins makes it difficult to audit who made security-relevant changes and increases the blast radius of a single compromised account
-        - **Principle of least privilege**: Most administrative tasks can be performed with more restricted roles such as Help Desk Admin, Application Admin, or Group Admin
+        - **Broad access:** Org admins can modify user accounts, reset credentials, assign applications, and change group memberships across the whole organization.
+        - **High-value targets:** The breadth of org admin access makes these accounts attractive targets for attackers seeking maximum impact.
+        - **Lateral movement:** A compromised org admin account lets an attacker escalate privileges and create backdoor accounts.
 
-        ### Okta recommends
+        **Risk mitigation**
 
-        Limit organization admin assignments to users who genuinely require broad organizational access. Use more specific admin roles (Help Desk Admin, Application Admin, Read-Only Admin) for users who only need a subset of administrative capabilities.
+        - **Reduced attack surface:** Keeping the count of org admins low limits the number of accounts that can grant an attacker far-reaching control.
+        - **Least privilege enforcement:** Restricting the role to those who genuinely need it contains the blast radius of any single compromised account.
+      audit: |
+        ### Audit via Admin Console
 
-        ### Security impact
+        1. In the Admin Console, go to **Security > Administrators**.
+        2. Filter the administrator list by the **Organization Administrator** role.
+        3. Count the users assigned that role.
 
-        High
+        A passing result shows the org admin count within the approved threshold; a failing result shows more org admins than the threshold allows.
 
-        ### User impact
+        ### Audit via API
 
-        None
+        Query the Okta API and inspect the result:
 
-        Reassigning users to more specific admin roles does not affect end-user sign-in or application access.
+        ```bash
+        curl -s -H "Authorization: SSWS $OKTA_API_TOKEN" \
+          "https://$OKTA_ORG.okta.com/api/v1/users"
+        ```
+
+        For each user, retrieve assigned roles with `GET /api/v1/users/{id}/roles`. A passing response has the number of users with a role `type` of `ORG_ADMIN` within the threshold; a failing response has more than the threshold.
       remediation:
         - id: console
           desc: |


### PR DESCRIPTION
Brings `mondoo-okta-security` (34 parent checks) up to the `content/CLAUDE.md` authoring standards.

## Changes

- **Audit sections** — added an `audit:` block to all 34 checks, each with `### Audit via Admin Console` and `### Audit via API` (curl against the Okta API) verification paths. Previously no check had an audit section.
- **Descriptions** — rewrote all 34 `desc:` bodies from the ad-hoc `## Okta Recommends` style to the docs template: lead assertion paragraph, bulleted **Why this matters**, bulleted **Risk mitigation**.
- **Compliance tags** — verified every `compliance/*` tag on all 34 checks against the authoritative framework control text across all 12 active frameworks; remapped where a better control fits and set to `false` where no control matches (PCI DSS has no genuine control for the two ThreatInsight IP-blocking checks, the password minimum-age check, the expiry-warning check, or the show-lockout-failures check).
- Version bump 2.3.0 → 2.3.1.

`cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)