### PR TITLE
:memo: Add Ansible remediation steps to the AI security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -307,6 +307,7 @@ fullchain
 fumadocs
 funcapp
 functionapp
+fuser
 fwpolicy
 gbs
 GCMAES
@@ -573,6 +574,7 @@ pii
 pipefail
 pkgng
 pki
+pkill
 pkr
 pmd
 pmf
@@ -732,7 +734,6 @@ tailnets
 tailscale
 tallylog
 tbl
-Tbps
 tde
 TDS
 tensorboard

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -179,7 +179,7 @@ queries:
           desc: |
             To stop and remove unapproved AI agent processes with Ansible:
 
-            This playbook terminates any running AI processes matching the known tool names and removes the associated packages. Define the `unapproved_ai_packages` list in your inventory or group variables before running.
+            This playbook terminates any running AI processes matching the known tool names and removes the associated packages. The `unapproved_ai_packages` list below holds placeholder values — replace them with the package names flagged on your endpoints.
 
             ```yaml
             ---
@@ -200,6 +200,11 @@ queries:
             - name: Remove unapproved AI packages (system)
               hosts: workstations
               become: true
+              vars:
+                unapproved_ai_packages:
+                  - ollama
+                  - lm-studio
+                  - gpt4all
               tasks:
                 - name: Remove unapproved AI packages
                   ansible.builtin.package:
@@ -291,13 +296,18 @@ queries:
           desc: |
             To remove unapproved AI packages installed via system package managers with Ansible:
 
-            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints. Define the `unapproved_ai_packages` list in your inventory or group variables before running.
+            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints. The `unapproved_ai_packages` list below holds placeholder values — replace them with the package names flagged on your endpoints.
 
             ```yaml
             ---
             - name: Remove unapproved AI packages
               hosts: workstations
               become: true
+              vars:
+                unapproved_ai_packages:
+                  - ollama
+                  - lm-studio
+                  - gpt4all
               tasks:
                 - name: Remove unapproved AI package
                   ansible.builtin.package:
@@ -367,13 +377,18 @@ queries:
           desc: |
             To remove unapproved AI packages installed via Homebrew with Ansible:
 
-            This playbook removes unapproved AI packages from Homebrew on macOS endpoints. Define the `unapproved_homebrew_ai_packages` list in your inventory or group variables before running.
+            This playbook removes unapproved AI packages from Homebrew on macOS endpoints. The `unapproved_homebrew_ai_packages` list below holds placeholder values — replace them with the package names flagged on your endpoints.
 
             ```yaml
             ---
             - name: Remove unapproved Homebrew AI packages
               hosts: workstations
               become: false
+              vars:
+                unapproved_homebrew_ai_packages:
+                  - ollama
+                  - lm-studio
+                  - gpt4all
               tasks:
                 - name: Remove unapproved Homebrew AI package
                   community.general.homebrew:
@@ -2782,12 +2797,14 @@ queries:
           desc: |
             To remove Cursor-specific VS Code extensions with Ansible:
 
-            This playbook uninstalls Cursor-specific extensions from VS Code on the endpoint.
+            This playbook uninstalls a Cursor-specific extension from VS Code on the endpoint. The `cursor_extension_name` value is a placeholder — replace it with the `publisher.extension` identifier flagged on your endpoints.
 
             ```yaml
             ---
             - name: Remove the Cursor-specific VS Code extension
               hosts: workstations
+              vars:
+                cursor_extension_name: cursor.example-extension
               tasks:
                 - name: Uninstall the Cursor-specific extension
                   ansible.builtin.command:

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -179,7 +179,7 @@ queries:
           desc: |
             To stop and remove unapproved AI agent processes with Ansible:
 
-            This playbook terminates any running AI processes matching the known tool names and removes the associated packages.
+            This playbook terminates any running AI processes matching the known tool names and removes the associated packages. Define the `unapproved_ai_packages` list in your inventory or group variables before running.
 
             ```yaml
             ---
@@ -291,7 +291,7 @@ queries:
           desc: |
             To remove unapproved AI packages installed via system package managers with Ansible:
 
-            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints.
+            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints. Define the `unapproved_ai_packages` list in your inventory or group variables before running.
 
             ```yaml
             ---
@@ -367,7 +367,7 @@ queries:
           desc: |
             To remove unapproved AI packages installed via Homebrew with Ansible:
 
-            This playbook removes unapproved AI packages from Homebrew on macOS endpoints.
+            This playbook removes unapproved AI packages from Homebrew on macOS endpoints. Define the `unapproved_homebrew_ai_packages` list in your inventory or group variables before running.
 
             ```yaml
             ---
@@ -2791,7 +2791,7 @@ queries:
               tasks:
                 - name: Uninstall the Cursor-specific extension
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension {{ cursor_extension_name }}
+                    cmd: "code --uninstall-extension {{ cursor_extension_name }}"
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2945,26 +2945,30 @@ queries:
             - Gemini CLI: `~/.gemini/` (`%USERPROFILE%\.gemini\` on Windows)
         - id: ansible
           desc: |
-            To remove unapproved MCP server entries from AI agent configuration files with Ansible:
+            To surgically remove an unapproved MCP server entry from AI agent configuration files with Ansible:
 
-            This playbook removes unapproved MCP server configuration entries from each AI agent's settings file. Review and edit the `mcp_config_paths` variable to match your environment before running.
+            This playbook deletes a single named MCP server from each agent's `mcpServers` object using a JSON patch, leaving the rest of the configuration file intact. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. For agents whose configuration nests `mcpServers` under another key, adjust the JSON pointer in the `path` accordingly. Each file is backed up before modification.
 
             ```yaml
             ---
-            - name: Remove unapproved MCP servers
+            - name: Remove an unapproved MCP server
               hosts: workstations
+              vars:
+                unapproved_mcp_server: example-server
+                mcp_config_files:
+                  - "{{ ansible_env.HOME }}/.claude/settings.json"
+                  - "{{ ansible_env.HOME }}/.cursor/mcp.json"
+                  - "{{ ansible_env.HOME }}/.gemini/settings.json"
               tasks:
-                - name: Remove unapproved MCP server configuration files
-                  ansible.builtin.file:
-                    path: "{{ item }}"
-                    state: absent
-                  loop:
-                    - "{{ ansible_env.HOME }}/.claude/settings.json"
-                    - "{{ ansible_env.HOME }}/.cursor/mcp.json"
-                    - "{{ ansible_env.HOME }}/.codex/config.json"
-                    - "{{ ansible_env.HOME }}/.config/github-copilot/settings.json"
-                    - "{{ ansible_env.HOME }}/.codeium/windsurf/mcp_config.json"
-                    - "{{ ansible_env.HOME }}/.gemini/settings.json"
+                - name: Remove the unapproved server from each agent's mcpServers object
+                  community.general.json_patch:
+                    src: "{{ item }}"
+                    operations:
+                      - op: remove
+                        path: "/mcpServers/{{ unapproved_mcp_server }}"
+                    backup: true
+                  loop: "{{ mcp_config_files }}"
+                  failed_when: false
             ```
 
   # ---------------------------------------------------------------------------

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -175,6 +175,38 @@ queries:
             Stop-Process -Name <process_name>
             winget uninstall <tool_name>
             ```
+        - id: ansible
+          desc: |
+            To stop and remove unapproved AI agent processes with Ansible:
+
+            This playbook terminates any running AI processes matching the known tool names and removes the associated packages.
+
+            ```yaml
+            ---
+            - name: Remove unapproved AI agent processes
+              hosts: workstations
+              tasks:
+                - name: Kill unapproved AI agent processes
+                  ansible.builtin.command:
+                    cmd: pkill -f "{{ item }}"
+                  loop:
+                    - ollama
+                    - lmstudio
+                    - cursor
+                    - windsurf
+                    - codeium
+                  failed_when: false
+
+            - name: Remove unapproved AI packages (system)
+              hosts: workstations
+              become: true
+              tasks:
+                - name: Remove unapproved AI packages
+                  ansible.builtin.package:
+                    name: "{{ item }}"
+                    state: absent
+                  loop: "{{ unapproved_ai_packages }}"
+            ```
 
   - uid: mondoo-ai-security-no-unapproved-ai-packages
     title: No unapproved AI tools installed via package managers
@@ -255,6 +287,24 @@ queries:
             ```powershell
             winget uninstall <package_name>
             ```
+        - id: ansible
+          desc: |
+            To remove unapproved AI packages installed via system package managers with Ansible:
+
+            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints.
+
+            ```yaml
+            ---
+            - name: Remove unapproved AI packages
+              hosts: workstations
+              become: true
+              tasks:
+                - name: Remove unapproved AI package
+                  ansible.builtin.package:
+                    name: "{{ item }}"
+                    state: absent
+                  loop: "{{ unapproved_ai_packages }}"
+            ```
 
   - uid: mondoo-ai-security-no-unapproved-homebrew-ai-packages
     title: No unapproved AI tools installed via Homebrew
@@ -312,6 +362,24 @@ queries:
 
             ```bash
             brew uninstall <package_name>
+            ```
+        - id: ansible
+          desc: |
+            To remove unapproved AI packages installed via Homebrew with Ansible:
+
+            This playbook removes unapproved AI packages from Homebrew on macOS endpoints.
+
+            ```yaml
+            ---
+            - name: Remove unapproved Homebrew AI packages
+              hosts: workstations
+              become: false
+              tasks:
+                - name: Remove unapproved Homebrew AI package
+                  community.general.homebrew:
+                    name: "{{ item }}"
+                    state: absent
+                  loop: "{{ unapproved_homebrew_ai_packages }}"
             ```
 
   # ---------------------------------------------------------------------------
@@ -389,6 +457,26 @@ queries:
             Remove-Item -Recurse -Force "$env:USERPROFILE\.cursor"
             winget uninstall Cursor
             ```
+        - id: ansible
+          desc: |
+            To remove Cursor configuration directories with Ansible:
+
+            This playbook removes the Cursor editor configuration directories from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Cursor
+              hosts: workstations
+              tasks:
+                - name: Remove Cursor configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/Library/Application Support/Cursor"
+                    - "{{ ansible_env.HOME }}/.cursor"
+                    - "{{ ansible_env.HOME }}/.config/Cursor"
+            ```
 
   - uid: mondoo-ai-security-no-windsurf
     title: Windsurf editor is not configured on this endpoint
@@ -462,6 +550,26 @@ queries:
             Remove-Item -Recurse -Force "$env:USERPROFILE\.codeium\windsurf"
             winget uninstall Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove Windsurf configuration directories with Ansible:
+
+            This playbook removes the Windsurf editor configuration directories from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Windsurf
+              hosts: workstations
+              tasks:
+                - name: Remove Windsurf configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/Library/Application Support/Windsurf"
+                    - "{{ ansible_env.HOME }}/.codeium/windsurf"
+                    - "{{ ansible_env.HOME }}/.config/Windsurf"
+            ```
 
   - uid: mondoo-ai-security-no-goose
     title: Goose AI agent is not configured on this endpoint
@@ -524,6 +632,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:APPDATA\goose"
+            ```
+        - id: ansible
+          desc: |
+            To remove Goose configuration directories with Ansible:
+
+            This playbook removes the Goose AI agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Goose
+              hosts: workstations
+              tasks:
+                - name: Remove Goose configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.config/goose"
             ```
 
   - uid: mondoo-ai-security-no-zed
@@ -589,6 +715,26 @@ queries:
             rm -rf ~/.config/zed
             rm -rf ~/.local/share/zed
             ```
+        - id: ansible
+          desc: |
+            To remove Zed configuration directories with Ansible:
+
+            This playbook removes the Zed editor configuration directories from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Zed
+              hosts: workstations
+              tasks:
+                - name: Remove Zed configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/Library/Application Support/Zed"
+                    - "{{ ansible_env.HOME }}/.config/zed"
+                    - "{{ ansible_env.HOME }}/.local/share/zed"
+            ```
 
   - uid: mondoo-ai-security-no-cline
     title: Cline agent is not configured on this endpoint
@@ -644,6 +790,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
+            ```
+        - id: ansible
+          desc: |
+            To remove Cline configuration directories with Ansible:
+
+            This playbook removes the Cline agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Cline
+              hosts: workstations
+              tasks:
+                - name: Remove Cline configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.cline"
             ```
 
   - uid: mondoo-ai-security-no-roo
@@ -701,6 +865,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.roo"
             ```
+        - id: ansible
+          desc: |
+            To remove Roo Code configuration directories with Ansible:
+
+            This playbook removes the Roo Code agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Roo Code
+              hosts: workstations
+              tasks:
+                - name: Remove Roo Code configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.roo"
+            ```
 
   - uid: mondoo-ai-security-no-continuedev
     title: Continue agent is not configured on this endpoint
@@ -756,6 +938,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.continue"
+            ```
+        - id: ansible
+          desc: |
+            To remove Continue configuration directories with Ansible:
+
+            This playbook removes the Continue agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Continue
+              hosts: workstations
+              tasks:
+                - name: Remove Continue configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.continue"
             ```
 
   - uid: mondoo-ai-security-no-trae
@@ -813,6 +1013,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.trae"
             ```
+        - id: ansible
+          desc: |
+            To remove Trae configuration directories with Ansible:
+
+            This playbook removes the Trae agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Trae
+              hosts: workstations
+              tasks:
+                - name: Remove Trae configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.trae"
+            ```
 
   - uid: mondoo-ai-security-no-opencode
     title: OpenCode agent is not configured on this endpoint
@@ -868,6 +1086,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:APPDATA\opencode"
+            ```
+        - id: ansible
+          desc: |
+            To remove OpenCode configuration directories with Ansible:
+
+            This playbook removes the OpenCode agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove OpenCode
+              hosts: workstations
+              tasks:
+                - name: Remove OpenCode configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.config/opencode"
             ```
 
   - uid: mondoo-ai-security-no-kiro
@@ -925,6 +1161,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.kiro"
             ```
+        - id: ansible
+          desc: |
+            To remove Kiro configuration directories with Ansible:
+
+            This playbook removes the Kiro agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Kiro
+              hosts: workstations
+              tasks:
+                - name: Remove Kiro configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.kiro"
+            ```
 
   - uid: mondoo-ai-security-no-pi
     title: Pi agent is not configured on this endpoint
@@ -980,6 +1234,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.pi\agent"
+            ```
+        - id: ansible
+          desc: |
+            To remove Pi agent configuration directories with Ansible:
+
+            This playbook removes the Pi agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Pi
+              hosts: workstations
+              tasks:
+                - name: Remove Pi configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.pi/agent"
             ```
 
   - uid: mondoo-ai-security-no-mistral-vibe
@@ -1037,6 +1309,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.vibe"
             ```
+        - id: ansible
+          desc: |
+            To remove Mistral Vibe configuration directories with Ansible:
+
+            This playbook removes the Mistral Vibe agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Mistral Vibe
+              hosts: workstations
+              tasks:
+                - name: Remove Mistral Vibe configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.vibe"
+            ```
 
   - uid: mondoo-ai-security-no-antigravity
     title: Antigravity agent is not configured on this endpoint
@@ -1092,6 +1382,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.gemini\antigravity"
+            ```
+        - id: ansible
+          desc: |
+            To remove Antigravity configuration directories with Ansible:
+
+            This playbook removes the Antigravity agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Antigravity
+              hosts: workstations
+              tasks:
+                - name: Remove Antigravity configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.gemini/antigravity"
             ```
 
   - uid: mondoo-ai-security-no-ibm-bob
@@ -1149,6 +1457,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.bob"
             ```
+        - id: ansible
+          desc: |
+            To remove IBM Bob configuration directories with Ansible:
+
+            This playbook removes the IBM Bob agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove IBM Bob
+              hosts: workstations
+              tasks:
+                - name: Remove IBM Bob configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.bob"
+            ```
 
   - uid: mondoo-ai-security-no-openclaw
     title: OpenClaw is not configured on this endpoint
@@ -1204,6 +1530,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.openclaw"
+            ```
+        - id: ansible
+          desc: |
+            To remove OpenClaw configuration directories with Ansible:
+
+            This playbook removes the OpenClaw agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove OpenClaw
+              hosts: workstations
+              tasks:
+                - name: Remove OpenClaw configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.openclaw"
             ```
 
   - uid: mondoo-ai-security-no-snowflake-cortex
@@ -1261,6 +1605,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.snowflake\cortex"
             ```
+        - id: ansible
+          desc: |
+            To remove Snowflake Cortex configuration directories with Ansible:
+
+            This playbook removes the Snowflake Cortex Code agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Snowflake Cortex Code
+              hosts: workstations
+              tasks:
+                - name: Remove Snowflake Cortex configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.snowflake/cortex"
+            ```
 
   - uid: mondoo-ai-security-no-junie
     title: Junie is not configured on this endpoint
@@ -1317,6 +1679,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.junie"
             ```
+        - id: ansible
+          desc: |
+            To remove Junie configuration directories with Ansible:
+
+            This playbook removes the Junie agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Junie
+              hosts: workstations
+              tasks:
+                - name: Remove Junie configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.junie"
+            ```
 
   - uid: mondoo-ai-security-no-augment
     title: Augment is not configured on this endpoint
@@ -1372,6 +1752,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.augment"
+            ```
+        - id: ansible
+          desc: |
+            To remove Augment configuration directories with Ansible:
+
+            This playbook removes the Augment agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Augment
+              hosts: workstations
+              tasks:
+                - name: Remove Augment configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.augment"
             ```
 
   - uid: mondoo-ai-security-no-warp
@@ -1435,6 +1833,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
             ```
+        - id: ansible
+          desc: |
+            To remove Warp AI terminal configuration directories with Ansible:
+
+            This playbook removes the Warp terminal configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Warp
+              hosts: workstations
+              tasks:
+                - name: Remove Warp configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.warp"
+            ```
 
   - uid: mondoo-ai-security-no-kilocode
     title: Kilo Code is not configured on this endpoint
@@ -1490,6 +1906,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.kilocode"
+            ```
+        - id: ansible
+          desc: |
+            To remove Kilo Code configuration directories with Ansible:
+
+            This playbook removes the Kilo Code agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Kilo Code
+              hosts: workstations
+              tasks:
+                - name: Remove Kilo Code configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.kilocode"
             ```
 
   - uid: mondoo-ai-security-no-openhands
@@ -1547,6 +1981,24 @@ queries:
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.openhands"
             ```
+        - id: ansible
+          desc: |
+            To remove OpenHands configuration directories with Ansible:
+
+            This playbook removes the OpenHands agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove OpenHands
+              hosts: workstations
+              tasks:
+                - name: Remove OpenHands configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.openhands"
+            ```
 
   - uid: mondoo-ai-security-no-qwen-code
     title: Qwen Code is not configured on this endpoint
@@ -1602,6 +2054,24 @@ queries:
 
             ```powershell
             Remove-Item -Recurse -Force "$env:USERPROFILE\.qwen"
+            ```
+        - id: ansible
+          desc: |
+            To remove Qwen Code configuration directories with Ansible:
+
+            This playbook removes the Qwen Code agent configuration directory from the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove Qwen Code
+              hosts: workstations
+              tasks:
+                - name: Remove Qwen Code configuration directories
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.qwen"
             ```
 
   # ---------------------------------------------------------------------------
@@ -1668,6 +2138,24 @@ queries:
             cursor --uninstall-extension codeium.codeium     # Cursor
             windsurf --uninstall-extension codeium.codeium   # Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove the Codeium VS Code extension with Ansible:
+
+            This playbook uninstalls the Codeium extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Codeium VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Codeium extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension codeium.codeium
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-vscode-tabnine-extension
     title: No Tabnine extensions in VS Code-compatible editors
@@ -1729,6 +2217,24 @@ queries:
             code --uninstall-extension tabnine.tabnine-vscode       # VS Code
             cursor --uninstall-extension tabnine.tabnine-vscode     # Cursor
             windsurf --uninstall-extension tabnine.tabnine-vscode   # Windsurf
+            ```
+        - id: ansible
+          desc: |
+            To remove the Tabnine VS Code extension with Ansible:
+
+            This playbook uninstalls the Tabnine extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Tabnine VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Tabnine extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension tabnine.tabnine-vscode
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
             ```
 
   - uid: mondoo-ai-security-no-vscode-supermaven-extension
@@ -1792,6 +2298,24 @@ queries:
             cursor --uninstall-extension supermaven.supermaven     # Cursor
             windsurf --uninstall-extension supermaven.supermaven   # Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove the Supermaven VS Code extension with Ansible:
+
+            This playbook uninstalls the Supermaven extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Supermaven VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Supermaven extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension supermaven.supermaven
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-vscode-continue-extension
     title: No Continue extensions in VS Code-compatible editors
@@ -1853,6 +2377,24 @@ queries:
             code --uninstall-extension continue.continue       # VS Code
             cursor --uninstall-extension continue.continue     # Cursor
             windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+        - id: ansible
+          desc: |
+            To remove the Continue VS Code extension with Ansible:
+
+            This playbook uninstalls the Continue extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Continue VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Continue extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension continue.continue
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
             ```
 
   - uid: mondoo-ai-security-no-vscode-cline-extension
@@ -1916,6 +2458,24 @@ queries:
             cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
             windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove the Cline VS Code extension with Ansible:
+
+            This playbook uninstalls the Cline extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Cline VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Cline extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension saoudrizwan.claude-dev
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-vscode-cody-extension
     title: No Sourcegraph Cody extensions in VS Code-compatible editors
@@ -1977,6 +2537,24 @@ queries:
             code --uninstall-extension sourcegraph.cody-ai       # VS Code
             cursor --uninstall-extension sourcegraph.cody-ai     # Cursor
             windsurf --uninstall-extension sourcegraph.cody-ai   # Windsurf
+            ```
+        - id: ansible
+          desc: |
+            To remove the Sourcegraph Cody VS Code extension with Ansible:
+
+            This playbook uninstalls the Sourcegraph Cody extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Sourcegraph Cody VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Sourcegraph Cody extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension sourcegraph.cody-ai
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
             ```
 
   - uid: mondoo-ai-security-no-vscode-codex-extension
@@ -2040,6 +2618,24 @@ queries:
             cursor --uninstall-extension openai.codex     # Cursor
             windsurf --uninstall-extension openai.codex   # Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove the OpenAI Codex VS Code extension with Ansible:
+
+            This playbook uninstalls the OpenAI Codex extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the OpenAI Codex VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the OpenAI Codex extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension openai.codex
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-vscode-claude-extension
     title: No Claude extensions in VS Code-compatible editors
@@ -2101,6 +2697,24 @@ queries:
             code --uninstall-extension anthropic.claude       # VS Code
             cursor --uninstall-extension anthropic.claude     # Cursor
             windsurf --uninstall-extension anthropic.claude   # Windsurf
+            ```
+        - id: ansible
+          desc: |
+            To remove the Anthropic Claude VS Code extension with Ansible:
+
+            This playbook uninstalls the Anthropic Claude extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Anthropic Claude VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Anthropic Claude extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension anthropic.claude
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
             ```
 
   - uid: mondoo-ai-security-no-vscode-cursor-extension
@@ -2164,6 +2778,24 @@ queries:
             cursor --uninstall-extension <cursor.extension-name>     # Cursor
             windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
             ```
+        - id: ansible
+          desc: |
+            To remove Cursor-specific VS Code extensions with Ansible:
+
+            This playbook uninstalls Cursor-specific extensions from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Cursor-specific VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Cursor-specific extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension {{ cursor_extension_name }}
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-vscode-roo-extension
     title: No Roo Code extensions in VS Code-compatible editors
@@ -2225,6 +2857,24 @@ queries:
             code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
             cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
             windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+        - id: ansible
+          desc: |
+            To remove the Roo Code VS Code extension with Ansible:
+
+            This playbook uninstalls the Roo Code extension from VS Code on the endpoint.
+
+            ```yaml
+            ---
+            - name: Remove the Roo Code VS Code extension
+              hosts: workstations
+              tasks:
+                - name: Uninstall the Roo Code extension
+                  ansible.builtin.command:
+                    cmd: code --uninstall-extension rooveterinaryinc.roo-cline
+                  register: uninstall
+                  changed_when: "'successfully uninstalled' in uninstall.stdout"
+                  failed_when: false
             ```
 
   # ---------------------------------------------------------------------------
@@ -2293,6 +2943,29 @@ queries:
             - GitHub Copilot: `~/.config/github-copilot/` (`%APPDATA%\github-copilot\` on Windows)
             - Windsurf: `~/.codeium/windsurf/` (`%USERPROFILE%\.codeium\windsurf\` on Windows)
             - Gemini CLI: `~/.gemini/` (`%USERPROFILE%\.gemini\` on Windows)
+        - id: ansible
+          desc: |
+            To remove unapproved MCP server entries from AI agent configuration files with Ansible:
+
+            This playbook removes unapproved MCP server configuration entries from each AI agent's settings file. Review and edit the `mcp_config_paths` variable to match your environment before running.
+
+            ```yaml
+            ---
+            - name: Remove unapproved MCP servers
+              hosts: workstations
+              tasks:
+                - name: Remove unapproved MCP server configuration files
+                  ansible.builtin.file:
+                    path: "{{ item }}"
+                    state: absent
+                  loop:
+                    - "{{ ansible_env.HOME }}/.claude/settings.json"
+                    - "{{ ansible_env.HOME }}/.cursor/mcp.json"
+                    - "{{ ansible_env.HOME }}/.codex/config.json"
+                    - "{{ ansible_env.HOME }}/.config/github-copilot/settings.json"
+                    - "{{ ansible_env.HOME }}/.codeium/windsurf/mcp_config.json"
+                    - "{{ ansible_env.HOME }}/.gemini/settings.json"
+            ```
 
   # ---------------------------------------------------------------------------
   # Local LLM runtimes
@@ -2370,6 +3043,45 @@ queries:
             Stop-Process -Name ollama
             winget uninstall Ollama
             ```
+        - id: ansible
+          desc: |
+            To stop and remove local LLM runtimes with Ansible:
+
+            This playbook stops any running Ollama process and removes the Ollama package from the system.
+
+            ```yaml
+            ---
+            - name: Remove local LLM runtimes
+              hosts: workstations
+              tasks:
+                - name: Kill local LLM runtime processes
+                  ansible.builtin.command:
+                    cmd: pkill -f "{{ item }}"
+                  loop:
+                    - ollama
+                    - llama
+                    - lmstudio
+                    - localai
+                    - gpt4all
+                  failed_when: false
+
+            - name: Remove local LLM runtime packages (system)
+              hosts: workstations
+              become: true
+              tasks:
+                - name: Stop and disable Ollama service
+                  ansible.builtin.systemd_service:
+                    name: ollama
+                    state: stopped
+                    enabled: false
+                  failed_when: false
+
+                - name: Remove Ollama package
+                  ansible.builtin.package:
+                    name: ollama
+                    state: absent
+                  failed_when: false
+            ```
 
   - uid: mondoo-ai-security-no-local-llm-listening-ports
     title: No local LLM inference servers are listening
@@ -2430,4 +3142,24 @@ queries:
             ```powershell
             Get-NetTCPConnection -LocalPort <port> | Select-Object OwningProcess
             Stop-Process -Id <PID>
+            ```
+        - id: ansible
+          desc: |
+            To stop the process listening on a local LLM inference port with Ansible:
+
+            This playbook kills any process listening on the known LLM inference ports (11434 for Ollama, 1234 for LM Studio, 1337 for LocalAI).
+
+            ```yaml
+            ---
+            - name: Stop local LLM inference servers
+              hosts: workstations
+              tasks:
+                - name: Kill processes listening on LLM inference ports
+                  ansible.builtin.command:
+                    cmd: "fuser -k {{ item }}/tcp"
+                  loop:
+                    - "11434"
+                    - "1234"
+                    - "1337"
+                  failed_when: false
             ```


### PR DESCRIPTION
## What

Adds an `- id: ansible` remediation entry to every check (38 total) in `mondoo-ai-security.mql.yaml`, alongside the existing `gui`/`cli` steps. This gives fleet operators a playbook-based path to remediate unapproved AI tooling across managed endpoints.

## Details

Each Ansible playbook mirrors the fix already documented in that check's `cli` entry:

- **Config-directory removal** — `ansible.builtin.file` with `state: absent` against the exact per-user config paths each check inspects (e.g. `~/.cursor`, `~/Library/Application Support/Cursor`, `~/.config/Cursor`).
- **VS Code extensions** — `code --uninstall-extension <publisher.extension>` using the exact extension IDs from each check.
- **Packages/processes** — `ansible.builtin.package`, `community.general.homebrew`, and `pkill`/`fuser` for system-package, Homebrew, process, and listening-port checks.

Entries are placed last in each `remediation:` list, following the repo's `gui → cli → script → ansible` ordering convention. No other fields (tags, `desc`, `audit`, `mql`, `gui`, `cli`) were modified.

## Scope note

`mondoo-vllm-security` was considered but intentionally left out — its checks are scoped to remote HTTP posture (reverse-proxy/gateway-level fixes), where Ansible is not a clean fit.

## Testing

`cnspec policy lint content/mondoo-ai-security.mql.yaml` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)