### PR TITLE
Fix Claude Code plugin install syntax

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -22,8 +22,8 @@ Register the cnspec repository as a plugin marketplace:
 Install a skill:
 
 ```shell
-/plugin install mql@mondoohq/cnspec
-/plugin install policy-graph@mondoohq/cnspec
+/plugin install mql@cnspec-skills
+/plugin install policy-graph@cnspec-skills
 ```
 
 ### Codex

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,8 +26,8 @@ cnspec skills are compatible with Claude Code, Codex, Gemini CLI, and Cursor.
 2. Install a skill:
 
 ```
-/plugin install mql@mondoohq/cnspec
-/plugin install policy-graph@mondoohq/cnspec
+/plugin install mql@cnspec-skills
+/plugin install policy-graph@cnspec-skills
 ```
 
 ### Codex


### PR DESCRIPTION
## Summary
- Fix `/plugin install` commands in docs to use marketplace name (`@cnspec-skills`) instead of GitHub path (`@mondoohq/cnspec`)
- The GitHub path is only used for `/plugin marketplace add`, not `/plugin install`

## Test plan
- [x] Verified `/plugin install mql@cnspec-skills` succeeds
- [x] Verified `/plugin install policy-graph@cnspec-skills` succeeds
- [x] Confirmed no other `@mondoohq/cnspec` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)