### PR TITLE
Update AI security policy v2.0.0

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -673,6 +673,7 @@ sentinelone
 servicebus
 serviceprincipals
 setblockall
+setenv
 setglobalstate
 setxattr
 sfn

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-ai-security
     name: Mondoo AI Security
-    version: 1.0.0
+    version: 2.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -25,9 +25,9 @@ policies:
         - AI assistant extensions installed in Visual Studio Code
         - Model Context Protocol (MCP) servers running outside the approved allow-list
         - Local large language model runtimes
-        - LLM ports listening on the network
+        - LLM inference servers exposed beyond localhost
 
-        By default, only GitHub Copilot and Claude Code are approved. Customize the allow-lists by overriding the `props` values for your environment.
+        **Aggregate allow-lists.** The `no-unapproved-ai-processes`, `no-unapproved-ai-packages`, and `no-unapproved-homebrew-ai-packages` checks remain governed by the existing `mondooAiSecurityApprovedProcesses` / `mondooAiSecurityApprovedPackages` / `mondooAiSecurityApprovedHomebrewPackages` regex properties (default: `(?i)(copilot|claude)`). Likewise, approved MCP servers are governed by `mondooAiSecurityApprovedMcpServers`.
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
@@ -768,7 +768,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: cline.skills.length == 0
+    mql: |
+      cline.skills.length == 0
     docs:
       desc: |
         Cline is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -842,7 +843,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: roo.skills.length == 0
+    mql: |
+      roo.skills.length == 0
     docs:
       desc: |
         Roo Code is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -916,7 +918,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: continuedev.skills.length == 0
+    mql: |
+      continuedev.skills.length == 0
     docs:
       desc: |
         Continue is an open-source AI coding assistant that connects to a range of cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -990,7 +993,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: trae.skills.length == 0
+    mql: |
+      trae.skills.length == 0
     docs:
       desc: |
         Trae is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1064,7 +1068,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: opencode.skills.length == 0
+    mql: |
+      opencode.skills.length == 0
     docs:
       desc: |
         OpenCode is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1138,7 +1143,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: kiro.skills.length == 0
+    mql: |
+      kiro.skills.length == 0
     docs:
       desc: |
         Kiro is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1212,7 +1218,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: pi.skills.length == 0
+    mql: |
+      pi.skills.length == 0
     docs:
       desc: |
         Pi is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1286,7 +1293,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: mistral.vibe.skills.length == 0
+    mql: |
+      mistral.vibe.skills.length == 0
     docs:
       desc: |
         Mistral Vibe is an AI coding agent from Mistral that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1360,7 +1368,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: antigravity.skills.length == 0
+    mql: |
+      antigravity.skills.length == 0
     docs:
       desc: |
         Antigravity is an AI coding agent from Google that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1434,7 +1443,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: ibm.bob.skills.length == 0
+    mql: |
+      ibm.bob.skills.length == 0
     docs:
       desc: |
         IBM Bob is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1508,7 +1518,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: openclaw.skills.length == 0
+    mql: |
+      openclaw.skills.length == 0
     docs:
       desc: |
         OpenClaw is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1582,7 +1593,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: snowflake.cortex.skills.length == 0
+    mql: |
+      snowflake.cortex.skills.length == 0
     docs:
       desc: |
         Snowflake Cortex Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1656,7 +1668,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: junie.skills.length == 0
+    mql: |
+      junie.skills.length == 0
     docs:
       desc: |
         Junie is an AI coding agent from JetBrains that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1730,7 +1743,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: augment.skills.length == 0
+    mql: |
+      augment.skills.length == 0
     docs:
       desc: |
         Augment is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1804,7 +1818,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: warp.skills.length == 0
+    mql: |
+      warp.skills.length == 0
     docs:
       desc: |
         Warp is an AI-powered terminal that sends command history and context to cloud model providers for its AI features. When it is configured on an endpoint, command output and code context can be transmitted to third-party services. Endpoints should carry only the terminals approved by the security team.
@@ -1884,7 +1899,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: kilocode.skills.length == 0
+    mql: |
+      kilocode.skills.length == 0
     docs:
       desc: |
         Kilo Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1958,7 +1974,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: openhands.skills.length == 0
+    mql: |
+      openhands.skills.length == 0
     docs:
       desc: |
         OpenHands is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -2032,7 +2049,8 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
-    mql: qwen.code.skills.length == 0
+    mql: |
+      qwen.code.skills.length == 0
     docs:
       desc: |
         Qwen Code is an AI coding agent from Alibaba that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -3145,7 +3163,7 @@ queries:
             ```
 
   - uid: mondoo-ai-security-no-local-llm-listening-ports
-    title: No local LLM inference servers are listening
+    title: No local LLM inference servers are exposed beyond localhost
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -3162,21 +3180,20 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      ports.listening.where(
+      ports.listening.where(address != "127.0.0.1" && address != "[::1]").none(
         port == 11434 || port == 1234 || port == 1337
-      ).length == 0
+      )
     docs:
       desc: |
-        Local LLM inference servers expose an HTTP API on well-known ports — 11434 for Ollama, 1234 for LM Studio, and 1337 for LocalAI. A service listening on one of these ports indicates an active inference server that can process data outside approved channels and, if bound to a non-loopback address, can be reached by other hosts. Endpoints should run only the LLM servers approved by the security team.
+        Local LLM inference servers expose an HTTP API on well-known ports — 11434 for Ollama, 1234 for LM Studio, and 1337 for LocalAI. Listening on `127.0.0.1` or `::1` is acceptable because it limits the server to the local machine. The check fails when one of these ports is bound to `0.0.0.0`, a LAN address, or any other non-loopback interface, because that exposes the model to other hosts on the network.
 
         **Why this matters**
 
-        - **Active inference endpoint:** A listening port confirms a running server that can accept prompts and process sensitive data.
         - **Network exposure:** If the server binds to a non-loopback interface, other hosts on the network can submit prompts to it.
         - **Uncontrolled processing:** Data sent to a local inference API bypasses the review and logging applied to sanctioned tooling.
         - **Inventory gaps:** An unsanctioned inference server leaves security teams without an accurate picture of how data is processed on the endpoint.
       audit: |-
-        To verify that no local LLM inference server is listening:
+        To verify that no local LLM inference server is exposed beyond localhost:
 
         1. Open a terminal on the endpoint.
         2. List listening sockets on the LLM inference ports:
@@ -3185,42 +3202,53 @@ queries:
            lsof -nP -iTCP:11434 -iTCP:1234 -iTCP:1337 -sTCP:LISTEN
            ```
 
-        The endpoint passes when no process is listening on any of these ports. A process bound to port 11434, 1234, or 1337 is a failing result.
+        The endpoint passes when no process is listening on any of these ports on a non-loopback address. A process bound to `127.0.0.1` or `::1` is acceptable.
       remediation:
         - id: cli
           desc: |
-            To identify and stop the process listening on the flagged port:
+            Identify the process bound to the flagged port and reconfigure it to bind to `127.0.0.1` only:
 
             macOS and Linux:
 
             ```bash
             lsof -i :<port>
-            kill <PID>
+            # Ollama: restart with the loopback bind address
+            launchctl setenv OLLAMA_HOST 127.0.0.1:11434
+            # then restart the Ollama service / app
             ```
+
+            For LM Studio and LocalAI, change the "Server host" / `address` setting in the app or config file from `0.0.0.0` to `127.0.0.1` and restart the server.
 
             Windows:
 
             ```powershell
-            Get-NetTCPConnection -LocalPort <port> | Select-Object OwningProcess
-            Stop-Process -Id <PID>
+            Get-NetTCPConnection -LocalPort 11434,1234,1337 | Select-Object LocalAddress,LocalPort,OwningProcess
+            # Ollama: set the loopback bind address and restart
+            [Environment]::SetEnvironmentVariable("OLLAMA_HOST", "127.0.0.1:11434", "User")
             ```
+
+            For LM Studio and LocalAI, change the server host from `0.0.0.0` to `127.0.0.1` in the application settings and restart the server.
         - id: ansible
           desc: |
-            To stop the process listening on a local LLM inference port with Ansible:
+            Reconfigure local LLM inference servers to bind to localhost with Ansible:
 
-            This playbook stops any process listening on the known LLM inference ports (11434 for Ollama, 1234 for LM Studio, 1337 for LocalAI). It uses `lsof`, which is available on both Linux and macOS.
+            This playbook configures Ollama to bind to `127.0.0.1` on known LLM inference ports. It uses `lsof`, which is available on both Linux and macOS.
 
             ```yaml
             ---
-            - name: Stop local LLM inference servers
+            - name: Rebind local LLM inference servers to localhost
               hosts: workstations
               tasks:
-                - name: Stop processes listening on LLM inference ports
-                  ansible.builtin.shell: "lsof -ti tcp:{{ item }} -s TCP:LISTEN | xargs kill"
-                  loop:
-                    - "11434"
-                    - "1234"
-                    - "1337"
-                  changed_when: false
-                  failed_when: false
+                - name: Configure Ollama to bind to localhost
+                  ansible.builtin.lineinfile:
+                    path: /etc/default/ollama
+                    regexp: '^OLLAMA_HOST='
+                    line: 'OLLAMA_HOST=127.0.0.1:11434'
+                    create: true
+                  notify: restart ollama
+              handlers:
+                - name: restart ollama
+                  ansible.builtin.systemd:
+                    name: ollama
+                    state: restarted
             ```


### PR DESCRIPTION
## Summary
- Bump policy version to 2.0.0
- Improve LLM listening ports check to only flag non-loopback binds — localhost (`127.0.0.1`/`::1`) is now allowed, remediation guides rebinding instead of killing the process
- Normalize single-line `mql:` entries to block-scalar `mql: |` format for consistency
- Update policy description with aggregate allow-list documentation

## Test plan
- [x] `cnspec policy lint` passes
- [ ] Verify LLM listening ports check passes for localhost-bound servers and fails for non-loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)