### PR TITLE
:memo: Polish Ansible remediation in the AI security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -306,7 +306,6 @@ fullchain
 fumadocs
 funcapp
 functionapp
-fuser
 fwpolicy
 gbs
 GCMAES

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -2155,18 +2155,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Codeium VS Code extension with Ansible:
+            To remove the Codeium extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Codeium extension from VS Code on the endpoint.
+            This playbook uninstalls the Codeium extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Codeium VS Code extension
+            - name: Remove the Codeium extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Codeium extension
+                - name: Uninstall the Codeium extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension codeium.codeium
+                    cmd: "{{ item }} --uninstall-extension codeium.codeium"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2235,18 +2239,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Tabnine VS Code extension with Ansible:
+            To remove the Tabnine extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Tabnine extension from VS Code on the endpoint.
+            This playbook uninstalls the Tabnine extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Tabnine VS Code extension
+            - name: Remove the Tabnine extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Tabnine extension
+                - name: Uninstall the Tabnine extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension tabnine.tabnine-vscode
+                    cmd: "{{ item }} --uninstall-extension tabnine.tabnine-vscode"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2315,18 +2323,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Supermaven VS Code extension with Ansible:
+            To remove the Supermaven extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Supermaven extension from VS Code on the endpoint.
+            This playbook uninstalls the Supermaven extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Supermaven VS Code extension
+            - name: Remove the Supermaven extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Supermaven extension
+                - name: Uninstall the Supermaven extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension supermaven.supermaven
+                    cmd: "{{ item }} --uninstall-extension supermaven.supermaven"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2395,18 +2407,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Continue VS Code extension with Ansible:
+            To remove the Continue extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Continue extension from VS Code on the endpoint.
+            This playbook uninstalls the Continue extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Continue VS Code extension
+            - name: Remove the Continue extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Continue extension
+                - name: Uninstall the Continue extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension continue.continue
+                    cmd: "{{ item }} --uninstall-extension continue.continue"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2475,18 +2491,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Cline VS Code extension with Ansible:
+            To remove the Cline extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Cline extension from VS Code on the endpoint.
+            This playbook uninstalls the Cline extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Cline VS Code extension
+            - name: Remove the Cline extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Cline extension
+                - name: Uninstall the Cline extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension saoudrizwan.claude-dev
+                    cmd: "{{ item }} --uninstall-extension saoudrizwan.claude-dev"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2555,18 +2575,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Sourcegraph Cody VS Code extension with Ansible:
+            To remove the Sourcegraph Cody extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Sourcegraph Cody extension from VS Code on the endpoint.
+            This playbook uninstalls the Sourcegraph Cody extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Sourcegraph Cody VS Code extension
+            - name: Remove the Sourcegraph Cody extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Sourcegraph Cody extension
+                - name: Uninstall the Sourcegraph Cody extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension sourcegraph.cody-ai
+                    cmd: "{{ item }} --uninstall-extension sourcegraph.cody-ai"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2635,18 +2659,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the OpenAI Codex VS Code extension with Ansible:
+            To remove the OpenAI Codex extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the OpenAI Codex extension from VS Code on the endpoint.
+            This playbook uninstalls the OpenAI Codex extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the OpenAI Codex VS Code extension
+            - name: Remove the OpenAI Codex extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the OpenAI Codex extension
+                - name: Uninstall the OpenAI Codex extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension openai.codex
+                    cmd: "{{ item }} --uninstall-extension openai.codex"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2715,18 +2743,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Anthropic Claude VS Code extension with Ansible:
+            To remove the Anthropic Claude extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Anthropic Claude extension from VS Code on the endpoint.
+            This playbook uninstalls the Anthropic Claude extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Anthropic Claude VS Code extension
+            - name: Remove the Anthropic Claude extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Anthropic Claude extension
+                - name: Uninstall the Anthropic Claude extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension anthropic.claude
+                    cmd: "{{ item }} --uninstall-extension anthropic.claude"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2795,20 +2827,24 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove Cursor-specific VS Code extensions with Ansible:
+            To remove Cursor-specific extensions from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls a Cursor-specific extension from VS Code on the endpoint. The `cursor_extension_name` value is a placeholder — replace it with the `publisher.extension` identifier flagged on your endpoints.
+            This playbook uninstalls a Cursor-specific extension from VS Code, Cursor, and Windsurf on the endpoint. The `cursor_extension_name` value is a placeholder — replace it with the `publisher.extension` identifier flagged on your endpoints.
 
             ```yaml
             ---
-            - name: Remove the Cursor-specific VS Code extension
+            - name: Remove the Cursor-specific extension from VS Code-compatible editors
               hosts: workstations
               vars:
                 cursor_extension_name: cursor.example-extension
               tasks:
-                - name: Uninstall the Cursor-specific extension
+                - name: Uninstall the Cursor-specific extension from each editor
                   ansible.builtin.command:
-                    cmd: "code --uninstall-extension {{ cursor_extension_name }}"
+                    cmd: "{{ item }} --uninstall-extension {{ cursor_extension_name }}"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -2877,18 +2913,22 @@ queries:
             ```
         - id: ansible
           desc: |
-            To remove the Roo Code VS Code extension with Ansible:
+            To remove the Roo Code extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Roo Code extension from VS Code on the endpoint.
+            This playbook uninstalls the Roo Code extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
-            - name: Remove the Roo Code VS Code extension
+            - name: Remove the Roo Code extension from VS Code-compatible editors
               hosts: workstations
               tasks:
-                - name: Uninstall the Roo Code extension
+                - name: Uninstall the Roo Code extension from each editor
                   ansible.builtin.command:
-                    cmd: code --uninstall-extension rooveterinaryinc.roo-cline
+                    cmd: "{{ item }} --uninstall-extension rooveterinaryinc.roo-cline"
+                  loop:
+                    - code
+                    - cursor
+                    - windsurf
                   register: uninstall
                   changed_when: "'successfully uninstalled' in uninstall.stdout"
                   failed_when: false
@@ -3068,7 +3108,7 @@ queries:
           desc: |
             To stop and remove local LLM runtimes with Ansible:
 
-            This playbook stops any running Ollama process and removes the Ollama package from the system.
+            This playbook stops any running local LLM runtime process, then stops and removes the Ollama package and service. Ollama is the runtime distributed as a system package and service; LM Studio, GPT4All, and LocalAI are installed as standalone applications or containers and must be removed through their own uninstallers.
 
             ```yaml
             ---
@@ -3168,19 +3208,19 @@ queries:
           desc: |
             To stop the process listening on a local LLM inference port with Ansible:
 
-            This playbook kills any process listening on the known LLM inference ports (11434 for Ollama, 1234 for LM Studio, 1337 for LocalAI).
+            This playbook stops any process listening on the known LLM inference ports (11434 for Ollama, 1234 for LM Studio, 1337 for LocalAI). It uses `lsof`, which is available on both Linux and macOS.
 
             ```yaml
             ---
             - name: Stop local LLM inference servers
               hosts: workstations
               tasks:
-                - name: Kill processes listening on LLM inference ports
-                  ansible.builtin.command:
-                    cmd: "fuser -k {{ item }}/tcp"
+                - name: Stop processes listening on LLM inference ports
+                  ansible.builtin.shell: "lsof -ti tcp:{{ item }} -s TCP:LISTEN | xargs kill"
                   loop:
                     - "11434"
                     - "1234"
                     - "1337"
+                  changed_when: false
                   failed_when: false
             ```


### PR DESCRIPTION
## What

Follow-up to #2593, addressing a second round of automated review comments that landed after that PR was already merged.

## Changes

- **VS Code extension parity** — the 10 `no-vscode-*-extension` remediation playbooks now loop over `code`, `cursor`, and `windsurf`, matching the editor variants already shown in each check's `cli` remediation step.
- **Cross-platform port cleanup** — the `no-local-llm-listening-ports` playbook used `fuser -k`, which is Linux-only. It now uses `lsof … | xargs kill`, which works on both Linux and macOS endpoints.
- **Accurate LLM runtime wording** — the `no-local-llm-runtimes` playbook description now explains that only Ollama ships as a system package/service; LM Studio, GPT4All, and LocalAI are standalone apps or containers removed through their own uninstallers.
- **Dictionary cleanup** — drops the now-unused `fuser` entry from `.github/actions/spelling/expect.txt`.

## Testing

`cnspec policy lint content/mondoo-ai-security.mql.yaml` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)