### PR TITLE
:memo: Backfill Terraform remediation coverage on GCP, OCI, and AWS

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -62321,7 +62321,6 @@ queries:
           originMtlsClientCertificate.notAfter > time.now + 30 * time.day
         )
       )
-  # No Terraform variants: CloudFront trust stores are managed via the CloudFront API and do not yet have a Terraform resource analog.
   - uid: mondoo-aws-security-cloudfront-trust-store-not-empty
     title: Ensure CloudFront trust stores contain at least one CA certificate
     impact: 90
@@ -62344,6 +62343,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that CloudFront trust stores configured for viewer mTLS contain at least one CA certificate. A trust store with `numberOfCaCertificates == 0` is referenced by the distribution but has no anchors to validate viewer client certificates against, which results in either every certificate being rejected (outage) or, depending on configuration, every certificate being accepted (mTLS bypass).
@@ -62427,6 +62438,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.cloudfront.trustStores.all(numberOfCaCertificates > 0)
+  - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudfront_trust_store")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_cloudfront_trust_store").all(
+        blocks.where(type == "ca_certificates_bundle_source") != empty
+      )
+  - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cloudfront_trust_store")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cloudfront_trust_store").all(
+        change.after["ca_certificates_bundle_source"] != null && change.after["ca_certificates_bundle_source"] != empty
+      )
+  - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cloudfront_trust_store")
+    mql: |
+      terraform.state.resources.where(type == "aws_cloudfront_trust_store").all(
+        values["ca_certificates_bundle_source"] != null && values["ca_certificates_bundle_source"] != empty
+      )
   # No Terraform variants: this check correlates origin domain heuristics against optional origin mTLS configuration; the heuristic is best applied at runtime where origin DNS resolution is observable.
   - uid: mondoo-aws-security-cloudfront-private-origin-mtls
     title: Ensure CloudFront distributions to internal origins use origin mTLS
@@ -62897,7 +62926,6 @@ queries:
       terraform.state.resources.where(type == "aws_transfer_connector").all(
         values["logging_role"] != null && values["logging_role"] != ""
       )
-  # No Terraform variants: the AWS Terraform provider does not yet expose a Transfer Web App resource. Add Terraform variants once the resource lands in the provider.
   - uid: mondoo-aws-security-transfer-web-app-not-public
     title: Ensure Transfer Family Web Apps are not exposed via PUBLIC endpoints
     impact: 90
@@ -62920,6 +62948,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Transfer Family Web Apps are not configured with `endpointType=PUBLIC`. A public endpoint exposes the browser-based file transfer front door directly to the internet; even with strong IAM Identity Center authentication this exposes the login surface to credential stuffing and session-hijack attacks.
@@ -62997,7 +63037,24 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.transfer.webApps.all(endpointType != "PUBLIC")
-  # No Terraform variants: workflow step types are heterogeneous unions surfaced as `[]dict` and require structural inspection that is more reliable at runtime than against arbitrary Terraform shapes.
+  - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_web_app")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_web_app").all(
+        blocks.where(type == "endpoint_details") != empty
+      )
+  - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_web_app")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_web_app").all(
+        change.after["endpoint_details"] != null && change.after["endpoint_details"] != empty
+      )
+  - uid: mondoo-aws-security-transfer-web-app-not-public-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_web_app")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_web_app").all(
+        values["endpoint_details"] != null && values["endpoint_details"] != empty
+      )
   - uid: mondoo-aws-security-transfer-workflow-exception-handling
     title: Ensure Transfer workflows with DECRYPT or COPY define onExceptionSteps
     impact: 70
@@ -63020,6 +63077,18 @@ queries:
         tags:
           mondoo.com/filter-title: AWS Account
           mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that any Transfer Family workflow containing `DECRYPT` or `COPY` steps also defines `onExceptionSteps`. Without exception handling, a partial workflow failure leaves intermediate decrypted or copied files in their staging location, where they may persist longer than intended and bypass the encryption posture the workflow was meant to maintain.
@@ -63121,6 +63190,27 @@ queries:
       aws.transfer.workflows.where(
         steps.any(_['Type'] == "DECRYPT" || _['Type'] == "COPY")
       ).all(onExceptionSteps != null && onExceptionSteps.length > 0)
+  - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_workflow")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_transfer_workflow").all(
+        blocks.where(type == "steps").none(arguments["type"] == "DECRYPT" || arguments["type"] == "COPY") ||
+        blocks.where(type == "on_exception_steps") != empty
+      )
+  - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_transfer_workflow")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_transfer_workflow").all(
+        change.after["steps"].none(_["type"] == "DECRYPT" || _["type"] == "COPY") ||
+        change.after["on_exception_steps"] != null && change.after["on_exception_steps"] != empty
+      )
+  - uid: mondoo-aws-security-transfer-workflow-exception-handling-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_transfer_workflow")
+    mql: |
+      terraform.state.resources.where(type == "aws_transfer_workflow").all(
+        values["steps"].none(_["type"] == "DECRYPT" || _["type"] == "COPY") ||
+        values["on_exception_steps"] != null && values["on_exception_steps"] != empty
+      )
   # No CloudFormation variant: AWS::Bedrock::CustomModel is not a CloudFormation resource type.
   - uid: mondoo-aws-security-bedrock-custom-model-cmk-encryption
     title: Ensure Bedrock custom models use a customer-managed KMS key

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -63160,12 +63160,12 @@ queries:
                 decrypt_step_details {
                   name                  = "decrypt-files"
                   type                  = "PGP"
-                  source_file_location  = "${original.file}"
+                  source_file_location  = "$${original.file}"
                   overwrite_existing    = "TRUE"
                   destination_file_location {
                     s3_file_location {
                       bucket = aws_s3_bucket.dest.bucket
-                      key    = "decrypted/${transfer:UploadDate}/${transfer:UserName}/"
+                      key    = "decrypted/$${transfer:UploadDate}/$${transfer:UserName}/"
                     }
                   }
                 }
@@ -63176,7 +63176,7 @@ queries:
 
                 delete_step_details {
                   name                 = "delete-on-error"
-                  source_file_location = "${original.file}"
+                  source_file_location = "$${original.file}"
                 }
               }
             }

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -37685,6 +37685,7 @@ queries:
             ```
 
             When creating new training jobs, pass only non-sensitive tuning values via `--hyper-parameters`.
+        # No Terraform remediation: SageMaker training jobs are imperative API calls and have no Terraform resource; the hyperparameter map is set at job creation time and cannot be changed after the fact.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html#your-algorithms-training-algo-env-variables
         title: Amazon SageMaker - Training Job Environment Variables
@@ -37794,6 +37795,7 @@ queries:
               --hub-content-document file://model-document.json \
               --hub-content-markdown file://internal-review.md
             ```
+        # No Terraform remediation: SageMaker hub content is imported via an imperative API call (`ImportHubContent`) that has no Terraform resource in hashicorp/aws; the markdown documentation field cannot be set through Terraform.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html
         title: Amazon SageMaker - Private JumpStart Hubs
@@ -37906,6 +37908,7 @@ queries:
               --model-approval-status Rejected \
               --approval-description "Reverted: approved without running registered validation."
             ```
+        # No Terraform remediation: SageMaker model package approval status and approval description are set via imperative `UpdateModelPackage` API calls and are not managed by any Terraform resource in hashicorp/aws.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry-approve.html
         title: Amazon SageMaker - Update the Approval Status of a Model
@@ -38361,6 +38364,40 @@ queries:
               --role-name <sagemaker-exec-role> \
               --policy-arn arn:aws:iam::aws:policy/AmazonSageMakerFullAccess
             ```
+        - id: terraform
+          desc: |
+            To ensure the SageMaker domain default execution role is not `AdministratorAccess` in Terraform, create a scoped IAM role and reference it in the domain's `default_user_settings`:
+
+            ```hcl
+            resource "aws_iam_role" "sagemaker_domain_exec" {
+              name = "sagemaker-domain-exec-role"
+
+              assume_role_policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect    = "Allow"
+                  Principal = { Service = "sagemaker.amazonaws.com" }
+                  Action    = "sts:AssumeRole"
+                }]
+              })
+            }
+
+            resource "aws_iam_role_policy_attachment" "sagemaker_domain_exec_policy" {
+              role       = aws_iam_role.sagemaker_domain_exec.name
+              policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+            }
+
+            resource "aws_sagemaker_domain" "example" {
+              domain_name = "example-domain"
+              auth_mode   = "IAM"
+              vpc_id      = aws_vpc.example.id
+              subnet_ids  = [aws_subnet.example.id]
+
+              default_user_settings {
+                execution_role = aws_iam_role.sagemaker_domain_exec.arn
+              }
+            }
+            ```
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html
         title: Amazon SageMaker - Execution Roles
@@ -38457,6 +38494,35 @@ queries:
             aws iam detach-role-policy \
               --role-name <notebook-role> \
               --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+            ```
+        - id: terraform
+          desc: |
+            To ensure a SageMaker notebook instance uses a scoped IAM role without `AdministratorAccess` in Terraform:
+
+            ```hcl
+            resource "aws_iam_role" "sagemaker_notebook_exec" {
+              name = "sagemaker-notebook-exec-role"
+
+              assume_role_policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect    = "Allow"
+                  Principal = { Service = "sagemaker.amazonaws.com" }
+                  Action    = "sts:AssumeRole"
+                }]
+              })
+            }
+
+            resource "aws_iam_role_policy_attachment" "sagemaker_notebook_exec_policy" {
+              role       = aws_iam_role.sagemaker_notebook_exec.name
+              policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+            }
+
+            resource "aws_sagemaker_notebook_instance" "example" {
+              name          = "example-notebook"
+              role_arn      = aws_iam_role.sagemaker_notebook_exec.arn
+              instance_type = "ml.t3.medium"
+            }
             ```
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html
@@ -38557,6 +38623,7 @@ queries:
               --role-name <training-or-processing-role> \
               --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
             ```
+        # No Terraform remediation: SageMaker training and processing jobs are imperative API calls (`CreateTrainingJob`, `CreateProcessingJob`) with no Terraform resource in hashicorp/aws; the job role is resolved and checked at runtime, not from a static configuration.
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html
         title: Amazon SageMaker - Execution Roles
@@ -39706,6 +39773,7 @@ queries:
               ]' \
               --replication-info-list file://replication-info.json
             ```
+        # No Terraform remediation: The `aws_msk_replicator` Terraform resource only models MSK-to-MSK replication; external (non-MSK) Apache Kafka cluster configuration including `EncryptionInTransit.Type` is not exposed in the hashicorp/aws provider.
     refs:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-replicator-encryption.html
         title: Amazon MSK Replicator - Encryption in Transit
@@ -52908,6 +52976,7 @@ queries:
             ```
 
             Note: The `--user-settings` parameter requires all user settings to be specified together. Omitting `DOMAIN_SMART_CARD_SIGN_IN` and `DOMAIN_PASSWORD_SIGN_IN` actions from the list leaves URL-related redirection disabled. Adjust other settings as needed for your environment.
+        # No Terraform remediation: The `HOST_TO_CLIENT_URL_REDIRECTION` action is not a supported value in the `aws_appstream_stack` `user_settings` block in the hashicorp/aws provider; URL-redirection policy must be set through the console or CLI.
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/url-redirection.html
         title: Amazon AppStream 2.0 - URL Redirection
@@ -61880,6 +61949,7 @@ queries:
             ```
 
             To remove sharing entirely, run `aws appstream delete-image-permissions --name <image-name> --shared-account-id <account-id>` for each previously-shared account.
+        # No Terraform remediation: There is no `aws_appstream_image` resource in the hashicorp/aws provider; customer-built AppStream images and their visibility settings are managed through the console or CLI, not Terraform.
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/share-image-with-other-accounts.html
         title: Amazon AppStream 2.0 - Share an image with other AWS accounts
@@ -62238,6 +62308,7 @@ queries:
             aws acm describe-certificate --certificate-arn <arn> --query 'Certificate.NotAfter'
             aws cloudfront update-distribution --id <dist-id> --distribution-config file://updated-config.json
             ```
+        # No Terraform remediation: Certificate expiry is operational state, not configuration; Terraform cannot enforce that a certificate has not expired — rotate the certificate and re-import it.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
         title: Amazon CloudFront - Origin mutual TLS
@@ -62326,6 +62397,29 @@ queries:
             ```
 
             Use `aws cloudfront update-trust-store --id <id> --if-match <etag> --ca-certificates-bundle-source <source>` to replace the CA bundle. The `--ca-certificates-bundle-source` value is the JSON shape described in the CloudFront API reference (S3 location of the bundle).
+        - id: terraform
+          desc: |
+            To create a CloudFront trust store populated with CA certificates in Terraform, use `aws_cloudfront_trust_store` and supply a CA bundle from S3:
+
+            ```hcl
+            resource "aws_s3_object" "ca_bundle" {
+              bucket = aws_s3_bucket.certs.bucket
+              key    = "ca-bundle.pem"
+              source = "ca-bundle.pem"
+            }
+
+            resource "aws_cloudfront_trust_store" "example" {
+              name = "example-trust-store"
+
+              ca_certificates_bundle_source {
+                ca_certificates_bundle_s3_location {
+                  bucket = aws_s3_bucket.certs.bucket
+                  key    = aws_s3_object.ca_bundle.key
+                  region = var.aws_region
+                }
+              }
+            }
+            ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mutual-tls-authentication.html
         title: Amazon CloudFront - Configuring mutual TLS authentication
@@ -62409,6 +62503,7 @@ queries:
             ```
 
             Edit `config.json` to set `Origins.Items[N].CustomOriginConfig.OriginMtlsConfig` before calling `update-distribution`.
+        # No Terraform remediation: Origin mTLS (`CustomOriginConfig.OriginMtlsConfig`) is not exposed as an argument in the `aws_cloudfront_distribution` origin block in the hashicorp/aws provider; configure origin mTLS through the console or CLI.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
         title: Amazon CloudFront - Origin mutual TLS
@@ -62500,6 +62595,7 @@ queries:
             ```
 
             The `--ca-certificates-bundle-source` value is the JSON shape described in the CloudFront API reference (S3 location of the current PEM bundle).
+        # No Terraform remediation: The freshness of a trust store CA bundle is operational telemetry, not static configuration; Terraform cannot assert that the bundle was refreshed within the last year — update the bundle and re-apply.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mutual-tls-authentication.html
         title: Amazon CloudFront - Configuring mutual TLS authentication
@@ -62606,6 +62702,47 @@ queries:
             ```
 
             `scoped-policy.json` should list explicit bucket ARNs and the minimum actions needed (`s3:GetObject`, `s3:PutObject`).
+        - id: terraform
+          desc: |
+            To create a Transfer Family connector with a scoped `access_role` in Terraform, attach a least-privilege IAM policy to the role:
+
+            ```hcl
+            resource "aws_iam_role" "connector_access" {
+              name = "transfer-connector-access-role"
+
+              assume_role_policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect    = "Allow"
+                  Principal = { Service = "transfer.amazonaws.com" }
+                  Action    = "sts:AssumeRole"
+                }]
+              })
+            }
+
+            resource "aws_iam_role_policy" "connector_access_policy" {
+              name = "connector-scoped-access"
+              role = aws_iam_role.connector_access.id
+
+              policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect   = "Allow"
+                  Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+                  Resource = "arn:aws:s3:::my-transfer-bucket/*"
+                }]
+              })
+            }
+
+            resource "aws_transfer_connector" "example" {
+              url         = "https://partner.example.com"
+              access_role = aws_iam_role.connector_access.arn
+
+              sftp_config {
+                trusted_host_keys = [var.partner_host_key]
+              }
+            }
+            ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/configure-as2-connector.html
         title: AWS Transfer Family - Connector access role
@@ -62835,6 +62972,24 @@ queries:
               --identity-provider-details Type=IDENTITY_CENTER,InstanceArn=<arn>,Role=<role-arn> \
               --access-endpoint <internal-endpoint>
             ```
+        - id: terraform
+          desc: |
+            To create a Transfer Family Web App with a non-public endpoint in Terraform, set `access_endpoint` to an internal URL via `endpoint_details`:
+
+            ```hcl
+            resource "aws_transfer_web_app" "example" {
+              identity_provider_details {
+                server_id = var.identity_center_instance_arn
+                role      = aws_iam_role.web_app.arn
+              }
+
+              endpoint_details {
+                vpc_endpoint_id = aws_vpc_endpoint.transfer.id
+              }
+
+              access_endpoint = "https://internal.example.com"
+            }
+            ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/web-apps.html
         title: AWS Transfer Family - Web Apps
@@ -62921,6 +63076,41 @@ queries:
             aws transfer create-workflow \
               --steps file://steps.json \
               --on-exception-steps file://exception-steps.json
+            ```
+        - id: terraform
+          desc: |
+            To create a Transfer Family workflow with exception handling steps in Terraform, use the `on_exception_steps` argument in `aws_transfer_workflow`:
+
+            ```hcl
+            resource "aws_transfer_workflow" "example" {
+              description = "Workflow with DECRYPT step and exception handling"
+
+              steps {
+                type = "DECRYPT"
+
+                decrypt_step_details {
+                  name                  = "decrypt-files"
+                  type                  = "PGP"
+                  source_file_location  = "${original.file}"
+                  overwrite_existing    = "TRUE"
+                  destination_file_location {
+                    s3_file_location {
+                      bucket = aws_s3_bucket.dest.bucket
+                      key    = "decrypted/${transfer:UploadDate}/${transfer:UserName}/"
+                    }
+                  }
+                }
+              }
+
+              on_exception_steps {
+                type = "DELETE"
+
+                delete_step_details {
+                  name                 = "delete-on-error"
+                  source_file_location = "${original.file}"
+                }
+              }
+            }
             ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/nominal-steps-workflow.html
@@ -63472,6 +63662,26 @@ queries:
               --type container \
               --container-properties '{"image":"<image>","privileged":false,"vcpus":1,"memory":2048,"jobRoleArn":"<role-arn>"}'
             ```
+        - id: terraform
+          desc: |
+            To register a non-privileged Batch job definition in Terraform, set `privileged` to `false` inside the `container_properties` JSON:
+
+            ```hcl
+            resource "aws_batch_job_definition" "example" {
+              name = "example"
+              type = "container"
+
+              container_properties = jsonencode({
+                image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/example:latest"
+                privileged = false
+                jobRoleArn = aws_iam_role.job_role.arn
+                resourceRequirements = [
+                  { type = "VCPU", value = "1" },
+                  { type = "MEMORY", value = "2048" }
+                ]
+              })
+            }
+            ```
         - id: cloudformation
           desc: |
             To register a non-privileged Batch job definition in CloudFormation, leave `Privileged` off or set it to `false` under `ContainerProperties`:
@@ -63599,6 +63809,26 @@ queries:
               --job-definition-name <name> \
               --type container \
               --container-properties '{"image":"123456789012.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>","vcpus":1,"memory":2048,"jobRoleArn":"<role-arn>","executionRoleArn":"<exec-role-arn>"}'
+            ```
+        - id: terraform
+          desc: |
+            To register a Batch job definition that pulls from a private ECR repository in Terraform, set `image` inside `container_properties` to a private registry URI:
+
+            ```hcl
+            resource "aws_batch_job_definition" "example" {
+              name = "example"
+              type = "container"
+
+              container_properties = jsonencode({
+                image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/example:latest"
+                jobRoleArn       = aws_iam_role.job_role.arn
+                executionRoleArn = aws_iam_role.exec_role.arn
+                resourceRequirements = [
+                  { type = "VCPU", value = "1" },
+                  { type = "MEMORY", value = "2048" }
+                ]
+              })
+            }
             ```
         - id: cloudformation
           desc: |
@@ -63752,6 +63982,29 @@ queries:
             ```bash
             aws batch update-job-queue --job-queue <queue> --compute-environment-order order=1,computeEnvironment=<new-env-arn>
             ```
+        - id: terraform
+          desc: |
+            To create an AWS Batch compute environment that uses only private subnets in Terraform:
+
+            ```hcl
+            resource "aws_batch_compute_environment" "example" {
+              compute_environment_name = "example-private"
+              type                     = "MANAGED"
+              state                    = "ENABLED"
+              service_role             = aws_iam_role.batch_service.arn
+
+              compute_resources {
+                type               = "EC2"
+                min_vcpus          = 0
+                max_vcpus          = 64
+                desired_vcpus      = 0
+                instance_role      = aws_iam_instance_profile.ecs_instance.arn
+                instance_type      = ["optimal"]
+                subnets            = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+                security_group_ids = [aws_security_group.batch.id]
+              }
+            }
+            ```
     refs:
       - url: https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html
         title: AWS Batch compute environments
@@ -63865,6 +64118,56 @@ queries:
             aws iam create-policy --policy-name <name> --policy-document file://policy.json
             aws iam attach-role-policy --role-name <role-name> --policy-arn <new-policy-arn>
             aws iam detach-role-policy --role-name <role-name> --policy-arn <old-wildcard-policy-arn>
+            ```
+        - id: terraform
+          desc: |
+            To create a Batch job role without wildcard permissions in Terraform, attach a least-privilege managed policy and reference the role in the job definition:
+
+            ```hcl
+            resource "aws_iam_role" "batch_job_role" {
+              name = "batch-job-role"
+
+              assume_role_policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect    = "Allow"
+                  Principal = { Service = "ecs-tasks.amazonaws.com" }
+                  Action    = "sts:AssumeRole"
+                }]
+              })
+            }
+
+            resource "aws_iam_policy" "batch_job_policy" {
+              name = "batch-job-least-privilege"
+
+              policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect   = "Allow"
+                  Action   = ["s3:GetObject", "s3:PutObject"]
+                  Resource = "arn:aws:s3:::my-job-bucket/*"
+                }]
+              })
+            }
+
+            resource "aws_iam_role_policy_attachment" "batch_job_attachment" {
+              role       = aws_iam_role.batch_job_role.name
+              policy_arn = aws_iam_policy.batch_job_policy.arn
+            }
+
+            resource "aws_batch_job_definition" "example" {
+              name = "example"
+              type = "container"
+
+              container_properties = jsonencode({
+                image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/example:latest"
+                jobRoleArn = aws_iam_role.batch_job_role.arn
+                resourceRequirements = [
+                  { type = "VCPU", value = "1" },
+                  { type = "MEMORY", value = "2048" }
+                ]
+              })
+            }
             ```
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
@@ -63987,6 +64290,66 @@ queries:
             aws iam create-policy --policy-name <name> --policy-document file://policy.json
             aws iam attach-role-policy --role-name <role-name> --policy-arn <scoped-arn>
             aws iam detach-role-policy --role-name <role-name> --policy-arn <wildcard-arn>
+            ```
+        - id: terraform
+          desc: |
+            To create a Step Functions state machine with a scoped execution role in Terraform, attach a least-privilege policy with explicit resource ARNs:
+
+            ```hcl
+            resource "aws_iam_role" "sfn_exec" {
+              name = "sfn-execution-role"
+
+              assume_role_policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect    = "Allow"
+                  Principal = { Service = "states.amazonaws.com" }
+                  Action    = "sts:AssumeRole"
+                }]
+              })
+            }
+
+            resource "aws_iam_policy" "sfn_policy" {
+              name = "sfn-least-privilege"
+
+              policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [
+                  {
+                    Effect   = "Allow"
+                    Action   = "lambda:InvokeFunction"
+                    Resource = aws_lambda_function.example.arn
+                  },
+                  {
+                    Effect   = "Allow"
+                    Action   = ["dynamodb:PutItem", "dynamodb:GetItem"]
+                    Resource = aws_dynamodb_table.example.arn
+                  }
+                ]
+              })
+            }
+
+            resource "aws_iam_role_policy_attachment" "sfn_attach" {
+              role       = aws_iam_role.sfn_exec.name
+              policy_arn = aws_iam_policy.sfn_policy.arn
+            }
+
+            resource "aws_sfn_state_machine" "example" {
+              name     = "example"
+              role_arn = aws_iam_role.sfn_exec.arn
+
+              definition = jsonencode({
+                Comment = "Example state machine"
+                StartAt = "InvokeFunction"
+                States  = {
+                  InvokeFunction = {
+                    Type     = "Task"
+                    Resource = aws_lambda_function.example.arn
+                    End      = true
+                  }
+                }
+              })
+            }
             ```
     refs:
       - url: https://docs.aws.amazon.com/step-functions/latest/dg/concepts-iam.html

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -29463,6 +29463,18 @@ queries:
               --shard-count=3 \
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
+        - id: terraform
+          desc: |
+            Set `kms_key` on the `google_memorystore_instance` resource. Backup collections inherit the key from their source instance automatically:
+
+            ```hcl
+            resource "google_memorystore_instance" "cache" {
+              instance_id = "my-instance"
+              location    = "us-central1"
+              shard_count = 3
+              kms_key     = "projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"
+            }
+            ```
     refs:
       - url: https://cloud.google.com/memorystore/docs/valkey/backup-and-restore
         title: Memorystore backup and restore
@@ -30648,6 +30660,22 @@ queries:
               --public-access-prevention \
               --default-encryption-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
+        - id: terraform
+          desc: |
+            Configure the GCS bucket used as a Datastream destination with all three required controls on the `google_storage_bucket` resource:
+
+            ```hcl
+            resource "google_storage_bucket" "datastream_destination" {
+              name                        = "my-datastream-destination"
+              location                    = "US"
+              uniform_bucket_level_access = true
+              public_access_prevention    = "enforced"
+
+              encryption {
+                default_kms_key_name = "projects/my-project/locations/us/keyRings/my-ring/cryptoKeys/my-key"
+              }
+            }
+            ```
     refs:
       - url: https://cloud.google.com/storage/docs/uniform-bucket-level-access
         title: Cloud Storage - Uniform bucket-level access
@@ -31021,6 +31049,7 @@ queries:
             gcloud memcache instances describe INSTANCE_ID \
               --region=REGION --format="value(discoveryEndpoint)"
             ```
+        # No Terraform remediation: the discovery endpoint IP is output-only (computed by GCP from the authorized network's IP allocation) and cannot be set directly in any Terraform resource argument.
     refs:
       - url: https://cloud.google.com/memorystore/docs/memcached/auto-discovery-overview
         title: Memorystore for Memcached - Auto Discovery
@@ -33480,6 +33509,7 @@ queries:
               --service-account=vertex-training@PROJECT.iam.gserviceaccount.com \
               --config=config.yaml
             ```
+        # No Terraform remediation: Vertex AI custom training jobs are imperative API operations with no Terraform resource analog; the fix lives in the job submission tooling, not in static infrastructure configuration.
     refs:
       - url: https://cloud.google.com/vertex-ai/docs/general/custom-service-account
         title: Vertex AI - Use a custom service account

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -30641,6 +30641,13 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.datastream.connectionProfiles.where(profileType == "gcs").all(
+        bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
+        bucket.iamConfiguration["publicAccessPrevention"] == "enforced" &&
+        bucket.defaultKmsKey != null
+      )
     docs:
       desc: |
         This check ensures that Cloud Storage buckets used as Datastream GCS destinations have three controls in place: uniform bucket-level access enabled, public access prevention enforced, and CMEK configured. A Datastream GCS destination receives a continuously-updated mirror of the source database, so a bucket that is weaker than the source database's own controls undermines the overall data protection posture.
@@ -30720,61 +30727,6 @@ queries:
         title: Cloud Storage - Uniform bucket-level access
       - url: https://cloud.google.com/storage/docs/public-access-prevention
         title: Cloud Storage - Public access prevention
-    variants:
-      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-gcp
-        tags:
-          mondoo.com/filter-title: GCP Datastream
-          mondoo.com/filter-icon: gcp
-      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-hcl
-        tags:
-          mondoo.com/filter-title: Terraform HCL
-          mondoo.com/filter-icon: terraform
-      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-plan
-        tags:
-          mondoo.com/filter-title: Terraform Plan
-          mondoo.com/filter-icon: terraform
-      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-state
-        tags:
-          mondoo.com/filter-title: Terraform State
-          mondoo.com/filter-icon: terraform
-  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-gcp
-    filters: asset.platform == 'gcp'
-    mql: |
-      gcp.datastream.connectionProfiles.where(profileType == "gcs").all(
-        bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
-        bucket.iamConfiguration["publicAccessPrevention"] == "enforced" &&
-        bucket.defaultKmsKey != null
-      )
-  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-hcl
-    filters: |
-      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_storage_bucket')
-    mql: |
-      terraform.resources('google_storage_bucket').all(
-        arguments.uniform_bucket_level_access == true &&
-        arguments.public_access_prevention == "enforced" &&
-        blocks.where(type == 'encryption') != empty &&
-        blocks.where(type == 'encryption').all(arguments.default_kms_key_name != empty && arguments.default_kms_key_name != "")
-      )
-  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-plan
-    filters: |
-      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_storage_bucket')
-    mql: |
-      terraform.plan.resourceChanges.where(type == 'google_storage_bucket').all(
-        change.after['uniform_bucket_level_access'] == true &&
-        change.after['public_access_prevention'] == "enforced" &&
-        change.after['encryption'] != empty &&
-        change.after['encryption'].any(_['default_kms_key_name'] != empty && _['default_kms_key_name'] != "")
-      )
-  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-state
-    filters: |
-      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_storage_bucket')
-    mql: |
-      terraform.state.resources.where(type == 'google_storage_bucket').all(
-        values['uniform_bucket_level_access'] == true &&
-        values['public_access_prevention'] == "enforced" &&
-        values['encryption'] != empty &&
-        values['encryption'].any(_['default_kms_key_name'] != empty && _['default_kms_key_name'] != "")
-      )
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc
     title: Ensure Datastream private connections do not peer the default VPC
     impact: 70

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -29478,9 +29478,48 @@ queries:
     refs:
       - url: https://cloud.google.com/memorystore/docs/valkey/backup-and-restore
         title: Memorystore backup and restore
+    variants:
+      - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP Memorystore (Valkey/Redis)
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+  - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-gcp
     filters: asset.platform == 'gcp'
     mql: |
       gcp.memorystore.backupCollections.all(kmsKey != null)
+  - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_memorystore_instance')
+    mql: |
+      terraform.resources('google_memorystore_instance').all(
+        arguments.kms_key != empty && arguments.kms_key != ""
+      )
+  - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_memorystore_instance')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_memorystore_instance').all(
+        change.after['kms_key'] != empty && change.after['kms_key'] != ""
+      )
+  - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_memorystore_instance')
+    mql: |
+      terraform.state.resources.where(type == 'google_memorystore_instance').all(
+        values['kms_key'] != empty && values['kms_key'] != ""
+      )
   # No Terraform variants: google_memorystore_instance only exposes
   # `psc_auto_connections` (private PSC) as a configurable input. The runtime
   # check evaluates `pscAttachmentDetails[].connectionType == "PUBLIC_ENDPOINT"`,
@@ -30681,12 +30720,60 @@ queries:
         title: Cloud Storage - Uniform bucket-level access
       - url: https://cloud.google.com/storage/docs/public-access-prevention
         title: Cloud Storage - Public access prevention
+    variants:
+      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-gcp
+        tags:
+          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-gcp
     filters: asset.platform == 'gcp'
     mql: |
       gcp.datastream.connectionProfiles.where(profileType == "gcs").all(
         bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
         bucket.iamConfiguration["publicAccessPrevention"] == "enforced" &&
         bucket.defaultKmsKey != null
+      )
+  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_storage_bucket')
+    mql: |
+      terraform.resources('google_storage_bucket').all(
+        arguments.uniform_bucket_level_access == true &&
+        arguments.public_access_prevention == "enforced" &&
+        blocks.where(type == 'encryption') != empty &&
+        blocks.where(type == 'encryption').all(arguments.default_kms_key_name != empty && arguments.default_kms_key_name != "")
+      )
+  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_storage_bucket').all(
+        change.after['uniform_bucket_level_access'] == true &&
+        change.after['public_access_prevention'] == "enforced" &&
+        change.after['encryption'] != empty &&
+        change.after['encryption'].any(_['default_kms_key_name'] != empty && _['default_kms_key_name'] != "")
+      )
+  - uid: mondoo-gcp-security-datastream-gcs-destination-bucket-hardened-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_storage_bucket')
+    mql: |
+      terraform.state.resources.where(type == 'google_storage_bucket').all(
+        values['uniform_bucket_level_access'] == true &&
+        values['public_access_prevention'] == "enforced" &&
+        values['encryption'] != empty &&
+        values['encryption'].any(_['default_kms_key_name'] != empty && _['default_kms_key_name'] != "")
       )
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc
     title: Ensure Datastream private connections do not peer the default VPC

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -202,6 +202,7 @@ queries:
             ```
 
             Contact each listed user and direct them to enable MFA through their OCI Console profile settings.
+        # No Terraform remediation: MFA activation is end-user runtime state; the `oci_identity_user` Terraform resource has no field that toggles or evidences MFA enrollment.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/usingmfa.htm
         title: CIS OCI Foundations Benchmark 1.7
@@ -277,6 +278,7 @@ queries:
             ```
 
             Contact each listed user and ask them to verify their email through the OCI Console.
+        # No Terraform remediation: email verification is end-user-driven runtime state; the `oci_identity_user` Terraform resource sets the email address but cannot express whether it has been verified.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingusers.htm
         title: OCI IAM user management
@@ -509,6 +511,7 @@ queries:
             ```bash
             oci iam user api-key delete --user-id USER_OCID --fingerprint KEY_FINGERPRINT
             ```
+        # No Terraform remediation: API key active state is runtime-only telemetry; the `oci_identity_api_key` Terraform resource has no `state` argument that reflects or controls whether a key is active or inactive.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm
         title: OCI API key management
@@ -591,6 +594,7 @@ queries:
             ```bash
             oci iam auth-token delete --user-id USER_OCID --auth-token-id TOKEN_OCID
             ```
+        # No Terraform remediation: auth token active state is runtime-only telemetry; the `oci_identity_auth_token` Terraform resource has no `state` argument that reflects or controls whether a token is active on an inactive user account.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm
         title: OCI auth token management
@@ -1606,6 +1610,7 @@ queries:
             ```
 
             NOTE: The OCI CLI does not support disabling users directly. Disable or delete stale users through the OCI Console or by removing all credentials (API keys, auth tokens, passwords) via the CLI.
+        # No Terraform remediation: last-login recency is runtime telemetry; the `oci_identity_user` Terraform resource has no field for `last-successful-login-time` and there is no HCL change that marks an account stale or active.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingusers.htm
         title: CIS OCI Foundations Benchmark 1.13
@@ -2956,6 +2961,7 @@ queries:
             ```bash
             oci iam auth-token create --user-id <user-ocid> --description "Rotated <date>"
             ```
+        # No Terraform remediation: auth token expiry and creation timestamps are runtime-only fields; the `oci_identity_auth_token` Terraform resource exposes neither `expires` nor `time_created` as configurable arguments.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm
         title: OCI - Managing User Credentials
@@ -3039,6 +3045,7 @@ queries:
             ```bash
             oci iam group remove-user --user-id <user-ocid> --group-id <group-ocid>
             ```
+        # No Terraform remediation: group membership count is cross-resource runtime state; Terraform resources for `oci_identity_user_group_membership` manage individual memberships and there is no HCL expression that enforces a maximum member count across all memberships referencing a group.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managinggroups.htm
         title: OCI - Managing Groups
@@ -4158,6 +4165,7 @@ queries:
               --cipher-suite-name oci-modern-ssl-cipher-suite-v1 \
               --protocols '["TLSv1.2","TLSv1.3"]'
             ```
+        # No Terraform remediation: this check requires cross-resource correlation — grouping `oci_lb_listener` resources by their `load_balancer_id` and asserting that each group containing an HTTP listener also contains an HTTPS listener — which has no clean equivalent in HCL/plan/state without unsupported cross-resource graph traversal.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managinglisteners.htm
         title: OCI - Managing Listeners
@@ -4383,6 +4391,7 @@ queries:
             ```bash
             oci ce cluster update --cluster-id <cluster-ocid> --kubernetes-version <new-version>
             ```
+        # No Terraform remediation: `availableKubernetesUpgrades` is runtime telemetry derived from Oracle's supported-version list at scan time; no `oci_containerengine_cluster` Terraform argument exposes the count of pending upgrades, so there is no static HCL change that resolves this finding.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengupgradingk8smasternode.htm
         title: OCI - Upgrading Kubernetes on a Cluster
@@ -5208,6 +5217,7 @@ queries:
               --prohibit-public-ip-on-vnic true \
               --display-name private-db-subnet
             ```
+        # No Terraform remediation: this check requires cross-resource lookup from `oci_database_db_system` to its referenced `oci_core_subnet` to read `prohibit_public_ip_on_vnic`; cross-resource graph traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Database/Concepts/databaseoverview.htm
         title: OCI - Database Service Overview
@@ -5302,6 +5312,7 @@ queries:
               --rt-id <route-table-ocid> \
               --route-rules '[{"destination":"all-<region>-services-in-oracle-services-network","destinationType":"SERVICE_CIDR_BLOCK","networkEntityId":"<service-gateway-ocid>"}]'
             ```
+        # No Terraform remediation: this check requires three-hop cross-resource traversal from `oci_database_db_system` to its subnet to the subnet's route table to inspect individual route rules; this graph walk is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingroutetables.htm
         title: OCI - Managing Route Tables
@@ -5537,6 +5548,7 @@ queries:
             ```bash
             oci vault secret rotate --secret-id <secret-ocid>
             ```
+        # No Terraform remediation: `timeOfCurrentVersionExpiry` is runtime telemetry on the active secret version; the `oci_vault_secret` Terraform resource has no field that exposes whether the current version is past its expiry, and there is no HCL change that resolves an expired version.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/rotatingsecrets.htm
         title: OCI - Rotating Secrets
@@ -8203,6 +8215,7 @@ queries:
               --certificate-id <certificate-ocid> \
               --certificate-rules '[{"ruleType":"CERTIFICATE_RENEWAL_RULE","advanceRenewalPeriod":"P30D","renewalInterval":"P365D"}]'
             ```
+        # No Terraform remediation: certificate expiry is dynamic operational telemetry derived from the issuance time and validity duration of the current cert version; there is no HCL change that resolves an expired or near-expiry certificate — the fix is to issue a new version through the OCI Certificates Management service.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/certificates/managing-certificates.htm
         title: OCI - Managing Certificates


### PR DESCRIPTION
## What

`content/CLAUDE.md` requires every cloud check's `remediation:` list to carry **either** a `- id: terraform` entry **or** a `# No Terraform remediation:` comment, and a check with Terraform remediation should ship Terraform `variants:`. This PR closes the remaining gaps in three nearly-complete policies.

## Changes

| Policy | `- id: terraform` added | `# No Terraform remediation:` added |
|--------|------------------------|-------------------------------------|
| GCP    | 2                      | 2                                   |
| OCI    | 0                      | 13                                  |
| AWS    | 11                     | 10                                  |

- **No-TF-remediation comments** went on checks that inspect operational/runtime telemetry, cross-resource correlations, or surfaces managed only via imperative API/CLI calls.
- **Terraform HCL remediation** was added where a real provider resource exists (`google_memorystore_instance`, `google_storage_bucket`, `aws_batch_job_definition`, `aws_sagemaker_domain`, `aws_transfer_*`, `aws_sfn_state_machine`, etc.).

## Terraform variants

The checks that gained `- id: terraform` remediation were also resolved for `variants:`:

- **GCP (2)** — both converted to `variants:` blocks with `-gcp` / `-terraform-hcl` / `-terraform-plan` / `-terraform-state` children.
- **AWS (3)** — `cloudfront-trust-store-not-empty`, `transfer-web-app-not-public`, `transfer-workflow-exception-handling` gained faithful `-terraform-hcl`/`-plan`/`-state` variants.
- **AWS (8)** — checks whose control walks cross-resource IAM policy documents / subnet attributes, or a JSON-encoded `container_properties` string, keep a `# No Terraform variants:` comment. A faithful variant is not expressible for these, and a vacuous one would be worse than none (per CLAUDE.md).

## Testing

`cnspec policy lint` passes clean for all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)