### PR TITLE
:memo: Bring the Slack security policy up to authoring standards

### DIFF
--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.5.0
+    version: 1.5.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -49,35 +49,55 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       slack.users.admins.length < 5 && slack.users.admins.length > 1
     docs:
       desc: |
-        This check verifies that your Slack workspace has between 2 and 4 administrator accounts, balancing operational resilience with security risk reduction.
+        This check ensures that the Slack workspace is configured to keep the number of administrator accounts between 2 and 4. Slack does not cap how many members can hold the admin or owner role, so workspaces tend to accumulate privileged accounts over time.
 
         **Why this matters**
 
-        The number of administrator accounts directly impacts both operational capability and security exposure:
+        - **Operational resilience:** Keeping at least two administrators avoids a single point of failure if one person is unavailable or leaves the organization.
+        - **Reduced attack surface:** Each admin account is a high-value target, so a small privileged group means fewer accounts an attacker can compromise.
+        - **Accountability:** A limited set of administrators keeps it clear who can make security-sensitive changes and simplifies audit reviews.
+        - **Shared responsibility:** Multiple administrators allow workload to be shared while keeping the privileged group small and reviewable.
 
-          - **Single point of failure**: Having only one admin creates operational risk if that person is unavailable or leaves the organization.
-          - **Expanded attack surface**: Each admin account is a high-value target; more admins means more potential compromise vectors.
-          - **Privilege creep**: Organizations often accumulate admins over time without removing former ones, unnecessarily expanding risk.
-          - **Audit complexity**: Too many admins makes it difficult to track who made security-sensitive changes.
-          - **Shared responsibility**: Multiple admins enable load sharing while keeping the privileged group small and accountable.
+        **Risk mitigation**
 
-        Maintain 2-4 administrators who actively need the privileges, and regularly review whether each admin account is still necessary.
+        - **Privilege creep prevention:** Regularly reviewing whether each admin account is still needed stops former or inactive admins from retaining access.
+        - **Containment:** A small admin group limits the blast radius if a privileged credential is phished or stolen.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage members**.
+        3. Filter the member list by **Account type** and select **Workspace Admins** and **Workspace Owners**.
+        4. Count the members shown.
+
+        A passing result shows between 2 and 4 members with the admin or owner role; a failing result shows 1 member or 5 or more members holding those roles.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/users.list"
+        ```
+
+        A passing response lists between 2 and 4 members where `is_admin` or `is_owner` is `true`; a failing response shows fewer than 2 or more than 4 such members.
       remediation: |
         Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Change a member's role](https://slack.com/help/articles/218124397-Change-a-members-role) in the Slack documentation.
     refs:
@@ -90,7 +110,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -99,26 +119,47 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       slack.users.admins.all(has2FA == true && twoFactorType == "app")
     docs:
       desc: |
-        This check verifies that all Slack administrator accounts use app-based two-factor authentication (TOTP) rather than SMS-based verification.
+        This check ensures that every Slack administrator account is configured to use app-based two-factor authentication rather than SMS verification. Slack supports both SMS and authenticator-app second factors, and SMS remains an option unless administrators deliberately choose the stronger method.
 
         **Why this matters**
 
-        Administrator accounts have full control over workspace security and require the strongest authentication protection:
+        - **SIM swap resistance:** Authenticator apps cannot be intercepted by attackers who convince a carrier to transfer a phone number to a device they control.
+        - **Protection from network attacks:** App-based codes are not exposed to known weaknesses in the cellular signaling network that allow SMS interception.
+        - **Social engineering resistance:** Codes generated on a device cannot be redirected by tricking carrier support staff.
+        - **Privileged account protection:** Administrators can disable security controls, export data, and add users, so their accounts warrant the strongest available factor.
+        - **Compliance alignment:** Many frameworks recommend or require phishing-resistant authentication for privileged accounts.
 
-          - **SIM swapping attacks**: SMS codes can be intercepted by attackers who convince carriers to transfer phone numbers.
-          - **SS7 vulnerabilities**: The cellular signaling network has known weaknesses that allow SMS interception.
-          - **Social engineering**: Carrier support staff can be tricked into redirecting SMS messages to attackers.
-          - **Elevated privileges**: Compromised admin accounts can disable security controls, export data, and add malicious users.
-          - **Regulatory requirements**: Many compliance frameworks recommend or require phishing-resistant authentication for privileged accounts.
+        **Risk mitigation**
 
-        Require all administrators to use authenticator apps (like Google Authenticator, Authy, or 1Password) instead of SMS for 2FA.
+        - **Account takeover prevention:** Removing SMS as an option closes the most common path used to bypass two-factor authentication on high-value accounts.
+        - **Consistent enforcement:** Standardizing administrators on authenticator apps ensures no privileged account silently falls back to a weaker factor.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage members**.
+        3. Filter the list to show **Workspace Admins** and **Workspace Owners**.
+        4. Review the **2FA** column for each administrator and confirm the method shown is an authentication app rather than SMS.
+
+        A passing result shows every administrator using an authentication app for two-factor authentication; a failing result shows an administrator with two-factor authentication disabled or set to SMS.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/users.list"
+        ```
+
+        A passing response shows every member with `is_admin` or `is_owner` set to `true` also having `has_2fa` set to `true` and `two_factor_type` set to `app`; a failing response shows an administrator with `has_2fa` false or `two_factor_type` set to `sms`.
       remediation: |
         Make sure that all admin accounts use authentication applications for two-factor authentication rather than SMS. To learn about setting up two-factor authentication to use an application, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
@@ -131,7 +172,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
@@ -140,26 +181,46 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
-      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       slack.users.members.where(name != /deactivateduser/).all( has2FA == true || enterpriseUser != empty || id=="USLACKBOT" )
     docs:
       desc: |
-        This check verifies that all active Slack users have two-factor authentication enabled on their accounts.
+        This check ensures that every active Slack user is configured with two-factor authentication enabled on their account. Slack leaves two-factor authentication optional for individual members unless an owner enforces it at the workspace or organization level.
 
         **Why this matters**
 
-        Two-factor authentication provides critical protection against credential-based attacks across all user accounts:
+        - **Credential stuffing resistance:** Passwords leaked from other services cannot be reused to access Slack when a second factor is required.
+        - **Phishing protection:** Even if a user enters credentials on a fake login page, an attacker cannot complete sign-in without the second factor.
+        - **Lateral movement containment:** A compromised account cannot easily be used to reach sensitive channels or impersonate employees when two-factor authentication blocks the login.
+        - **Data exfiltration prevention:** Blocking unauthorized sign-ins prevents attackers from searching and exporting confidential conversations and files.
+        - **Compliance alignment:** SOC 2, ISO 27001, and other frameworks require or recommend multi-factor authentication.
 
-          - **Credential stuffing**: Passwords leaked from other services can be used to access Slack if 2FA is not enabled.
-          - **Phishing protection**: Even if users enter credentials on a fake login page, attackers cannot complete authentication without the second factor.
-          - **Lateral movement**: Compromised user accounts can be used to access sensitive channels and impersonate employees.
-          - **Data exfiltration**: Attackers with account access can search and export confidential conversations and files.
-          - **Compliance requirements**: SOC 2, ISO 27001, and other frameworks require or recommend multi-factor authentication.
+        **Risk mitigation**
 
-        Enable 2FA requirements at the workspace or organization level to ensure all users are protected, not just those who opt in.
+        - **Workspace-wide enforcement:** Requiring two-factor authentication at the workspace or organization level protects every member instead of only those who opt in.
+        - **Reduced account takeover risk:** A mandatory second factor closes the most common path attackers use to convert a stolen password into account access.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage members** and review the **2FA** column for each active member.
+        3. To confirm enforcement, open **Settings & administration > Workspace settings** and select the **Authentication** tab, then verify that two-factor authentication is required for all members.
+
+        A passing result shows two-factor authentication required for the workspace and enabled for every active member; a failing result shows an active member without two-factor authentication or workspace enforcement turned off.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/users.list"
+        ```
+
+        A passing response shows every active member, where `deleted` is `false` and `is_bot` is `false`, with `has_2fa` set to `true`; a failing response shows an active human member with `has_2fa` set to `false`.
       remediation: |
         Make sure that all users have some form of two-factor authentication enabled. To learn about setting up two-factor authentication, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
@@ -172,18 +233,18 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: false
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
+      compliance/nist-csf-2: nist-csf-2-id-am-03
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-20
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: false
     props:
       - uid: mondooSlackSecurityExternalChannelName
         title: Enter your naming pattern for externally shared Slack channels in the mql below
@@ -193,19 +254,40 @@ queries:
       slack.conversations.where(isExtShared && isChannel ).all(name == props.mondooSlackSecurityExternalChannelName )
     docs:
       desc: |
-        This check verifies that externally shared Slack channels follow a consistent naming pattern (such as "ext-" or "external-") that clearly identifies them.
+        This check ensures that every externally shared Slack channel is named with a consistent pattern that identifies it as external, such as a prefix of "ext-" or "external-". Slack does not enforce naming conventions for shared channels, so externally shared channels can otherwise look identical to internal ones.
 
         **Why this matters**
 
-        Clear visual distinction between internal and external channels prevents accidental information disclosure:
+        - **Context awareness:** A clear naming pattern lets users immediately recognize when they are communicating with parties outside the organization.
+        - **Leakage prevention:** Without distinct naming, employees may share confidential information in a channel they assume is internal.
+        - **Audit efficiency:** Consistent naming makes it straightforward to locate and review every external communication channel.
+        - **Access control reviews:** Security teams can quickly identify external channels during periodic access reviews.
+        - **Automated monitoring:** A predictable naming convention supports automated alerting on external channel activity.
 
-          - **Context awareness**: Users immediately know when they're communicating with external parties based on channel name.
-          - **Sensitive information leakage**: Without clear naming, employees may share confidential information in channels they believe are internal.
-          - **Audit and compliance**: Consistent naming makes it easy to identify and review all external communication channels.
-          - **Access control reviews**: Security teams can quickly locate external channels during periodic access reviews.
-          - **Policy enforcement**: Naming conventions support automated monitoring and alerting for external channel activity.
+        **Risk mitigation**
 
-        Establish and enforce a naming convention (like prefixing with "ext-" or "external-") for all channels shared with parties outside your organization.
+        - **Accidental disclosure prevention:** Visible external markers reduce the chance that sensitive information is posted to an outside audience by mistake.
+        - **Governance enforcement:** A documented naming standard gives administrators a reliable basis for monitoring and enforcing external sharing policy.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage channels**.
+        3. Filter the channel list by **Channel type** and select externally shared channels, including Slack Connect channels.
+        4. Review the name of each external channel against your documented naming pattern.
+
+        A passing result shows every externally shared channel using the agreed naming pattern; a failing result shows an externally shared channel whose name does not match the pattern.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/conversations.list?types=public_channel,private_channel"
+        ```
+
+        A passing response shows every channel with `is_ext_shared` set to `true` having a `name` that matches your external naming pattern; a failing response shows an externally shared channel with a non-conforming `name`.
       remediation: |
         Make sure to use a fixed pattern for all externally shared channels. To learn more, read [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
     refs:
@@ -218,18 +300,18 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-20
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: false
     mql: |
       slack.conversations.where(isChannel == true)
         .any(
@@ -240,19 +322,39 @@ queries:
         )
     docs:
       desc: |
-        This check verifies that your Slack workspace has at least one channel that is exclusively internal and not shared with external users, organizations, or other workspaces.
+        This check ensures that the Slack workspace is configured with at least one channel that is exclusively internal and not shared with external users, other organizations, or other workspaces. A workspace whose channels are all shared in some way leaves no guaranteed space for confidential internal communication.
 
         **Why this matters**
 
-        Internal-only channels are essential for confidential organizational communication:
+        - **Confidential discussion space:** Sensitive topics such as personnel matters, strategy, and security incidents need a channel with no external access.
+        - **Configuration signal:** A workspace with no internal channels can indicate improper setup or misuse.
+        - **Compliance boundaries:** Some communications must remain within organizational boundaries to satisfy regulatory requirements.
+        - **Incident response:** Security incidents should be coordinated where external parties cannot observe them.
+        - **Employee-only topics:** Onboarding and HR discussions require a channel guaranteed to exclude contractors and external partners.
 
-          - **Confidential discussions**: Sensitive topics like personnel matters, strategy, or security incidents require channels without external access.
-          - **Shadow IT indicator**: A workspace with no internal channels may indicate improper workspace configuration or misuse.
-          - **Compliance boundaries**: Certain communications must remain within organizational boundaries for regulatory compliance.
-          - **Incident response**: Security incidents should be coordinated in channels that external parties cannot access.
-          - **Onboarding and HR**: Employee-only topics require channels guaranteed to exclude contractors or external partners.
+        **Risk mitigation**
 
-        Ensure at least one channel exists for purely internal communication, and clearly communicate its purpose to employees.
+        - **Information leakage prevention:** A dedicated internal channel gives employees a safe place to discuss sensitive matters without external exposure.
+        - **Clear scoping:** Maintaining and communicating the purpose of an internal-only channel reduces the chance that confidential conversations happen in shared channels.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage channels**.
+        3. Review the channel list and identify channels that are not shared with external users, other organizations, or other workspaces.
+
+        A passing result shows at least one channel that is fully internal with no external or cross-workspace sharing; a failing result shows that every channel is shared in some form.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/conversations.list?types=public_channel,private_channel"
+        ```
+
+        A passing response includes at least one channel where `is_shared`, `is_ext_shared`, `is_org_shared`, and `is_pending_ext_shared` are all `false`; a failing response shows no such channel.
       remediation: |
         Create at least one channel that is for internal workspace use only. To learn more, read [Slack Connect: Manage channel invitation settings and permissions](https://slack.com/help/articles/1500012572621-Slack-Connect--Manage-channel-invitation-settings-and-permissions-) in the Slack documentation.
     refs:
@@ -265,18 +367,18 @@ queries:
     impact: 50
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-20
+      compliance/pci-dss-4: pcidss-requirement-7-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       slack.conversations.where(isChannel == true)
         .where(
@@ -294,19 +396,40 @@ queries:
         )
     docs:
       desc: |
-        This check verifies that internal-only channels do not contain external members such as guest users, strangers, or single-channel guests.
+        This check ensures that internal-only Slack channels are kept free of external members such as guest users, single-channel guests, and strangers from connected organizations. Channels that are not externally shared can still pick up restricted or guest accounts as members, which undermines their internal status.
 
         **Why this matters**
 
-        Internal channels can be compromised by the presence of users who should not have access to internal communications:
+        - **Guest access control:** Guest accounts can be added to channels meant for employees only if membership is not reviewed.
+        - **Stranger detection:** Users from connected organizations can appear in channels through Slack Connect features.
+        - **Single-channel guest scope:** Limited-access guests may end up in channels beyond their intended scope.
+        - **Leakage prevention:** External members in a channel believed to be internal can read confidential discussions and files.
+        - **Accurate trust assumptions:** Verified membership prevents employees from sharing sensitive information under a false belief that the channel is internal-only.
 
-          - **Guest user access**: Guest accounts may inadvertently be added to channels meant for employees only.
-          - **Stranger presence**: Users from connected organizations may appear in channels through Slack Connect features.
-          - **Single-channel guests**: Limited-access guests might be present in channels beyond their intended scope.
-          - **Information leakage**: External members in "internal" channels can access confidential discussions and files.
-          - **False sense of security**: Employees may share sensitive information believing the channel is internal-only.
+        **Risk mitigation**
 
-        Regularly audit internal channel membership to ensure only authorized employees are present, and remove any external users immediately.
+        - **Membership audits:** Regularly reviewing internal channel membership ensures only authorized employees remain and external users are removed promptly.
+        - **Confidentiality assurance:** Keeping guest and restricted accounts out of internal channels preserves a reliable space for sensitive communication.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage channels** and select a channel that should be internal only.
+        3. Open the channel's member list and review each member's account type.
+        4. Confirm that no member is a guest, single-channel guest, or external user.
+
+        A passing result shows at least one internal channel whose members are all full members of your organization; a failing result shows an internal channel that includes a guest, restricted, or external member.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/conversations.members?channel=$CHANNEL_ID"
+        ```
+
+        Cross-reference each returned member ID against `users.list`. A passing response shows an internal channel where no member has `is_restricted`, `is_ultra_restricted`, or `is_stranger` set to `true`; a failing response shows such a member present.
       remediation: |
         Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
     refs:
@@ -319,18 +442,18 @@ queries:
     impact: 75
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-20
+      compliance/pci-dss-4: pcidss-requirement-7-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     props:
       - uid: mondooSlackSecurityAllowListedDomains
         title: Enter your domains in the mql below
@@ -339,19 +462,40 @@ queries:
     mql: slack.conversations.where(isExtShared == false ).all( members.all( profile['email'] == props.mondooSlackSecurityAllowListedDomains ) )
     docs:
       desc: |
-        This check verifies that all members of internal (non-externally-shared) channels have email addresses from your organization's allowed domains.
+        This check ensures that every member of an internal, non-externally-shared Slack channel has an email address from one of your organization's approved domains. Slack channel membership can include accounts with unexpected email domains unless membership is verified against an allowlist.
 
         **Why this matters**
 
-        Domain-based access control ensures that only authorized users can access internal communications:
+        - **Unauthorized access detection:** An email address from a domain that is not approved can indicate an account added incorrectly or maliciously.
+        - **Former employee identification:** Personal email accounts or previous employer domains point to users who should no longer have access.
+        - **Third-party scope control:** Vendor or partner accounts in internal channels can reach information beyond their engagement scope.
+        - **Data governance:** Regulations often require that certain data be accessible only to employees with corporate identities.
+        - **Offboarding verification:** Domain allowlisting surfaces users who should have been removed when they left the organization.
 
-          - **Unauthorized access**: Users with email addresses from unauthorized domains may have been added incorrectly or maliciously.
-          - **Former employee access**: Personal email accounts or previous employer domains indicate users who shouldn't have access.
-          - **Third-party infiltration**: Vendor or partner users in internal channels can access information beyond their engagement scope.
-          - **Data governance**: Regulatory requirements often mandate that certain data only be accessible to employees with corporate identities.
-          - **Offboarding gaps**: Domain allowlisting helps identify users who should have been removed when they left the organization.
+        **Risk mitigation**
 
-        Configure your allowed domains list to match your organization's email domains, and regularly review internal channel membership.
+        - **Membership reviews:** Configuring the allowed domain list to match your corporate domains and reviewing internal channel membership catches accounts that do not belong.
+        - **Identity enforcement:** Limiting internal channels to approved domains keeps confidential communication scoped to verified organizational identities.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage channels** and select an internal channel.
+        3. Open the channel's member list and review the email address associated with each member.
+        4. Confirm that every email domain appears on your organization's approved domain list.
+
+        A passing result shows every internal channel member with an email address from an approved domain; a failing result shows a member whose email domain is not on the allowlist.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/conversations.members?channel=$CHANNEL_ID"
+        ```
+
+        Resolve each member ID with `users.list` and read the `profile.email` field. A passing response shows every member of an internal channel with an email domain on your allowlist; a failing response shows a member with an email domain that is not approved.
       remediation: |
         Review all internal channels for members with email domains not on your allowlist. Remove unauthorized users and investigate how they gained access. To manage workspace membership, read [Manage members in your Slack workspace](https://slack.com/help/articles/201314026-Manage-members-in-a-workspace) in the Slack documentation.
     refs:
@@ -364,18 +508,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-13
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-16
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-6
       compliance/nist-csf-2: nist-csf-2-pr-aa-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-12
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       slack.users.members
         .where(
@@ -389,19 +533,40 @@ queries:
         .all(isEmailConfirmed == true)
     docs:
       desc: |
-        This check verifies that every active (non-bot, non-deactivated, non-pending-invite) member of the Slack workspace has a confirmed email address.
+        This check ensures that every active Slack member, excluding bots, deactivated accounts, and pending invites, has a confirmed email address. An unconfirmed email address means Slack has not verified that the account holder actually controls the email it was registered with, which breaks an assumption that downstream security controls depend on.
 
         **Why this matters**
 
-        An unconfirmed email address means Slack has not verified that the person using the account actually controls the email it was registered with. That breaks a core assumption most downstream security controls depend on:
+        - **Account takeover resistance:** Attackers can register accounts with look-alike domains and never prove ownership before participating in channels and direct messages.
+        - **Identity spoofing prevention:** Unconfirmed accounts can impersonate employees, partners, or executives in phishing and social engineering without being caught by email domain controls.
+        - **Recovery flow integrity:** When an email was never verified, a password reset link may be delivered to an address the real user cannot access, enabling a silent hijack.
+        - **Trustworthy allowlists:** Domain-based allowlisting assumes the email is real, so an unconfirmed address means the allowlist is protecting a string rather than a verified identity.
+        - **Audit trail reliability:** Messages, file uploads, and channel joins attributed to an unconfirmed user cannot be reliably traced back to a person.
 
-          - **Account takeover via typo-squatting**: Attackers can register accounts with look-alike domains (`acme-co.com` vs. `acme.co`) and never need to prove ownership to participate in channels and DMs.
-          - **Identity spoofing**: Unconfirmed accounts can impersonate employees, partners, or executives in phishing and social-engineering attacks without being caught by email-domain controls.
-          - **Password reset pivot**: If the email was never verified, a recovery flow that emails a reset link may deliver it to an address the real user cannot access — enabling silent hijack.
-          - **Bypassing SSO / domain allowlists**: Workspaces that rely on domain-based allowlisting assume the email is real; an unconfirmed address means the allowlist is protecting a string, not a verified identity.
-          - **Audit trail integrity**: Messages, file uploads, and channel joins attributed to an unconfirmed user cannot be reliably traced back to a human.
+        **Risk mitigation**
 
-        Review every flagged account and require the user to confirm their email address, or deactivate the account if it cannot be verified.
+        - **Verified membership:** Requiring every flagged user to confirm their email address, or deactivating accounts that cannot be verified, ensures each account maps to a real person.
+        - **Stronger onboarding:** Requiring SSO or a verified corporate domain at sign-up prevents new accounts from being created with unverified addresses.
+      audit: |
+        ### Audit via Admin Settings
+
+        1. Sign in to your Slack workspace as an owner or admin.
+        2. Open **Settings & administration > Manage members**.
+        3. Review the member list for accounts flagged as having an unconfirmed or pending email address.
+        4. Open **Settings & administration > Workspace settings** to confirm that sign-in options require SSO or a verified corporate domain.
+
+        A passing result shows every active human member with a confirmed email address; a failing result shows an active member whose email address is still unconfirmed.
+
+        ### Audit via API
+
+        Query the Slack Web API and inspect the result:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+          "https://slack.com/api/users.list"
+        ```
+
+        A passing response shows every active human member, where `deleted` and `is_bot` are `false`, with `is_email_confirmed` set to `true`; a failing response shows such a member with `is_email_confirmed` set to `false`.
       remediation: |
         Investigate each flagged user:
 


### PR DESCRIPTION
Brings `mondoo-slack-security` (8 checks) up to the `content/CLAUDE.md` authoring standards.

## Changes

- **Audit sections** — added an `audit:` block to all 8 checks, each with `### Audit via Admin Settings` and `### Audit via API` (curl against the Slack Web API) verification paths. Previously no check had an audit section.
- **Descriptions** — rewrote all 8 `desc:` bodies to the docs template: lead assertion paragraph, bulleted **Why this matters**, bulleted **Risk mitigation**.
- **Compliance tags** — verified every `compliance/*` tag on all 8 checks against the authoritative framework control text across all 12 active frameworks; remapped where a better control fits and set to `false` where no control matches (the channel-naming check has no genuine control in several frameworks, since a naming convention is not itself a technical access control).
- Version bump 1.5.0 → 1.5.1.

`cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)