### PR TITLE
:memo: Verify compliance framework mappings on the Microsoft 365 policy

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.3.0
+    version: 2.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -101,11 +101,11 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-de-cm-3
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-10
-      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -300,11 +300,11 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-de-cm-3
-      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-10
-      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-7
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -1094,14 +1094,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       microsoft.policies.identitySecurityDefaultsEnforcementPolicy.isEnabled == false
     docs:
@@ -1186,12 +1186,12 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
       compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-1
-      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(1,4))
@@ -1330,7 +1330,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-19
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-3-1-4
@@ -1430,14 +1430,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
       compliance/pci-dss-4: pcidss-requirement-8-3-6
       compliance/soc2-2017: soc2-control-cc6-1-8
-      compliance/vda-isa-5: vda-isa-5-4-1-3
+      compliance/vda-isa-5: vda-isa-5-3-1-4
     mql: |
       microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.windows10GeneralConfiguration").all(properties.passwordMinimumLength >= 8)
       microsoft.devicemanagement.deviceConfigurations.where( properties["@odata.type"] == "#microsoft.graph.macOSGeneralDeviceConfiguration").all(properties.passwordMinimumLength >= 8)
@@ -1557,7 +1557,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1657,9 +1657,9 @@ queries:
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
       compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-5-4-1
       compliance/soc2-2017: soc2-control-cc6-6-4
@@ -1799,16 +1799,16 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
-      compliance/nis-2: nis-2-21-2-e
+      compliance/nis-2: nis-2-21-2-d
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-3
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-9
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps == false
@@ -2175,7 +2175,7 @@ queries:
       compliance/nis-2: false
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
       compliance/pci-dss-4: pcidss-requirement-5-4-1
       compliance/soc2-2017: soc2-control-cc6-8-4
@@ -2266,7 +2266,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-10
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2447,7 +2447,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
@@ -2530,7 +2530,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
@@ -2615,12 +2615,12 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nis-2: nis-2-21-2-d
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-9
@@ -2713,7 +2713,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
-      compliance/vda-isa-5: vda-isa-5-4-1-2
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       microsoft.identityAndAccess.roleEligibilityScheduleInstances != empty
     docs:
@@ -2795,18 +2795,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
-      compliance/hipaa: false
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-5-4-1
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/v=DMARC1/))
       microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/p=quarantine|p=reject/))


### PR DESCRIPTION
Completes the `content/CLAUDE.md` authoring-standards audit for `mondoo-m365-security` (23 checks) by verifying the compliance tags.

## Changes

- **Compliance tags** — verified every `compliance/*` tag on all 23 Microsoft 365 checks against the authoritative framework control text across all 12 active frameworks. Remapped where a better control fits and set to `false` where no control matches; 37 tag values were corrected. The most common corrections moved SPF/DMARC/anti-phishing checks onto the precise spam-protection and boundary controls each framework provides, and moved admin-count and consent checks onto least-privilege and authorization controls.
- Version bump 2.3.0 → 2.3.1.

The audit sections and the docs-template descriptions were already in place from earlier work, so this pass is scoped to the compliance verification phase.

`cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)