### PR TITLE
:memo: Verify compliance framework mappings on the VMware vSphere policies

### DIFF
--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline
     name: Mondoo VMware vSphere ESXi Security
-    version: 2.0.0
+    version: 2.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -88,18 +88,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
       compliance/pci-dss-4: pcidss-requirement-8-3-4
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.advancedSettings['Security.AccountUnlockTime'] == 900
     docs:
@@ -161,17 +161,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
       compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc7-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.kernelModules.where( loaded == true ).all( signedStatus != "Unsigned" )
     docs:
@@ -242,18 +242,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
-      compliance/nist-sp-800-53-rev5: false
-      compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthEnabled'] == true )
       vsphere.host.properties['config']['storageDevice']['hostBusAdapter'].where( _['driver'] == 'iscsi_vmk' ).all( _['authenticationProperties']['chapAuthenticationType'] == 'chapPreferred' )
@@ -330,17 +330,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-3-1
     mql: |
       vsphere.host.dnsConfig.dhcp == false
       vsphere.host.dnsConfig.servers != empty
@@ -406,17 +406,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.advancedSettings['Net.DVFilterBindIpAddress'] == empty
     docs:
@@ -483,18 +483,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
       compliance/pci-dss-4: pcidss-requirement-8-2-8
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] <= 300
       vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] != 0
@@ -561,17 +561,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.advancedSettings['Config.HostAgent.plugins.solo.enableMob'] == false
     docs:
@@ -633,17 +633,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       vsphere.host.properties['config']['lockdownMode'] == "lockdownNormal"
     docs:
@@ -705,17 +705,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a7
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
-      compliance/dora: false
+      compliance/dora: dora-art-10
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
       compliance/pci-dss-4: pcidss-requirement-10-6-1
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.services.where( key == "ntpd").all( running == true )
       vsphere.host.services.where( key == "ntpd").all( policy == "on" )
@@ -780,17 +780,17 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a6
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-02
+      compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.advancedSettings['Syslog.global.logDir'] != ""
@@ -854,17 +854,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan-vsphere
         tags:
@@ -951,17 +951,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-vsphere
         tags:
@@ -1045,17 +1045,17 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a6
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-02
+      compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
-      compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: false
+      compliance/pci-dss-4: pcidss-requirement-10-3-3
+      compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.advancedSettings['Syslog.global.logHost'] != ""
@@ -1119,17 +1119,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.services.where( key == "TSM-SSH").all( running == false )
       vsphere.host.services.where( key == "TSM-SSH").all( policy == "off" )
@@ -1196,17 +1196,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       vsphere.host.properties['config']['lockdownMode'] == "lockdownStrict"
     docs:
@@ -1268,18 +1268,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
       compliance/pci-dss-4: pcidss-requirement-8-2-8
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] <= 600
       vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] != 0
@@ -1338,17 +1338,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-4
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-3-1
     mql: vsphere.host.advancedSettings['Mem.ShareForceSalting'] == 2
     docs:
       desc: |-
@@ -1412,18 +1412,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
       compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
-      compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
-      compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.services.where( running == true ).all( ruleset != [] )
       vsphere.host.properties['config']['firewall']['ruleset'].all( _['allowedHosts']['allIp'] == false )
@@ -1482,14 +1482,14 @@ queries:
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1549,17 +1549,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.services.where( key == "TSM").all( running == false )
       vsphere.host.services.where( key == "TSM").all( policy == "off" )
@@ -1621,17 +1621,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
-      compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
       compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc7-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: vsphere.host.acceptanceLevel == /VMwareCertified|VMwareAccepted|PartnerSupported/
     docs:
       desc: |-
@@ -1694,18 +1694,18 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
       compliance/pci-dss-4: pcidss-requirement-8-3-4
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5
     docs:
@@ -1767,18 +1767,18 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: false
-      compliance/dora: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
-      compliance/iso-27001-2022: false
-      compliance/nis-2: false
-      compliance/nist-csf-1: false
-      compliance/nist-csf-2: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-18
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
       compliance/pci-dss-4: pcidss-requirement-8-2-8
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] <= 3600
       vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] != 0
@@ -1842,17 +1842,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.services.where( key == "slpd" ).all( running == false )
       vsphere.host.services.where( key == "slpd" ).all( policy == "off" )
@@ -1919,17 +1919,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.services.where( key == "snmpd" ).all( running == false )
       vsphere.host.services.where( key == "snmpd" ).all( policy == "off" )
@@ -1995,17 +1995,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/pci-dss-4: pcidss-requirement-1-4-3
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-vsphere
         tags:
@@ -2098,17 +2098,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/pci-dss-4: pcidss-requirement-1-4-3
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-mac-address-change-policy-is-set-to-reject-vsphere
         tags:
@@ -2201,17 +2201,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: false
-      compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     variants:
       - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-promiscuous-mode-policy-is-set-to-reject-vsphere
         tags:
@@ -2305,17 +2305,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
+      compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-8
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
       compliance/pci-dss-4: pcidss-requirement-2-2-1
-      compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/soc2-2017: soc2-control-cc7-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.host.secureBootEnabled == true
     docs:

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-security-baseline
     name: Mondoo VMware vSphere Security Baseline
-    version: 2.0.0
+    version: 2.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -103,17 +103,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-a-virtual-trusted-platform-module-is-present-vsphere
         tags:
@@ -195,17 +195,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled-vsphere
         tags:
@@ -293,17 +293,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled-vsphere
         tags:
@@ -388,17 +388,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-get-is-disabled-vsphere
         tags:
@@ -487,17 +487,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-drag-and-drop-version-set-is-disabled-vsphere
         tags:
@@ -586,17 +586,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-getcreds-is-disabled-vsphere
         tags:
@@ -685,17 +685,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-launch-menu-is-disabled-vsphere
         tags:
@@ -784,17 +784,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-protocol-handler-is-set-to-disabled-vsphere
         tags:
@@ -883,17 +883,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-guest-host-interaction-tray-icon-is-disabled-vsphere
         tags:
@@ -982,17 +982,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-hardware-based-3d-acceleration-is-disabled-vsphere
         tags:
@@ -1080,17 +1080,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled-vsphere
         tags:
@@ -1179,17 +1179,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-information-is-not-sent-to-guests-vsphere
         tags:
@@ -1277,17 +1277,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
-      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited-vsphere
         tags:
@@ -1366,17 +1366,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled-vsphere
         tags:
@@ -1466,17 +1466,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
-      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all(
         vms.all(
@@ -1536,17 +1536,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
-      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-10
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time-vsphere
         tags:
@@ -1640,17 +1640,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( advancedSettings.where ( key.contains('pciPassthru')).length == 0 ) )
     docs:
@@ -1703,17 +1703,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled-vsphere
         tags:
@@ -1802,17 +1802,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-shell-action-is-disabled-vsphere
         tags:
@@ -1901,16 +1901,16 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-a
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-the-number-of-vm-log-files-is-configured-properly-vsphere
@@ -2000,17 +2000,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-trash-folder-state-is-disabled-vsphere
         tags:
@@ -2099,17 +2099,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines-vsphere
         tags:
@@ -2191,17 +2191,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled-vsphere
         tags:
@@ -2277,17 +2277,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-modification-and-disconnection-of-devices-is-disabled-vsphere
         tags:
@@ -2363,17 +2363,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-active-is-disabled-vsphere
         tags:
@@ -2462,17 +2462,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-interlock-is-disabled-vsphere
         tags:
@@ -2561,17 +2561,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-is-disabled-vsphere
         tags:
@@ -2660,17 +2660,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-push-update-is-disabled-vsphere
         tags:
@@ -2759,17 +2759,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-taskbar-is-disabled-vsphere
         tags:
@@ -2858,17 +2858,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-unity-window-contents-is-disabled-vsphere
         tags:
@@ -2958,17 +2958,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('CD') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -3022,17 +3022,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where( _['deviceInfo']['label'].contains('Floppy') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -3086,17 +3086,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Parallel') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -3151,17 +3151,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['connected'] == false ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('Serial') ).all( _['connectable']['startConnected'] == false ) ) )
@@ -3216,17 +3216,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['connected'] == false || _['connectable']['connected'] == null ) ) )
       vsphere.datacenters.all( vms.all( properties['config']['hardware']['device'].where ( _['deviceInfo']['label'].contains('USB') ).all( _['connectable']['startConnected'] == false || _['connectable']['startConnected'] == null ) ) )
@@ -3279,17 +3279,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-shrinking-is-disabled-vsphere
         tags:
@@ -3378,17 +3378,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-disk-wiping-is-disabled-vsphere
         tags:
@@ -3544,17 +3544,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
-      compliance/pci-dss-4: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled-vsphere
         tags:
@@ -3638,17 +3638,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled-vsphere
         tags:
@@ -3733,17 +3733,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-drag-and-drop-operations-is-disabled-vsphere
         tags:
@@ -3828,17 +3828,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-gui-options-is-disabled-vsphere
         tags:
@@ -3923,17 +3923,17 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a16
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
-      compliance/dora: false
-      compliance/hipaa: false
-      compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
-      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-a
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-3
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-paste-operations-are-disabled-vsphere
         tags:
@@ -4018,16 +4018,16 @@ queries:
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a6
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
-      compliance/dora: false
-      compliance/hipaa: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-a
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
       compliance/pci-dss-4: pcidss-requirement-10-2-1
-      compliance/soc2-2017: false
+      compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     variants:
       - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-log-file-size-is-limited-vsphere


### PR DESCRIPTION
Completes the `content/CLAUDE.md` authoring-standards audit for the two VMware vSphere policies by verifying the compliance tags:

- `mondoo-vmware-vsphere` — 44 checks
- `mondoo-vmware-vsphere-esxi` — 29 checks

## Changes

- **Compliance tags** — verified every `compliance/*` tag on all 73 checks across both policies against the authoritative framework control text for all 12 active frameworks. Remapped where a better control fits and set to `false` where no control matches. Many ESXi checks that were previously `false` now carry a verified control; the VM-hardening checks were retagged onto the precise least-functionality, data-leakage, integrity, and boundary controls each framework provides.
- Version bump 2.0.0 → 2.0.1 on both policies.

The audit sections and the docs-template descriptions were already in place from earlier work, so this pass is scoped to the compliance verification phase.

`cnspec policy lint` passes for both policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)