### PR TITLE
Add policy graph commands for navigating bundle structure

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -207,6 +207,7 @@ debconf
 decryptable
 definitionally
 defn
+disa
 dentries
 denygroups
 denyusers
@@ -239,6 +240,7 @@ EBSKMS
 ecdhe
 ECDSAP
 edr
+etcs
 efg
 efi
 EFSKMS

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -101,6 +101,7 @@ bucketpolicychanges
 Burstable
 BYOD
 bypassable
+callees
 cbc
 cbt
 ccc
@@ -259,6 +260,7 @@ eraagent
 esac
 eset
 ESKMS
+etcsshsshd
 ethertype
 etm
 eventhub
@@ -326,6 +328,7 @@ gmail
 godo
 gpt
 grafana
+Graphviz
 grouplist
 groupname
 grouppolicy
@@ -750,6 +753,7 @@ tmsh
 TNS
 toset
 totp
+Tpng
 trae
 trayicon
 trojanized

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,24 @@ test/lint/golangci-lint/run/new: prep/tools
 	golangci-lint --version
 	golangci-lint run --timeout 10m --config .github/.golangci.yaml --new-from-rev $(shell git log -n 1 origin/main --pretty=format:"%H")
 
+.PHONY: install/skills
+install/skills:
+	@echo "Installing cnspec skills to ~/.claude ..."
+	@for skill_dir in skills/*/skills/*/; do \
+		name=$$(basename $$skill_dir); \
+		mkdir -p ~/.claude/skills/$$name/references; \
+		cp $$skill_dir/SKILL.md ~/.claude/skills/$$name/; \
+		cp $$skill_dir/references/*.md ~/.claude/skills/$$name/references/ 2>/dev/null || true; \
+		echo "  ✓ $$name"; \
+	done
+	@for cmd in skills/*/commands/*.md; do \
+		[ -f "$$cmd" ] || continue; \
+		mkdir -p ~/.claude/commands; \
+		cp $$cmd ~/.claude/commands/; \
+		echo "  ✓ command: $$(basename $$cmd)"; \
+	done
+	@echo "Done. Skills available in all projects."
+
 license: license/headers/check
 
 license/headers/check:

--- a/apps/cnspec/cmd/policy_graph.go
+++ b/apps/cnspec/cmd/policy_graph.go
@@ -1,0 +1,301 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/v13/internal/bundle"
+)
+
+func init() {
+	policyCmd.AddCommand(policyGraphCmd)
+
+	policyGraphCallersCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphCmd.AddCommand(policyGraphCallersCmd)
+
+	policyGraphCalleesCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphCmd.AddCommand(policyGraphCalleesCmd)
+
+	policyGraphContextCmd.Flags().Int("depth", 2, "Neighborhood depth (hops)")
+	policyGraphCmd.AddCommand(policyGraphContextCmd)
+
+	policyGraphPathsCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphCmd.AddCommand(policyGraphPathsCmd)
+
+	policyGraphReachableCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphCmd.AddCommand(policyGraphReachableCmd)
+
+	policyGraphExportCmd.Flags().String("format", "json", "Output format: json, dot")
+	policyGraphCmd.AddCommand(policyGraphExportCmd)
+}
+
+var policyGraphCmd = &cobra.Command{
+	Use:   "graph",
+	Short: "Navigate policy bundle structure via graph commands",
+	Long:  "Build and query a graph of policies, checks, frameworks, and controls from .mql.yaml bundle files.",
+}
+
+var policyGraphCallersCmd = &cobra.Command{
+	Use:   "callers <uid> <path>",
+	Short: "Show what references a node (inbound edges)",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		uid, paths := args[0], args[1:]
+		g := mustBuildGraph(paths)
+		node := mustFindNode(g, uid)
+
+		edges := g.InEdges(node.ID)
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			printJSON(edgesWithNodes(g, edges, true))
+			return
+		}
+		fmt.Printf("%s is referenced by:\n", node.QualName)
+		for _, e := range edges {
+			name := e.Source
+			loc := ""
+			if n := g.Node(e.Source); n != nil {
+				name = n.QualName
+				loc = fmt.Sprintf(" (%s:%d)", n.File, n.Line)
+			}
+			fmt.Printf("  [%s] %s%s\n", e.Kind, name, loc)
+		}
+	},
+}
+
+var policyGraphCalleesCmd = &cobra.Command{
+	Use:   "callees <uid> <path>",
+	Short: "Show what a node contains or references (outbound edges)",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		uid, paths := args[0], args[1:]
+		g := mustBuildGraph(paths)
+		node := mustFindNode(g, uid)
+
+		edges := g.OutEdges(node.ID)
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			printJSON(edgesWithNodes(g, edges, false))
+			return
+		}
+		fmt.Printf("%s contains/references:\n", node.QualName)
+		for _, e := range edges {
+			name := e.Target
+			loc := ""
+			if n := g.Node(e.Target); n != nil {
+				name = n.QualName
+				loc = fmt.Sprintf(" (%s:%d)", n.File, n.Line)
+			}
+			fmt.Printf("  [%s] %s%s\n", e.Kind, name, loc)
+		}
+	},
+}
+
+var policyGraphContextCmd = &cobra.Command{
+	Use:   "context <uid> <path>",
+	Short: "Show LLM-friendly context with YAML snippets",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		uid, paths := args[0], args[1:]
+		depth, _ := cmd.Flags().GetInt("depth")
+		g := mustBuildGraph(paths)
+		node := mustFindNode(g, uid)
+
+		if err := g.WriteContext(os.Stdout, node.ID, depth, ""); err != nil {
+			log.Fatal().Err(err).Msg("failed to write context")
+		}
+	},
+}
+
+var policyGraphPathsCmd = &cobra.Command{
+	Use:   "paths <from-uid> <to-uid> <path>",
+	Short: "Find paths between two nodes",
+	Args:  cobra.MinimumNArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		fromUID, toUID, paths := args[0], args[1], args[2:]
+		g := mustBuildGraph(paths)
+		fromNode := mustFindNode(g, fromUID)
+		toNode := mustFindNode(g, toUID)
+
+		results := g.FindPaths(fromNode.ID, toNode.ID, 20)
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			printJSON(results)
+			return
+		}
+		if len(results) == 0 {
+			fmt.Printf("No paths found from %s to %s\n", fromNode.QualName, toNode.QualName)
+			return
+		}
+		for i, path := range results {
+			fmt.Printf("Path %d:\n", i+1)
+			for j, nodeID := range path {
+				name := nodeID
+				if n := g.Node(nodeID); n != nil {
+					name = n.QualName
+				}
+				if j > 0 {
+					fmt.Print("  → ")
+				} else {
+					fmt.Print("  ")
+				}
+				fmt.Println(name)
+			}
+		}
+	},
+}
+
+var policyGraphReachableCmd = &cobra.Command{
+	Use:   "reachable <uid> <path>",
+	Short: "Show all nodes reachable from a node",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		uid, paths := args[0], args[1:]
+		g := mustBuildGraph(paths)
+		node := mustFindNode(g, uid)
+
+		reachable := g.Reachable(node.ID)
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			var nodes []*bundle.GraphNode
+			for _, id := range reachable {
+				if n := g.Node(id); n != nil {
+					nodes = append(nodes, n)
+				}
+			}
+			printJSON(nodes)
+			return
+		}
+		fmt.Printf("%d nodes reachable from %s:\n", len(reachable), node.QualName)
+		for _, id := range reachable {
+			name := id
+			loc := ""
+			if n := g.Node(id); n != nil {
+				name = n.QualName
+				loc = fmt.Sprintf(" (%s:%d)", n.File, n.Line)
+			}
+			fmt.Printf("  %s%s\n", name, loc)
+		}
+	},
+}
+
+var policyGraphExportCmd = &cobra.Command{
+	Use:   "export <path>",
+	Short: "Export the full policy graph",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		format, _ := cmd.Flags().GetString("format")
+		g := mustBuildGraph(args)
+
+		switch format {
+		case "json":
+			printJSON(g)
+		case "dot":
+			writeDot(g)
+		default:
+			log.Fatal().Str("format", format).Msg("unknown format (use json or dot)")
+		}
+	},
+}
+
+func mustBuildGraph(paths []string) *bundle.PolicyGraph {
+	g, err := bundle.BuildGraphFromPaths(paths...)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to build graph")
+	}
+	return g
+}
+
+func mustFindNode(g *bundle.PolicyGraph, uid string) *bundle.GraphNode {
+	nodes := g.FindNode(uid)
+	if len(nodes) == 0 {
+		log.Fatal().Str("uid", uid).Msg("no node found matching query")
+	}
+	if len(nodes) == 1 {
+		return nodes[0]
+	}
+	// Prefer exact name match
+	for _, n := range nodes {
+		if n.Name == uid {
+			return n
+		}
+	}
+	// Prefer exact qual_name match
+	for _, n := range nodes {
+		if n.QualName == uid {
+			return n
+		}
+	}
+	// Ambiguous — show options
+	fmt.Fprintf(os.Stderr, "Ambiguous query %q matched %d nodes:\n", uid, len(nodes))
+	for _, n := range nodes {
+		fmt.Fprintf(os.Stderr, "  %s (%s) at %s:%d\n", n.QualName, n.Kind, n.File, n.Line)
+	}
+	os.Exit(1)
+	return nil
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		log.Fatal().Err(err).Msg("failed to encode JSON")
+	}
+}
+
+type edgeResult struct {
+	Edge *bundle.GraphEdge `json:"edge"`
+	Node *bundle.GraphNode `json:"node,omitempty"`
+}
+
+func edgesWithNodes(g *bundle.PolicyGraph, edges []*bundle.GraphEdge, useSource bool) []edgeResult {
+	var results []edgeResult
+	for _, e := range edges {
+		id := e.Target
+		if useSource {
+			id = e.Source
+		}
+		results = append(results, edgeResult{
+			Edge: e,
+			Node: g.Node(id),
+		})
+	}
+	return results
+}
+
+func writeDot(g *bundle.PolicyGraph) {
+	fmt.Println("digraph policy_graph {")
+	fmt.Println("  rankdir=LR;")
+	fmt.Println("  node [shape=box, fontname=monospace];")
+	for _, n := range g.Nodes {
+		color := "white"
+		switch n.Kind {
+		case bundle.KindPolicy:
+			color = "lightblue"
+		case bundle.KindCheck:
+			color = "lightyellow"
+		case bundle.KindFramework:
+			color = "lightgreen"
+		case bundle.KindControl:
+			color = "palegreen"
+		case bundle.KindGroup:
+			color = "lavender"
+		}
+		label := strings.ReplaceAll(n.QualName, `"`, `\"`)
+		fmt.Printf("  %q [label=%q, style=filled, fillcolor=%q];\n", n.ID, label, color)
+	}
+	for _, e := range g.Edges {
+		if strings.HasPrefix(e.Source, "?:") || strings.HasPrefix(e.Target, "?:") {
+			continue
+		}
+		style := "solid"
+		if e.Kind == bundle.EdgeMapsTo {
+			style = "dashed"
+		}
+		fmt.Printf("  %q -> %q [label=%q, style=%s];\n", e.Source, e.Target, e.Kind, style)
+	}
+	fmt.Println("}")
+}

--- a/apps/cnspec/cmd/policy_graph.go
+++ b/apps/cnspec/cmd/policy_graph.go
@@ -241,14 +241,8 @@ var policyGraphSearchCmd = &cobra.Command{
 		}
 
 		for _, n := range results {
-			title := n.Title
-			if len(title) > 40 {
-				title = title[:37] + "..."
-			}
-			qualName := n.QualName
-			if len(qualName) > 50 {
-				qualName = qualName[:47] + "..."
-			}
+			title := truncateRunes(n.Title, 40)
+			qualName := truncateRunes(n.QualName, 50)
 			fmt.Printf("%-12s %-50s %-40s (%s:%d)\n", n.Kind, qualName, title, n.File, n.Line)
 		}
 	},
@@ -317,6 +311,14 @@ func edgesWithNodes(g *bundle.PolicyGraph, edges []*bundle.GraphEdge, useSource 
 		})
 	}
 	return results
+}
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-3]) + "..."
 }
 
 func writeDot(g *bundle.PolicyGraph) {

--- a/apps/cnspec/cmd/policy_graph.go
+++ b/apps/cnspec/cmd/policy_graph.go
@@ -34,6 +34,13 @@ func init() {
 
 	policyGraphExportCmd.Flags().String("format", "json", "Output format: json, dot")
 	policyGraphCmd.AddCommand(policyGraphExportCmd)
+
+	policyGraphSearchCmd.Flags().String("kind", "", "Filter by node kind (policy, check, group, query, framework, control)")
+	policyGraphSearchCmd.Flags().String("tag", "", "Filter by tag key")
+	policyGraphSearchCmd.Flags().Int("impact", 0, "Minimum impact score")
+	policyGraphSearchCmd.Flags().Int("limit", 50, "Maximum results")
+	policyGraphSearchCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphCmd.AddCommand(policyGraphSearchCmd)
 }
 
 var policyGraphCmd = &cobra.Command{
@@ -197,6 +204,52 @@ var policyGraphExportCmd = &cobra.Command{
 			writeDot(g)
 		default:
 			log.Fatal().Str("format", format).Msg("unknown format (use json or dot)")
+		}
+	},
+}
+
+var policyGraphSearchCmd = &cobra.Command{
+	Use:   "search <query> <path>",
+	Short: "Search for nodes by name, title, or UID",
+	Long:  "Find policy graph nodes using multi-strategy search: exact name, prefix, or substring match across names, qualified names, and titles.",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		query, paths := args[0], args[1:]
+		g := mustBuildGraph(paths)
+		idx := g.BuildNodeIndex()
+
+		kind, _ := cmd.Flags().GetString("kind")
+		tag, _ := cmd.Flags().GetString("tag")
+		impact, _ := cmd.Flags().GetInt("impact")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		results := idx.Search(query, bundle.SearchOpts{
+			Kind:      bundle.NodeKind(kind),
+			TagKey:    tag,
+			MinImpact: impact,
+			Limit:     limit,
+		})
+
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			printJSON(results)
+			return
+		}
+
+		if len(results) == 0 {
+			fmt.Printf("No nodes found matching %q\n", query)
+			return
+		}
+
+		for _, n := range results {
+			title := n.Title
+			if len(title) > 40 {
+				title = title[:37] + "..."
+			}
+			qualName := n.QualName
+			if len(qualName) > 50 {
+				qualName = qualName[:47] + "..."
+			}
+			fmt.Printf("%-12s %-50s %-40s (%s:%d)\n", n.Kind, qualName, title, n.File, n.Line)
 		}
 	},
 }

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,334 @@
+# cnspec policy graph
+
+Navigate and query the structure of cnspec policy bundles (`.mql.yaml` files) using graph commands. These commands build a graph of policies, groups, checks, frameworks, controls, and their relationships, then let you explore it without reading thousands of lines of YAML.
+
+## Quick start
+
+```bash
+# Build cnspec (or use an installed binary)
+make cnspec/build
+
+# See what's in a policy bundle
+cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json
+
+# What does a policy contain?
+cnspec policy graph callees mondoo-linux-security ./content/mondoo-linux-security.mql.yaml
+
+# What references a specific check?
+cnspec policy graph callers mondoo-linux-security-ssh-root-login-is-disabled ./content/
+
+# Full context with YAML snippets
+cnspec policy graph context mondoo-linux-security-ssh-root-login-is-disabled ./content/ --depth 2
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `cnspec policy graph callers <uid> <path>` | What references this node (inbound edges) |
+| `cnspec policy graph callees <uid> <path>` | What this node contains/references (outbound edges) |
+| `cnspec policy graph context <uid> <path>` | LLM-friendly context with YAML snippets |
+| `cnspec policy graph paths <from> <to> <path>` | Find paths between two nodes |
+| `cnspec policy graph reachable <uid> <path>` | All nodes transitively reachable |
+| `cnspec policy graph export <path>` | Export the full graph |
+
+### Flags
+
+- `--json` — JSON output (callers, callees, paths, reachable)
+- `--depth N` — Neighborhood depth for context (default 2)
+- `--format json|dot` — Export format (export command only)
+
+### Path argument
+
+The `<path>` argument can be:
+
+- A directory: walks for all `.mql.yaml` files recursively
+- One or more specific `.mql.yaml` files
+- Multiple paths: `cnspec policy graph callers check-uid file1.mql.yaml file2.mql.yaml`
+
+## Graph concepts
+
+### Node types
+
+| Kind | Description |
+|------|-------------|
+| `policy` | A security policy (e.g., `mondoo-linux-security`) |
+| `group` | A group of checks within a policy (e.g., "SSH Configuration") |
+| `check` | A scoring query with MQL code and impact rating |
+| `query` | A data-only query (no scoring) |
+| `framework` | A compliance framework (e.g., CIS Benchmark, ISO 27001) |
+| `control` | A control within a framework (e.g., CIS 5.2.1) |
+| `framework_map` | Maps framework controls to policy checks |
+
+### Edge types
+
+| Kind | Description |
+|------|-------------|
+| `contains` | Structural parent-child (policy -> group -> check, framework -> control) |
+| `maps_to` | Compliance mapping (control -> check/policy via framework_map) |
+| `depends_on` | Policy/framework dependencies |
+| `variant_of` | Check variant relationship (parent -> platform-specific variant) |
+
+## Examples
+
+### Get an overview of a policy bundle
+
+```bash
+$ cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json | \
+    python3 -c "
+import json, sys, collections
+d = json.load(sys.stdin)
+kinds = collections.Counter(n['kind'] for n in d['nodes'])
+print(f'Nodes: {len(d[\"nodes\"])}, Edges: {len(d[\"edges\"])}')
+for k, v in kinds.most_common(): print(f'  {k}: {v}')
+"
+```
+
+```
+Nodes: 130, Edges: 129
+  check: 119
+  group: 10
+  policy: 1
+```
+
+### Explore policy structure top-down
+
+Start by seeing what a policy contains:
+
+```bash
+$ cnspec policy graph callees mondoo-linux-security ./content/mondoo-linux-security.mql.yaml
+```
+
+```
+policy:mondoo-linux-security contains/references:
+  [contains] group:mondoo-linux-security-group-0 (content/mondoo-linux-security.mql.yaml:37)
+  [contains] group:mondoo-linux-security-group-1 (content/mondoo-linux-security.mql.yaml:47)
+  [contains] group:mondoo-linux-security-group-2 (content/mondoo-linux-security.mql.yaml:59)
+  [contains] group:mondoo-linux-security-group-3 (content/mondoo-linux-security.mql.yaml:69)
+  [contains] group:mondoo-linux-security-group-4 (content/mondoo-linux-security.mql.yaml:84)
+  [contains] group:mondoo-linux-security-group-5 (content/mondoo-linux-security.mql.yaml:96)
+  [contains] group:mondoo-linux-security-group-6 (content/mondoo-linux-security.mql.yaml:118)
+  [contains] group:mondoo-linux-security-group-7 (content/mondoo-linux-security.mql.yaml:142)
+  [contains] group:mondoo-linux-security-group-8 (content/mondoo-linux-security.mql.yaml:173)
+  [contains] group:mondoo-linux-security-group-9 (content/mondoo-linux-security.mql.yaml:180)
+```
+
+Then drill into a specific group to see its checks:
+
+```bash
+$ cnspec policy graph callees mondoo-linux-security-group-6 ./content/mondoo-linux-security.mql.yaml
+```
+
+```
+group:mondoo-linux-security-group-6 contains/references:
+  [contains] check:mondoo-linux-security-only-strong-ciphers-are-used (content/mondoo-linux-security.mql.yaml:11173)
+  [contains] check:mondoo-linux-security-only-strong-kex-algorithms-are-used (content/mondoo-linux-security.mql.yaml:11398)
+  [contains] check:mondoo-linux-security-only-strong-mac-algorithms-are-used (content/mondoo-linux-security.mql.yaml:11287)
+  [contains] check:mondoo-linux-security-permissions-on-etcsshsshd-config-are-configured (content/mondoo-linux-security.mql.yaml:9061)
+  [contains] check:mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured (content/mondoo-linux-security.mql.yaml:9917)
+  [contains] check:mondoo-linux-security-permissions-on-ssh-public-host-key-files-are-configured (content/mondoo-linux-security.mql.yaml:10022)
+  [contains] check:mondoo-linux-security-ssh-access-is-limited (content/mondoo-linux-security.mql.yaml:11835)
+  [contains] check:mondoo-linux-security-ssh-hostbasedauthentication-is-disabled (content/mondoo-linux-security.mql.yaml:10707)
+  [contains] check:mondoo-linux-security-ssh-idle-timeout-interval-is-configured (content/mondoo-linux-security.mql.yaml:11596)
+  [contains] check:mondoo-linux-security-ssh-ignorerhosts-is-enabled (content/mondoo-linux-security.mql.yaml:10592)
+  [contains] check:mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less (content/mondoo-linux-security.mql.yaml:11734)
+  [contains] check:mondoo-linux-security-ssh-loglevel-is-appropriate (content/mondoo-linux-security.mql.yaml:10244)
+  [contains] check:mondoo-linux-security-ssh-maxauthtries-is-set-to-4-or-less (content/mondoo-linux-security.mql.yaml:10477)
+  [contains] check:mondoo-linux-security-ssh-permitemptypasswords-is-disabled (content/mondoo-linux-security.mql.yaml:10943)
+  [contains] check:mondoo-linux-security-ssh-permituserenvironment-is-disabled (content/mondoo-linux-security.mql.yaml:11058)
+  [contains] check:mondoo-linux-security-ssh-protocol-is-set-to-2 (content/mondoo-linux-security.mql.yaml:10125)
+  [contains] check:mondoo-linux-security-ssh-root-login-is-disabled (content/mondoo-linux-security.mql.yaml:10822)
+  [contains] check:mondoo-linux-security-ssh-warning-banner-is-configured (content/mondoo-linux-security.mql.yaml:11980)
+  [contains] check:mondoo-linux-security-ssh-x11-forwarding-is-disabled (content/mondoo-linux-security.mql.yaml:10363)
+```
+
+### Find what references a check
+
+```bash
+$ cnspec policy graph callers mondoo-linux-security-ssh-root-login-is-disabled \
+    ./content/mondoo-linux-security.mql.yaml
+```
+
+```
+check:mondoo-linux-security-ssh-root-login-is-disabled is referenced by:
+  [contains] group:mondoo-linux-security-group-6 (content/mondoo-linux-security.mql.yaml:118)
+```
+
+When framework bundles are loaded, this also shows compliance control mappings via `[maps_to]` edges.
+
+### Trace the path from policy to check
+
+```bash
+$ cnspec policy graph paths mondoo-linux-security \
+    mondoo-linux-security-ssh-root-login-is-disabled \
+    ./content/mondoo-linux-security.mql.yaml
+```
+
+```
+Path 1:
+  policy:mondoo-linux-security
+  → group:mondoo-linux-security-group-6
+  → check:mondoo-linux-security-ssh-root-login-is-disabled
+```
+
+### Find all SSH-related checks
+
+```bash
+$ cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json | \
+    python3 -c "import json,sys; [print(n['name']) for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+```
+
+```
+mondoo-linux-security-permissions-on-etcsshsshd-config-are-configured
+mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured
+mondoo-linux-security-permissions-on-ssh-public-host-key-files-are-configured
+mondoo-linux-security-ssh-protocol-is-set-to-2
+mondoo-linux-security-ssh-loglevel-is-appropriate
+mondoo-linux-security-ssh-x11-forwarding-is-disabled
+mondoo-linux-security-ssh-maxauthtries-is-set-to-4-or-less
+mondoo-linux-security-ssh-ignorerhosts-is-enabled
+mondoo-linux-security-ssh-hostbasedauthentication-is-disabled
+mondoo-linux-security-ssh-root-login-is-disabled
+mondoo-linux-security-ssh-permitemptypasswords-is-disabled
+mondoo-linux-security-ssh-permituserenvironment-is-disabled
+mondoo-linux-security-ssh-idle-timeout-interval-is-configured
+mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less
+mondoo-linux-security-ssh-access-is-limited
+mondoo-linux-security-ssh-warning-banner-is-configured
+```
+
+### Get full context for a check
+
+The `context` command produces LLM-friendly markdown with YAML source snippets, compliance tags, and relationships:
+
+```bash
+$ cnspec policy graph context mondoo-linux-security-ssh-root-login-is-disabled \
+    ./content/mondoo-linux-security.mql.yaml --depth 2
+```
+
+```
+# Policy context for check:mondoo-linux-security-ssh-root-login-is-disabled
+
+**Focus**: `check:mondoo-linux-security-ssh-root-login-is-disabled` (check) at content/mondoo-linux-security.mql.yaml:10822
+**Title**: Ensure SSH root login is disabled or set to prohibit-password
+**Impact**: 100
+**Tags**: compliance/csa-cloud-controls-matrix-4=cloud-controls-matrix-4-iam-02, compliance/dora=dora-art-9, ...
+**Neighborhood**: 21 nodes within 2 hops
+
+## content/mondoo-linux-security.mql.yaml
+
+### check:mondoo-linux-security-ssh-root-login-is-disabled (check, L10822) ← FOCUS
+**Title**: Ensure SSH root login is disabled or set to prohibit-password
+**Impact**: 100
+Referenced by: group:mondoo-linux-security-group-6 [contains]
+
+​```yaml
+  - uid: mondoo-linux-security-ssh-root-login-is-disabled
+    title: Ensure SSH root login is disabled or set to prohibit-password
+    ...
+​```
+```
+
+### Show all reachable nodes from a policy
+
+```bash
+$ cnspec policy graph reachable mondoo-linux-security \
+    ./content/mondoo-linux-security.mql.yaml
+```
+
+```
+129 nodes reachable from policy:mondoo-linux-security:
+  group:mondoo-linux-security-group-0 (content/mondoo-linux-security.mql.yaml:37)
+  group:mondoo-linux-security-group-1 (content/mondoo-linux-security.mql.yaml:47)
+  ...
+  check:mondoo-linux-security-aide-is-installed (content/mondoo-linux-security.mql.yaml:198)
+  check:mondoo-linux-security-core-dumps-are-restricted (content/mondoo-linux-security.mql.yaml:543)
+  ...
+```
+
+### Scan the entire content directory
+
+Point at a directory to walk all `.mql.yaml` files:
+
+```bash
+$ cnspec policy graph export ./content/ --format json | \
+    python3 -c "
+import json, sys, collections
+d = json.load(sys.stdin)
+kinds = collections.Counter(n['kind'] for n in d['nodes'])
+print(f'Nodes: {len(d[\"nodes\"])}, Edges: {len(d[\"edges\"])}')
+for k, v in kinds.most_common(): print(f'  {k}: {v}')
+"
+```
+
+```
+Nodes: 7462, Edges: 7240
+  check: 6952
+  group: 452
+  policy: 58
+```
+
+### JSON output
+
+All commands except `context` and `export` support `--json` for structured output:
+
+```bash
+$ cnspec policy graph callees mondoo-linux-security ./content/mondoo-linux-security.mql.yaml --json
+```
+
+```json
+[
+  {
+    "edge": {
+      "source": "content/mondoo-linux-security.mql.yaml::policy:mondoo-linux-security",
+      "target": "content/mondoo-linux-security.mql.yaml::group:mondoo-linux-security-group-0",
+      "kind": "contains"
+    },
+    "node": {
+      "id": "content/mondoo-linux-security.mql.yaml::group:mondoo-linux-security-group-0",
+      "name": "mondoo-linux-security-group-0",
+      "qual_name": "group:mondoo-linux-security-group-0",
+      "kind": "group",
+      "file": "content/mondoo-linux-security.mql.yaml",
+      "line": 37,
+      "column": 9,
+      "title": "Core",
+      "parent_id": "content/mondoo-linux-security.mql.yaml::policy:mondoo-linux-security"
+    }
+  },
+  ...
+]
+```
+
+### Generate a visual diagram
+
+```bash
+cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format dot > policy.dot
+dot -Tpng policy.dot -o policy.png
+```
+
+Node colors: policies (blue), groups (lavender), checks (yellow), frameworks (green), controls (pale green).
+
+## Framework and compliance mapping
+
+When framework bundles are loaded alongside policy bundles, the graph includes compliance relationships:
+
+```bash
+# Load both policy and framework bundles
+cnspec policy graph callers <check-uid> ./policies/ ./frameworks/
+
+# Trace framework control → check mapping
+cnspec policy graph paths <control-uid> <check-uid> ./policies/ ./frameworks/
+```
+
+Framework maps create `maps_to` edges from controls to checks, so `callers` on a check shows which compliance controls require it, and `paths` traces the full chain: framework -> control -> check.
+
+## Claude Code skill
+
+A Claude Code skill is included for AI-assisted policy navigation. Install it with:
+
+```bash
+make install/skills
+```
+
+This makes the `/policy-graph` slash command and auto-trigger skill available in all Claude Code projects.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -25,6 +25,7 @@ cnspec policy graph context mondoo-linux-security-ssh-root-login-is-disabled ./c
 
 | Command | Purpose |
 |---------|---------|
+| `cnspec policy graph search <query> <path>` | Find nodes by name, title, or UID |
 | `cnspec policy graph callers <uid> <path>` | What references this node (inbound edges) |
 | `cnspec policy graph callees <uid> <path>` | What this node contains/references (outbound edges) |
 | `cnspec policy graph context <uid> <path>` | LLM-friendly context with YAML snippets |
@@ -34,7 +35,11 @@ cnspec policy graph context mondoo-linux-security-ssh-root-login-is-disabled ./c
 
 ### Flags
 
-- `--json` — JSON output (callers, callees, paths, reachable)
+- `--json` — JSON output (search, callers, callees, paths, reachable)
+- `--kind` — Filter by node kind: policy, check, group, query, framework, control (search only)
+- `--tag` — Filter by tag key (search only)
+- `--impact N` — Minimum impact score (search only)
+- `--limit N` — Maximum results, default 50 (search only)
 - `--depth N` — Neighborhood depth for context (default 2)
 - `--format json|dot` — Export format (export command only)
 
@@ -70,6 +75,47 @@ The `<path>` argument can be:
 | `variant_of` | Check variant relationship (parent -> platform-specific variant) |
 
 ## Examples
+
+### Search for nodes
+
+```bash
+# Find all SSH-related checks
+$ cnspec policy graph search ssh ./content/ --kind check
+```
+
+```
+check        check:mondoo-linux-security-ssh-root-login-is-d... Ensure SSH root login is disabled or ... (content/mondoo-linux-security.mql.yaml:10822)
+check        check:mondoo-linux-security-ssh-x11-forwarding-... Ensure SSH X11 forwarding is disabled    (content/mondoo-linux-security.mql.yaml:10363)
+...
+```
+
+```bash
+# Find checks by title (searches titles, not just UIDs)
+$ cnspec policy graph search "root login" ./content/ --kind check
+```
+
+```
+check        check:mondoo-junos-security-ssh-root-login-disa... Ensure root login via SSH is denied      (content/mondoo-junos-security.mql.yaml:101)
+check        check:mondoo-freebsd-security-ssh-root-login-is... Ensure SSH root login is disabled        (content/mondoo-freebsd-security.mql.yaml:2458)
+check        check:mondoo-linux-security-ssh-root-login-is-d... Ensure SSH root login is disabled or ... (content/mondoo-linux-security.mql.yaml:10822)
+...
+```
+
+```bash
+# List all policies
+$ cnspec policy graph search "" ./content/ --kind policy
+```
+
+```
+policy       policy:mondoo-linux-security                       Mondoo Linux Security                    (content/mondoo-linux-security.mql.yaml:4)
+policy       policy:mondoo-aws-security                         Mondoo AWS Security                      (content/mondoo-aws-security.mql.yaml:4)
+...
+```
+
+```bash
+# JSON output for programmatic use
+$ cnspec policy graph search ssh ./content/ --kind check --json --limit 2
+```
 
 ### Get an overview of a policy bundle
 
@@ -174,27 +220,14 @@ Path 1:
 ### Find all SSH-related checks
 
 ```bash
-$ cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json | \
-    python3 -c "import json,sys; [print(n['name']) for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+$ cnspec policy graph search ssh ./content/mondoo-linux-security.mql.yaml --kind check
 ```
 
 ```
-mondoo-linux-security-permissions-on-etcsshsshd-config-are-configured
-mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured
-mondoo-linux-security-permissions-on-ssh-public-host-key-files-are-configured
-mondoo-linux-security-ssh-protocol-is-set-to-2
-mondoo-linux-security-ssh-loglevel-is-appropriate
-mondoo-linux-security-ssh-x11-forwarding-is-disabled
-mondoo-linux-security-ssh-maxauthtries-is-set-to-4-or-less
-mondoo-linux-security-ssh-ignorerhosts-is-enabled
-mondoo-linux-security-ssh-hostbasedauthentication-is-disabled
-mondoo-linux-security-ssh-root-login-is-disabled
-mondoo-linux-security-ssh-permitemptypasswords-is-disabled
-mondoo-linux-security-ssh-permituserenvironment-is-disabled
-mondoo-linux-security-ssh-idle-timeout-interval-is-configured
-mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less
-mondoo-linux-security-ssh-access-is-limited
-mondoo-linux-security-ssh-warning-banner-is-configured
+check        check:mondoo-linux-security-permissions-on-etcs... Ensure secure permissions on /etc/ssh... (content/mondoo-linux-security.mql.yaml:9061)
+check        check:mondoo-linux-security-ssh-protocol-is-set... Ensure SSH protocol is set to 2          (content/mondoo-linux-security.mql.yaml:10125)
+check        check:mondoo-linux-security-ssh-root-login-is-d... Ensure SSH root login is disabled or ... (content/mondoo-linux-security.mql.yaml:10822)
+...
 ```
 
 ### Get full context for a check

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -325,10 +325,44 @@ Framework maps create `maps_to` edges from controls to checks, so `callers` on a
 
 ## Claude Code skill
 
-A Claude Code skill is included for AI-assisted policy navigation. Install it with:
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill is included for AI-assisted policy navigation. The skill teaches Claude how to use the graph commands to answer questions about policy bundles.
+
+### Installation
 
 ```bash
 make install/skills
 ```
 
-This makes the `/policy-graph` slash command and auto-trigger skill available in all Claude Code projects.
+This copies the skill files to `~/.claude/`, making them available across all projects:
+
+- `~/.claude/commands/policy-graph.md` — Slash command definition
+- `~/.claude/skills/policy-graph/` — Auto-trigger skill with references
+
+### Usage in Claude Code
+
+**Slash command** — type `/policy-graph` followed by your question:
+
+```
+/policy-graph What SSH checks does the Linux security policy have?
+/policy-graph Which compliance controls map to the root login check?
+/policy-graph Show me the structure of mondoo-aws-security
+```
+
+**Auto-trigger** — the skill activates automatically when Claude detects questions about policy structure, compliance mappings, or bundle navigation. Ask naturally:
+
+```
+What checks are in the Linux security policy?
+How does this framework control connect to that check?
+Find all SSH-related checks in the content directory.
+```
+
+### What the skill does
+
+When triggered, Claude uses graph commands to:
+
+1. **Orient** — `export --format json` to understand the bundle (node counts by kind)
+2. **Locate** — `export` with filtering to find specific nodes by name
+3. **Navigate** — `callers`/`callees`/`paths` to explore relationships
+4. **Context** — `context --depth 2` for deep investigation with YAML source snippets
+
+The skill only reads `.mql.yaml` files — it does not scan assets, write queries, or modify bundles.

--- a/internal/bundle/graph.go
+++ b/internal/bundle/graph.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13/policy"
 )
 
@@ -197,7 +198,10 @@ func (g *PolicyGraph) findPathsDFS(current, dst string, path []string, visited m
 	for _, e := range g.outEdges[current] {
 		if !visited[e.Target] {
 			visited[e.Target] = true
-			g.findPathsDFS(e.Target, dst, append(path, e.Target), visited, maxDepth, results)
+			newPath := make([]string, len(path)+1)
+			copy(newPath, path)
+			newPath[len(path)] = e.Target
+			g.findPathsDFS(e.Target, dst, newPath, visited, maxDepth, results)
 			delete(visited, e.Target)
 		}
 	}
@@ -266,6 +270,7 @@ func (g *PolicyGraph) resolveEdges() {
 		if ids, ok := nameIdx[unresolved]; ok && len(ids) == 1 {
 			return ids[0]
 		}
+		log.Warn().Str("ref", unresolved).Msg("unresolved edge reference")
 		return ref
 	}
 	for _, e := range g.Edges {
@@ -594,11 +599,11 @@ func extractFrameworkMap(g *PolicyGraph, file string, fm *FrameworkMap) {
 		})
 	}
 	for _, cm := range fm.Controls {
-		extractControlMapping(g, file, cm, fmID)
+		extractControlMapping(g, cm, fmID)
 	}
 }
 
-func extractControlMapping(g *PolicyGraph, _ string, cm *ControlMap, fmapID string) {
+func extractControlMapping(g *PolicyGraph, cm *ControlMap, fmapID string) {
 	if cm.Uid == "" {
 		return
 	}

--- a/internal/bundle/graph.go
+++ b/internal/bundle/graph.go
@@ -1,0 +1,647 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/v13/policy"
+)
+
+type NodeKind string
+
+const (
+	KindPolicy       NodeKind = "policy"
+	KindGroup        NodeKind = "group"
+	KindCheck        NodeKind = "check"
+	KindQuery        NodeKind = "query"
+	KindFramework    NodeKind = "framework"
+	KindControl      NodeKind = "control"
+	KindFrameworkMap NodeKind = "framework_map"
+)
+
+type EdgeKind string
+
+const (
+	EdgeContains  EdgeKind = "contains"
+	EdgeMapsTo    EdgeKind = "maps_to"
+	EdgeDependsOn EdgeKind = "depends_on"
+	EdgeVariantOf EdgeKind = "variant_of"
+)
+
+type GraphNode struct {
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	QualName string            `json:"qual_name"`
+	Kind     NodeKind          `json:"kind"`
+	File     string            `json:"file"`
+	Line     int               `json:"line"`
+	Column   int               `json:"column"`
+	Title    string            `json:"title,omitempty"`
+	MQL      string            `json:"mql,omitempty"`
+	Impact   int               `json:"impact,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	ParentID string            `json:"parent_id,omitempty"`
+}
+
+type GraphEdge struct {
+	Source string   `json:"source"`
+	Target string   `json:"target"`
+	Kind   EdgeKind `json:"kind"`
+}
+
+type PolicyGraph struct {
+	Nodes []*GraphNode `json:"nodes"`
+	Edges []*GraphEdge `json:"edges"`
+
+	nodeIdx  map[string]*GraphNode
+	outEdges map[string][]*GraphEdge
+	inEdges  map[string][]*GraphEdge
+	built    bool
+}
+
+func NewPolicyGraph() *PolicyGraph {
+	return &PolicyGraph{
+		nodeIdx: make(map[string]*GraphNode),
+	}
+}
+
+func (g *PolicyGraph) addNode(n *GraphNode) {
+	if _, exists := g.nodeIdx[n.ID]; exists {
+		return
+	}
+	g.nodeIdx[n.ID] = n
+	g.Nodes = append(g.Nodes, n)
+	g.built = false
+}
+
+func (g *PolicyGraph) addEdge(e *GraphEdge) {
+	g.Edges = append(g.Edges, e)
+	g.built = false
+}
+
+func (g *PolicyGraph) Build() {
+	g.outEdges = make(map[string][]*GraphEdge, len(g.Nodes))
+	g.inEdges = make(map[string][]*GraphEdge, len(g.Nodes))
+	for _, e := range g.Edges {
+		g.outEdges[e.Source] = append(g.outEdges[e.Source], e)
+		g.inEdges[e.Target] = append(g.inEdges[e.Target], e)
+	}
+	g.built = true
+}
+
+func (g *PolicyGraph) ensureBuilt() {
+	if !g.built {
+		g.Build()
+	}
+}
+
+func (g *PolicyGraph) Node(id string) *GraphNode {
+	return g.nodeIdx[id]
+}
+
+func (g *PolicyGraph) FindNode(query string) []*GraphNode {
+	query = strings.ToLower(query)
+	var result []*GraphNode
+	for _, n := range g.Nodes {
+		if strings.Contains(strings.ToLower(n.Name), query) ||
+			strings.Contains(strings.ToLower(n.QualName), query) ||
+			strings.Contains(strings.ToLower(n.ID), query) {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+func (g *PolicyGraph) InEdges(nodeID string, kinds ...EdgeKind) []*GraphEdge {
+	g.ensureBuilt()
+	if len(kinds) == 0 {
+		return g.inEdges[nodeID]
+	}
+	kindSet := make(map[EdgeKind]bool, len(kinds))
+	for _, k := range kinds {
+		kindSet[k] = true
+	}
+	var result []*GraphEdge
+	for _, e := range g.inEdges[nodeID] {
+		if kindSet[e.Kind] {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func (g *PolicyGraph) OutEdges(nodeID string, kinds ...EdgeKind) []*GraphEdge {
+	g.ensureBuilt()
+	if len(kinds) == 0 {
+		return g.outEdges[nodeID]
+	}
+	kindSet := make(map[EdgeKind]bool, len(kinds))
+	for _, k := range kinds {
+		kindSet[k] = true
+	}
+	var result []*GraphEdge
+	for _, e := range g.outEdges[nodeID] {
+		if kindSet[e.Kind] {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func (g *PolicyGraph) Reachable(nodeID string) []string {
+	g.ensureBuilt()
+	visited := map[string]bool{nodeID: true}
+	queue := []string{nodeID}
+	var result []string
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, e := range g.outEdges[current] {
+			if !visited[e.Target] {
+				visited[e.Target] = true
+				result = append(result, e.Target)
+				queue = append(queue, e.Target)
+			}
+		}
+	}
+	return result
+}
+
+func (g *PolicyGraph) FindPaths(srcID, dstID string, maxDepth int) [][]string {
+	g.ensureBuilt()
+	if maxDepth <= 0 {
+		maxDepth = 20
+	}
+	var results [][]string
+	g.findPathsDFS(srcID, dstID, []string{srcID}, map[string]bool{srcID: true}, maxDepth, &results)
+	return results
+}
+
+func (g *PolicyGraph) findPathsDFS(current, dst string, path []string, visited map[string]bool, maxDepth int, results *[][]string) {
+	if len(path) > maxDepth {
+		return
+	}
+	if current == dst {
+		cp := make([]string, len(path))
+		copy(cp, path)
+		*results = append(*results, cp)
+		return
+	}
+	for _, e := range g.outEdges[current] {
+		if !visited[e.Target] {
+			visited[e.Target] = true
+			g.findPathsDFS(e.Target, dst, append(path, e.Target), visited, maxDepth, results)
+			delete(visited, e.Target)
+		}
+	}
+}
+
+func (g *PolicyGraph) Neighborhood(nodeID string, depth int) []*GraphNode {
+	g.ensureBuilt()
+	if depth <= 0 {
+		depth = 2
+	}
+	visited := map[string]bool{nodeID: true}
+	type entry struct {
+		id    string
+		level int
+	}
+	queue := []entry{{nodeID, 0}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current.level >= depth {
+			continue
+		}
+		for _, e := range g.outEdges[current.id] {
+			if !visited[e.Target] && g.nodeIdx[e.Target] != nil {
+				visited[e.Target] = true
+				queue = append(queue, entry{e.Target, current.level + 1})
+			}
+		}
+		for _, e := range g.inEdges[current.id] {
+			if !visited[e.Source] && g.nodeIdx[e.Source] != nil {
+				visited[e.Source] = true
+				queue = append(queue, entry{e.Source, current.level + 1})
+			}
+		}
+	}
+	var result []*GraphNode
+	for id := range visited {
+		if n := g.nodeIdx[id]; n != nil {
+			result = append(result, n)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].File != result[j].File {
+			return result[i].File < result[j].File
+		}
+		return result[i].Line < result[j].Line
+	})
+	return result
+}
+
+func (g *PolicyGraph) resolveEdges() {
+	nameIdx := make(map[string][]string)
+	qualIdx := make(map[string][]string)
+	for _, n := range g.Nodes {
+		nameIdx[n.Name] = append(nameIdx[n.Name], n.ID)
+		qualIdx[n.QualName] = append(qualIdx[n.QualName], n.ID)
+	}
+	resolve := func(ref string) string {
+		if !strings.HasPrefix(ref, "?:") {
+			return ref
+		}
+		unresolved := strings.TrimPrefix(ref, "?:")
+		if ids, ok := qualIdx[unresolved]; ok && len(ids) == 1 {
+			return ids[0]
+		}
+		if ids, ok := nameIdx[unresolved]; ok && len(ids) == 1 {
+			return ids[0]
+		}
+		return ref
+	}
+	for _, e := range g.Edges {
+		e.Source = resolve(e.Source)
+		e.Target = resolve(e.Target)
+	}
+	g.built = false
+}
+
+func nodeID(file string, kind NodeKind, uid string) string {
+	return file + "::" + string(kind) + ":" + uid
+}
+
+func qualName(kind NodeKind, uid string) string {
+	return string(kind) + ":" + uid
+}
+
+// BuildGraphFromPaths walks a path for .mql.yaml files, parses them, and builds a graph.
+func BuildGraphFromPaths(paths ...string) (*PolicyGraph, error) {
+	files, err := policy.WalkPolicyBundleFiles(paths...)
+	if err != nil {
+		return nil, err
+	}
+
+	bundles := make(map[string]*Bundle, len(files))
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read "+f)
+		}
+		b, err := ParseYaml(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse "+f)
+		}
+		rel, err := filepath.Rel(".", f)
+		if err != nil {
+			rel = f
+		}
+		bundles[rel] = b
+	}
+	return BuildGraph(bundles), nil
+}
+
+// BuildGraph builds a PolicyGraph from pre-parsed bundles keyed by filename.
+func BuildGraph(bundles map[string]*Bundle) *PolicyGraph {
+	g := NewPolicyGraph()
+	files := make([]string, 0, len(bundles))
+	for f := range bundles {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, file := range files {
+		extractBundle(g, file, bundles[file])
+	}
+	g.resolveEdges()
+	g.Build()
+	return g
+}
+
+func extractBundle(g *PolicyGraph, file string, b *Bundle) {
+	for _, q := range b.Queries {
+		extractTopLevelQuery(g, file, q)
+	}
+	for _, p := range b.Policies {
+		extractPolicy(g, file, p)
+	}
+	for _, fw := range b.Frameworks {
+		extractFramework(g, file, fw)
+	}
+	for _, fm := range b.FrameworkMaps {
+		extractFrameworkMap(g, file, fm)
+	}
+}
+
+func extractTopLevelQuery(g *PolicyGraph, file string, q *Mquery) {
+	if q.Uid == "" {
+		return
+	}
+	kind := KindCheck
+	if q.Mql == "" && len(q.Variants) == 0 {
+		kind = KindQuery
+	}
+	impact := 0
+	if q.Impact != nil && q.Impact.Value != nil {
+		impact = int(q.Impact.Value.Value)
+	}
+	id := nodeID(file, kind, q.Uid)
+	title := q.Title
+	if title == "" && q.Docs != nil {
+		title = q.Docs.Desc
+	}
+	g.addNode(&GraphNode{
+		ID:       id,
+		Name:     q.Uid,
+		QualName: qualName(kind, q.Uid),
+		Kind:     kind,
+		File:     file,
+		Line:     q.FileContext.Line,
+		Column:   q.FileContext.Column,
+		Title:    title,
+		MQL:      q.Mql,
+		Impact:   impact,
+		Tags:     q.Tags,
+	})
+	for _, v := range q.Variants {
+		if v.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: id,
+			Target: "?:" + qualName(KindCheck, v.Uid),
+			Kind:   EdgeVariantOf,
+		})
+	}
+}
+
+func extractPolicy(g *PolicyGraph, file string, p *Policy) {
+	if p.Uid == "" {
+		return
+	}
+	pID := nodeID(file, KindPolicy, p.Uid)
+	g.addNode(&GraphNode{
+		ID:       pID,
+		Name:     p.Uid,
+		QualName: qualName(KindPolicy, p.Uid),
+		Kind:     KindPolicy,
+		File:     file,
+		Line:     p.FileContext.Line,
+		Column:   p.FileContext.Column,
+		Title:    p.Name,
+	})
+	for i, grp := range p.Groups {
+		extractPolicyGroup(g, file, grp, pID, p.Uid, i)
+	}
+}
+
+func extractPolicyGroup(g *PolicyGraph, file string, grp *PolicyGroup, policyID string, policyUID string, idx int) {
+	groupUID := grp.Uid
+	if groupUID == "" {
+		groupUID = fmt.Sprintf("%s-group-%d", policyUID, idx)
+	}
+	gID := nodeID(file, KindGroup, groupUID)
+	title := grp.Title
+	g.addNode(&GraphNode{
+		ID:       gID,
+		Name:     groupUID,
+		QualName: qualName(KindGroup, groupUID),
+		Kind:     KindGroup,
+		File:     file,
+		Line:     grp.FileContext.Line,
+		Column:   grp.FileContext.Column,
+		Title:    title,
+		ParentID: policyID,
+	})
+	g.addEdge(&GraphEdge{Source: policyID, Target: gID, Kind: EdgeContains})
+
+	for _, c := range grp.Checks {
+		if c.Uid == "" {
+			continue
+		}
+		if c.Mql != "" || c.Title != "" {
+			extractInlineQuery(g, file, c, KindCheck, gID)
+		}
+		g.addEdge(&GraphEdge{
+			Source: gID,
+			Target: "?:" + qualName(KindCheck, c.Uid),
+			Kind:   EdgeContains,
+		})
+	}
+	for _, q := range grp.Queries {
+		if q.Uid == "" {
+			continue
+		}
+		if q.Mql != "" || q.Title != "" {
+			extractInlineQuery(g, file, q, KindQuery, gID)
+		}
+		g.addEdge(&GraphEdge{
+			Source: gID,
+			Target: "?:" + qualName(KindQuery, q.Uid),
+			Kind:   EdgeContains,
+		})
+	}
+	for _, pr := range grp.Policies {
+		if pr.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: gID,
+			Target: "?:" + qualName(KindPolicy, pr.Uid),
+			Kind:   EdgeDependsOn,
+		})
+	}
+}
+
+func extractInlineQuery(g *PolicyGraph, file string, q *Mquery, kind NodeKind, parentID string) {
+	if q.Uid == "" {
+		return
+	}
+	impact := 0
+	if q.Impact != nil && q.Impact.Value != nil {
+		impact = int(q.Impact.Value.Value)
+	}
+	title := q.Title
+	if title == "" && q.Docs != nil {
+		title = q.Docs.Desc
+	}
+	id := nodeID(file, kind, q.Uid)
+	g.addNode(&GraphNode{
+		ID:       id,
+		Name:     q.Uid,
+		QualName: qualName(kind, q.Uid),
+		Kind:     kind,
+		File:     file,
+		Line:     q.FileContext.Line,
+		Column:   q.FileContext.Column,
+		Title:    title,
+		MQL:      q.Mql,
+		Impact:   impact,
+		Tags:     q.Tags,
+		ParentID: parentID,
+	})
+	for _, v := range q.Variants {
+		if v.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: id,
+			Target: "?:" + qualName(KindCheck, v.Uid),
+			Kind:   EdgeVariantOf,
+		})
+	}
+}
+
+func extractFramework(g *PolicyGraph, file string, fw *Framework) {
+	if fw.Uid == "" {
+		return
+	}
+	fwID := nodeID(file, KindFramework, fw.Uid)
+	g.addNode(&GraphNode{
+		ID:       fwID,
+		Name:     fw.Uid,
+		QualName: qualName(KindFramework, fw.Uid),
+		Kind:     KindFramework,
+		File:     file,
+		Line:     fw.FileContext.Line,
+		Column:   fw.FileContext.Column,
+		Title:    fw.Name,
+	})
+	for _, dep := range fw.Dependencies {
+		if dep.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: fwID,
+			Target: "?:" + qualName(KindFramework, dep.Uid),
+			Kind:   EdgeDependsOn,
+		})
+	}
+	for _, grp := range fw.Groups {
+		for _, ctrl := range grp.Controls {
+			extractControl(g, file, ctrl, fwID)
+		}
+	}
+	for _, fm := range fw.FrameworkMaps {
+		extractFrameworkMap(g, file, fm)
+	}
+}
+
+func extractControl(g *PolicyGraph, file string, ctrl *Control, frameworkID string) {
+	if ctrl.Uid == "" {
+		return
+	}
+	cID := nodeID(file, KindControl, ctrl.Uid)
+	title := ctrl.Title
+	if title == "" && ctrl.Docs != nil {
+		title = ctrl.Docs.Desc
+	}
+	g.addNode(&GraphNode{
+		ID:       cID,
+		Name:     ctrl.Uid,
+		QualName: qualName(KindControl, ctrl.Uid),
+		Kind:     KindControl,
+		File:     file,
+		Line:     ctrl.FileContext.Line,
+		Column:   ctrl.FileContext.Column,
+		Title:    title,
+		ParentID: frameworkID,
+		Tags:     ctrl.Tags,
+	})
+	g.addEdge(&GraphEdge{Source: frameworkID, Target: cID, Kind: EdgeContains})
+}
+
+func extractFrameworkMap(g *PolicyGraph, file string, fm *FrameworkMap) {
+	if fm.Uid == "" && fm.FrameworkOwner == nil {
+		return
+	}
+	fmUID := fm.Uid
+	if fmUID == "" && fm.FrameworkOwner != nil {
+		fmUID = "fmap-" + fm.FrameworkOwner.Uid
+	}
+	fmID := nodeID(file, KindFrameworkMap, fmUID)
+	g.addNode(&GraphNode{
+		ID:       fmID,
+		Name:     fmUID,
+		QualName: qualName(KindFrameworkMap, fmUID),
+		Kind:     KindFrameworkMap,
+		File:     file,
+		Line:     fm.FileContext.Line,
+		Column:   fm.FileContext.Column,
+	})
+	if fm.FrameworkOwner != nil && fm.FrameworkOwner.Uid != "" {
+		g.addEdge(&GraphEdge{
+			Source: fmID,
+			Target: "?:" + qualName(KindFramework, fm.FrameworkOwner.Uid),
+			Kind:   EdgeDependsOn,
+		})
+	}
+	for _, pd := range fm.PolicyDependencies {
+		if pd.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: fmID,
+			Target: "?:" + qualName(KindPolicy, pd.Uid),
+			Kind:   EdgeDependsOn,
+		})
+	}
+	for _, cm := range fm.Controls {
+		extractControlMapping(g, file, cm, fmID)
+	}
+}
+
+func extractControlMapping(g *PolicyGraph, _ string, cm *ControlMap, fmapID string) {
+	if cm.Uid == "" {
+		return
+	}
+	controlTarget := "?:" + qualName(KindControl, cm.Uid)
+	g.addEdge(&GraphEdge{Source: fmapID, Target: controlTarget, Kind: EdgeContains})
+	for _, ref := range cm.Checks {
+		if ref.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: controlTarget,
+			Target: "?:" + qualName(KindCheck, ref.Uid),
+			Kind:   EdgeMapsTo,
+		})
+	}
+	for _, ref := range cm.Queries {
+		if ref.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: controlTarget,
+			Target: "?:" + qualName(KindQuery, ref.Uid),
+			Kind:   EdgeMapsTo,
+		})
+	}
+	for _, ref := range cm.Policies {
+		if ref.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: controlTarget,
+			Target: "?:" + qualName(KindPolicy, ref.Uid),
+			Kind:   EdgeMapsTo,
+		})
+	}
+	for _, ref := range cm.Controls {
+		if ref.Uid == "" {
+			continue
+		}
+		g.addEdge(&GraphEdge{
+			Source: controlTarget,
+			Target: "?:" + qualName(KindControl, ref.Uid),
+			Kind:   EdgeMapsTo,
+		})
+	}
+}

--- a/internal/bundle/graph.go
+++ b/internal/bundle/graph.go
@@ -107,6 +107,10 @@ func (g *PolicyGraph) Node(id string) *GraphNode {
 	return g.nodeIdx[id]
 }
 
+func (g *PolicyGraph) BuildNodeIndex() *NodeIndex {
+	return BuildNodeIndex(g)
+}
+
 func (g *PolicyGraph) FindNode(query string) []*GraphNode {
 	query = strings.ToLower(query)
 	var result []*GraphNode

--- a/internal/bundle/graph_context.go
+++ b/internal/bundle/graph_context.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// WriteContext writes a markdown-formatted context document for an LLM.
+func (g *PolicyGraph) WriteContext(w io.Writer, nodeID string, depth int, rootDir string) error {
+	g.ensureBuilt()
+
+	center := g.nodeIdx[nodeID]
+	if center == nil {
+		return errors.New("node " + nodeID + " not found")
+	}
+
+	nodes := g.Neighborhood(nodeID, depth)
+
+	fmt.Fprintf(w, "# Policy context for %s\n\n", center.QualName)
+	fmt.Fprintf(w, "**Focus**: `%s` (%s) at %s:%d\n", center.QualName, center.Kind, center.File, center.Line)
+	if center.Title != "" {
+		fmt.Fprintf(w, "**Title**: %s\n", center.Title)
+	}
+	if center.Impact > 0 {
+		fmt.Fprintf(w, "**Impact**: %d\n", center.Impact)
+	}
+	if len(center.Tags) > 0 {
+		var tags []string
+		for k, v := range center.Tags {
+			tags = append(tags, k+"="+v)
+		}
+		sort.Strings(tags)
+		fmt.Fprintf(w, "**Tags**: %s\n", strings.Join(tags, ", "))
+	}
+	fmt.Fprintf(w, "**Neighborhood**: %d nodes within %d hops\n\n", len(nodes), depth)
+
+	fileGroups := make(map[string][]*GraphNode)
+	for _, n := range nodes {
+		fileGroups[n.File] = append(fileGroups[n.File], n)
+	}
+
+	var files []string
+	for f := range fileGroups {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+
+	fileCache := make(map[string][]string)
+
+	for _, file := range files {
+		fmt.Fprintf(w, "## %s\n\n", file)
+
+		for _, n := range fileGroups[file] {
+			role := ""
+			if n.ID == nodeID {
+				role = " ← FOCUS"
+			}
+			fmt.Fprintf(w, "### %s (%s, L%d)%s\n", n.QualName, n.Kind, n.Line, role)
+			if n.Title != "" {
+				fmt.Fprintf(w, "**Title**: %s\n", n.Title)
+			}
+			if n.Impact > 0 {
+				fmt.Fprintf(w, "**Impact**: %d\n", n.Impact)
+			}
+
+			inNames := g.inEdgeNames(n.ID)
+			outNames := g.outEdgeNames(n.ID)
+			if len(inNames) > 0 {
+				fmt.Fprintf(w, "Referenced by: %s\n", strings.Join(inNames, ", "))
+			}
+			if len(outNames) > 0 {
+				fmt.Fprintf(w, "Contains: %s\n", strings.Join(outNames, ", "))
+			}
+			fmt.Fprintln(w)
+
+			lines, ok := fileCache[file]
+			if !ok {
+				lines = readSourceLines(rootDir, file)
+				fileCache[file] = lines
+			}
+			if lines != nil && n.Line > 0 {
+				endLine := estimateEndLine(nodes, n, len(lines))
+				snippet := extractSnippet(lines, n.Line, endLine)
+				if snippet != "" {
+					fmt.Fprintf(w, "```yaml\n%s\n```\n\n", snippet)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *PolicyGraph) inEdgeNames(nodeID string) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, e := range g.inEdges[nodeID] {
+		name := e.Source
+		if n := g.nodeIdx[e.Source]; n != nil {
+			name = n.QualName
+		}
+		label := fmt.Sprintf("%s [%s]", name, e.Kind)
+		if !seen[label] {
+			seen[label] = true
+			names = append(names, label)
+		}
+	}
+	return names
+}
+
+func (g *PolicyGraph) outEdgeNames(nodeID string) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, e := range g.outEdges[nodeID] {
+		name := e.Target
+		if n := g.nodeIdx[e.Target]; n != nil {
+			name = n.QualName
+		}
+		label := fmt.Sprintf("%s [%s]", name, e.Kind)
+		if !seen[label] {
+			seen[label] = true
+			names = append(names, label)
+		}
+	}
+	return names
+}
+
+func readSourceLines(rootDir, relPath string) []string {
+	path := relPath
+	if rootDir != "" {
+		path = filepath.Join(rootDir, relPath)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return strings.Split(string(data), "\n")
+}
+
+func estimateEndLine(siblings []*GraphNode, current *GraphNode, totalLines int) int {
+	nextLine := totalLines
+	for _, n := range siblings {
+		if n.File == current.File && n.Line > current.Line && n.Line < nextLine {
+			nextLine = n.Line - 1
+		}
+	}
+	maxLines := 40
+	if current.Line+maxLines < nextLine {
+		nextLine = current.Line + maxLines
+	}
+	return nextLine
+}
+
+func extractSnippet(lines []string, startLine, endLine int) string {
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	if startLine > len(lines) {
+		return ""
+	}
+	return strings.Join(lines[startLine-1:endLine], "\n")
+}

--- a/internal/bundle/graph_context.go
+++ b/internal/bundle/graph_context.go
@@ -139,6 +139,7 @@ func readSourceLines(rootDir, relPath string) []string {
 	if rootDir != "" {
 		path = filepath.Join(rootDir, relPath)
 	}
+	path = filepath.Clean(path)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil

--- a/internal/bundle/graph_test.go
+++ b/internal/bundle/graph_test.go
@@ -1,0 +1,334 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildGraph_Policies(t *testing.T) {
+	data := []byte(`
+policies:
+  - uid: linux-security
+    name: Linux Security
+    groups:
+      - title: SSH Configuration
+        checks:
+          - uid: sshd-ciphers
+            title: Ensure strong ciphers
+            impact: 80
+            mql: |
+              sshd.config.ciphers.none(_ == "3des-cbc")
+        queries:
+          - uid: sshd-config-data
+            title: SSH config data
+            mql: |
+              sshd.config { * }
+queries:
+  - uid: sshd-ciphers
+    title: Ensure strong ciphers
+    impact: 80
+    mql: |
+      sshd.config.ciphers.none(_ == "3des-cbc")
+  - uid: sshd-config-data
+    title: SSH config data
+    mql: |
+      sshd.config { * }
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"test.mql.yaml": b})
+
+	// Should have: 1 policy, 1 group, 2 checks/queries (from top-level queries)
+	policyNodes := findByKind(g, KindPolicy)
+	assert.Len(t, policyNodes, 1)
+	assert.Equal(t, "linux-security", policyNodes[0].Name)
+
+	groupNodes := findByKind(g, KindGroup)
+	assert.Len(t, groupNodes, 1)
+	assert.Equal(t, "SSH Configuration", groupNodes[0].Title)
+
+	checkNodes := findByKind(g, KindCheck)
+	assert.GreaterOrEqual(t, len(checkNodes), 1)
+
+	// Policy -> Group containment edge
+	pID := policyNodes[0].ID
+	outEdges := g.OutEdges(pID, EdgeContains)
+	assert.Len(t, outEdges, 1)
+	assert.Equal(t, groupNodes[0].ID, outEdges[0].Target)
+
+	// Group -> Check containment edge (resolved)
+	gID := groupNodes[0].ID
+	groupOut := g.OutEdges(gID, EdgeContains)
+	assert.GreaterOrEqual(t, len(groupOut), 1)
+}
+
+func TestBuildGraph_Frameworks(t *testing.T) {
+	data := []byte(`
+frameworks:
+  - uid: cis-benchmark
+    name: CIS Benchmark
+    groups:
+      - title: Access Control
+        controls:
+          - uid: cis-1.1
+            title: Ensure SSH is configured
+          - uid: cis-1.2
+            title: Ensure passwords are strong
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"fw.mql.yaml": b})
+
+	fwNodes := findByKind(g, KindFramework)
+	assert.Len(t, fwNodes, 1)
+	assert.Equal(t, "CIS Benchmark", fwNodes[0].Title)
+
+	ctrlNodes := findByKind(g, KindControl)
+	assert.Len(t, ctrlNodes, 2)
+
+	// Framework -> Control containment
+	fwID := fwNodes[0].ID
+	outEdges := g.OutEdges(fwID, EdgeContains)
+	assert.Len(t, outEdges, 2)
+}
+
+func TestBuildGraph_FrameworkMaps(t *testing.T) {
+	data := []byte(`
+queries:
+  - uid: check-ssh
+    title: Check SSH
+    impact: 80
+    mql: sshd.config.ciphers.length > 0
+frameworks:
+  - uid: cis-benchmark
+    name: CIS Benchmark
+    groups:
+      - title: Access Control
+        controls:
+          - uid: cis-1.1
+            title: Ensure SSH is configured
+framework_maps:
+  - uid: cis-to-policy
+    framework_owner:
+      uid: cis-benchmark
+    controls:
+      - uid: cis-1.1
+        checks:
+          - uid: check-ssh
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"mapped.mql.yaml": b})
+
+	// Control -> Check maps_to edge should be resolved
+	ctrlNodes := findByKind(g, KindControl)
+	require.Len(t, ctrlNodes, 1)
+
+	checkNodes := findByKind(g, KindCheck)
+	require.Len(t, checkNodes, 1)
+
+	outEdges := g.OutEdges(ctrlNodes[0].ID, EdgeMapsTo)
+	assert.Len(t, outEdges, 1)
+	assert.Equal(t, checkNodes[0].ID, outEdges[0].Target)
+}
+
+func TestBuildGraph_Variants(t *testing.T) {
+	data := []byte(`
+queries:
+  - uid: parent-check
+    title: Parent Check
+    variants:
+      - uid: parent-check-aws
+      - uid: parent-check-gcp
+  - uid: parent-check-aws
+    title: AWS variant
+    mql: aws.ec2.instances { tags["Name"] != empty }
+  - uid: parent-check-gcp
+    title: GCP variant
+    mql: gcp.compute.instances { name != empty }
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"variants.mql.yaml": b})
+
+	nodes := g.FindNode("parent-check")
+	require.GreaterOrEqual(t, len(nodes), 1)
+
+	parentID := ""
+	for _, n := range nodes {
+		if n.Name == "parent-check" {
+			parentID = n.ID
+			break
+		}
+	}
+	require.NotEmpty(t, parentID)
+
+	variantEdges := g.OutEdges(parentID, EdgeVariantOf)
+	assert.Len(t, variantEdges, 2)
+}
+
+func TestBuildGraph_CrossFileResolve(t *testing.T) {
+	checks := []byte(`
+queries:
+  - uid: my-check
+    title: My Check
+    impact: 90
+    mql: users.list.length > 0
+`)
+	policies := []byte(`
+policies:
+  - uid: my-policy
+    name: My Policy
+    groups:
+      - title: Group 1
+        checks:
+          - uid: my-check
+`)
+	bChecks, err := ParseYaml(checks)
+	require.NoError(t, err)
+	bPolicies, err := ParseYaml(policies)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{
+		"checks.mql.yaml":   bChecks,
+		"policies.mql.yaml": bPolicies,
+	})
+
+	// The group should have a resolved edge to the check in the other file
+	groupNodes := findByKind(g, KindGroup)
+	require.Len(t, groupNodes, 1)
+
+	outEdges := g.OutEdges(groupNodes[0].ID, EdgeContains)
+	resolved := false
+	for _, e := range outEdges {
+		if g.Node(e.Target) != nil && g.Node(e.Target).Name == "my-check" {
+			resolved = true
+		}
+	}
+	assert.True(t, resolved, "cross-file check reference should be resolved")
+}
+
+func TestPolicyGraph_FindPaths(t *testing.T) {
+	data := []byte(`
+queries:
+  - uid: check-a
+    title: Check A
+    impact: 80
+    mql: "true"
+frameworks:
+  - uid: fw
+    name: Framework
+    groups:
+      - title: Controls
+        controls:
+          - uid: ctrl-1
+            title: Control 1
+framework_maps:
+  - framework_owner:
+      uid: fw
+    controls:
+      - uid: ctrl-1
+        checks:
+          - uid: check-a
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"paths.mql.yaml": b})
+
+	ctrlNodes := findByKind(g, KindControl)
+	require.Len(t, ctrlNodes, 1)
+	checkNodes := findByKind(g, KindCheck)
+	require.Len(t, checkNodes, 1)
+
+	paths := g.FindPaths(ctrlNodes[0].ID, checkNodes[0].ID, 5)
+	assert.GreaterOrEqual(t, len(paths), 1)
+}
+
+func TestPolicyGraph_Reachable(t *testing.T) {
+	data := []byte(`
+queries:
+  - uid: check-1
+    title: Check 1
+    impact: 80
+    mql: "true"
+  - uid: check-2
+    title: Check 2
+    impact: 70
+    mql: "true"
+policies:
+  - uid: pol
+    name: Policy
+    groups:
+      - title: Group 1
+        checks:
+          - uid: check-1
+          - uid: check-2
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"reach.mql.yaml": b})
+
+	polNodes := findByKind(g, KindPolicy)
+	require.Len(t, polNodes, 1)
+
+	reachable := g.Reachable(polNodes[0].ID)
+	assert.GreaterOrEqual(t, len(reachable), 2) // at least group + checks
+}
+
+func TestPolicyGraph_WriteContext(t *testing.T) {
+	data := []byte(`
+queries:
+  - uid: check-x
+    title: Important Check
+    impact: 90
+    mql: |
+      users.where(name == "root").list { shell != "/bin/bash" }
+policies:
+  - uid: security-pol
+    name: Security Policy
+    groups:
+      - title: User Checks
+        checks:
+          - uid: check-x
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"ctx.mql.yaml": b})
+
+	checkNodes := findByKind(g, KindCheck)
+	require.GreaterOrEqual(t, len(checkNodes), 1)
+
+	var buf bytes.Buffer
+	err = g.WriteContext(&buf, checkNodes[0].ID, 2, "")
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Policy context for")
+	assert.Contains(t, output, "check-x")
+	assert.Contains(t, output, "Important Check")
+	assert.Contains(t, output, "Impact")
+	assert.Contains(t, output, "FOCUS")
+}
+
+func findByKind(g *PolicyGraph, kind NodeKind) []*GraphNode {
+	var result []*GraphNode
+	for _, n := range g.Nodes {
+		if n.Kind == kind {
+			result = append(result, n)
+		}
+	}
+	return result
+}

--- a/internal/bundle/node_index.go
+++ b/internal/bundle/node_index.go
@@ -1,0 +1,199 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"sort"
+	"strings"
+)
+
+// NodeIndex provides fast node lookups by name, qualified name, kind, and file.
+// It uses a search cascade: exact name → exact qualName → prefix → substring.
+type NodeIndex struct {
+	byName     map[string][]*GraphNode
+	byQualName map[string][]*GraphNode
+	byTitle    map[string][]*GraphNode
+	byKind     map[NodeKind][]*GraphNode
+	byFile     map[string][]*GraphNode
+	sorted     []string // sorted lowercase names for prefix binary search
+}
+
+// BuildNodeIndex creates a NodeIndex from a PolicyGraph's nodes.
+func BuildNodeIndex(g *PolicyGraph) *NodeIndex {
+	idx := &NodeIndex{
+		byName:     make(map[string][]*GraphNode),
+		byQualName: make(map[string][]*GraphNode),
+		byTitle:    make(map[string][]*GraphNode),
+		byKind:     make(map[NodeKind][]*GraphNode),
+		byFile:     make(map[string][]*GraphNode),
+	}
+
+	nameSet := make(map[string]bool)
+	for _, n := range g.Nodes {
+		lower := strings.ToLower(n.Name)
+		idx.byName[lower] = append(idx.byName[lower], n)
+		nameSet[lower] = true
+
+		lowerQual := strings.ToLower(n.QualName)
+		idx.byQualName[lowerQual] = append(idx.byQualName[lowerQual], n)
+
+		if n.Title != "" {
+			lowerTitle := strings.ToLower(n.Title)
+			idx.byTitle[lowerTitle] = append(idx.byTitle[lowerTitle], n)
+		}
+
+		idx.byKind[n.Kind] = append(idx.byKind[n.Kind], n)
+		idx.byFile[n.File] = append(idx.byFile[n.File], n)
+	}
+
+	idx.sorted = make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		idx.sorted = append(idx.sorted, name)
+	}
+	sort.Strings(idx.sorted)
+	return idx
+}
+
+// ExactName returns nodes whose Name exactly matches (case-insensitive).
+func (idx *NodeIndex) ExactName(name string) []*GraphNode {
+	return idx.byName[strings.ToLower(name)]
+}
+
+// ExactQualName returns nodes whose QualName exactly matches (case-insensitive).
+func (idx *NodeIndex) ExactQualName(qualName string) []*GraphNode {
+	return idx.byQualName[strings.ToLower(qualName)]
+}
+
+// Prefix returns nodes whose Name starts with the given prefix (case-insensitive).
+// Uses binary search on a sorted name slice for O(log n) lookup.
+func (idx *NodeIndex) Prefix(prefix string, limit int) []*GraphNode {
+	lower := strings.ToLower(prefix)
+	i := sort.SearchStrings(idx.sorted, lower)
+
+	var result []*GraphNode
+	for ; i < len(idx.sorted) && strings.HasPrefix(idx.sorted[i], lower); i++ {
+		nodes := idx.byName[idx.sorted[i]]
+		result = append(result, nodes...)
+		if limit > 0 && len(result) >= limit {
+			return result[:limit]
+		}
+	}
+	return result
+}
+
+// Substring returns nodes whose Name, QualName, or Title contains the query (case-insensitive).
+func (idx *NodeIndex) Substring(query string, limit int) []*GraphNode {
+	lower := strings.ToLower(query)
+	seen := make(map[string]bool)
+	var result []*GraphNode
+
+	for name, nodes := range idx.byName {
+		if strings.Contains(name, lower) {
+			for _, n := range nodes {
+				if !seen[n.ID] {
+					seen[n.ID] = true
+					result = append(result, n)
+					if limit > 0 && len(result) >= limit {
+						return result
+					}
+				}
+			}
+		}
+	}
+
+	for qualName, nodes := range idx.byQualName {
+		if strings.Contains(qualName, lower) {
+			for _, n := range nodes {
+				if !seen[n.ID] {
+					seen[n.ID] = true
+					result = append(result, n)
+					if limit > 0 && len(result) >= limit {
+						return result
+					}
+				}
+			}
+		}
+	}
+
+	for title, nodes := range idx.byTitle {
+		if strings.Contains(title, lower) {
+			for _, n := range nodes {
+				if !seen[n.ID] {
+					seen[n.ID] = true
+					result = append(result, n)
+					if limit > 0 && len(result) >= limit {
+						return result
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// ByKind returns all nodes of a specific kind.
+func (idx *NodeIndex) ByKind(kind NodeKind) []*GraphNode {
+	return idx.byKind[kind]
+}
+
+// SearchOpts controls filtering for the Search method.
+type SearchOpts struct {
+	Kind      NodeKind
+	TagKey    string
+	MinImpact int
+	Limit     int
+}
+
+// Search finds nodes matching a query using a cascade: exact name → exact qualName → prefix → substring.
+// Results are filtered by SearchOpts and capped at Limit (default 50).
+func (idx *NodeIndex) Search(query string, opts SearchOpts) []*GraphNode {
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+
+	var candidates []*GraphNode
+
+	if query == "" {
+		// Empty query with kind filter: return all nodes of that kind.
+		if opts.Kind != "" {
+			candidates = idx.ByKind(opts.Kind)
+		}
+	} else {
+		candidates = idx.ExactName(query)
+		if len(candidates) == 0 {
+			candidates = idx.ExactQualName(query)
+		}
+		if len(candidates) == 0 {
+			candidates = idx.Prefix(query, 0)
+		}
+		if len(candidates) == 0 {
+			candidates = idx.Substring(query, 0)
+		}
+	}
+
+	if opts.Kind != "" || opts.TagKey != "" || opts.MinImpact > 0 {
+		filtered := make([]*GraphNode, 0, len(candidates))
+		for _, n := range candidates {
+			if opts.Kind != "" && n.Kind != opts.Kind {
+				continue
+			}
+			if opts.TagKey != "" {
+				if _, ok := n.Tags[opts.TagKey]; !ok {
+					continue
+				}
+			}
+			if opts.MinImpact > 0 && n.Impact < opts.MinImpact {
+				continue
+			}
+			filtered = append(filtered, n)
+		}
+		candidates = filtered
+	}
+
+	if len(candidates) > opts.Limit {
+		candidates = candidates[:opts.Limit]
+	}
+	return candidates
+}

--- a/internal/bundle/node_index_test.go
+++ b/internal/bundle/node_index_test.go
@@ -1,0 +1,303 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestIndex(t *testing.T) *NodeIndex {
+	t.Helper()
+	data := []byte(`
+policies:
+  - uid: linux-security
+    name: Linux Security
+    groups:
+      - title: SSH Configuration
+        checks:
+          - uid: ssh-root-login
+            title: Ensure SSH root login is disabled
+            impact: 100
+            tags:
+              compliance/cis: "5.2.10"
+            mql: |
+              sshd.config.params["PermitRootLogin"] == "no"
+          - uid: ssh-ciphers
+            title: Ensure only strong ciphers are used
+            impact: 80
+            mql: |
+              sshd.config.ciphers.none(_ == "3des-cbc")
+          - uid: ssh-protocol
+            title: Ensure SSH protocol is set to 2
+            impact: 90
+            mql: |
+              sshd.config.params["Protocol"] == "2"
+      - title: Filesystem
+        checks:
+          - uid: tmp-noexec
+            title: Ensure noexec option on /tmp
+            impact: 60
+            mql: |
+              mount.where(path == "/tmp").options.contains("noexec")
+queries:
+  - uid: ssh-root-login
+    title: Ensure SSH root login is disabled
+    impact: 100
+    tags:
+      compliance/cis: "5.2.10"
+    mql: |
+      sshd.config.params["PermitRootLogin"] == "no"
+  - uid: ssh-ciphers
+    title: Ensure only strong ciphers are used
+    impact: 80
+    mql: |
+      sshd.config.ciphers.none(_ == "3des-cbc")
+  - uid: ssh-protocol
+    title: Ensure SSH protocol is set to 2
+    impact: 90
+    mql: |
+      sshd.config.params["Protocol"] == "2"
+  - uid: tmp-noexec
+    title: Ensure noexec option on /tmp
+    impact: 60
+    mql: |
+      mount.where(path == "/tmp").options.contains("noexec")
+`)
+	b, err := ParseYaml(data)
+	require.NoError(t, err)
+
+	g := BuildGraph(map[string]*Bundle{"test.mql.yaml": b})
+	return g.BuildNodeIndex()
+}
+
+func TestNodeIndex_ExactName(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	nodes := idx.ExactName("ssh-root-login")
+	assert.NotEmpty(t, nodes)
+	assert.Equal(t, "ssh-root-login", nodes[0].Name)
+
+	// Case-insensitive
+	nodes = idx.ExactName("SSH-Root-Login")
+	assert.NotEmpty(t, nodes)
+}
+
+func TestNodeIndex_ExactQualName(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	nodes := idx.ExactQualName("check:ssh-root-login")
+	assert.NotEmpty(t, nodes)
+	assert.Equal(t, KindCheck, nodes[0].Kind)
+
+	nodes = idx.ExactQualName("policy:linux-security")
+	assert.NotEmpty(t, nodes)
+	assert.Equal(t, KindPolicy, nodes[0].Kind)
+}
+
+func TestNodeIndex_Prefix(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	nodes := idx.Prefix("ssh-", 0)
+	assert.GreaterOrEqual(t, len(nodes), 3, "should find at least 3 SSH checks")
+	for _, n := range nodes {
+		assert.True(t, len(n.Name) >= 4 && n.Name[:4] == "ssh-",
+			"expected name to start with ssh-, got %s", n.Name)
+	}
+}
+
+func TestNodeIndex_Substring(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	// Substring in name
+	nodes := idx.Substring("ciphers", 0)
+	assert.NotEmpty(t, nodes)
+	found := false
+	for _, n := range nodes {
+		if n.Name == "ssh-ciphers" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "should find ssh-ciphers by substring")
+}
+
+func TestNodeIndex_TitleSearch(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	// "root login" is in the title but not the name
+	nodes := idx.Substring("root login", 0)
+	assert.NotEmpty(t, nodes, "should find node by title substring")
+	found := false
+	for _, n := range nodes {
+		if n.Name == "ssh-root-login" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "should find ssh-root-login by title 'root login'")
+}
+
+func TestNodeIndex_SearchCascade(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	// Exact name match should return only that node, not substring matches
+	nodes := idx.Search("ssh-root-login", SearchOpts{})
+	assert.NotEmpty(t, nodes)
+	assert.Equal(t, "ssh-root-login", nodes[0].Name)
+}
+
+func TestNodeIndex_KindFilter(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	// Without filter: should find policy AND checks matching "linux"
+	all := idx.Search("linux", SearchOpts{})
+	assert.NotEmpty(t, all)
+
+	// With kind filter: only policy
+	policies := idx.Search("linux", SearchOpts{Kind: KindPolicy})
+	assert.NotEmpty(t, policies)
+	for _, n := range policies {
+		assert.Equal(t, KindPolicy, n.Kind)
+	}
+}
+
+func TestNodeIndex_TagFilter(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	// Only ssh-root-login has the compliance/cis tag
+	nodes := idx.Search("ssh", SearchOpts{TagKey: "compliance/cis"})
+	assert.NotEmpty(t, nodes)
+	for _, n := range nodes {
+		_, ok := n.Tags["compliance/cis"]
+		assert.True(t, ok, "expected node %s to have compliance/cis tag", n.Name)
+	}
+}
+
+func TestNodeIndex_Limit(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	nodes := idx.Search("ssh", SearchOpts{Limit: 1})
+	assert.Len(t, nodes, 1)
+}
+
+func TestNodeIndex_EmptyQueryWithKind(t *testing.T) {
+	idx := buildTestIndex(t)
+
+	policies := idx.Search("", SearchOpts{Kind: KindPolicy})
+	assert.NotEmpty(t, policies)
+	for _, n := range policies {
+		assert.Equal(t, KindPolicy, n.Kind)
+	}
+}
+
+func BenchmarkNodeIndex_Build(b *testing.B) {
+	data := []byte(`
+policies:
+  - uid: bench-policy
+    name: Benchmark Policy
+    groups:
+      - title: Group 1
+        checks:
+          - uid: check-001
+            title: Check one
+            impact: 80
+            mql: "true"
+          - uid: check-002
+            title: Check two
+            impact: 60
+            mql: "true"
+          - uid: check-003
+            title: Check three
+            impact: 90
+            mql: "true"
+queries:
+  - uid: check-001
+    title: Check one
+    impact: 80
+    mql: "true"
+  - uid: check-002
+    title: Check two
+    impact: 60
+    mql: "true"
+  - uid: check-003
+    title: Check three
+    impact: 90
+    mql: "true"
+`)
+	bun, _ := ParseYaml(data)
+	g := BuildGraph(map[string]*Bundle{"bench.mql.yaml": bun})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = BuildNodeIndex(g)
+	}
+}
+
+func BenchmarkNodeIndex_Search(b *testing.B) {
+	data := []byte(`
+policies:
+  - uid: bench-policy
+    name: Benchmark Policy
+    groups:
+      - title: Group 1
+        checks:
+          - uid: check-001
+            title: Check one
+            impact: 80
+            mql: "true"
+          - uid: check-002
+            title: Check two
+            impact: 60
+            mql: "true"
+          - uid: check-003
+            title: Check three
+            impact: 90
+            mql: "true"
+queries:
+  - uid: check-001
+    title: Check one
+    impact: 80
+    mql: "true"
+  - uid: check-002
+    title: Check two
+    impact: 60
+    mql: "true"
+  - uid: check-003
+    title: Check three
+    impact: 90
+    mql: "true"
+`)
+	bun, _ := ParseYaml(data)
+	g := BuildGraph(map[string]*Bundle{"bench.mql.yaml": bun})
+	idx := BuildNodeIndex(g)
+
+	b.Run("ExactName", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = idx.ExactName("check-001")
+		}
+	})
+	b.Run("Prefix", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = idx.Prefix("check-", 50)
+		}
+	})
+	b.Run("Substring", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = idx.Substring("check", 50)
+		}
+	})
+	b.Run("SearchCascade", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = idx.Search("check-001", SearchOpts{})
+		}
+	})
+}

--- a/skills/policy-graph/.claude-plugin/plugin.json
+++ b/skills/policy-graph/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "policy-graph",
+  "version": "1.0.0",
+  "description": "Navigate cnspec policy bundles using graph commands for LLMs",
+  "author": {
+    "name": "Mondoo, Inc."
+  },
+  "repository": "https://github.com/mondoohq/cnspec",
+  "license": "BUSL-1.1",
+  "keywords": ["cnspec", "policy", "graph", "compliance", "framework", "mql", "security"]
+}

--- a/skills/policy-graph/README.md
+++ b/skills/policy-graph/README.md
@@ -22,6 +22,14 @@ Provides structured navigation of `.mql.yaml` policy bundles that replaces manua
 /policy-graph trace the path from CIS benchmark to SSH ciphers check
 ```
 
+## Installation
+
+```bash
+make install/skills
+```
+
+This copies the skill to `~/.claude/`, making it available in all Claude Code projects.
+
 ## Requirements
 
 - `cnspec` CLI installed and on PATH (or `go run ./apps/cnspec` from the repo)

--- a/skills/policy-graph/README.md
+++ b/skills/policy-graph/README.md
@@ -1,0 +1,28 @@
+# policy-graph
+
+A Claude Code skill for navigating and understanding cnspec policy bundles using graph commands.
+
+## What it does
+
+Provides structured navigation of `.mql.yaml` policy bundles that replaces manual file reading with single commands:
+
+- **Callers**: Find what policies, groups, or compliance controls reference a check
+- **Callees**: Find what checks, queries, or sub-policies a policy contains
+- **Context**: Get LLM-friendly markdown with YAML snippets for any node
+- **Paths**: Trace compliance mappings from frameworks to checks
+- **Reachable**: Find all nodes transitively reachable from a starting point
+- **Export**: Export the full graph as JSON or DOT
+
+## Usage
+
+```
+/policy-graph what checks does mondoo-linux-security contain?
+/policy-graph which compliance controls map to the SSH root login check?
+/policy-graph show me the context for mondoo-aws-security-iam-root-user-mfa
+/policy-graph trace the path from CIS benchmark to SSH ciphers check
+```
+
+## Requirements
+
+- `cnspec` CLI installed and on PATH (or `go run ./apps/cnspec` from the repo)
+- Works with any `.mql.yaml` policy bundle files

--- a/skills/policy-graph/commands/policy-graph.md
+++ b/skills/policy-graph/commands/policy-graph.md
@@ -1,0 +1,71 @@
+---
+name: policy-graph
+description: Navigates cnspec policy/framework bundles using graph commands. Use when exploring policies, finding checks, tracing compliance mappings, or understanding policy structure.
+argument-hint: "<question about policies, or specific navigation task>"
+allowed-tools: Bash Read Glob Grep
+---
+
+# Policy Bundle Navigation with cnspec policy graph
+
+**Task:** $ARGUMENTS
+
+Use `cnspec policy graph` commands to answer the question or complete the investigation. The graph is built on the fly from `.mql.yaml` files — no setup needed.
+
+## Workflow
+
+Choose the appropriate phase based on the task:
+
+### Phase 1: Orient (understand what's in the bundle)
+
+```bash
+# Export graph and count nodes by kind
+cnspec policy graph export ./content/ --format json | python3 -c "
+import json, sys, collections
+d = json.load(sys.stdin)
+kinds = collections.Counter(n['kind'] for n in d['nodes'])
+print(f'Nodes: {len(d[\"nodes\"])}, Edges: {len(d[\"edges\"])}')
+for k, v in kinds.most_common(): print(f'  {k}: {v}')
+"
+```
+
+### Phase 2: Locate (find specific nodes)
+
+```bash
+# Find nodes by name (substring match)
+cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json | \
+  python3 -c "import json,sys; [print(f'{n[\"kind\"]}:{n[\"name\"]}') for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+```
+
+### Phase 3: Navigate (explore relationships)
+
+```bash
+# What references this check? (policies, groups, compliance controls)
+cnspec policy graph callers <check-uid> ./content/
+
+# What does this policy contain? (groups, checks, queries)
+cnspec policy graph callees <policy-uid> ./content/
+
+# Trace compliance mapping: framework control → check
+cnspec policy graph paths <control-uid> <check-uid> ./content/
+
+# All nodes reachable from a starting point
+cnspec policy graph reachable <policy-uid> ./content/
+```
+
+### Phase 4: Context (deep dive with source)
+
+```bash
+# Full LLM-friendly context with YAML snippets
+cnspec policy graph context <uid> ./content/ --depth 2
+```
+
+This shows the node, its neighbors, relationship labels, and the actual YAML source from the bundle files.
+
+## Guidelines
+
+- Use `--json` when you need to process results programmatically
+- The `<path>` argument can be a directory or specific `.mql.yaml` files
+- Node UIDs use substring matching — you don't need the full UID
+- Use `context` for deep investigation — it shows source code and all relationships
+- Use `callers` to understand "who uses this check" (compliance tracing)
+- Use `callees` to understand "what's in this policy" (structure exploration)

--- a/skills/policy-graph/commands/policy-graph.md
+++ b/skills/policy-graph/commands/policy-graph.md
@@ -31,9 +31,10 @@ for k, v in kinds.most_common(): print(f'  {k}: {v}')
 ### Phase 2: Locate (find specific nodes)
 
 ```bash
-# Find nodes by name (substring match)
-cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json | \
-  python3 -c "import json,sys; [print(f'{n[\"kind\"]}:{n[\"name\"]}') for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+# Find nodes by name, title, or UID
+cnspec policy graph search ssh ./content/
+cnspec policy graph search "root login" ./content/ --kind check
+cnspec policy graph search "" ./content/ --kind policy
 ```
 
 ### Phase 3: Navigate (explore relationships)

--- a/skills/policy-graph/skills/policy-graph/SKILL.md
+++ b/skills/policy-graph/skills/policy-graph/SKILL.md
@@ -27,6 +27,7 @@ Navigate and understand cnspec policy bundles (`.mql.yaml` files) using structur
 
 | Command | Purpose |
 |---------|---------|
+| `cnspec policy graph search <query> <path>` | Find nodes by name, title, or UID |
 | `cnspec policy graph callers <uid> <path>` | What references this node (inbound edges) |
 | `cnspec policy graph callees <uid> <path>` | What this node contains/references (outbound edges) |
 | `cnspec policy graph context <uid> <path> [--depth N]` | LLM-friendly context with YAML snippets |
@@ -34,7 +35,7 @@ Navigate and understand cnspec policy bundles (`.mql.yaml` files) using structur
 | `cnspec policy graph reachable <uid> <path>` | All nodes transitively reachable |
 | `cnspec policy graph export <path> [--format json\|dot]` | Export full graph |
 
-All commands support `--json` for structured output.
+All commands support `--json` for structured output. Search also supports `--kind`, `--tag`, `--impact`, and `--limit`.
 
 ## Graph Concepts
 

--- a/skills/policy-graph/skills/policy-graph/SKILL.md
+++ b/skills/policy-graph/skills/policy-graph/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: policy-graph
+description: Navigates cnspec policy/framework bundles using graph commands. Use when exploring policies, finding checks, tracing compliance mappings, or understanding policy structure.
+allowed-tools: Bash Read Glob Grep
+---
+
+# cnspec Policy Graph Navigation
+
+Navigate and understand cnspec policy bundles (`.mql.yaml` files) using structured graph commands.
+
+## When to Use
+
+- Exploring policy bundle structure ("what checks does this policy have?")
+- Finding compliance mappings ("which framework controls map to this check?")
+- Tracing relationships ("how does this framework relate to that check?")
+- Understanding large bundles (10K+ line `.mql.yaml` files)
+- Getting context for a specific check with its MQL code, impact, and docs
+
+## When NOT to Use
+
+- Scanning assets with cnspec (`cnspec scan`)
+- Writing MQL queries
+- Linting bundles (`cnspec policy lint`)
+- Editing policy YAML directly (use the Read/Edit tools for that)
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `cnspec policy graph callers <uid> <path>` | What references this node (inbound edges) |
+| `cnspec policy graph callees <uid> <path>` | What this node contains/references (outbound edges) |
+| `cnspec policy graph context <uid> <path> [--depth N]` | LLM-friendly context with YAML snippets |
+| `cnspec policy graph paths <from> <to> <path>` | Find paths between two nodes |
+| `cnspec policy graph reachable <uid> <path>` | All nodes transitively reachable |
+| `cnspec policy graph export <path> [--format json\|dot]` | Export full graph |
+
+All commands support `--json` for structured output.
+
+## Graph Concepts
+
+### Node Types
+
+- **policy**: A security policy (e.g., `mondoo-linux-security`)
+- **group**: A group of checks within a policy (e.g., "SSH Configuration")
+- **check**: A scoring query with MQL code and impact rating
+- **query**: A data-only query (no scoring)
+- **framework**: A compliance framework (e.g., CIS Benchmark, ISO 27001)
+- **control**: A control within a framework (e.g., CIS 5.2.1)
+- **framework_map**: Maps framework controls to policy checks
+
+### Edge Types
+
+- **contains**: Structural parent-child (policy → group → check, framework → control)
+- **maps_to**: Compliance mapping (control → check/policy via framework_map)
+- **depends_on**: Policy/framework dependencies
+- **variant_of**: Check variant relationship (parent → platform-specific variant)

--- a/skills/policy-graph/skills/policy-graph/references/graph-commands.md
+++ b/skills/policy-graph/skills/policy-graph/references/graph-commands.md
@@ -1,0 +1,94 @@
+# cnspec policy graph Commands
+
+## callers
+
+Show all inbound edges to a node — what references it.
+
+```bash
+cnspec policy graph callers <uid> <path>
+cnspec policy graph callers <uid> <path> --json
+```
+
+Returns for each inbound edge: the source node's qualified name, edge kind, and source location.
+
+**Use cases**: find which policies include a check, which compliance controls map to a check, which frameworks reference a policy.
+
+## callees
+
+Show all outbound edges from a node — what it contains or references.
+
+```bash
+cnspec policy graph callees <uid> <path>
+cnspec policy graph callees <uid> <path> --json
+```
+
+**Use cases**: list all checks in a policy, list all controls in a framework, see what a group contains.
+
+## context
+
+Generate LLM-friendly markdown with YAML source snippets for a node and its N-hop neighborhood.
+
+```bash
+cnspec policy graph context <uid> <path>
+cnspec policy graph context <uid> <path> --depth 3
+```
+
+Output includes:
+- Focus node metadata (kind, uid, title, location, impact, compliance tags)
+- N-hop neighborhood grouped by file
+- YAML source snippets in fenced code blocks
+- Relationship labels: "Referenced by" (inbound), "Contains" (outbound)
+
+Default depth is 2 hops.
+
+## paths
+
+Find all simple paths between two nodes.
+
+```bash
+cnspec policy graph paths <from-uid> <to-uid> <path>
+cnspec policy graph paths <from-uid> <to-uid> <path> --json
+```
+
+Searches up to depth 20. Shows each path as a chain of qualified node names.
+
+**Use cases**: trace how a framework control connects to a specific check through the framework_map → control → check chain.
+
+## reachable
+
+Show all nodes transitively reachable by following outbound edges.
+
+```bash
+cnspec policy graph reachable <uid> <path>
+cnspec policy graph reachable <uid> <path> --json
+```
+
+**Use cases**: find all checks reachable from a policy, find all nodes in a framework's scope.
+
+## export
+
+Export the full policy graph.
+
+```bash
+cnspec policy graph export <path> --format json
+cnspec policy graph export <path> --format dot
+```
+
+Formats:
+- `json`: Full graph with nodes and edges arrays
+- `dot`: Graphviz DOT format for visualization
+
+**Use cases**: understand the full structure of a bundle, generate visual diagrams, programmatic analysis.
+
+## Common Flags
+
+- `--json`: Output as JSON (available on callers, callees, paths, reachable)
+- `--depth N`: Neighborhood depth for context (default 2)
+- `--format json|dot`: Export format (export command only)
+
+## Path Argument
+
+The `<path>` argument can be:
+- A directory: walks for all `.mql.yaml` files recursively
+- One or more specific `.mql.yaml` files
+- Multiple paths: `cnspec policy graph callers check-uid file1.mql.yaml file2.mql.yaml`

--- a/skills/policy-graph/skills/policy-graph/references/graph-commands.md
+++ b/skills/policy-graph/skills/policy-graph/references/graph-commands.md
@@ -1,5 +1,27 @@
 # cnspec policy graph Commands
 
+## search
+
+Find nodes by name, title, or UID using multi-strategy search: exact name, prefix, or substring match.
+
+```bash
+cnspec policy graph search <query> <path>
+cnspec policy graph search <query> <path> --kind check
+cnspec policy graph search <query> <path> --kind check --json
+cnspec policy graph search "" <path> --kind policy
+```
+
+Flags:
+- `--kind`: Filter by node kind (policy, check, group, query, framework, control)
+- `--tag`: Filter by tag key (e.g. `compliance/cis`)
+- `--impact N`: Minimum impact score
+- `--limit N`: Maximum results (default 50)
+- `--json`: Output as JSON
+
+Search cascade: tries exact name match first, then prefix, then substring (including titles). An empty query with `--kind` lists all nodes of that kind.
+
+**Use cases**: find checks by topic ("ssh", "root login"), list all policies, find checks with specific compliance tags.
+
 ## callers
 
 Show all inbound edges to a node — what references it.

--- a/skills/policy-graph/skills/policy-graph/references/navigation-patterns.md
+++ b/skills/policy-graph/skills/policy-graph/references/navigation-patterns.md
@@ -50,16 +50,19 @@ cnspec policy graph reachable <policy-uid> ./content/
 ## "Find all SSH-related checks"
 
 ```bash
-# Export and filter by name
-cnspec policy graph export ./content/ --format json | \
-  python3 -c "import json,sys; [print(f'{n[\"kind\"]}:{n[\"name\"]} - {n.get(\"title\",\"\")}') for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+cnspec policy graph search ssh ./content/ --kind check
+```
+
+## "Find checks by title"
+
+```bash
+cnspec policy graph search "root login" ./content/ --kind check
 ```
 
 ## "What policies are in this bundle directory?"
 
 ```bash
-cnspec policy graph export ./content/ --format json | \
-  python3 -c "import json,sys; [print(f'{n[\"name\"]}: {n.get(\"title\",\"\")}') for n in json.load(sys.stdin)['nodes'] if n['kind'] == 'policy']"
+cnspec policy graph search "" ./content/ --kind policy
 ```
 
 ## "Generate a visual diagram"

--- a/skills/policy-graph/skills/policy-graph/references/navigation-patterns.md
+++ b/skills/policy-graph/skills/policy-graph/references/navigation-patterns.md
@@ -1,0 +1,86 @@
+# Navigation Patterns
+
+Common patterns for using cnspec policy graph to answer questions about policy bundles.
+
+## "What checks does this policy have?"
+
+```bash
+cnspec policy graph callees mondoo-linux-security ./content/mondoo-linux-security.mql.yaml
+```
+
+Shows all groups, then use callees on a group to see its checks.
+
+## "Which compliance controls map to this check?"
+
+```bash
+cnspec policy graph callers <check-uid> ./content/
+```
+
+Look for `[maps_to]` edges — those come from framework controls via framework_maps.
+
+## "How does framework X relate to check Y?"
+
+```bash
+cnspec policy graph paths <framework-uid> <check-uid> ./content/
+```
+
+Shows the chain: framework → (contains) → control → (maps_to) → check.
+
+## "Show me everything about this check"
+
+```bash
+cnspec policy graph context <check-uid> ./content/ --depth 2
+```
+
+Shows the check's MQL code, impact, compliance tags, which policy groups reference it, and which framework controls map to it — all with YAML source snippets.
+
+## "What's the full structure of this policy?"
+
+```bash
+# First see the groups
+cnspec policy graph callees <policy-uid> ./content/
+
+# Then drill into a specific group
+cnspec policy graph callees <group-id> ./content/
+
+# Or get the full reachable set
+cnspec policy graph reachable <policy-uid> ./content/
+```
+
+## "Find all SSH-related checks"
+
+```bash
+# Export and filter by name
+cnspec policy graph export ./content/ --format json | \
+  python3 -c "import json,sys; [print(f'{n[\"kind\"]}:{n[\"name\"]} - {n.get(\"title\",\"\")}') for n in json.load(sys.stdin)['nodes'] if 'ssh' in n['name'].lower()]"
+```
+
+## "What policies are in this bundle directory?"
+
+```bash
+cnspec policy graph export ./content/ --format json | \
+  python3 -c "import json,sys; [print(f'{n[\"name\"]}: {n.get(\"title\",\"\")}') for n in json.load(sys.stdin)['nodes'] if n['kind'] == 'policy']"
+```
+
+## "Generate a visual diagram"
+
+```bash
+cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format dot > policy.dot
+dot -Tpng policy.dot -o policy.png
+```
+
+## "Compare two policies"
+
+```bash
+# Export each and compare node lists
+cnspec policy graph export ./content/mondoo-linux-security.mql.yaml --format json > linux.json
+cnspec policy graph export ./content/mondoo-aws-security.mql.yaml --format json > aws.json
+python3 -c "
+import json
+linux = {n['name'] for n in json.load(open('linux.json'))['nodes'] if n['kind'] == 'check'}
+aws = {n['name'] for n in json.load(open('aws.json'))['nodes'] if n['kind'] == 'check'}
+print(f'Linux-only checks: {len(linux - aws)}')
+print(f'AWS-only checks: {len(aws - linux)}')
+print(f'Shared checks: {len(linux & aws)}')
+"
+```


### PR DESCRIPTION
## Summary

Adds `cnspec policy graph` subcommands for navigating the structure of `.mql.yaml` policy bundles. These commands build a graph of policies, groups, checks, frameworks, controls, and their relationships, enabling structured exploration without reading thousands of lines of YAML.

### Commands

| Command | Purpose |
|---------|---------|
| `search <query> <path>` | Find nodes by name, title, or UID |
| `callers <uid> <path>` | What references this node (inbound edges) |
| `callees <uid> <path>` | What this node contains/references (outbound edges) |
| `context <uid> <path>` | LLM-friendly context with YAML snippets |
| `paths <from> <to> <path>` | Find paths between two nodes |
| `reachable <uid> <path>` | All nodes transitively reachable |
| `export <path>` | Export full graph as JSON or DOT |

### Search

Multi-strategy indexed search: exact name → exact qualName → prefix (binary search) → substring (including titles). Supports `--kind`, `--tag`, `--impact`, and `--limit` filters.

```bash
cnspec policy graph search ssh ./content/ --kind check
cnspec policy graph search "root login" ./content/ --kind check
cnspec policy graph search "" ./content/ --kind policy
```

### Claude Code Skill

Includes a Claude Code skill (`skills/policy-graph/`) that teaches agents how to navigate policy bundles using graph commands. Install with `make install/skills`.

## Test plan

- [x] Unit tests for graph building, node index, paths, reachability, and context rendering
- [x] Benchmarks for NodeIndex (Build: 1.6µs, ExactName: 19ns, Prefix: 112ns, Substring: 438ns)
- [x] CLI smoke tests against real content directory
- [x] Existing bundle tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)