### PR TITLE
Add skills README, fix naming, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ If you're interested in writing your own policies or contributing policies back 
 | VMware vSphere                | `vsphere`                  | `cnspec scan vsphere user@domain@host --ask-pass`                                                                                                     |
 | Windows hosts                 | `local`, `ssh`, `winrm`    | `cnspec scan local`,<br></br>`cnspec scan ssh Administrator@IP_ADDRESS --ask-pass` or<br></br>`cnspec scan winrm Administrator@IP_ADDRESS --ask-pass` |
 
+## Agent skills
+
+cnspec includes agent skills that give coding agents MQL expertise and policy navigation capabilities. Skills work across Claude Code, Cursor, Gemini CLI, and Codex.
+
+| Skill | Description |
+|-------|-------------|
+| [mql](skills/mql/) | MQL query development with syntax guidance, platform-specific patterns, and schema discovery |
+| [policy-graph](skills/policy-graph/) | Navigate policy bundles using graph commands — search, trace compliance mappings, explore structure |
+
+See [skills/README.md](skills/README.md) for installation instructions and details.
+
 ## What's next?
 
 There are so many things cnspec can do, from testing your entire fleet for vulnerabilities to gathering information and creating reports for auditors. With its custom policies, cnspec can scan any component you care about!

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -356,20 +356,13 @@ cnspec policy graph paths <control-uid> <check-uid> ./policies/ ./frameworks/
 
 Framework maps create `maps_to` edges from controls to checks, so `callers` on a check shows which compliance controls require it, and `paths` traces the full chain: framework -> control -> check.
 
-## Claude Code skill
+## Agent skill
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill is included for AI-assisted policy navigation. The skill teaches Claude how to use the graph commands to answer questions about policy bundles.
+An agent skill is included for AI-assisted policy navigation. The skill teaches coding agents how to use the graph commands to answer questions about policy bundles. It works across Claude Code, Codex, Gemini CLI, and Cursor.
 
 ### Installation
 
-```bash
-make install/skills
-```
-
-This copies the skill files to `~/.claude/`, making them available across all projects:
-
-- `~/.claude/commands/policy-graph.md` — Slash command definition
-- `~/.claude/skills/policy-graph/` — Auto-trigger skill with references
+See [skills/README.md](../skills/README.md) for installation instructions.
 
 ### Usage in Claude Code
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -26,12 +26,6 @@ Install a skill:
 /plugin install policy-graph@mondoohq/cnspec
 ```
 
-Or install all skills locally from a checkout:
-
-```bash
-make install/skills
-```
-
 ### Codex
 
 Copy or symlink skill directories from `skills/` into one of Codex's standard `.agents/skills` locations (e.g., `$REPO_ROOT/.agents/skills` or `$HOME/.agents/skills`).

--- a/scripts/generate-agents/main.go
+++ b/scripts/generate-agents/main.go
@@ -25,7 +25,7 @@ import (
 type skill struct {
 	Name        string
 	Description string
-	Path        string // relative path to the skill dir (e.g. "skills/mondoo-mql/skills/mondoo-mql")
+	Path        string // relative path to the skill dir (e.g. "skills/mql")
 }
 
 type marketplaceJSON struct {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,125 @@
+# cnspec Skills
+
+cnspec skills are definitions for MQL development and policy navigation tasks. They are interoperable with all major coding agent tools like Anthropic's Claude Code, OpenAI Codex, Google DeepMind's Gemini CLI, and Cursor.
+
+The skills in this repository follow the standardized [Agent Skills](https://agentskills.io/home) format.
+
+> [!TIP]
+> If your agent doesn't support skills, you can use [`agents/AGENTS.md`](../agents/AGENTS.md) directly as a fallback.
+
+## How do skills work?
+
+Skills are self-contained folders that package instructions and resources together for an AI agent to use on a specific use case. Each folder includes a `SKILL.md` file with YAML frontmatter (name and description) followed by the guidance your coding agent follows while the skill is active.
+
+## Installation
+
+cnspec skills are compatible with Claude Code, Codex, Gemini CLI, and Cursor.
+
+### Claude Code
+
+1. Register the repository as a plugin marketplace:
+
+```
+/plugin marketplace add mondoohq/cnspec
+```
+
+2. Install a skill:
+
+```
+/plugin install mql@mondoohq/cnspec
+/plugin install policy-graph@mondoohq/cnspec
+```
+
+### Codex
+
+1. Copy or symlink skill directories from `skills/` into one of Codex's standard `.agents/skills` locations (e.g., `$REPO_ROOT/.agents/skills` or `$HOME/.agents/skills`) as described in the [Codex Skills guide](https://developers.openai.com/codex/skills/).
+
+2. Once available, Codex will discover the skill and load the `SKILL.md` instructions automatically.
+
+3. If your Codex setup still relies on `AGENTS.md`, use the generated [`agents/AGENTS.md`](../agents/AGENTS.md) file as a fallback.
+
+### Gemini CLI
+
+Install locally:
+
+```
+gemini extensions install . --consent
+```
+
+Or from GitHub:
+
+```
+gemini extensions install https://github.com/mondoohq/cnspec.git --consent
+```
+
+See [Gemini CLI extensions docs](https://geminicli.com/docs/extensions/#installing-an-extension) for more help.
+
+### Cursor
+
+This repository includes Cursor plugin manifests:
+
+- `.cursor-plugin/plugin.json`
+- `.cursor-plugin/marketplace.json`
+
+Install from repository URL or local checkout via the Cursor plugin flow.
+
+## Available skills
+
+| Name | Description | Documentation |
+|------|-------------|---------------|
+| `mql` | MQL query development with syntax guidance, platform-specific patterns, and schema discovery | [SKILL.md](mql/SKILL.md) |
+| `policy-graph` | Navigate cnspec policy bundles using graph commands — search, trace compliance mappings, explore structure | [SKILL.md](policy-graph/SKILL.md) |
+
+### mql
+
+The MQL skill provides comprehensive guidance for writing MQL queries and security policies:
+
+- **MQL Reference** — Complete syntax documentation, best practices, and anti-patterns
+- **Platform Samples** — Ready-to-use patterns for AWS, Azure, Linux, Windows, and Microsoft 365
+- **Schema Discovery** — Real-time schema lookup via `cnspec` CLI or Mondoo MCP tools
+- **Query Validation** — Compile-time syntax and semantic checking
+- **Policy Management** — Linting, formatting, and scaffolding policy bundles
+
+### policy-graph
+
+The policy graph skill provides structured navigation of `.mql.yaml` policy bundles:
+
+- **Search** — Find nodes by name, title, or UID
+- **Callers/Callees** — Explore inbound and outbound relationships
+- **Context** — Get LLM-friendly markdown with YAML snippets for any node
+- **Paths** — Trace compliance mappings from frameworks to checks
+- **Reachable** — Find all nodes transitively reachable from a starting point
+
+See [docs/graph.md](../docs/graph.md) for full command documentation.
+
+## Adding a new skill
+
+1. Create a directory under `skills/<name>/` with a `SKILL.md` containing frontmatter:
+
+   ```markdown
+   ---
+   name: <skill-name>
+   description: <one-line description of when to use this skill>
+   ---
+
+   # Skill content here
+   ```
+
+2. Add the skill to the marketplace manifests in `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json`.
+
+3. Regenerate `agents/AGENTS.md`:
+
+   ```bash
+   make skills/generate
+   ```
+
+4. Verify everything is in sync:
+
+   ```bash
+   make skills/generate/check
+   ```
+
+## Requirements
+
+- `cnspec` CLI installed and on PATH
+- Works with any `.mql.yaml` policy or query pack files

--- a/skills/mql/README.md
+++ b/skills/mql/README.md
@@ -17,18 +17,9 @@ Provides comprehensive guidance for writing MQL queries and security policies:
 The skill automatically activates when working on MQL-related tasks. You can also invoke it directly:
 
 ```
-/mondoo-mql
+/mql
 ```
 
 ## Installation
 
-```bash
-make install/skills
-```
-
-This copies the skill to `~/.claude/`, making it available in all Claude Code projects.
-
-## Requirements
-
-- `cnspec` CLI installed and on PATH (or `go run ./apps/cnspec` from the repo)
-- Works with any `.mql.yaml` policy or query pack files
+See [skills/README.md](../README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.

--- a/skills/policy-graph/README.md
+++ b/skills/policy-graph/README.md
@@ -1,6 +1,6 @@
 # policy-graph
 
-A Claude Code skill for navigating and understanding cnspec policy bundles using graph commands.
+An agent skill for navigating and understanding cnspec policy bundles using graph commands.
 
 ## What it does
 
@@ -24,13 +24,4 @@ Provides structured navigation of `.mql.yaml` policy bundles that replaces manua
 
 ## Installation
 
-```bash
-make install/skills
-```
-
-This copies the skill to `~/.claude/`, making it available in all Claude Code projects.
-
-## Requirements
-
-- `cnspec` CLI installed and on PATH (or `go run ./apps/cnspec` from the repo)
-- Works with any `.mql.yaml` policy bundle files
+See [skills/README.md](../README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.


### PR DESCRIPTION
## Summary

- **Add `skills/README.md`** with installation instructions for Claude Code, Codex, Gemini CLI, and Cursor (modeled after [huggingface/skills](https://github.com/huggingface/skills))
- **Replace remaining `mondoo-mql` references** with `mql` in skill README and generator code comment
- **Add agent skills section** to root README with links to both skills
- **Remove `make install/skills`** from user-facing docs — it's a development convenience, not the installation path for users
- **Update per-skill READMEs** to point to the central `skills/README.md` and use agent-agnostic language ("agent skill" instead of "Claude Code skill")
- **Update `docs/graph.md`** and `docs/skills.md`  to reference `skills/README.md` for installation

## Test plan

- [ ] `grep -rn mondoo-mql skills/ scripts/ README.md` returns no results
- [ ] `grep -rn 'make install/skills' skills/ docs/ README.md` returns no results (only in Makefile)
- [ ] Links in skills/README.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)