### PR TITLE
Don't reduce risk score for fixed (value=100) checks

### DIFF
--- a/policy/risk_factor.go
+++ b/policy/risk_factor.go
@@ -344,6 +344,11 @@ func AdjustRiskScore(score *Score, sortedRisks ...[]*ScoredRiskInfo) {
 		return
 	}
 	score.RiskScore = score.Value
+	// If the check is fixed (value == 100), risk factors cannot reduce the
+	// risk score: there is nothing left to amplify.
+	if score.Value == 100 {
+		return
+	}
 	// Adjust the score based on the risk factors
 	for risk := range mergeSorted(cmpScoredRiskFactors, sortedRisks...) {
 		risk.AdjustRiskScore(score, risk.IsDetected)

--- a/policy/risk_factor_test.go
+++ b/policy/risk_factor_test.go
@@ -288,6 +288,51 @@ func TestRiskFactor_AdjustRiskScoreMultiple2(t *testing.T) {
 			expectedScore: 0, // applied a c b
 		},
 		{
+			name: "fixed score: toxic detected does not reduce",
+			scoredRiskInfos1: []*ScoredRiskInfo{
+				{
+					RiskFactor:       &RiskFactor{Mrn: "a", Magnitude: &RiskMagnitude{Value: 0.2, IsToxic: true}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: true},
+				},
+			},
+			baseScore:     100,
+			expectedScore: 100,
+		},
+		{
+			name: "fixed score: mixed risk factors do not reduce",
+			scoredRiskInfos1: []*ScoredRiskInfo{
+				{
+					RiskFactor:       &RiskFactor{Mrn: "open-ports", Magnitude: &RiskMagnitude{Value: 0.05}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: true},
+				},
+				{
+					RiskFactor:       &RiskFactor{Mrn: "private-ssh-keys", Magnitude: &RiskMagnitude{Value: 0.05}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: false},
+				},
+				{
+					RiskFactor:       &RiskFactor{Mrn: "claude-llm-agent", Magnitude: &RiskMagnitude{Value: 0.05, IsToxic: true}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: true},
+				},
+				{
+					RiskFactor:       &RiskFactor{Mrn: "high-open-connections", Magnitude: &RiskMagnitude{Value: 0.05, IsToxic: true}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: true},
+				},
+			},
+			baseScore:     100,
+			expectedScore: 100,
+		},
+		{
+			name: "fixed score: max toxic detected does not reduce",
+			scoredRiskInfos1: []*ScoredRiskInfo{
+				{
+					RiskFactor:       &RiskFactor{Mrn: "a", Magnitude: &RiskMagnitude{Value: 1, IsToxic: true}},
+					ScoredRiskFactor: &ScoredRiskFactor{IsDetected: true},
+				},
+			},
+			baseScore:     100,
+			expectedScore: 100,
+		},
+		{
 			name: "test toxic sorted 2",
 			scoredRiskInfos1: []*ScoredRiskInfo{
 				{


### PR DESCRIPTION
## Summary
- Risk factors that are toxic with a positive magnitude directly subtract from `RiskScore` (`policy/risk_factor.go:155`), so a fully-passing check (`value == 100`) could be dragged below 100 by any detected toxic factor — e.g. a check at 100 with two toxic+detected factors of magnitude 0.05 was landing at 90.
- Adds an early return in the package-level `AdjustRiskScore` when `score.Value == 100`: the check is fixed, so there is nothing for risk factors to amplify.
- Existing relative factors already had no math effect on a base of 100, so this change is purely about preventing toxic factors from regressing a passing score.

## Test plan
- [x] `go test ./policy -run RiskFactor`
- [x] New cases in `TestRiskFactor_AdjustRiskScoreMultiple2` cover: single toxic detected (mag 0.2), the original four-factor mix from the bug report, and a max-magnitude (1.0) toxic detected — all expect `RiskScore` to remain 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)